### PR TITLE
feat: support `HasName` and `HasNamespace` for types

### DIFF
--- a/Source/aweXpect.Reflection/Collections/Filter.cs
+++ b/Source/aweXpect.Reflection/Collections/Filter.cs
@@ -5,7 +5,7 @@ namespace aweXpect.Reflection.Collections;
 /// <summary>
 ///     Filters specify which entities must satisfy the requirements.
 /// </summary>
-public static class Filter
+internal static class Filter
 {
 	/// <summary>
 	///     Creates a new <see cref="IFilter{TEntity}" /> from the given <paramref name="predicate" />.
@@ -18,6 +18,12 @@ public static class Filter
 	/// </summary>
 	public static IFilter<TEntity> Suffix<TEntity>(Func<TEntity, bool> predicate, string suffix)
 		=> new GenericSuffixFilter<TEntity>(predicate, suffix);
+
+	/// <summary>
+	///     Creates a new <see cref="IFilter{TEntity}" /> from the given <paramref name="predicate" />.
+	/// </summary>
+	public static IFilter<TEntity> Suffix<TEntity>(Func<TEntity, bool> predicate, Func<string> suffix)
+		=> new GenericSuffixFuncFilter<TEntity>(predicate, suffix);
 
 	private sealed class GenericPrefixFilter<TEntity> : IFilter<TEntity>
 	{
@@ -65,5 +71,29 @@ public static class Filter
 		/// <inheritdoc cref="object.ToString()" />
 		public override string ToString()
 			=> _suffix;
+	}
+
+	private sealed class GenericSuffixFuncFilter<TEntity> : IFilter<TEntity>
+	{
+		private readonly Func<TEntity, bool> _filter;
+		private readonly Func<string> _suffix;
+
+		public GenericSuffixFuncFilter(Func<TEntity, bool> filter, Func<string> suffix)
+		{
+			_filter = filter;
+			_suffix = suffix;
+		}
+
+		/// <inheritdoc cref="IFilter{TEntity}.Applies(TEntity)" />
+		public bool Applies(TEntity type)
+			=> _filter(type);
+
+		/// <inheritdoc cref="IFilter{TEntity}.Describes" />
+		public string Describes(string text)
+			=> text + _suffix();
+
+		/// <inheritdoc cref="object.ToString()" />
+		public override string ToString()
+			=> _suffix();
 	}
 }

--- a/Source/aweXpect.Reflection/Collections/Filtered.Types.cs
+++ b/Source/aweXpect.Reflection/Collections/Filtered.Types.cs
@@ -91,7 +91,10 @@ public static partial class Filtered
 			_description = events.GetDescription() + TypesSuffix;
 		}
 
-		protected Types(Types inner) : base(inner, inner.Filters)
+		/// <summary>
+		///     Container for a filterable collection of <see cref="Type" />.
+		/// </summary>
+		private Types(Types inner) : base(inner, inner.Filters)
 		{
 			_description = inner._description;
 			_assemblies = inner._assemblies;
@@ -143,115 +146,122 @@ public static partial class Filtered
 		///     Get all properties in the filtered types.
 		/// </summary>
 		public Properties Properties() => new(this, "properties ");
-		
-	public class StringEqualityResult : Types
-	{
-		private readonly StringEqualityOptions _options;
 
-		public StringEqualityResult(Types inner, StringEqualityOptions options) : base(inner)
+		/// <summary>
+		///     A Container for a filterable collection of <see cref="Type" />,
+		///     that also allows specifying string equality options.
+		/// </summary>
+		public class StringEqualityResult : Types
 		{
-			_options = options;
+			private readonly StringEqualityOptions _options;
+
+			internal StringEqualityResult(Types inner, StringEqualityOptions options) : base(inner)
+			{
+				_options = options;
+			}
+
+			/// <summary>
+			///     Ignores casing when comparing the <see langword="string" />s,
+			///     according to the <paramref name="ignoreCase" /> parameter.
+			/// </summary>
+			public StringEqualityResult IgnoringCase(bool ignoreCase = true)
+			{
+				_options.IgnoringCase(ignoreCase);
+				return this;
+			}
+
+			/// <summary>
+			///     Ignores leading white-space when comparing <see langword="string" />s,
+			///     according to the <paramref name="ignoreLeadingWhiteSpace" /> parameter.
+			/// </summary>
+			/// <remarks>
+			///     Note:<br />
+			///     This affects the index of first mismatch, as the removed whitespace is also ignored for the index calculation!
+			/// </remarks>
+			public StringEqualityResult IgnoringLeadingWhiteSpace(bool ignoreLeadingWhiteSpace = true)
+			{
+				_options.IgnoringLeadingWhiteSpace(ignoreLeadingWhiteSpace);
+				return this;
+			}
+
+			/// <summary>
+			///     Ignores trailing white-space when comparing <see langword="string" />s,
+			///     according to the <paramref name="ignoreTrailingWhiteSpace" /> parameter.
+			/// </summary>
+			public StringEqualityResult IgnoringTrailingWhiteSpace(bool ignoreTrailingWhiteSpace = true)
+			{
+				_options.IgnoringTrailingWhiteSpace(ignoreTrailingWhiteSpace);
+				return this;
+			}
+
+			/// <summary>
+			///     Uses the provided <paramref name="comparer" /> for comparing <see langword="string" />s.
+			/// </summary>
+			public StringEqualityResult Using(IEqualityComparer<string> comparer)
+			{
+				_options.UsingComparer(comparer);
+				return this;
+			}
 		}
 
 		/// <summary>
-		///     Ignores casing when comparing the <see langword="string" />s,
-		///     according to the <paramref name="ignoreCase" /> parameter.
+		///     A Container for a filterable collection of <see cref="Type" />,
+		///     that also allows specifying string equality options and types.
 		/// </summary>
-		public StringEqualityResult IgnoringCase(bool ignoreCase = true)
+		public class StringEqualityResultType : StringEqualityResult
 		{
-			_options.IgnoringCase(ignoreCase);
-			return this;
-		}
+			private readonly StringEqualityOptions _options;
 
-		/// <summary>
-		///     Ignores leading white-space when comparing <see langword="string" />s,
-		///     according to the <paramref name="ignoreLeadingWhiteSpace" /> parameter.
-		/// </summary>
-		/// <remarks>
-		///     Note:<br />
-		///     This affects the index of first mismatch, as the removed whitespace is also ignored for the index calculation!
-		/// </remarks>
-		public StringEqualityResult IgnoringLeadingWhiteSpace(bool ignoreLeadingWhiteSpace = true)
-		{
-			_options.IgnoringLeadingWhiteSpace(ignoreLeadingWhiteSpace);
-			return this;
-		}
+			internal StringEqualityResultType(Types inner, StringEqualityOptions options) : base(inner, options)
+			{
+				_options = options;
+			}
 
-		/// <summary>
-		///     Ignores trailing white-space when comparing <see langword="string" />s,
-		///     according to the <paramref name="ignoreTrailingWhiteSpace" /> parameter.
-		/// </summary>
-		public StringEqualityResult IgnoringTrailingWhiteSpace(bool ignoreTrailingWhiteSpace = true)
-		{
-			_options.IgnoringTrailingWhiteSpace(ignoreTrailingWhiteSpace);
-			return this;
-		}
+			/// <summary>
+			///     Interprets the expected <see langword="string" /> to be exactly equal.
+			/// </summary>
+			public StringEqualityResult Exactly()
+			{
+				_options.Exactly();
+				return this;
+			}
 
-		/// <summary>
-		///     Uses the provided <paramref name="comparer" /> for comparing <see langword="string" />s.
-		/// </summary>
-		public StringEqualityResult Using(IEqualityComparer<string> comparer)
-		{
-			_options.UsingComparer(comparer);
-			return this;
+			/// <summary>
+			///     Interprets the expected <see langword="string" /> as a prefix, so that the actual value starts with it.
+			/// </summary>
+			public StringEqualityResult AsPrefix()
+			{
+				_options.AsPrefix();
+				return this;
+			}
+
+			/// <summary>
+			///     Interprets the expected <see langword="string" /> as <see cref="Regex" /> pattern.
+			/// </summary>
+			public StringEqualityResult AsRegex()
+			{
+				_options.AsRegex();
+				return this;
+			}
+
+			/// <summary>
+			///     Interprets the expected <see langword="string" /> as a suffix, so that the actual value ends with it.
+			/// </summary>
+			public StringEqualityResult AsSuffix()
+			{
+				_options.AsSuffix();
+				return this;
+			}
+
+			/// <summary>
+			///     Interprets the expected <see langword="string" /> as wildcard pattern.<br />
+			///     Supports * to match zero or more characters and ? to match exactly one character.
+			/// </summary>
+			public StringEqualityResult AsWildcard()
+			{
+				_options.AsWildcard();
+				return this;
+			}
 		}
 	}
-
-	public class StringEqualityResultType : StringEqualityResult
-	{
-		private readonly StringEqualityOptions _options;
-
-		public StringEqualityResultType(Types inner, StringEqualityOptions options) : base(inner, options)
-		{
-			_options = options;
-		}
-		
-		/// <summary>
-		///     Interprets the expected <see langword="string" /> to be exactly equal.
-		/// </summary>
-		public StringEqualityResult Exactly()
-		{
-			_options.Exactly();
-			return this;
-		}
-
-		/// <summary>
-		///     Interprets the expected <see langword="string" /> as a prefix, so that the actual value starts with it.
-		/// </summary>
-		public StringEqualityResult AsPrefix()
-		{
-			_options.AsPrefix();
-			return this;
-		}
-
-		/// <summary>
-		///     Interprets the expected <see langword="string" /> as <see cref="Regex" /> pattern.
-		/// </summary>
-		public StringEqualityResult AsRegex()
-		{
-			_options.AsRegex();
-			return this;
-		}
-
-		/// <summary>
-		///     Interprets the expected <see langword="string" /> as a suffix, so that the actual value ends with it.
-		/// </summary>
-		public StringEqualityResult AsSuffix()
-		{
-			_options.AsSuffix();
-			return this;
-		}
-
-		/// <summary>
-		///     Interprets the expected <see langword="string" /> as wildcard pattern.<br />
-		///     Supports * to match zero or more characters and ? to match exactly one character.
-		/// </summary>
-		public StringEqualityResult AsWildcard()
-		{
-			_options.AsWildcard();
-			return this;
-		}
-	}
-	}
-
 }

