### PR TITLE
chore: update aweXpect to v2.3.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,8 +3,8 @@
 		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageVersion Include="aweXpect" Version="2.2.0"/>
-		<PackageVersion Include="aweXpect.Core" Version="2.2.0"/>
+		<PackageVersion Include="aweXpect" Version="2.3.1"/>
+		<PackageVersion Include="aweXpect.Core" Version="2.3.1"/>
 	</ItemGroup>
 	<ItemGroup>
 		<PackageVersion Include="Nullable" Version="1.3.1"/>

--- a/Tests/aweXpect.Reflection.Tests/Collections/Filtered.Types.WhichInheritFrom.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Collections/Filtered.Types.WhichInheritFrom.Tests.cs
@@ -29,10 +29,10 @@ public sealed class Filtered
 
 					await That(Act).ThrowsException()
 						.WithMessage("""
-						             Expected that types which inherit from FooBase in assembly containing type WhichInheritFrom
+						             Expected that types which inherit from Filtered.Types.WhichInheritFrom.Tests.FooBase in assembly containing type Filtered.Types.WhichInheritFrom
 						             are all abstract,
 						             but it contained non-abstract types [
-						               FooDerived
+						               Filtered.Types.WhichInheritFrom.Tests.FooDerived
 						             ]
 						             """);
 				}

--- a/Tests/aweXpect.Reflection.Tests/Collections/FilteredExtensions.Methods.With.AttributeTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Collections/FilteredExtensions.Methods.With.AttributeTests.cs
@@ -21,7 +21,7 @@ public sealed partial class FilteredExtensions
 						typeof(Dummy).GetMethod(nameof(Dummy.MyBarMethod)),
 						typeof(DummyChild).GetMethod(nameof(DummyChild.MyBarMethod)),
 					]).InAnyOrder();
-					await That(methods.GetDescription()).IsEqualTo("methods with BarAttribute").AsPrefix();
+					await That(methods.GetDescription()).IsEqualTo("methods with FilteredExtensions.Methods.With.AttributeTests.BarAttribute").AsPrefix();
 				}
 
 				[Fact]
@@ -31,7 +31,7 @@ public sealed partial class FilteredExtensions
 						.Types().Methods().With<BarAttribute>(false);
 
 					await That(methods).HasSingle().Which.IsEqualTo(typeof(Dummy).GetMethod(nameof(Dummy.MyBarMethod)));
-					await That(methods.GetDescription()).IsEqualTo("methods with direct BarAttribute").AsPrefix();
+					await That(methods.GetDescription()).IsEqualTo("methods with direct FilteredExtensions.Methods.With.AttributeTests.BarAttribute").AsPrefix();
 				}
 
 				[Theory]
@@ -44,7 +44,7 @@ public sealed partial class FilteredExtensions
 
 					await That(methods).IsEqualTo(expectedTypes).InAnyOrder();
 					await That(methods.GetDescription())
-						.IsEqualTo("methods with FooAttribute matching foo => foo.Value == value").AsPrefix();
+						.IsEqualTo("methods with FilteredExtensions.Methods.With.AttributeTests.FooAttribute matching foo => foo.Value == value").AsPrefix();
 				}
 
 				[Fact]
@@ -56,7 +56,7 @@ public sealed partial class FilteredExtensions
 					await That(methods).HasSingle().Which
 						.IsEqualTo(typeof(Dummy).GetMethod(nameof(Dummy.MyFooMethod2)));
 					await That(methods.GetDescription())
-						.IsEqualTo("methods with direct FooAttribute matching foo => foo.Value == 2").AsPrefix();
+						.IsEqualTo("methods with direct FilteredExtensions.Methods.With.AttributeTests.FooAttribute matching foo => foo.Value == 2").AsPrefix();
 				}
 
 				[AttributeUsage(AttributeTargets.Method)]

--- a/Tests/aweXpect.Reflection.Tests/Collections/FilteredExtensions.Types.With.AttributeTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Collections/FilteredExtensions.Types.With.AttributeTests.cs
@@ -17,7 +17,7 @@ public sealed partial class FilteredExtensions
 						.Types().With<BarAttribute>();
 
 					await That(types).IsEqualTo([typeof(BarClass), typeof(BarChildClass),]).InAnyOrder();
-					await That(types.GetDescription()).IsEqualTo("types with BarAttribute").AsPrefix();
+					await That(types.GetDescription()).IsEqualTo("types with FilteredExtensions.Types.With.AttributeTests.BarAttribute").AsPrefix();
 				}
 
 				[Fact]
@@ -27,7 +27,7 @@ public sealed partial class FilteredExtensions
 						.Types().With<BarAttribute>(false);
 
 					await That(types).HasSingle().Which.IsEqualTo(typeof(BarClass));
-					await That(types.GetDescription()).IsEqualTo("types with direct BarAttribute").AsPrefix();
+					await That(types.GetDescription()).IsEqualTo("types with direct FilteredExtensions.Types.With.AttributeTests.BarAttribute").AsPrefix();
 				}
 
 				[Theory]