--- a/Source/aweXpect.Reflection/Collections/Filtered.Types.cs
+++ b/Source/aweXpect.Reflection/Collections/Filtered.Types.cs
@@ -1,6 +1,9 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using aweXpect.Core;
+using aweXpect.Options;
 
 // ReSharper disable MemberHidesStaticFromOuterClass
 
@@ -88,6 +91,12 @@ public static partial class Filtered
 			_description = events.GetDescription() + TypesSuffix;
 		}
 
+		protected Types(Types inner) : base(inner, inner.Filters)
+		{
+			_description = inner._description;
+			_assemblies = inner._assemblies;
+		}
+
 		/// <inheritdoc />
 		public string GetDescription()
 		{
@@ -134,5 +143,115 @@ public static partial class Filtered
 		///     Get all properties in the filtered types.
 		/// </summary>
 		public Properties Properties() => new(this, "properties ");
+		
+	public class StringEqualityResult : Types
+	{
+		private readonly StringEqualityOptions _options;
+
+		public StringEqualityResult(Types inner, StringEqualityOptions options) : base(inner)
+		{
+			_options = options;
+		}
+
+		/// <summary>
+		///     Ignores casing when comparing the <see langword="string" />s,
+		///     according to the <paramref name="ignoreCase" /> parameter.
+		/// </summary>
+		public StringEqualityResult IgnoringCase(bool ignoreCase = true)
+		{
+			_options.IgnoringCase(ignoreCase);
+			return this;
+		}
+
+		/// <summary>
+		///     Ignores leading white-space when comparing <see langword="string" />s,
+		///     according to the <paramref name="ignoreLeadingWhiteSpace" /> parameter.
+		/// </summary>
+		/// <remarks>
+		///     Note:<br />
+		///     This affects the index of first mismatch, as the removed whitespace is also ignored for the index calculation!
+		/// </remarks>
+		public StringEqualityResult IgnoringLeadingWhiteSpace(bool ignoreLeadingWhiteSpace = true)
+		{
+			_options.IgnoringLeadingWhiteSpace(ignoreLeadingWhiteSpace);
+			return this;
+		}
+
+		/// <summary>
+		///     Ignores trailing white-space when comparing <see langword="string" />s,
+		///     according to the <paramref name="ignoreTrailingWhiteSpace" /> parameter.
+		/// </summary>
+		public StringEqualityResult IgnoringTrailingWhiteSpace(bool ignoreTrailingWhiteSpace = true)
+		{
+			_options.IgnoringTrailingWhiteSpace(ignoreTrailingWhiteSpace);
+			return this;
+		}
+
+		/// <summary>
+		///     Uses the provided <paramref name="comparer" /> for comparing <see langword="string" />s.
+		/// </summary>
+		public StringEqualityResult Using(IEqualityComparer<string> comparer)
+		{
+			_options.UsingComparer(comparer);
+			return this;
+		}
 	}
+
+	public class StringEqualityResultType : StringEqualityResult
+	{
+		private readonly StringEqualityOptions _options;
+
+		public StringEqualityResultType(Types inner, StringEqualityOptions options) : base(inner, options)
+		{
+			_options = options;
+		}
+		
+		/// <summary>
+		///     Interprets the expected <see langword="string" /> to be exactly equal.
+		/// </summary>
+		public StringEqualityResult Exactly()
+		{
+			_options.Exactly();
+			return this;
+		}
+
+		/// <summary>
+		///     Interprets the expected <see langword="string" /> as a prefix, so that the actual value starts with it.
+		/// </summary>
+		public StringEqualityResult AsPrefix()
+		{
+			_options.AsPrefix();
+			return this;
+		}
+
+		/// <summary>
+		///     Interprets the expected <see langword="string" /> as <see cref="Regex" /> pattern.
+		/// </summary>
+		public StringEqualityResult AsRegex()
+		{
+			_options.AsRegex();
+			return this;
+		}
+
+		/// <summary>
+		///     Interprets the expected <see langword="string" /> as a suffix, so that the actual value ends with it.
+		/// </summary>
+		public StringEqualityResult AsSuffix()
+		{
+			_options.AsSuffix();
+			return this;
+		}
+
+		/// <summary>
+		///     Interprets the expected <see langword="string" /> as wildcard pattern.<br />
+		///     Supports * to match zero or more characters and ? to match exactly one character.
+		/// </summary>
+		public StringEqualityResult AsWildcard()
+		{
+			_options.AsWildcard();
+			return this;
+		}
+	}
+	}
+
 }

--- a/Source/aweXpect.Reflection/Collections/Filtered.cs
+++ b/Source/aweXpect.Reflection/Collections/Filtered.cs
@@ -14,13 +14,13 @@ public static partial class Filtered;
 /// <summary>
 ///     Base class for filtered collections of <typeparamref name="T" />.
 /// </summary>
-public abstract class Filtered<T, TFiltered>(IEnumerable<T> source) : IEnumerable<T>
+public abstract class Filtered<T, TFiltered>(IEnumerable<T> source, List<IFilter<T>>? filters = null) : IEnumerable<T>
 	where TFiltered : Filtered<T, TFiltered>
 {
 	/// <summary>
 	///     The filters on the source.
 	/// </summary>
-	protected List<IFilter<T>> Filters { get; } = [];
+	protected List<IFilter<T>> Filters { get; } = filters ?? [];
 
 	/// <inheritdoc />
 	public IEnumerator<T> GetEnumerator() => source.Where(a => Filters.All(f => f.Applies(a))).GetEnumerator();

--- a/Source/aweXpect.Reflection/Collections/FilteredExtensions.Types.WithName.cs
+++ b/Source/aweXpect.Reflection/Collections/FilteredExtensions.Types.WithName.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using aweXpect.Core;
+using aweXpect.Options;
+
+namespace aweXpect.Reflection.Collections;
+
+public static partial class FilteredExtensions
+{
+	/// <summary>
+	///     Filter for types with the <paramref name="expected" /> name.
+	/// </summary>
+	public static Filtered.Types.StringEqualityResultType WithName(this Filtered.Types @this, string expected)
+	{
+		StringEqualityOptions options = new();
+		return new Filtered.Types.StringEqualityResultType(@this.Which(Filter.Suffix<Type>(
+				type => options.AreConsideredEqual(type.Name, expected),
+				() => $"with name {options.GetExpectation(expected, ExpectationGrammars.None)} ")),
+			options);
+	}
+
+	/// <summary>
+	///     Filter for types with the <paramref name="expected" /> namespace.
+	/// </summary>
+	public static Filtered.Types.StringEqualityResultType WithNamespace(this Filtered.Types @this, string expected)
+	{
+		StringEqualityOptions options = new();
+		return new Filtered.Types.StringEqualityResultType(@this.Which(Filter.Suffix<Type>(
+				type => options.AreConsideredEqual(type.Namespace, expected),
+				() => $"with namespace {options.GetExpectation(expected, ExpectationGrammars.None)} ")),
+			options);
+	}
+}

--- a/Source/aweXpect.Reflection/ThatType.HasName.cs
+++ b/Source/aweXpect.Reflection/ThatType.HasName.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Text;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Options;
+using aweXpect.Reflection.Extensions;
+using aweXpect.Results;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Reflection;
+
+public static partial class ThatType
+{
+	/// <summary>
+	///     Verifies that the <see cref="Type" /> has the <paramref name="expected" /> name.
+	/// </summary>
+	public static StringEqualityTypeResult<Type?, IThat<Type?>> HasName(
+		this IThat<Type?> subject, string expected)
+	{
+		StringEqualityOptions options = new();
+		return new StringEqualityTypeResult<Type?, IThat<Type?>>(subject.Get().ExpectationBuilder.AddConstraint(
+				(it, grammars)
+					=> new HasNameConstraint(it, grammars, expected, options)),
+			subject,
+			options);
+	}
+
+	private sealed class HasNameConstraint(
+		string it,
+		ExpectationGrammars grammars,
+		string expected,
+		StringEqualityOptions options)
+		: ConstraintResult.WithNotNullValue<Type?>(it, grammars),
+			IValueConstraint<Type?>
+	{
+		public ConstraintResult IsMetBy(Type? actual)
+		{
+			Actual = actual;
+			Outcome = options.AreConsideredEqual(actual?.Name, expected) ? Outcome.Success : Outcome.Failure;
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("has name ").Append(options.GetExpectation(expected, Grammars));
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append(options.GetExtendedFailure(It, Grammars, Actual?.Name, expected));
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("does not have name ").Append(options.GetExpectation(expected, Grammars));
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+			=> AppendNormalResult(stringBuilder, indentation);
+	}
+}

--- a/Source/aweXpect.Reflection/ThatType.HasNamespace.cs
+++ b/Source/aweXpect.Reflection/ThatType.HasNamespace.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Text;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Options;
+using aweXpect.Reflection.Extensions;
+using aweXpect.Results;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Reflection;
+
+public static partial class ThatType
+{
+	/// <summary>
+	///     Verifies that the <see cref="Type" /> has the <paramref name="expected" /> namespace.
+	/// </summary>
+	public static StringEqualityTypeResult<Type?, IThat<Type?>> HasNamespace(
+		this IThat<Type?> subject, string expected)
+	{
+		StringEqualityOptions options = new();
+		return new StringEqualityTypeResult<Type?, IThat<Type?>>(subject.Get().ExpectationBuilder.AddConstraint(
+				(it, grammars)
+					=> new HasNamespaceConstraint(it, grammars, expected, options)),
+			subject,
+			options);
+	}
+
+	private sealed class HasNamespaceConstraint(
+		string it,
+		ExpectationGrammars grammars,
+		string expected,
+		StringEqualityOptions options)
+		: ConstraintResult.WithNotNullValue<Type?>(it, grammars),
+			IValueConstraint<Type?>
+	{
+		public ConstraintResult IsMetBy(Type? actual)
+		{
+			Actual = actual;
+			Outcome = options.AreConsideredEqual(actual?.Namespace, expected) ? Outcome.Success : Outcome.Failure;
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("has namespace ").Append(options.GetExpectation(expected, Grammars));
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append(options.GetExtendedFailure(It, Grammars, Actual?.Namespace, expected));
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("does not have namespace ").Append(options.GetExpectation(expected, Grammars));
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+			=> AppendNormalResult(stringBuilder, indentation);
+	}
+}

--- a/Source/aweXpect.Reflection/ThatTypes.HaveName.cs
+++ b/Source/aweXpect.Reflection/ThatTypes.HaveName.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Options;
+using aweXpect.Reflection.Extensions;
+using aweXpect.Results;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Reflection;
+
+public static partial class ThatTypes
+{
+	/// <summary>
+	///     Verifies that all items in the filtered collection of <see cref="Type" /> have
+	///     the <paramref name="expected"/> name.
+	/// </summary>
+	public static StringEqualityTypeResult<IEnumerable<Type>, IThat<IEnumerable<Type>>> HaveName(
+		this IThat<IEnumerable<Type>> subject, string expected)
+	{
+		var options = new StringEqualityOptions();
+		return new(subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new HaveNameConstraint(it, grammars, expected, options)),
+			subject,
+			options);
+	}
+
+	private sealed class HaveNameConstraint(
+		string it,
+		ExpectationGrammars grammars,
+		string expected,
+		StringEqualityOptions options)
+		: ConstraintResult.WithValue<IEnumerable<Type>>(grammars),
+			IValueConstraint<IEnumerable<Type>>
+	{
+		public ConstraintResult IsMetBy(IEnumerable<Type> actual)
+		{
+			Actual = actual;
+			Outcome = actual.All(type => options.AreConsideredEqual(type.Name, expected)) ? Outcome.Success : Outcome.Failure;
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("all have name ").Append(options.GetExpectation(expected, Grammars));
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(it).Append(" contained not matching types ");
+			Formatter.Format(stringBuilder, Actual?.Where(type => !options.AreConsideredEqual(type.Name, expected)),
+				FormattingOptions.Indented(indentation));
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("all have name ").Append(options.GetExpectation(expected, Grammars));
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(it).Append(" only contained matching types ");
+			Formatter.Format(stringBuilder, Actual?.Where(type => options.AreConsideredEqual(type.Name, expected)),
+				FormattingOptions.Indented(indentation));
+		}
+	}
+}

--- a/Source/aweXpect.Reflection/ThatTypes.HaveNamespace.cs
+++ b/Source/aweXpect.Reflection/ThatTypes.HaveNamespace.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Options;
+using aweXpect.Reflection.Extensions;
+using aweXpect.Results;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Reflection;
+
+public static partial class ThatTypes
+{
+	/// <summary>
+	///     Verifies that all items in the filtered collection of <see cref="Type" /> have
+	///     the <paramref name="expected"/> namespace.
+	/// </summary>
+	public static StringEqualityTypeResult<IEnumerable<Type>, IThat<IEnumerable<Type>>> HaveNamespace(
+		this IThat<IEnumerable<Type>> subject, string expected)
+	{
+		var options = new StringEqualityOptions();
+		return new(subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new HaveNamespaceConstraint(it, grammars, expected, options)),
+			subject,
+			options);
+	}
+
+	private sealed class HaveNamespaceConstraint(
+		string it,
+		ExpectationGrammars grammars,
+		string expected,
+		StringEqualityOptions options)
+		: ConstraintResult.WithValue<IEnumerable<Type>>(grammars),
+			IValueConstraint<IEnumerable<Type>>
+	{
+		public ConstraintResult IsMetBy(IEnumerable<Type> actual)
+		{
+			Actual = actual;
+			Outcome = actual.All(type => options.AreConsideredEqual(type.Namespace, expected)) ? Outcome.Success : Outcome.Failure;
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("all have namespace ").Append(options.GetExpectation(expected, Grammars));
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(it).Append(" contained not matching types ");
+			Formatter.Format(stringBuilder, Actual?.Where(type => !options.AreConsideredEqual(type.Namespace, expected)),
+				FormattingOptions.Indented(indentation));
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("all have namespace ").Append(options.GetExpectation(expected, Grammars));
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(it).Append(" only contained matching types ");
+			Formatter.Format(stringBuilder, Actual?.Where(type => options.AreConsideredEqual(type.Namespace, expected)),
+				FormattingOptions.Indented(indentation));
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net8.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net8.0.txt
@@ -12,11 +12,6 @@ namespace aweXpect.Reflection.Collections
         Public = 8,
         Any = 15,
     }
-    public static class Filter
-    {
-        public static aweXpect.Reflection.Collections.IFilter<TEntity> Prefix<TEntity>(System.Func<TEntity, bool> predicate, string prefix) { }
-        public static aweXpect.Reflection.Collections.IFilter<TEntity> Suffix<TEntity>(System.Func<TEntity, bool> predicate, string suffix) { }
-    }
     public static class Filtered
     {
         public class Assemblies : aweXpect.Reflection.Collections.Filtered<System.Reflection.Assembly, aweXpect.Reflection.Collections.Filtered.Assemblies>, aweXpect.Core.IDescribableSubject
@@ -53,6 +48,7 @@ namespace aweXpect.Reflection.Collections
         }
         public class Types : aweXpect.Reflection.Collections.Filtered<System.Type, aweXpect.Reflection.Collections.Filtered.Types>, aweXpect.Core.IDescribableSubject
         {
+            protected Types(aweXpect.Reflection.Collections.Filtered.Types inner) { }
             public aweXpect.Reflection.Collections.Filtered.Assemblies Assemblies() { }
             public aweXpect.Reflection.Collections.Filtered.Constructors Constructors() { }
             public aweXpect.Reflection.Collections.Filtered.Events Events() { }
@@ -60,6 +56,23 @@ namespace aweXpect.Reflection.Collections
             public string GetDescription() { }
             public aweXpect.Reflection.Collections.Filtered.Methods Methods() { }
             public aweXpect.Reflection.Collections.Filtered.Properties Properties() { }
+            public class StringEqualityResult : aweXpect.Reflection.Collections.Filtered.Types
+            {
+                public StringEqualityResult(aweXpect.Reflection.Collections.Filtered.Types inner, aweXpect.Options.StringEqualityOptions options) { }
+                public aweXpect.Reflection.Collections.Filtered.Types.StringEqualityResult IgnoringCase(bool ignoreCase = true) { }
+                public aweXpect.Reflection.Collections.Filtered.Types.StringEqualityResult IgnoringLeadingWhiteSpace(bool ignoreLeadingWhiteSpace = true) { }
+                public aweXpect.Reflection.Collections.Filtered.Types.StringEqualityResult IgnoringTrailingWhiteSpace(bool ignoreTrailingWhiteSpace = true) { }
+                public aweXpect.Reflection.Collections.Filtered.Types.StringEqualityResult Using(System.Collections.Generic.IEqualityComparer<string> comparer) { }
+            }
+            public class StringEqualityResultType : aweXpect.Reflection.Collections.Filtered.Types.StringEqualityResult
+            {
+                public StringEqualityResultType(aweXpect.Reflection.Collections.Filtered.Types inner, aweXpect.Options.StringEqualityOptions options) { }
+                public aweXpect.Reflection.Collections.Filtered.Types.StringEqualityResult AsPrefix() { }
+                public aweXpect.Reflection.Collections.Filtered.Types.StringEqualityResult AsRegex() { }
+                public aweXpect.Reflection.Collections.Filtered.Types.StringEqualityResult AsSuffix() { }
+                public aweXpect.Reflection.Collections.Filtered.Types.StringEqualityResult AsWildcard() { }
+                public aweXpect.Reflection.Collections.Filtered.Types.StringEqualityResult Exactly() { }
+            }
         }
     }
     public static class FilteredExtensions
@@ -79,11 +92,13 @@ namespace aweXpect.Reflection.Collections
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Collections.Filtered.Types With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Types @this, System.Func<TAttribute, bool>? predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
             where TAttribute : System.Attribute { }
+        public static aweXpect.Reflection.Collections.Filtered.Types.StringEqualityResultType WithName(this aweXpect.Reflection.Collections.Filtered.Types @this, string expected) { }
+        public static aweXpect.Reflection.Collections.Filtered.Types.StringEqualityResultType WithNamespace(this aweXpect.Reflection.Collections.Filtered.Types @this, string expected) { }
     }
     public abstract class Filtered<T, TFiltered> : System.Collections.Generic.IEnumerable<T>, System.Collections.IEnumerable
         where TFiltered : aweXpect.Reflection.Collections.Filtered<T, TFiltered>
     {
-        protected Filtered(System.Collections.Generic.IEnumerable<T> source) { }
+        protected Filtered(System.Collections.Generic.IEnumerable<T> source, System.Collections.Generic.List<aweXpect.Reflection.Collections.IFilter<T>>? filters = null) { }
         protected System.Collections.Generic.List<aweXpect.Reflection.Collections.IFilter<T>> Filters { get; }
         public System.Collections.Generic.IEnumerator<T> GetEnumerator() { }
         public TFiltered Which(aweXpect.Reflection.Collections.IFilter<T> filter) { }
@@ -113,6 +128,8 @@ namespace aweXpect.Reflection
             where TAttribute : System.Attribute { }
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> Has<TAttribute>(this aweXpect.Core.IThat<System.Type?> subject, System.Func<TAttribute, bool>? predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
             where TAttribute : System.Attribute { }
+        public static aweXpect.Results.StringEqualityTypeResult<System.Type?, aweXpect.Core.IThat<System.Type?>> HasName(this aweXpect.Core.IThat<System.Type?> subject, string expected) { }
+        public static aweXpect.Results.StringEqualityTypeResult<System.Type?, aweXpect.Core.IThat<System.Type?>> HasNamespace(this aweXpect.Core.IThat<System.Type?> subject, string expected) { }
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsAClass(this aweXpect.Core.IThat<System.Type?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsAbstract(this aweXpect.Core.IThat<System.Type?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsAnInterface(this aweXpect.Core.IThat<System.Type?> subject) { }
@@ -144,5 +161,7 @@ namespace aweXpect.Reflection
             where TAttribute : System.Attribute { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type>>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type>> subject, System.Func<TAttribute, bool>? predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
             where TAttribute : System.Attribute { }
+        public static aweXpect.Results.StringEqualityTypeResult<System.Collections.Generic.IEnumerable<System.Type>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type>>> HaveName(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type>> subject, string expected) { }
+        public static aweXpect.Results.StringEqualityTypeResult<System.Collections.Generic.IEnumerable<System.Type>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type>>> HaveNamespace(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type>> subject, string expected) { }
     }
 }

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net8.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net8.0.txt
@@ -48,7 +48,6 @@ namespace aweXpect.Reflection.Collections
         }
         public class Types : aweXpect.Reflection.Collections.Filtered<System.Type, aweXpect.Reflection.Collections.Filtered.Types>, aweXpect.Core.IDescribableSubject
         {
-            protected Types(aweXpect.Reflection.Collections.Filtered.Types inner) { }
             public aweXpect.Reflection.Collections.Filtered.Assemblies Assemblies() { }
             public aweXpect.Reflection.Collections.Filtered.Constructors Constructors() { }
             public aweXpect.Reflection.Collections.Filtered.Events Events() { }
@@ -58,7 +57,6 @@ namespace aweXpect.Reflection.Collections
             public aweXpect.Reflection.Collections.Filtered.Properties Properties() { }
             public class StringEqualityResult : aweXpect.Reflection.Collections.Filtered.Types
             {
-                public StringEqualityResult(aweXpect.Reflection.Collections.Filtered.Types inner, aweXpect.Options.StringEqualityOptions options) { }
                 public aweXpect.Reflection.Collections.Filtered.Types.StringEqualityResult IgnoringCase(bool ignoreCase = true) { }
                 public aweXpect.Reflection.Collections.Filtered.Types.StringEqualityResult IgnoringLeadingWhiteSpace(bool ignoreLeadingWhiteSpace = true) { }
                 public aweXpect.Reflection.Collections.Filtered.Types.StringEqualityResult IgnoringTrailingWhiteSpace(bool ignoreTrailingWhiteSpace = true) { }
@@ -66,7 +64,6 @@ namespace aweXpect.Reflection.Collections
             }
             public class StringEqualityResultType : aweXpect.Reflection.Collections.Filtered.Types.StringEqualityResult
             {
-                public StringEqualityResultType(aweXpect.Reflection.Collections.Filtered.Types inner, aweXpect.Options.StringEqualityOptions options) { }
                 public aweXpect.Reflection.Collections.Filtered.Types.StringEqualityResult AsPrefix() { }
                 public aweXpect.Reflection.Collections.Filtered.Types.StringEqualityResult AsRegex() { }
                 public aweXpect.Reflection.Collections.Filtered.Types.StringEqualityResult AsSuffix() { }

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_netstandard2.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_netstandard2.0.txt
@@ -12,11 +12,6 @@ namespace aweXpect.Reflection.Collections
         Public = 8,
         Any = 15,
     }
-    public static class Filter
-    {
-        public static aweXpect.Reflection.Collections.IFilter<TEntity> Prefix<TEntity>(System.Func<TEntity, bool> predicate, string prefix) { }
-        public static aweXpect.Reflection.Collections.IFilter<TEntity> Suffix<TEntity>(System.Func<TEntity, bool> predicate, string suffix) { }
-    }
     public static class Filtered
     {
         public class Assemblies : aweXpect.Reflection.Collections.Filtered<System.Reflection.Assembly, aweXpect.Reflection.Collections.Filtered.Assemblies>, aweXpect.Core.IDescribableSubject
@@ -53,6 +48,7 @@ namespace aweXpect.Reflection.Collections
         }
         public class Types : aweXpect.Reflection.Collections.Filtered<System.Type, aweXpect.Reflection.Collections.Filtered.Types>, aweXpect.Core.IDescribableSubject
         {
+            protected Types(aweXpect.Reflection.Collections.Filtered.Types inner) { }
             public aweXpect.Reflection.Collections.Filtered.Assemblies Assemblies() { }
             public aweXpect.Reflection.Collections.Filtered.Constructors Constructors() { }
             public aweXpect.Reflection.Collections.Filtered.Events Events() { }
@@ -60,6 +56,23 @@ namespace aweXpect.Reflection.Collections
             public string GetDescription() { }
             public aweXpect.Reflection.Collections.Filtered.Methods Methods() { }
             public aweXpect.Reflection.Collections.Filtered.Properties Properties() { }
+            public class StringEqualityResult : aweXpect.Reflection.Collections.Filtered.Types
+            {
+                public StringEqualityResult(aweXpect.Reflection.Collections.Filtered.Types inner, aweXpect.Options.StringEqualityOptions options) { }
+                public aweXpect.Reflection.Collections.Filtered.Types.StringEqualityResult IgnoringCase(bool ignoreCase = true) { }
+                public aweXpect.Reflection.Collections.Filtered.Types.StringEqualityResult IgnoringLeadingWhiteSpace(bool ignoreLeadingWhiteSpace = true) { }
+                public aweXpect.Reflection.Collections.Filtered.Types.StringEqualityResult IgnoringTrailingWhiteSpace(bool ignoreTrailingWhiteSpace = true) { }
+                public aweXpect.Reflection.Collections.Filtered.Types.StringEqualityResult Using(System.Collections.Generic.IEqualityComparer<string> comparer) { }
+            }
+            public class StringEqualityResultType : aweXpect.Reflection.Collections.Filtered.Types.StringEqualityResult
+            {
+                public StringEqualityResultType(aweXpect.Reflection.Collections.Filtered.Types inner, aweXpect.Options.StringEqualityOptions options) { }
+                public aweXpect.Reflection.Collections.Filtered.Types.StringEqualityResult AsPrefix() { }
+                public aweXpect.Reflection.Collections.Filtered.Types.StringEqualityResult AsRegex() { }
+                public aweXpect.Reflection.Collections.Filtered.Types.StringEqualityResult AsSuffix() { }
+                public aweXpect.Reflection.Collections.Filtered.Types.StringEqualityResult AsWildcard() { }
+                public aweXpect.Reflection.Collections.Filtered.Types.StringEqualityResult Exactly() { }
+            }
         }
     }
     public static class FilteredExtensions
@@ -79,11 +92,13 @@ namespace aweXpect.Reflection.Collections
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Collections.Filtered.Types With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Types @this, System.Func<TAttribute, bool>? predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
             where TAttribute : System.Attribute { }
+        public static aweXpect.Reflection.Collections.Filtered.Types.StringEqualityResultType WithName(this aweXpect.Reflection.Collections.Filtered.Types @this, string expected) { }
+        public static aweXpect.Reflection.Collections.Filtered.Types.StringEqualityResultType WithNamespace(this aweXpect.Reflection.Collections.Filtered.Types @this, string expected) { }
     }
     public abstract class Filtered<T, TFiltered> : System.Collections.Generic.IEnumerable<T>, System.Collections.IEnumerable
         where TFiltered : aweXpect.Reflection.Collections.Filtered<T, TFiltered>
     {
-        protected Filtered(System.Collections.Generic.IEnumerable<T> source) { }
+        protected Filtered(System.Collections.Generic.IEnumerable<T> source, System.Collections.Generic.List<aweXpect.Reflection.Collections.IFilter<T>>? filters = null) { }
         protected System.Collections.Generic.List<aweXpect.Reflection.Collections.IFilter<T>> Filters { get; }
         public System.Collections.Generic.IEnumerator<T> GetEnumerator() { }
         public TFiltered Which(aweXpect.Reflection.Collections.IFilter<T> filter) { }
@@ -113,6 +128,8 @@ namespace aweXpect.Reflection
             where TAttribute : System.Attribute { }
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> Has<TAttribute>(this aweXpect.Core.IThat<System.Type?> subject, System.Func<TAttribute, bool>? predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
             where TAttribute : System.Attribute { }
+        public static aweXpect.Results.StringEqualityTypeResult<System.Type?, aweXpect.Core.IThat<System.Type?>> HasName(this aweXpect.Core.IThat<System.Type?> subject, string expected) { }
+        public static aweXpect.Results.StringEqualityTypeResult<System.Type?, aweXpect.Core.IThat<System.Type?>> HasNamespace(this aweXpect.Core.IThat<System.Type?> subject, string expected) { }
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsAClass(this aweXpect.Core.IThat<System.Type?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsAbstract(this aweXpect.Core.IThat<System.Type?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsAnInterface(this aweXpect.Core.IThat<System.Type?> subject) { }
@@ -144,5 +161,7 @@ namespace aweXpect.Reflection
             where TAttribute : System.Attribute { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type>>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type>> subject, System.Func<TAttribute, bool>? predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
             where TAttribute : System.Attribute { }
+        public static aweXpect.Results.StringEqualityTypeResult<System.Collections.Generic.IEnumerable<System.Type>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type>>> HaveName(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type>> subject, string expected) { }
+        public static aweXpect.Results.StringEqualityTypeResult<System.Collections.Generic.IEnumerable<System.Type>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type>>> HaveNamespace(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type>> subject, string expected) { }
     }
 }

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_netstandard2.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_netstandard2.0.txt
@@ -48,7 +48,6 @@ namespace aweXpect.Reflection.Collections
         }
         public class Types : aweXpect.Reflection.Collections.Filtered<System.Type, aweXpect.Reflection.Collections.Filtered.Types>, aweXpect.Core.IDescribableSubject
         {
-            protected Types(aweXpect.Reflection.Collections.Filtered.Types inner) { }
             public aweXpect.Reflection.Collections.Filtered.Assemblies Assemblies() { }
             public aweXpect.Reflection.Collections.Filtered.Constructors Constructors() { }
             public aweXpect.Reflection.Collections.Filtered.Events Events() { }
@@ -58,7 +57,6 @@ namespace aweXpect.Reflection.Collections
             public aweXpect.Reflection.Collections.Filtered.Properties Properties() { }
             public class StringEqualityResult : aweXpect.Reflection.Collections.Filtered.Types
             {
-                public StringEqualityResult(aweXpect.Reflection.Collections.Filtered.Types inner, aweXpect.Options.StringEqualityOptions options) { }
                 public aweXpect.Reflection.Collections.Filtered.Types.StringEqualityResult IgnoringCase(bool ignoreCase = true) { }
                 public aweXpect.Reflection.Collections.Filtered.Types.StringEqualityResult IgnoringLeadingWhiteSpace(bool ignoreLeadingWhiteSpace = true) { }
                 public aweXpect.Reflection.Collections.Filtered.Types.StringEqualityResult IgnoringTrailingWhiteSpace(bool ignoreTrailingWhiteSpace = true) { }
@@ -66,7 +64,6 @@ namespace aweXpect.Reflection.Collections
             }
             public class StringEqualityResultType : aweXpect.Reflection.Collections.Filtered.Types.StringEqualityResult
             {
-                public StringEqualityResultType(aweXpect.Reflection.Collections.Filtered.Types inner, aweXpect.Options.StringEqualityOptions options) { }
                 public aweXpect.Reflection.Collections.Filtered.Types.StringEqualityResult AsPrefix() { }
                 public aweXpect.Reflection.Collections.Filtered.Types.StringEqualityResult AsRegex() { }
                 public aweXpect.Reflection.Collections.Filtered.Types.StringEqualityResult AsSuffix() { }

--- a/Tests/aweXpect.Reflection.Tests/Collections/FilteredExtensions.Methods.With.AttributeTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Collections/FilteredExtensions.Methods.With.AttributeTests.cs
@@ -3,7 +3,7 @@ using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Collections;
 
-public partial class FilteredExtensions
+public sealed partial class FilteredExtensions
 {
 	public class Methods
 	{

--- a/Tests/aweXpect.Reflection.Tests/Collections/FilteredExtensions.Types.With.AttributeTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Collections/FilteredExtensions.Types.With.AttributeTests.cs
@@ -2,9 +2,9 @@
 
 namespace aweXpect.Reflection.Tests.Collections;
 
-public partial class FilteredExtensions
+public sealed partial class FilteredExtensions
 {
-	public class Types
+	public sealed partial class Types
 	{
 		public sealed class With
 		{

--- a/Tests/aweXpect.Reflection.Tests/Collections/FilteredExtensions.Types.WithName.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Collections/FilteredExtensions.Types.WithName.Tests.cs
@@ -1,0 +1,140 @@
+﻿using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Tests.TestHelpers;
+
+namespace aweXpect.Reflection.Tests.Collections;
+
+public sealed partial class FilteredExtensions
+{
+	public sealed partial class Types
+	{
+		public sealed class WithName
+		{
+			public sealed class Tests
+			{
+				[Fact]
+				public async Task ShouldFilterForTypesWithName()
+				{
+					Reflection.Collections.Filtered.Types types = In.AssemblyContaining<FilteredExtensions>()
+						.Types().WithName(nameof(SomeClassToVerifyTheNameOfIt));
+
+					await That(types).HasSingle().Which.IsEqualTo(typeof(SomeClassToVerifyTheNameOfIt));
+					await That(types.GetDescription())
+						.IsEqualTo("types with name equal to \"SomeClassToVerifyTheNameOfIt\" in assembly").AsPrefix();
+				}
+
+				[Fact]
+				public async Task ShouldSupportAsPrefix()
+				{
+					Reflection.Collections.Filtered.Types types = In.AssemblyContaining<FilteredExtensions>()
+						.Types().WithName("SomeClassToVerifyTheNameOf").AsPrefix();
+
+					await That(types).HasSingle().Which.IsEqualTo(typeof(SomeClassToVerifyTheNameOfIt));
+					await That(types.GetDescription())
+						.IsEqualTo("types with name start with \"SomeClassToVerifyTheNameOf\" in assembly").AsPrefix();
+				}
+
+				[Fact]
+				public async Task ShouldSupportAsRegex()
+				{
+					Reflection.Collections.Filtered.Types types = In.AssemblyContaining<FilteredExtensions>()
+						.Types().WithName("[a-zA-Z]*VerifyTheNameOfIt").AsRegex();
+
+					await That(types).HasSingle().Which.IsEqualTo(typeof(SomeClassToVerifyTheNameOfIt));
+					await That(types.GetDescription())
+						.IsEqualTo("types with name matching regex \"[a-zA-Z]*VerifyTheNameOfIt\" in assembly")
+						.AsPrefix();
+				}
+
+				[Fact]
+				public async Task ShouldSupportAsSuffix()
+				{
+					Reflection.Collections.Filtered.Types types = In.AssemblyContaining<FilteredExtensions>()
+						.Types().WithName("ClassToVerifyTheNameOfIt").AsSuffix();
+
+					await That(types).HasSingle().Which.IsEqualTo(typeof(SomeClassToVerifyTheNameOfIt));
+					await That(types.GetDescription())
+						.IsEqualTo("types with name end with \"ClassToVerifyTheNameOfIt\" in assembly").AsPrefix();
+				}
+
+				[Fact]
+				public async Task ShouldSupportAsWildcard()
+				{
+					Reflection.Collections.Filtered.Types types = In.AssemblyContaining<FilteredExtensions>()
+						.Types().WithName("*ToVerifyTheNameOf*").AsWildcard();
+
+					await That(types).HasSingle().Which.IsEqualTo(typeof(SomeClassToVerifyTheNameOfIt));
+					await That(types.GetDescription())
+						.IsEqualTo("types with name matching \"*ToVerifyTheNameOf*\" in assembly").AsPrefix();
+				}
+
+				[Fact]
+				public async Task ShouldSupportExactly()
+				{
+					Reflection.Collections.Filtered.Types types = In.AssemblyContaining<FilteredExtensions>()
+						.Types().WithName(nameof(SomeClassToVerifyTheNameOfIt)).Exactly();
+
+					await That(types).HasSingle().Which.IsEqualTo(typeof(SomeClassToVerifyTheNameOfIt));
+					await That(types.GetDescription())
+						.IsEqualTo("types with name equal to \"SomeClassToVerifyTheNameOfIt\" in assembly").AsPrefix();
+				}
+
+				[Fact]
+				public async Task ShouldSupportIgnoringCase()
+				{
+					Reflection.Collections.Filtered.Types types = In.AssemblyContaining<FilteredExtensions>()
+						.Types().WithName(nameof(SomeClassToVerifyTheNameOfIt).ToLowerInvariant()).IgnoringCase();
+
+					await That(types).HasSingle().Which.IsEqualTo(typeof(SomeClassToVerifyTheNameOfIt));
+					await That(types.GetDescription())
+						.IsEqualTo(
+							"types with name equal to \"someclasstoverifythenameofit\" ignoring case in assembly")
+						.AsPrefix();
+				}
+
+				[Fact]
+				public async Task ShouldSupportIgnoringLeadingWhiteSpace()
+				{
+					Reflection.Collections.Filtered.Types types = In.AssemblyContaining<FilteredExtensions>()
+						.Types().WithName("\t " + nameof(SomeClassToVerifyTheNameOfIt))
+						.IgnoringLeadingWhiteSpace();
+
+					await That(types).HasSingle().Which.IsEqualTo(typeof(SomeClassToVerifyTheNameOfIt));
+					await That(types.GetDescription())
+						.IsEqualTo(
+							"types with name equal to \"\\t SomeClassToVerifyTheNameOfIt\" ignoring leading white-space in assembly")
+						.AsPrefix();
+				}
+
+				[Fact]
+				public async Task ShouldSupportIgnoringTrailingWhiteSpace()
+				{
+					Reflection.Collections.Filtered.Types types = In.AssemblyContaining<FilteredExtensions>()
+						.Types().WithName(nameof(SomeClassToVerifyTheNameOfIt) + "\t ")
+						.IgnoringTrailingWhiteSpace();
+
+					await That(types).HasSingle().Which.IsEqualTo(typeof(SomeClassToVerifyTheNameOfIt));
+					await That(types.GetDescription())
+						.IsEqualTo(
+							"types with name equal to \"SomeClassToVerifyTheNameOfIt\\t \" ignoring trailing white-space in assembly")
+						.AsPrefix();
+				}
+
+				[Fact]
+				public async Task ShouldSupportUsingCustomComperer()
+				{
+					Reflection.Collections.Filtered.Types types = In.AssemblyContaining<FilteredExtensions>()
+						.Types().WithName("SOmEClAssTOVErIfyThENAmEofit")
+						.Using(new IgnoreCaseForVocalsComparer());
+
+					await That(types).HasSingle().Which.IsEqualTo(typeof(SomeClassToVerifyTheNameOfIt));
+					await That(types.GetDescription())
+						.IsEqualTo(
+							"types with name equal to \"SOmEClAssTOVErIfyThENAmEofit\" using IgnoreCaseForVocalsComparer in assembly")
+						.AsPrefix();
+				}
+
+				private class SomeClassToVerifyTheNameOfIt;
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/Collections/FilteredExtensions.Types.WithNamespace.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Collections/FilteredExtensions.Types.WithNamespace.Tests.cs
@@ -1,0 +1,139 @@
+﻿using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Tests.TestHelpers;
+using aweXpect.Reflection.Tests.TestHelpers.Types.ToVerifyingTheNamespaceOfIt;
+
+namespace aweXpect.Reflection.Tests.Collections;
+
+public sealed partial class FilteredExtensions
+{
+	public sealed partial class Types
+	{
+		public sealed class WithNamespace
+		{
+			public sealed class Tests
+			{
+				[Fact]
+				public async Task ShouldFilterForTypesWithNamespace()
+				{
+					Reflection.Collections.Filtered.Types types = In.AssemblyContaining<FilteredExtensions>()
+						.Types().WithNamespace("aweXpect.Reflection.Tests.TestHelpers.Types.ToVerifyingTheNamespaceOfIt");
+
+					await That(types).HasSingle().Which.IsEqualTo(typeof(SomeClassToVerifyTheNamespaceOfIt));
+					await That(types.GetDescription())
+						.IsEqualTo("types with namespace equal to \"aweXpect.Reflection.Tests.Test…\" in assembly").AsPrefix();
+				}
+
+				[Fact]
+				public async Task ShouldSupportAsPrefix()
+				{
+					Reflection.Collections.Filtered.Types types = In.AssemblyContaining<FilteredExtensions>()
+						.Types().WithNamespace("aweXpect.Reflection.Tests.TestHelpers.Types.ToVerifyingTheNamespaceOf").AsPrefix();
+
+					await That(types).HasSingle().Which.IsEqualTo(typeof(SomeClassToVerifyTheNamespaceOfIt));
+					await That(types.GetDescription())
+						.IsEqualTo("types with namespace start with \"aweXpect.Reflection.Tests.Test…\" in assembly").AsPrefix();
+				}
+
+				[Fact]
+				public async Task ShouldSupportAsRegex()
+				{
+					Reflection.Collections.Filtered.Types types = In.AssemblyContaining<FilteredExtensions>()
+						.Types().WithNamespace("[a-zA-Z\\.]*VerifyingTheNamespaceOfIt").AsRegex();
+
+					await That(types).HasSingle().Which.IsEqualTo(typeof(SomeClassToVerifyTheNamespaceOfIt));
+					await That(types.GetDescription())
+						.IsEqualTo("types with namespace matching regex \"[a-zA-Z\\.]*VerifyingTheNamespa…\" in assembly")
+						.AsPrefix();
+				}
+
+				[Fact]
+				public async Task ShouldSupportAsSuffix()
+				{
+					Reflection.Collections.Filtered.Types types = In.AssemblyContaining<FilteredExtensions>()
+						.Types().WithNamespace("VerifyingTheNamespaceOfIt").AsSuffix();
+
+					await That(types).HasSingle().Which.IsEqualTo(typeof(SomeClassToVerifyTheNamespaceOfIt));
+					await That(types.GetDescription())
+						.IsEqualTo("types with namespace end with \"VerifyingTheNamespaceOfIt\" in assembly").AsPrefix();
+				}
+
+				[Fact]
+				public async Task ShouldSupportAsWildcard()
+				{
+					Reflection.Collections.Filtered.Types types = In.AssemblyContaining<FilteredExtensions>()
+						.Types().WithNamespace("*ToVerifyingTheNamespaceOf*").AsWildcard();
+
+					await That(types).HasSingle().Which.IsEqualTo(typeof(SomeClassToVerifyTheNamespaceOfIt));
+					await That(types.GetDescription())
+						.IsEqualTo("types with namespace matching \"*ToVerifyingTheNamespaceOf*\" in assembly").AsPrefix();
+				}
+
+				[Fact]
+				public async Task ShouldSupportExactly()
+				{
+					Reflection.Collections.Filtered.Types types = In.AssemblyContaining<FilteredExtensions>()
+						.Types().WithNamespace("aweXpect.Reflection.Tests.TestHelpers.Types.ToVerifyingTheNamespaceOfIt").Exactly();
+
+					await That(types).HasSingle().Which.IsEqualTo(typeof(SomeClassToVerifyTheNamespaceOfIt));
+					await That(types.GetDescription())
+						.IsEqualTo("types with namespace equal to \"aweXpect.Reflection.Tests.Test…\" in assembly").AsPrefix();
+				}
+
+				[Fact]
+				public async Task ShouldSupportIgnoringCase()
+				{
+					Reflection.Collections.Filtered.Types types = In.AssemblyContaining<FilteredExtensions>()
+						.Types().WithNamespace("aweXpect.Reflection.Tests.TestHelpers.Types.ToVerifyingTheNamespaceOfIt".ToLowerInvariant()).IgnoringCase();
+
+					await That(types).HasSingle().Which.IsEqualTo(typeof(SomeClassToVerifyTheNamespaceOfIt));
+					await That(types.GetDescription())
+						.IsEqualTo(
+							"types with namespace equal to \"awexpect.reflection.tests.test…\" ignoring case in assembly")
+						.AsPrefix();
+				}
+
+				[Fact]
+				public async Task ShouldSupportIgnoringLeadingWhiteSpace()
+				{
+					Reflection.Collections.Filtered.Types types = In.AssemblyContaining<FilteredExtensions>()
+						.Types().WithNamespace("\t aweXpect.Reflection.Tests.TestHelpers.Types.ToVerifyingTheNamespaceOfIt")
+						.IgnoringLeadingWhiteSpace();
+
+					await That(types).HasSingle().Which.IsEqualTo(typeof(SomeClassToVerifyTheNamespaceOfIt));
+					await That(types.GetDescription())
+						.IsEqualTo(
+							"types with namespace equal to \"\\t aweXpect.Reflection.Tests.Te…\" ignoring leading white-space in assembly")
+						.AsPrefix();
+				}
+
+				[Fact]
+				public async Task ShouldSupportIgnoringTrailingWhiteSpace()
+				{
+					Reflection.Collections.Filtered.Types types = In.AssemblyContaining<FilteredExtensions>()
+						.Types().WithNamespace("aweXpect.Reflection.Tests.TestHelpers.Types.ToVerifyingTheNamespaceOfIt\t ")
+						.IgnoringTrailingWhiteSpace();
+
+					await That(types).HasSingle().Which.IsEqualTo(typeof(SomeClassToVerifyTheNamespaceOfIt));
+					await That(types.GetDescription())
+						.IsEqualTo(
+							"types with namespace equal to \"aweXpect.Reflection.Tests.Test…\" ignoring trailing white-space in assembly")
+						.AsPrefix();
+				}
+
+				[Fact]
+				public async Task ShouldSupportUsingCustomComperer()
+				{
+					Reflection.Collections.Filtered.Types types = In.AssemblyContaining<FilteredExtensions>()
+						.Types().WithNamespace("AwEXpEct.REflEctIOn.TEsts.TEstHelpers.Types.ToVerifyingTheNamespaceOfIt")
+						.Using(new IgnoreCaseForVocalsComparer());
+
+					await That(types).HasSingle().Which.IsEqualTo(typeof(SomeClassToVerifyTheNamespaceOfIt));
+					await That(types.GetDescription())
+						.IsEqualTo(
+							"types with namespace equal to \"AwEXpEct.REflEctIOn.TEsts.TEst…\" using IgnoreCaseForVocalsComparer in assembly")
+						.AsPrefix();
+				}
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/TestHelpers/IgnoreCaseForVocalsComparer.cs
+++ b/Tests/aweXpect.Reflection.Tests/TestHelpers/IgnoreCaseForVocalsComparer.cs
@@ -1,0 +1,31 @@
+﻿using System.Collections.Generic;
+
+namespace aweXpect.Reflection.Tests.TestHelpers;
+
+/// <summary>
+///     A test <see cref="IEqualityComparer{T}" /> for <see langword="string" />s that
+///     ignores case differences only in vocals.
+/// </summary>
+public sealed class IgnoreCaseForVocalsComparer : IEqualityComparer<string>
+{
+	private static string? LowercaseVocals(string? input)
+		=> input?.Replace('A', 'a')
+			.Replace('E', 'e')
+			.Replace('I', 'i')
+			.Replace('O', 'o')
+			.Replace('U', 'u');
+
+	#region IEqualityComparer<string> Members
+
+	public bool Equals(string? x, string? y)
+	{
+		string? adjustedX = LowercaseVocals(x);
+		string? adjustedY = LowercaseVocals(y);
+
+		return adjustedX?.Equals(adjustedY, StringComparison.Ordinal) == true;
+	}
+
+	public int GetHashCode(string obj) => obj.GetHashCode();
+
+	#endregion
+}

--- a/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/SomeClassToVerifyTheNamespaceOfIt.cs
+++ b/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/SomeClassToVerifyTheNamespaceOfIt.cs
@@ -1,0 +1,4 @@
+﻿// ReSharper disable once CheckNamespace
+namespace aweXpect.Reflection.Tests.TestHelpers.Types.ToVerifyingTheNamespaceOfIt;
+
+public class SomeClassToVerifyTheNamespaceOfIt;

--- a/Tests/aweXpect.Reflection.Tests/ThatType.HasName.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatType.HasName.Tests.cs
@@ -1,0 +1,82 @@
+﻿using aweXpect.Reflection.Tests.TestHelpers.Types;
+using Xunit.Sdk;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatType
+{
+	public sealed class HasName
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenExpectedValueIsOnlySubstring_ShouldFail()
+			{
+				Type subject = typeof(PublicAbstractClass);
+
+				async Task Act()
+					=> await That(subject).HasName("Abstract");
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has name equal to "Abstract",
+					             but it was "PublicAbstractClass" which differs at index 0:
+					                ↓ (actual)
+					               "PublicAbstractClass"
+					               "Abstract"
+					                ↑ (expected)
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenTypeHasExpectedPrefix_ShouldSucceed()
+			{
+				Type subject = typeof(PublicAbstractClass);
+
+				async Task Act()
+					=> await That(subject).HasName("PublicAbstract").AsPrefix();
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenTypeHasMatchingName_ShouldSucceed()
+			{
+				Type subject = typeof(PublicAbstractClass);
+
+				async Task Act()
+					=> await That(subject).HasName("PublicAbstractClass");
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenTypeIsNull_ShouldFail()
+			{
+				Type? subject = null;
+
+				async Task Act()
+					=> await That(subject).HasName("foo");
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             has name equal to "foo",
+					             but it was <null>
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenTypeMatchesIgnoringCase_ShouldSucceed()
+			{
+				Type subject = typeof(PublicAbstractClass);
+
+				async Task Act()
+					=> await That(subject).HasName("pUBLICaBSTRACTcLASS").IgnoringCase();
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatType.HasNamespace.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatType.HasNamespace.Tests.cs
@@ -1,0 +1,71 @@
+﻿using aweXpect.Reflection.Tests.TestHelpers.Types;
+using Xunit.Sdk;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatType
+{
+	public sealed class HasNamespace
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenExpectedValueIsOnlySubstring_ShouldFail()
+			{
+				Type subject = typeof(PublicAbstractClass);
+
+				async Task Act()
+					=> await That(subject).HasNamespace("Reflection.Tests.TestHelpers");
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has namespace equal to "Reflection.Tests.TestHelpers",
+					             but it was "aweXpect.Reflection.Tests.Test…" which differs at index 0:
+					                ↓ (actual)
+					               "aweXpect.Reflection.Tests.TestHelpers.Types"
+					               "Reflection.Tests.TestHelpers"
+					                ↑ (expected)
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenTypeHasExpectedPrefix_ShouldSucceed()
+			{
+				Type subject = typeof(PublicAbstractClass);
+
+				async Task Act()
+					=> await That(subject).HasNamespace("aweXpect.Reflection.Tests").AsPrefix();
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenTypeHasMatchingNamespace_ShouldSucceed()
+			{
+				Type subject = typeof(PublicAbstractClass);
+
+				async Task Act()
+					=> await That(subject).HasNamespace("aweXpect.Reflection.Tests.TestHelpers.Types");
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenTypeIsNull_ShouldFail()
+			{
+				Type? subject = null;
+
+				async Task Act()
+					=> await That(subject).HasNamespace("foo");
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             has namespace equal to "foo",
+					             but it was <null>
+					             """);
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.HaveName.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.HaveName.Tests.cs
@@ -1,0 +1,70 @@
+﻿using aweXpect.Reflection.Collections;
+using Xunit.Sdk;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatTypes
+{
+	public sealed class HaveName
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenTypesContainTypeWithDifferentName_ShouldFail()
+			{
+				Filtered.Types subject = In.AssemblyContaining<Tests>()
+					.Types().WithName("Some").AsPrefix();
+
+				async Task Act()
+					=> await That(subject).HaveName("SomeOtherClassName");
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that types with name start with "Some" in assembly containing type Tests
+					             all have name equal to "SomeOtherClassName",
+					             but it contained not matching types [
+					               *SomeClassToTestHaveNameForTypes*
+					             ]
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenTypesHaveName_ShouldSucceed()
+			{
+				Filtered.Types subject = In.AssemblyContaining<Tests>()
+					.Types().WithName(nameof(SomeClassToTestHaveNameForTypes));
+
+				async Task Act()
+					=> await That(subject).HaveName("SomeClassToTestHaveNameForTypes");
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenTypesMatchIgnoringCase_ShouldSucceed()
+			{
+				Filtered.Types subject = In.AssemblyContaining<Tests>()
+					.Types().WithName(nameof(SomeClassToTestHaveNameForTypes));
+
+				async Task Act()
+					=> await That(subject).HaveName("sOMEcLASStOtESThAVEnAMEfORtYPES").IgnoringCase();
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenTypesMatchPrefix_ShouldSucceed()
+			{
+				Filtered.Types subject = In.AssemblyContaining<Tests>()
+					.Types().WithName(nameof(SomeClassToTestHaveNameForTypes));
+
+				async Task Act()
+					=> await That(subject).HaveName("SomeClass").AsPrefix();
+
+				await That(Act).DoesNotThrow();
+			}
+
+			private class SomeClassToTestHaveNameForTypes;
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.HaveNamespace.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.HaveNamespace.Tests.cs
@@ -1,0 +1,71 @@
+﻿using aweXpect.Reflection.Collections;
+using Xunit.Sdk;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatTypes
+{
+	public sealed class HaveNamespace
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenTypesContainTypeWithDifferentNamespace_ShouldFail()
+			{
+				Filtered.Types subject = In.AssemblyContaining<Tests>()
+					.Types().WithNamespace("ToVerifyingTheNamespaceOfIt").AsSuffix();
+
+				async Task Act()
+					=> await That(subject).HaveNamespace("aweXpect.Reflection");
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that types with namespace end with "ToVerifyingTheNamespaceOfIt" in assembly containing type Tests
+					             all have namespace equal to "aweXpect.Reflection",
+					             but it contained not matching types [
+					               *SomeClassToVerifyTheNamespaceOfIt*
+					             ]
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenTypesHaveNamespace_ShouldSucceed()
+			{
+				Filtered.Types subject = In.AssemblyContaining<Tests>()
+					.Types().WithNamespace("ToVerifyingTheNamespaceOfIt").AsSuffix();
+
+				async Task Act()
+					=> await That(subject)
+						.HaveNamespace("aweXpect.Reflection.Tests.TestHelpers.Types.ToVerifyingTheNamespaceOfIt");
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenTypesMatchIgnoringCase_ShouldSucceed()
+			{
+				Filtered.Types subject = In.AssemblyContaining<Tests>()
+					.Types().WithNamespace("ToVerifyingTheNamespaceOfIt").AsSuffix();
+
+				async Task Act()
+					=> await That(subject)
+						.HaveNamespace("AWExPECT.rEFLECTION.tESTS.tESThELPERS.tYPES.tOvERIFYINGtHEnAMESPACEoFiT")
+						.IgnoringCase();
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenTypesMatchPrefix_ShouldSucceed()
+			{
+				Filtered.Types subject = In.AssemblyContaining<Tests>()
+					.Types().WithNamespace("ToVerifyingTheNamespaceOfIt").AsSuffix();
+
+				async Task Act()
+					=> await That(subject).HaveNamespace("aweXpect.Reflection.Tests").AsPrefix();
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}


### PR DESCRIPTION
Add expectations for types that verify the name or namespace:
- `HasName(string expected)`
- `HasNamespace(string expected)`

Also add corresponding filters:
- `WithName(string expected)`
- `WithNamespace(string expected)`

All expectations and filters allow specifying the string equality options (e.g. `AsPrefix()`, `IgnoringCase()`, ...)