@@ -40,7 +40,7 @@ public sealed partial class FilteredExtensions
 
 					await That(types).IsEqualTo(expectedTypes).InAnyOrder();
 					await That(types.GetDescription())
-						.IsEqualTo("types with FooAttribute matching foo => foo.Value == value").AsPrefix();
+						.IsEqualTo("types with FilteredExtensions.Types.With.AttributeTests.FooAttribute matching foo => foo.Value == value").AsPrefix();
 				}
 
 				[Fact]
@@ -51,7 +51,7 @@ public sealed partial class FilteredExtensions
 
 					await That(types).HasSingle().Which.IsEqualTo(typeof(FooClass2));
 					await That(types.GetDescription())
-						.IsEqualTo("types with direct FooAttribute matching foo => foo.Value == 2").AsPrefix();
+						.IsEqualTo("types with direct FilteredExtensions.Types.With.AttributeTests.FooAttribute matching foo => foo.Value == 2").AsPrefix();
 				}
 
 				[AttributeUsage(AttributeTargets.Class)]

--- a/Tests/aweXpect.Reflection.Tests/ThatType.Has.AttributeTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatType.Has.AttributeTests.cs
@@ -41,8 +41,8 @@ public sealed partial class ThatType
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
 					             Expected that subject
-					             has direct FooAttribute,
-					             but it did not in FooChildClass2
+					             has direct ThatType.Has.AttributeTests.FooAttribute,
+					             but it did not in ThatType.Has.AttributeTests.FooChildClass2
 					             """);
 			}
 
@@ -79,8 +79,8 @@ public sealed partial class ThatType
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
 					             Expected that subject
-					             has direct FooAttribute matching foo => foo.Value == 2,
-					             but it did not in FooChildClass2
+					             has direct ThatType.Has.AttributeTests.FooAttribute matching foo => foo.Value == 2,
+					             but it did not in ThatType.Has.AttributeTests.FooChildClass2
 					             """);
 			}
 
@@ -95,8 +95,8 @@ public sealed partial class ThatType
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
 					             Expected that subject
-					             has FooAttribute matching foo => foo.Value == 3,
-					             but it did not in FooClass2
+					             has ThatType.Has.AttributeTests.FooAttribute matching foo => foo.Value == 3,
+					             but it did not in ThatType.Has.AttributeTests.FooClass2
 					             """);
 			}
 
@@ -111,8 +111,8 @@ public sealed partial class ThatType
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
 					             Expected that subject
-					             has FooAttribute matching foo => foo.Value == 3,
-					             but it did not in FooChildClass2
+					             has ThatType.Has.AttributeTests.FooAttribute matching foo => foo.Value == 3,
+					             but it did not in ThatType.Has.AttributeTests.FooChildClass2
 					             """);
 			}
 
@@ -127,7 +127,7 @@ public sealed partial class ThatType
 				await That(Act).ThrowsException()
 					.WithMessage("""
 					             Expected that subject
-					             has FooAttribute,
+					             has ThatType.Has.AttributeTests.FooAttribute,
 					             but it was <null>
 					             """);
 			}

--- a/Tests/aweXpect.Reflection.Tests/ThatType.IsAbstract.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatType.IsAbstract.Tests.cs
@@ -30,7 +30,7 @@ public sealed partial class ThatType
 					.WithMessage($"""
 					              Expected that subject
 					              is abstract,
-					              but it was non-abstract {subject.Name}
+					              but it was non-abstract {Formatter.Format(subject)}
 					              """);
 			}
 

--- a/Tests/aweXpect.Reflection.Tests/ThatType.IsNotGeneric.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatType.IsNotGeneric.Tests.cs
@@ -20,7 +20,7 @@ public sealed partial class ThatType
 					.WithMessage("""
 					             Expected that subject
 					             is not generic,
-					             but it was generic PublicGenericClass<T>
+					             but it was generic PublicGenericClass<>
 					             """);
 			}
 

--- a/Tests/aweXpect.Reflection.Tests/ThatType.IsNotNested.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatType.IsNotNested.Tests.cs
@@ -20,7 +20,7 @@ public sealed partial class ThatType
 					.WithMessage("""
 					             Expected that subject
 					             is not nested,
-					             but it was nested PublicNestedClass
+					             but it was nested Container.PublicNestedClass
 					             """);
 			}
 

--- a/Tests/aweXpect.Reflection.Tests/ThatType.IsSealed.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatType.IsSealed.Tests.cs
@@ -19,7 +19,7 @@ public sealed partial class ThatType
 					.WithMessage($"""
 					              Expected that subject
 					              is sealed,
-					              but it was non-sealed {subject.Name}
+					              but it was non-sealed {Formatter.Format(subject)}
 					              """);
 			}
 

--- a/Tests/aweXpect.Reflection.Tests/ThatType.IsStatic.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatType.IsStatic.Tests.cs
@@ -19,7 +19,7 @@ public sealed partial class ThatType
 					.WithMessage($"""
 					              Expected that subject
 					              is static,
-					              but it was non-static {subject.Name}
+					              but it was non-static {Formatter.Format(subject)}
 					              """);
 			}
 

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.AreAbstract.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.AreAbstract.Tests.cs
@@ -18,7 +18,7 @@ public sealed partial class ThatTypes
 
 				await That(Act).ThrowsException()
 					.WithMessage("""
-					             Expected that types in assembly containing type AreAbstract
+					             Expected that types in assembly containing type ThatTypes.AreAbstract
 					             are all abstract,
 					             but it contained non-abstract types [
 					               *

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.AreNotAbstract.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.AreNotAbstract.Tests.cs
@@ -29,7 +29,7 @@ public sealed partial class ThatTypes
 
 				await That(Act).ThrowsException()
 					.WithMessage("""
-					             Expected that abstract types in assembly containing type AreAbstract
+					             Expected that abstract types in assembly containing type ThatTypes.AreAbstract
 					             are all not abstract,
 					             but it contained abstract types [
 					               *

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.Have.AttributeTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.Have.AttributeTests.cs
@@ -43,10 +43,10 @@ public sealed partial class ThatTypes
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
-					             Expected that types matching type => type == typeof(FooChildClass2) in assembly containing type AttributeTests
-					             all have FooAttribute,
+					             Expected that types matching type => type == typeof(FooChildClass2) in assembly containing type ThatTypes.Have.AttributeTests
+					             all have ThatTypes.Have.AttributeTests.FooAttribute,
 					             but it contained not matching types [
-					               FooChildClass2
+					               ThatTypes.Have.AttributeTests.FooChildClass2
 					             ]
 					             """);
 			}
@@ -86,10 +86,10 @@ public sealed partial class ThatTypes
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
-					             Expected that types matching type => type == typeof(FooChildClass2) in assembly containing type AttributeTests
-					             all have FooAttribute matching foo => foo.Value == 2,
+					             Expected that types matching type => type == typeof(FooChildClass2) in assembly containing type ThatTypes.Have.AttributeTests
+					             all have ThatTypes.Have.AttributeTests.FooAttribute matching foo => foo.Value == 2,
 					             but it contained not matching types [
-					               FooChildClass2
+					               ThatTypes.Have.AttributeTests.FooChildClass2
 					             ]
 					             """);
 			}
@@ -105,10 +105,10 @@ public sealed partial class ThatTypes
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
-					             Expected that types matching type => type == typeof(FooClass2) in assembly containing type AttributeTests
-					             all have direct FooAttribute matching foo => foo.Value == 3,
+					             Expected that types matching type => type == typeof(FooClass2) in assembly containing type ThatTypes.Have.AttributeTests
+					             all have direct ThatTypes.Have.AttributeTests.FooAttribute matching foo => foo.Value == 3,
 					             but it contained not matching types [
-					               FooClass2
+					               ThatTypes.Have.AttributeTests.FooClass2
 					             ]
 					             """);
 			}
@@ -124,10 +124,10 @@ public sealed partial class ThatTypes
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
-					             Expected that types matching type => type == typeof(FooChildClass2) in assembly containing type AttributeTests
-					             all have direct FooAttribute matching foo => foo.Value == 3,
+					             Expected that types matching type => type == typeof(FooChildClass2) in assembly containing type ThatTypes.Have.AttributeTests
+					             all have direct ThatTypes.Have.AttributeTests.FooAttribute matching foo => foo.Value == 3,
 					             but it contained not matching types [
-					               FooChildClass2
+					               ThatTypes.Have.AttributeTests.FooChildClass2
 					             ]
 					             """);
 			}

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.HaveName.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.HaveName.Tests.cs
@@ -20,7 +20,7 @@ public sealed partial class ThatTypes
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
-					             Expected that types with name start with "Some" in assembly containing type Tests
+					             Expected that types with name start with "Some" in assembly containing type ThatTypes.HaveName.Tests
 					             all have name equal to "SomeOtherClassName",
 					             but it contained not matching types [
 					               *SomeClassToTestHaveNameForTypes*

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.HaveNamespace.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.HaveNamespace.Tests.cs
@@ -20,7 +20,7 @@ public sealed partial class ThatTypes
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
-					             Expected that types with namespace end with "ToVerifyingTheNamespaceOfIt" in assembly containing type Tests
+					             Expected that types with namespace end with "ToVerifyingTheNamespaceOfIt" in assembly containing type ThatTypes.HaveNamespace.Tests
 					             all have namespace equal to "aweXpect.Reflection",
 					             but it contained not matching types [
 					               *SomeClassToVerifyTheNamespaceOfIt*

--- a/Tests/aweXpect.Reflection.Tests/Usings.cs
+++ b/Tests/aweXpect.Reflection.Tests/Usings.cs
@@ -3,3 +3,5 @@ global using System.Threading.Tasks;
 global using Xunit;
 global using aweXpect;
 global using static aweXpect.Expect;
+global using aweXpect.Formatting;
+global using static aweXpect.Formatting.Format;


### PR DESCRIPTION
Adjust tests to changes in how nested types are formatted (see https://github.com/aweXpect/aweXpect/pull/498).