### PR TITLE
feat: add `HasName` for `Assembly`

### DIFF
--- a/Source/aweXpect.Reflection/Collections/IChangeableFilter.cs
+++ b/Source/aweXpect.Reflection/Collections/IChangeableFilter.cs
@@ -9,7 +9,7 @@ public interface IChangeableFilter<TEntity> : IFilter<TEntity>
 {
 	/// <summary>
 	///     Updates the original filter by applying the <paramref name="predicate" /> on the original result
-	/// and updating the <paramref name="description" />.
+	///     and updating the <paramref name="description" />.
 	/// </summary>
 	void UpdateFilter(Func<bool, TEntity, bool> predicate, Func<string, string> description);
 }

--- a/Source/aweXpect.Reflection/Extensions/TypeExtensions.cs
+++ b/Source/aweXpect.Reflection/Extensions/TypeExtensions.cs
@@ -89,12 +89,12 @@ internal static class TypeExtensions
 	///     Defaults to <see langword="true" />
 	/// </param>
 	public static bool HasAttribute<TAttribute>(
-		this Type type,
+		this Type? type,
 		Func<TAttribute, bool>? predicate = null,
 		bool inherit = true)
 		where TAttribute : Attribute
 	{
-		object? attribute = type.GetCustomAttributes(typeof(TAttribute), inherit)
+		object? attribute = type?.GetCustomAttributes(typeof(TAttribute), inherit)
 			.FirstOrDefault();
 		if (attribute is TAttribute attributeValue)
 		{
@@ -242,19 +242,19 @@ internal static class TypeExtensions
 		return !forceDirect && type.InheritsFrom(parentType);
 	}
 
-	public static bool IsRecordClass(this Type type)
-		=> type.GetMethod("<Clone>$", BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly) is not
+	public static bool IsRecordClass(this Type? type)
+		=> type?.GetMethod("<Clone>$", BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly) is not
 			   null &&
 		   type.GetProperty("EqualityContract",
 				   BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly)?
 			   .GetMethod?.HasAttribute<CompilerGeneratedAttribute>() == true;
 
 
-	public static bool IsRecordStruct(this Type type) =>
+	public static bool IsRecordStruct(this Type? type) =>
 		// As noted here: https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-10.0/record-structs#open-questions
 		// recognizing record structs from metadata is an open point. The following check is based on common sense
 		// and heuristic testing, apparently giving good results but not supported by official documentation.
-		type.BaseType == typeof(ValueType) &&
+		type?.BaseType == typeof(ValueType) &&
 		type.GetMethod("PrintMembers", BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly, null,
 			[typeof(StringBuilder),], null) is not null &&
 		type.GetMethod("op_Equality", BindingFlags.Static | BindingFlags.Public | BindingFlags.DeclaredOnly, null,
@@ -266,7 +266,7 @@ internal static class TypeExtensions
 	/// </summary>
 	/// <param name="type">The <see cref="Type" />.</param>
 	/// <remarks>https://stackoverflow.com/a/1175901</remarks>
-	public static bool IsReallyStatic(this Type type)
+	public static bool IsReallyStatic(this Type? type)
 		=> type is { IsAbstract: true, IsSealed: true, IsInterface: false, };
 
 	/// <summary>
@@ -274,7 +274,7 @@ internal static class TypeExtensions
 	/// </summary>
 	/// <param name="type">The <see cref="Type" />.</param>
 	/// <remarks>https://stackoverflow.com/a/1175901</remarks>
-	public static bool IsReallySealed(this Type type)
+	public static bool IsReallySealed(this Type? type)
 		=> type is { IsAbstract: false, IsSealed: true, IsInterface: false, };
 
 	/// <summary>
@@ -282,7 +282,7 @@ internal static class TypeExtensions
 	/// </summary>
 	/// <param name="type">The <see cref="Type" />.</param>
 	/// <remarks>https://stackoverflow.com/a/1175901</remarks>
-	public static bool IsReallyAbstract(this Type type)
+	public static bool IsReallyAbstract(this Type? type)
 		=> type is { IsAbstract: true, IsSealed: false, IsInterface: false, };
 
 	/// <summary>

--- a/Source/aweXpect.Reflection/ThatAssemblies.HaveName.cs
+++ b/Source/aweXpect.Reflection/ThatAssemblies.HaveName.cs
@@ -18,11 +18,11 @@ public static partial class ThatAssemblies
 	///     Verifies that all items in the filtered collection of <see cref="Assembly" /> have
 	///     the <paramref name="expected" /> name.
 	/// </summary>
-	public static StringEqualityTypeResult<IEnumerable<Assembly>, IThat<IEnumerable<Assembly>>> HaveName(
-		this IThat<IEnumerable<Assembly>> subject, string expected)
+	public static StringEqualityTypeResult<IEnumerable<Assembly?>, IThat<IEnumerable<Assembly?>>> HaveName(
+		this IThat<IEnumerable<Assembly?>> subject, string expected)
 	{
 		StringEqualityOptions options = new();
-		return new StringEqualityTypeResult<IEnumerable<Assembly>, IThat<IEnumerable<Assembly>>>(subject.Get()
+		return new StringEqualityTypeResult<IEnumerable<Assembly?>, IThat<IEnumerable<Assembly?>>>(subject.Get()
 				.ExpectationBuilder.AddConstraint((it, grammars)
 					=> new HaveNameConstraint(it, grammars, expected, options)),
 			subject,
@@ -34,13 +34,13 @@ public static partial class ThatAssemblies
 		ExpectationGrammars grammars,
 		string expected,
 		StringEqualityOptions options)
-		: ConstraintResult.WithValue<IEnumerable<Assembly>>(grammars),
-			IValueConstraint<IEnumerable<Assembly>>
+		: ConstraintResult.WithValue<IEnumerable<Assembly?>>(grammars),
+			IValueConstraint<IEnumerable<Assembly?>>
 	{
-		public ConstraintResult IsMetBy(IEnumerable<Assembly> actual)
+		public ConstraintResult IsMetBy(IEnumerable<Assembly?> actual)
 		{
 			Actual = actual;
-			Outcome = actual.All(type => options.AreConsideredEqual(type.GetName().Name, expected))
+			Outcome = actual.All(type => options.AreConsideredEqual(type?.GetName().Name, expected))
 				? Outcome.Success
 				: Outcome.Failure;
 			return this;
@@ -52,7 +52,7 @@ public static partial class ThatAssemblies
 		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
 		{
 			stringBuilder.Append(it).Append(" contained not matching types ");
-			Formatter.Format(stringBuilder, Actual?.Where(type => !options.AreConsideredEqual(type.GetName().Name, expected)),
+			Formatter.Format(stringBuilder, Actual?.Where(type => !options.AreConsideredEqual(type?.GetName().Name, expected)),
 				FormattingOptions.Indented(indentation));
 		}
 
@@ -62,7 +62,7 @@ public static partial class ThatAssemblies
 		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
 		{
 			stringBuilder.Append(it).Append(" only contained matching types ");
-			Formatter.Format(stringBuilder, Actual?.Where(type => options.AreConsideredEqual(type.GetName().Name, expected)),
+			Formatter.Format(stringBuilder, Actual?.Where(type => options.AreConsideredEqual(type?.GetName().Name, expected)),
 				FormattingOptions.Indented(indentation));
 		}
 	}

--- a/Source/aweXpect.Reflection/ThatAssemblies.HaveName.cs
+++ b/Source/aweXpect.Reflection/ThatAssemblies.HaveName.cs
@@ -1,6 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 using aweXpect.Core;
 using aweXpect.Core.Constraints;
@@ -12,17 +12,17 @@ using aweXpect.Results;
 
 namespace aweXpect.Reflection;
 
-public static partial class ThatTypes
+public static partial class ThatAssemblies
 {
 	/// <summary>
-	///     Verifies that all items in the filtered collection of <see cref="Type" /> have
+	///     Verifies that all items in the filtered collection of <see cref="Assembly" /> have
 	///     the <paramref name="expected" /> name.
 	/// </summary>
-	public static StringEqualityTypeResult<IEnumerable<Type?>, IThat<IEnumerable<Type?>>> HaveName(
-		this IThat<IEnumerable<Type?>> subject, string expected)
+	public static StringEqualityTypeResult<IEnumerable<Assembly>, IThat<IEnumerable<Assembly>>> HaveName(
+		this IThat<IEnumerable<Assembly>> subject, string expected)
 	{
 		StringEqualityOptions options = new();
-		return new StringEqualityTypeResult<IEnumerable<Type?>, IThat<IEnumerable<Type?>>>(subject.Get()
+		return new StringEqualityTypeResult<IEnumerable<Assembly>, IThat<IEnumerable<Assembly>>>(subject.Get()
 				.ExpectationBuilder.AddConstraint((it, grammars)
 					=> new HaveNameConstraint(it, grammars, expected, options)),
 			subject,
@@ -34,13 +34,13 @@ public static partial class ThatTypes
 		ExpectationGrammars grammars,
 		string expected,
 		StringEqualityOptions options)
-		: ConstraintResult.WithValue<IEnumerable<Type?>>(grammars),
-			IValueConstraint<IEnumerable<Type?>>
+		: ConstraintResult.WithValue<IEnumerable<Assembly>>(grammars),
+			IValueConstraint<IEnumerable<Assembly>>
 	{
-		public ConstraintResult IsMetBy(IEnumerable<Type?> actual)
+		public ConstraintResult IsMetBy(IEnumerable<Assembly> actual)
 		{
 			Actual = actual;
-			Outcome = actual.All(type => options.AreConsideredEqual(type?.Name, expected))
+			Outcome = actual.All(type => options.AreConsideredEqual(type.GetName().Name, expected))
 				? Outcome.Success
 				: Outcome.Failure;
 			return this;
@@ -52,7 +52,7 @@ public static partial class ThatTypes
 		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
 		{
 			stringBuilder.Append(it).Append(" contained not matching types ");
-			Formatter.Format(stringBuilder, Actual?.Where(type => !options.AreConsideredEqual(type?.Name, expected)),
+			Formatter.Format(stringBuilder, Actual?.Where(type => !options.AreConsideredEqual(type.GetName().Name, expected)),
 				FormattingOptions.Indented(indentation));
 		}
 
@@ -62,7 +62,7 @@ public static partial class ThatTypes
 		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
 		{
 			stringBuilder.Append(it).Append(" only contained matching types ");
-			Formatter.Format(stringBuilder, Actual?.Where(type => options.AreConsideredEqual(type?.Name, expected)),
+			Formatter.Format(stringBuilder, Actual?.Where(type => options.AreConsideredEqual(type.GetName().Name, expected)),
 				FormattingOptions.Indented(indentation));
 		}
 	}

--- a/Source/aweXpect.Reflection/ThatAssemblies.cs
+++ b/Source/aweXpect.Reflection/ThatAssemblies.cs
@@ -1,0 +1,8 @@
+﻿using System.Reflection;
+
+namespace aweXpect.Reflection;
+
+/// <summary>
+///     Expectations on a collection of <see cref="Assembly" />.
+/// </summary>
+public static partial class ThatAssemblies;

--- a/Source/aweXpect.Reflection/ThatAssembly.HasName.cs
+++ b/Source/aweXpect.Reflection/ThatAssembly.HasName.cs
@@ -1,0 +1,56 @@
+﻿using System.Reflection;
+using System.Text;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Options;
+using aweXpect.Reflection.Extensions;
+using aweXpect.Results;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Reflection;
+
+public static partial class ThatAssembly
+{
+	/// <summary>
+	///     Verifies that the <see cref="Assembly" /> has the <paramref name="expected" /> name.
+	/// </summary>
+	public static StringEqualityTypeResult<Assembly?, IThat<Assembly?>> HasName(
+		this IThat<Assembly?> subject, string expected)
+	{
+		StringEqualityOptions options = new();
+		return new StringEqualityTypeResult<Assembly?, IThat<Assembly?>>(subject.Get().ExpectationBuilder.AddConstraint(
+				(it, grammars)
+					=> new HasNameConstraint(it, grammars, expected, options)),
+			subject,
+			options);
+	}
+
+	private sealed class HasNameConstraint(
+		string it,
+		ExpectationGrammars grammars,
+		string expected,
+		StringEqualityOptions options)
+		: ConstraintResult.WithNotNullValue<Assembly?>(it, grammars),
+			IValueConstraint<Assembly?>
+	{
+		public ConstraintResult IsMetBy(Assembly? actual)
+		{
+			Actual = actual;
+			Outcome = options.AreConsideredEqual(actual?.GetName().Name, expected) ? Outcome.Success : Outcome.Failure;
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("has name ").Append(options.GetExpectation(expected, Grammars));
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append(options.GetExtendedFailure(It, Grammars, Actual?.GetName().Name, expected));
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("does not have name ").Append(options.GetExpectation(expected, Grammars));
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+			=> AppendNormalResult(stringBuilder, indentation);
+	}
+}

--- a/Source/aweXpect.Reflection/ThatAssembly.cs
+++ b/Source/aweXpect.Reflection/ThatAssembly.cs
@@ -1,0 +1,8 @@
+﻿using System.Reflection;
+
+namespace aweXpect.Reflection;
+
+/// <summary>
+///     Expectations on <see cref="Assembly" />.
+/// </summary>
+public static partial class ThatAssembly;

--- a/Source/aweXpect.Reflection/ThatTypes.AreAbstract.cs
+++ b/Source/aweXpect.Reflection/ThatTypes.AreAbstract.cs
@@ -20,8 +20,8 @@ public static partial class ThatTypes
 	///     Static types or interfaces are not considered abstract, even though they
 	///     have <see cref="Type.IsAbstract" /> set to <see langword="true" />.
 	/// </remarks>
-	public static AndOrResult<IEnumerable<Type>, IThat<IEnumerable<Type>>> AreAbstract(
-		this IThat<IEnumerable<Type>> subject)
+	public static AndOrResult<IEnumerable<Type?>, IThat<IEnumerable<Type?>>> AreAbstract(
+		this IThat<IEnumerable<Type?>> subject)
 		=> new(subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
 				=> new AreAbstractConstraint(it, grammars)),
 			subject);
@@ -33,17 +33,17 @@ public static partial class ThatTypes
 	///     Static types or interfaces are considered not abstract, even though they
 	///     have <see cref="Type.IsAbstract" /> set to <see langword="true" />.
 	/// </remarks>
-	public static AndOrResult<IEnumerable<Type>, IThat<IEnumerable<Type>>> AreNotAbstract(
-		this IThat<IEnumerable<Type>> subject)
+	public static AndOrResult<IEnumerable<Type?>, IThat<IEnumerable<Type?>>> AreNotAbstract(
+		this IThat<IEnumerable<Type?>> subject)
 		=> new(subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
 				=> new AreNotAbstractConstraint(it, grammars)),
 			subject);
 
 	private sealed class AreAbstractConstraint(string it, ExpectationGrammars grammars)
-		: ConstraintResult.WithValue<IEnumerable<Type>>(grammars),
-			IValueConstraint<IEnumerable<Type>>
+		: ConstraintResult.WithValue<IEnumerable<Type?>>(grammars),
+			IValueConstraint<IEnumerable<Type?>>
 	{
-		public ConstraintResult IsMetBy(IEnumerable<Type> actual)
+		public ConstraintResult IsMetBy(IEnumerable<Type?> actual)
 		{
 			Actual = actual;
 			Outcome = actual.All(type => type.IsReallyAbstract()) ? Outcome.Success : Outcome.Failure;
@@ -72,10 +72,10 @@ public static partial class ThatTypes
 	}
 
 	private sealed class AreNotAbstractConstraint(string it, ExpectationGrammars grammars)
-		: ConstraintResult.WithValue<IEnumerable<Type>>(grammars),
-			IValueConstraint<IEnumerable<Type>>
+		: ConstraintResult.WithValue<IEnumerable<Type?>>(grammars),
+			IValueConstraint<IEnumerable<Type?>>
 	{
-		public ConstraintResult IsMetBy(IEnumerable<Type> actual)
+		public ConstraintResult IsMetBy(IEnumerable<Type?> actual)
 		{
 			Actual = actual;
 			Outcome = actual.All(type => !type.IsReallyAbstract()) ? Outcome.Success : Outcome.Failure;

--- a/Source/aweXpect.Reflection/ThatTypes.AreGeneric.cs
+++ b/Source/aweXpect.Reflection/ThatTypes.AreGeneric.cs
@@ -16,8 +16,8 @@ public static partial class ThatTypes
 	/// <summary>
 	///     Verifies that all items in the filtered collection of <see cref="Type" /> are generic.
 	/// </summary>
-	public static AndOrResult<IEnumerable<Type>, IThat<IEnumerable<Type>>> AreGeneric(
-		this IThat<IEnumerable<Type>> subject)
+	public static AndOrResult<IEnumerable<Type?>, IThat<IEnumerable<Type?>>> AreGeneric(
+		this IThat<IEnumerable<Type?>> subject)
 		=> new(subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
 				=> new AreGenericConstraint(it, grammars)),
 			subject);
@@ -25,20 +25,20 @@ public static partial class ThatTypes
 	/// <summary>
 	///     Verifies that all items in the filtered collection of <see cref="Type" /> are not generic.
 	/// </summary>
-	public static AndOrResult<IEnumerable<Type>, IThat<IEnumerable<Type>>> AreNotGeneric(
-		this IThat<IEnumerable<Type>> subject)
+	public static AndOrResult<IEnumerable<Type?>, IThat<IEnumerable<Type?>>> AreNotGeneric(
+		this IThat<IEnumerable<Type?>> subject)
 		=> new(subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
 				=> new AreNotGenericConstraint(it, grammars)),
 			subject);
 
 	private sealed class AreGenericConstraint(string it, ExpectationGrammars grammars)
-		: ConstraintResult.WithValue<IEnumerable<Type>>(grammars),
-			IValueConstraint<IEnumerable<Type>>
+		: ConstraintResult.WithValue<IEnumerable<Type?>>(grammars),
+			IValueConstraint<IEnumerable<Type?>>
 	{
-		public ConstraintResult IsMetBy(IEnumerable<Type> actual)
+		public ConstraintResult IsMetBy(IEnumerable<Type?> actual)
 		{
 			Actual = actual;
-			Outcome = actual.All(type => type.IsGenericType) ? Outcome.Success : Outcome.Failure;
+			Outcome = actual.All(type => type?.IsGenericType == true) ? Outcome.Success : Outcome.Failure;
 			return this;
 		}
 
@@ -48,7 +48,7 @@ public static partial class ThatTypes
 		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
 		{
 			stringBuilder.Append(it).Append(" contained non-generic types ");
-			Formatter.Format(stringBuilder, Actual?.Where(type => !type.IsGenericType),
+			Formatter.Format(stringBuilder, Actual?.Where(type => type?.IsGenericType != true),
 				FormattingOptions.Indented(indentation));
 		}
 
@@ -58,19 +58,19 @@ public static partial class ThatTypes
 		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
 		{
 			stringBuilder.Append(it).Append(" only contained generic types ");
-			Formatter.Format(stringBuilder, Actual?.Where(type => type.IsGenericType),
+			Formatter.Format(stringBuilder, Actual?.Where(type => type?.IsGenericType == true),
 				FormattingOptions.Indented(indentation));
 		}
 	}
 
 	private sealed class AreNotGenericConstraint(string it, ExpectationGrammars grammars)
-		: ConstraintResult.WithValue<IEnumerable<Type>>(grammars),
-			IValueConstraint<IEnumerable<Type>>
+		: ConstraintResult.WithValue<IEnumerable<Type?>>(grammars),
+			IValueConstraint<IEnumerable<Type?>>
 	{
-		public ConstraintResult IsMetBy(IEnumerable<Type> actual)
+		public ConstraintResult IsMetBy(IEnumerable<Type?> actual)
 		{
 			Actual = actual;
-			Outcome = actual.All(type => !type.IsGenericType) ? Outcome.Success : Outcome.Failure;
+			Outcome = actual.All(type => type?.IsGenericType != true) ? Outcome.Success : Outcome.Failure;
 			return this;
 		}
 
@@ -80,7 +80,7 @@ public static partial class ThatTypes
 		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
 		{
 			stringBuilder.Append(it).Append(" contained generic types ");
-			Formatter.Format(stringBuilder, Actual?.Where(type => type.IsGenericType),
+			Formatter.Format(stringBuilder, Actual?.Where(type => type?.IsGenericType == true),
 				FormattingOptions.Indented(indentation));
 		}
 
@@ -90,7 +90,7 @@ public static partial class ThatTypes
 		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
 		{
 			stringBuilder.Append(it).Append(" only contained non-generic types ");
-			Formatter.Format(stringBuilder, Actual?.Where(type => !type.IsGenericType),
+			Formatter.Format(stringBuilder, Actual?.Where(type => type?.IsGenericType != true),
 				FormattingOptions.Indented(indentation));
 		}
 	}

--- a/Source/aweXpect.Reflection/ThatTypes.AreNested.cs
+++ b/Source/aweXpect.Reflection/ThatTypes.AreNested.cs
@@ -16,8 +16,8 @@ public static partial class ThatTypes
 	/// <summary>
 	///     Verifies that all items in the filtered collection of <see cref="Type" /> are nested.
 	/// </summary>
-	public static AndOrResult<IEnumerable<Type>, IThat<IEnumerable<Type>>> AreNested(
-		this IThat<IEnumerable<Type>> subject)
+	public static AndOrResult<IEnumerable<Type?>, IThat<IEnumerable<Type?>>> AreNested(
+		this IThat<IEnumerable<Type?>> subject)
 		=> new(subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
 				=> new AreNestedConstraint(it, grammars)),
 			subject);
@@ -25,20 +25,20 @@ public static partial class ThatTypes
 	/// <summary>
 	///     Verifies that all items in the filtered collection of <see cref="Type" /> are not nested.
 	/// </summary>
-	public static AndOrResult<IEnumerable<Type>, IThat<IEnumerable<Type>>> AreNotNested(
-		this IThat<IEnumerable<Type>> subject)
+	public static AndOrResult<IEnumerable<Type?>, IThat<IEnumerable<Type?>>> AreNotNested(
+		this IThat<IEnumerable<Type?>> subject)
 		=> new(subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
 				=> new AreNotNestedConstraint(it, grammars)),
 			subject);
 
 	private sealed class AreNestedConstraint(string it, ExpectationGrammars grammars)
-		: ConstraintResult.WithValue<IEnumerable<Type>>(grammars),
-			IValueConstraint<IEnumerable<Type>>
+		: ConstraintResult.WithValue<IEnumerable<Type?>>(grammars),
+			IValueConstraint<IEnumerable<Type?>>
 	{
-		public ConstraintResult IsMetBy(IEnumerable<Type> actual)
+		public ConstraintResult IsMetBy(IEnumerable<Type?> actual)
 		{
 			Actual = actual;
-			Outcome = actual.All(type => type.IsNested) ? Outcome.Success : Outcome.Failure;
+			Outcome = actual.All(type => type?.IsNested == true) ? Outcome.Success : Outcome.Failure;
 			return this;
 		}
 
@@ -48,7 +48,7 @@ public static partial class ThatTypes
 		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
 		{
 			stringBuilder.Append(it).Append(" contained non-nested types ");
-			Formatter.Format(stringBuilder, Actual?.Where(type => !type.IsNested),
+			Formatter.Format(stringBuilder, Actual?.Where(type => type?.IsNested != true),
 				FormattingOptions.Indented(indentation));
 		}
 
@@ -58,19 +58,19 @@ public static partial class ThatTypes
 		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
 		{
 			stringBuilder.Append(it).Append(" only contained nested types ");
-			Formatter.Format(stringBuilder, Actual?.Where(type => type.IsNested),
+			Formatter.Format(stringBuilder, Actual?.Where(type => type?.IsNested == true),
 				FormattingOptions.Indented(indentation));
 		}
 	}
 
 	private sealed class AreNotNestedConstraint(string it, ExpectationGrammars grammars)
-		: ConstraintResult.WithValue<IEnumerable<Type>>(grammars),
-			IValueConstraint<IEnumerable<Type>>
+		: ConstraintResult.WithValue<IEnumerable<Type?>>(grammars),
+			IValueConstraint<IEnumerable<Type?>>
 	{
-		public ConstraintResult IsMetBy(IEnumerable<Type> actual)
+		public ConstraintResult IsMetBy(IEnumerable<Type?> actual)
 		{
 			Actual = actual;
-			Outcome = actual.All(type => !type.IsNested) ? Outcome.Success : Outcome.Failure;
+			Outcome = actual.All(type => type?.IsNested != true) ? Outcome.Success : Outcome.Failure;
 			return this;
 		}
 
@@ -80,7 +80,7 @@ public static partial class ThatTypes
 		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
 		{
 			stringBuilder.Append(it).Append(" contained nested types ");
-			Formatter.Format(stringBuilder, Actual?.Where(type => type.IsNested),
+			Formatter.Format(stringBuilder, Actual?.Where(type => type?.IsNested == true),
 				FormattingOptions.Indented(indentation));
 		}
 
@@ -90,7 +90,7 @@ public static partial class ThatTypes
 		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
 		{
 			stringBuilder.Append(it).Append(" only contained non-nested types ");
-			Formatter.Format(stringBuilder, Actual?.Where(type => !type.IsNested),
+			Formatter.Format(stringBuilder, Actual?.Where(type => type?.IsNested != true),
 				FormattingOptions.Indented(indentation));
 		}
 	}

--- a/Source/aweXpect.Reflection/ThatTypes.AreSealed.cs
+++ b/Source/aweXpect.Reflection/ThatTypes.AreSealed.cs
@@ -20,8 +20,8 @@ public static partial class ThatTypes
 	///     Static types are not considered sealed, even though they
 	///     have <see cref="Type.IsSealed" /> set to <see langword="true" />.
 	/// </remarks>
-	public static AndOrResult<IEnumerable<Type>, IThat<IEnumerable<Type>>> AreSealed(
-		this IThat<IEnumerable<Type>> subject)
+	public static AndOrResult<IEnumerable<Type?>, IThat<IEnumerable<Type?>>> AreSealed(
+		this IThat<IEnumerable<Type?>> subject)
 		=> new(subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
 				=> new AreSealedConstraint(it, grammars)),
 			subject);
@@ -33,17 +33,17 @@ public static partial class ThatTypes
 	///     Static types are considered not sealed, even though they
 	///     have <see cref="Type.IsSealed" /> set to <see langword="true" />.
 	/// </remarks>
-	public static AndOrResult<IEnumerable<Type>, IThat<IEnumerable<Type>>> AreNotSealed(
-		this IThat<IEnumerable<Type>> subject)
+	public static AndOrResult<IEnumerable<Type?>, IThat<IEnumerable<Type?>>> AreNotSealed(
+		this IThat<IEnumerable<Type?>> subject)
 		=> new(subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
 				=> new AreNotSealedConstraint(it, grammars)),
 			subject);
 
 	private sealed class AreSealedConstraint(string it, ExpectationGrammars grammars)
-		: ConstraintResult.WithValue<IEnumerable<Type>>(grammars),
-			IValueConstraint<IEnumerable<Type>>
+		: ConstraintResult.WithValue<IEnumerable<Type?>>(grammars),
+			IValueConstraint<IEnumerable<Type?>>
 	{
-		public ConstraintResult IsMetBy(IEnumerable<Type> actual)
+		public ConstraintResult IsMetBy(IEnumerable<Type?> actual)
 		{
 			Actual = actual;
 			Outcome = actual.All(type => type.IsReallySealed()) ? Outcome.Success : Outcome.Failure;

--- a/Source/aweXpect.Reflection/ThatTypes.AreStatic.cs
+++ b/Source/aweXpect.Reflection/ThatTypes.AreStatic.cs
@@ -16,8 +16,8 @@ public static partial class ThatTypes
 	/// <summary>
 	///     Verifies that all items in the filtered collection of <see cref="Type" /> are static.
 	/// </summary>
-	public static AndOrResult<IEnumerable<Type>, IThat<IEnumerable<Type>>> AreStatic(
-		this IThat<IEnumerable<Type>> subject)
+	public static AndOrResult<IEnumerable<Type?>, IThat<IEnumerable<Type?>>> AreStatic(
+		this IThat<IEnumerable<Type?>> subject)
 		=> new(subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
 				=> new AreStaticConstraint(it, grammars)),
 			subject);
@@ -25,17 +25,17 @@ public static partial class ThatTypes
 	/// <summary>
 	///     Verifies that all items in the filtered collection of <see cref="Type" /> are not static.
 	/// </summary>
-	public static AndOrResult<IEnumerable<Type>, IThat<IEnumerable<Type>>> AreNotStatic(
-		this IThat<IEnumerable<Type>> subject)
+	public static AndOrResult<IEnumerable<Type?>, IThat<IEnumerable<Type?>>> AreNotStatic(
+		this IThat<IEnumerable<Type?>> subject)
 		=> new(subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
 				=> new AreNotStaticConstraint(it, grammars)),
 			subject);
 
 	private sealed class AreStaticConstraint(string it, ExpectationGrammars grammars)
-		: ConstraintResult.WithValue<IEnumerable<Type>>(grammars),
-			IValueConstraint<IEnumerable<Type>>
+		: ConstraintResult.WithValue<IEnumerable<Type?>>(grammars),
+			IValueConstraint<IEnumerable<Type?>>
 	{
-		public ConstraintResult IsMetBy(IEnumerable<Type> actual)
+		public ConstraintResult IsMetBy(IEnumerable<Type?> actual)
 		{
 			Actual = actual;
 			Outcome = actual.All(type => type.IsReallyStatic()) ? Outcome.Success : Outcome.Failure;
@@ -64,10 +64,10 @@ public static partial class ThatTypes
 	}
 
 	private sealed class AreNotStaticConstraint(string it, ExpectationGrammars grammars)
-		: ConstraintResult.WithValue<IEnumerable<Type>>(grammars),
-			IValueConstraint<IEnumerable<Type>>
+		: ConstraintResult.WithValue<IEnumerable<Type?>>(grammars),
+			IValueConstraint<IEnumerable<Type?>>
 	{
-		public ConstraintResult IsMetBy(IEnumerable<Type> actual)
+		public ConstraintResult IsMetBy(IEnumerable<Type?> actual)
 		{
 			Actual = actual;
 			Outcome = actual.All(type => !type.IsReallyStatic()) ? Outcome.Success : Outcome.Failure;

--- a/Source/aweXpect.Reflection/ThatTypes.Have.cs
+++ b/Source/aweXpect.Reflection/ThatTypes.Have.cs
@@ -22,8 +22,8 @@ public static partial class ThatTypes
 	///     The optional parameter <paramref name="inherit" /> (default value <see langword="true" /> specifies, if
 	///     the attribute can be inherited from a base type.
 	/// </remarks>
-	public static AndOrResult<IEnumerable<Type>, IThat<IEnumerable<Type>>> Have<TAttribute>(
-		this IThat<IEnumerable<Type>> subject, bool inherit = true)
+	public static AndOrResult<IEnumerable<Type?>, IThat<IEnumerable<Type?>>> Have<TAttribute>(
+		this IThat<IEnumerable<Type?>> subject, bool inherit = true)
 		where TAttribute : Attribute
 		=> new(subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
 				=> new HaveAttributeConstraint<TAttribute>(it, grammars, inherit)),
@@ -37,8 +37,8 @@ public static partial class ThatTypes
 	///     The optional parameter <paramref name="inherit" /> (default value <see langword="true" /> specifies, if
 	///     the attribute can be inherited from a base type.
 	/// </remarks>
-	public static AndOrResult<IEnumerable<Type>, IThat<IEnumerable<Type>>> Have<TAttribute>(
-		this IThat<IEnumerable<Type>> subject,
+	public static AndOrResult<IEnumerable<Type?>, IThat<IEnumerable<Type?>>> Have<TAttribute>(
+		this IThat<IEnumerable<Type?>> subject,
 		Func<TAttribute, bool>? predicate,
 		bool inherit = true,
 		[CallerArgumentExpression("predicate")]
@@ -54,11 +54,11 @@ public static partial class ThatTypes
 		bool inherit,
 		Func<TAttribute, bool>? predicate = null,
 		string predicateExpression = "")
-		: ConstraintResult.WithValue<IEnumerable<Type>>(grammars),
-			IValueConstraint<IEnumerable<Type>>
+		: ConstraintResult.WithValue<IEnumerable<Type?>>(grammars),
+			IValueConstraint<IEnumerable<Type?>>
 		where TAttribute : Attribute
 	{
-		public ConstraintResult IsMetBy(IEnumerable<Type> actual)
+		public ConstraintResult IsMetBy(IEnumerable<Type?> actual)
 		{
 			Actual = actual;
 			Outcome = actual.All(type => type.HasAttribute(predicate, inherit)) ? Outcome.Success : Outcome.Failure;

--- a/Source/aweXpect.Reflection/ThatTypes.HaveNamespace.cs
+++ b/Source/aweXpect.Reflection/ThatTypes.HaveNamespace.cs
@@ -16,14 +16,15 @@ public static partial class ThatTypes
 {
 	/// <summary>
 	///     Verifies that all items in the filtered collection of <see cref="Type" /> have
-	///     the <paramref name="expected"/> namespace.
+	///     the <paramref name="expected" /> namespace.
 	/// </summary>
-	public static StringEqualityTypeResult<IEnumerable<Type>, IThat<IEnumerable<Type>>> HaveNamespace(
-		this IThat<IEnumerable<Type>> subject, string expected)
+	public static StringEqualityTypeResult<IEnumerable<Type?>, IThat<IEnumerable<Type?>>> HaveNamespace(
+		this IThat<IEnumerable<Type?>> subject, string expected)
 	{
-		var options = new StringEqualityOptions();
-		return new(subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new HaveNamespaceConstraint(it, grammars, expected, options)),
+		StringEqualityOptions options = new();
+		return new StringEqualityTypeResult<IEnumerable<Type?>, IThat<IEnumerable<Type?>>>(subject.Get()
+				.ExpectationBuilder.AddConstraint((it, grammars)
+					=> new HaveNamespaceConstraint(it, grammars, expected, options)),
 			subject,
 			options);
 	}
@@ -33,13 +34,15 @@ public static partial class ThatTypes
 		ExpectationGrammars grammars,
 		string expected,
 		StringEqualityOptions options)
-		: ConstraintResult.WithValue<IEnumerable<Type>>(grammars),
-			IValueConstraint<IEnumerable<Type>>
+		: ConstraintResult.WithValue<IEnumerable<Type?>>(grammars),
+			IValueConstraint<IEnumerable<Type?>>
 	{
-		public ConstraintResult IsMetBy(IEnumerable<Type> actual)
+		public ConstraintResult IsMetBy(IEnumerable<Type?> actual)
 		{
 			Actual = actual;
-			Outcome = actual.All(type => options.AreConsideredEqual(type.Namespace, expected)) ? Outcome.Success : Outcome.Failure;
+			Outcome = actual.All(type => options.AreConsideredEqual(type?.Namespace, expected))
+				? Outcome.Success
+				: Outcome.Failure;
 			return this;
 		}
 
@@ -49,7 +52,8 @@ public static partial class ThatTypes
 		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
 		{
 			stringBuilder.Append(it).Append(" contained not matching types ");
-			Formatter.Format(stringBuilder, Actual?.Where(type => !options.AreConsideredEqual(type.Namespace, expected)),
+			Formatter.Format(stringBuilder,
+				Actual?.Where(type => !options.AreConsideredEqual(type?.Namespace, expected)),
 				FormattingOptions.Indented(indentation));
 		}
 
@@ -59,7 +63,7 @@ public static partial class ThatTypes
 		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
 		{
 			stringBuilder.Append(it).Append(" only contained matching types ");
-			Formatter.Format(stringBuilder, Actual?.Where(type => options.AreConsideredEqual(type.Namespace, expected)),
+			Formatter.Format(stringBuilder, Actual?.Where(type => options.AreConsideredEqual(type?.Namespace, expected)),
 				FormattingOptions.Indented(indentation));
 		}
 	}

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net8.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net8.0.txt
@@ -132,6 +132,14 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Collections.Filtered.Assemblies EntryAssembly() { }
         public static aweXpect.Reflection.Collections.Filtered.Assemblies ExecutingAssembly() { }
     }
+    public static class ThatAssemblies
+    {
+        public static aweXpect.Results.StringEqualityTypeResult<System.Collections.Generic.IEnumerable<System.Reflection.Assembly>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.Assembly>>> HaveName(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.Assembly>> subject, string expected) { }
+    }
+    public static class ThatAssembly
+    {
+        public static aweXpect.Results.StringEqualityTypeResult<System.Reflection.Assembly?, aweXpect.Core.IThat<System.Reflection.Assembly?>> HasName(this aweXpect.Core.IThat<System.Reflection.Assembly?> subject, string expected) { }
+    }
     public static class ThatType
     {
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> Has<TAttribute>(this aweXpect.Core.IThat<System.Type?> subject, bool inherit = true)
@@ -157,21 +165,21 @@ namespace aweXpect.Reflection
     }
     public static class ThatTypes
     {
-        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type>>> AreAbstract(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type>> subject) { }
-        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type>>> AreGeneric(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type>> subject) { }
-        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type>>> AreNested(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type>> subject) { }
-        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type>>> AreNotAbstract(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type>> subject) { }
-        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type>>> AreNotGeneric(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type>> subject) { }
-        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type>>> AreNotNested(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type>> subject) { }
-        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type>>> AreNotSealed(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type>> subject) { }
-        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type>>> AreNotStatic(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type>> subject) { }
-        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type>>> AreSealed(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type>> subject) { }
-        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type>>> AreStatic(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type>> subject) { }
-        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type>>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type>> subject, bool inherit = true)
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreAbstract(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreGeneric(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreNested(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreNotAbstract(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreNotGeneric(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreNotNested(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreNotSealed(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreNotStatic(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreSealed(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreStatic(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject, bool inherit = true)
             where TAttribute : System.Attribute { }
-        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type>>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type>> subject, System.Func<TAttribute, bool>? predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject, System.Func<TAttribute, bool>? predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
             where TAttribute : System.Attribute { }
-        public static aweXpect.Results.StringEqualityTypeResult<System.Collections.Generic.IEnumerable<System.Type>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type>>> HaveName(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type>> subject, string expected) { }
-        public static aweXpect.Results.StringEqualityTypeResult<System.Collections.Generic.IEnumerable<System.Type>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type>>> HaveNamespace(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type>> subject, string expected) { }
+        public static aweXpect.Results.StringEqualityTypeResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> HaveName(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject, string expected) { }
+        public static aweXpect.Results.StringEqualityTypeResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> HaveNamespace(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject, string expected) { }
     }
 }

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net8.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net8.0.txt
@@ -134,7 +134,7 @@ namespace aweXpect.Reflection
     }
     public static class ThatAssemblies
     {
-        public static aweXpect.Results.StringEqualityTypeResult<System.Collections.Generic.IEnumerable<System.Reflection.Assembly>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.Assembly>>> HaveName(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.Assembly>> subject, string expected) { }
+        public static aweXpect.Results.StringEqualityTypeResult<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>>> HaveName(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>> subject, string expected) { }
     }
     public static class ThatAssembly
     {

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_netstandard2.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_netstandard2.0.txt
@@ -132,6 +132,14 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Collections.Filtered.Assemblies EntryAssembly() { }
         public static aweXpect.Reflection.Collections.Filtered.Assemblies ExecutingAssembly() { }
     }
+    public static class ThatAssemblies
+    {
+        public static aweXpect.Results.StringEqualityTypeResult<System.Collections.Generic.IEnumerable<System.Reflection.Assembly>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.Assembly>>> HaveName(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.Assembly>> subject, string expected) { }
+    }
+    public static class ThatAssembly
+    {
+        public static aweXpect.Results.StringEqualityTypeResult<System.Reflection.Assembly?, aweXpect.Core.IThat<System.Reflection.Assembly?>> HasName(this aweXpect.Core.IThat<System.Reflection.Assembly?> subject, string expected) { }
+    }
     public static class ThatType
     {
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> Has<TAttribute>(this aweXpect.Core.IThat<System.Type?> subject, bool inherit = true)
@@ -157,21 +165,21 @@ namespace aweXpect.Reflection
     }
     public static class ThatTypes
     {
-        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type>>> AreAbstract(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type>> subject) { }
-        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type>>> AreGeneric(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type>> subject) { }
-        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type>>> AreNested(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type>> subject) { }
-        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type>>> AreNotAbstract(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type>> subject) { }
-        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type>>> AreNotGeneric(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type>> subject) { }
-        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type>>> AreNotNested(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type>> subject) { }
-        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type>>> AreNotSealed(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type>> subject) { }
-        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type>>> AreNotStatic(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type>> subject) { }
-        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type>>> AreSealed(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type>> subject) { }
-        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type>>> AreStatic(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type>> subject) { }
-        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type>>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type>> subject, bool inherit = true)
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreAbstract(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreGeneric(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreNested(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreNotAbstract(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreNotGeneric(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreNotNested(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreNotSealed(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreNotStatic(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreSealed(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreStatic(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject, bool inherit = true)
             where TAttribute : System.Attribute { }
-        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type>>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type>> subject, System.Func<TAttribute, bool>? predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject, System.Func<TAttribute, bool>? predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
             where TAttribute : System.Attribute { }
-        public static aweXpect.Results.StringEqualityTypeResult<System.Collections.Generic.IEnumerable<System.Type>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type>>> HaveName(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type>> subject, string expected) { }
-        public static aweXpect.Results.StringEqualityTypeResult<System.Collections.Generic.IEnumerable<System.Type>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type>>> HaveNamespace(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type>> subject, string expected) { }
+        public static aweXpect.Results.StringEqualityTypeResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> HaveName(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject, string expected) { }
+        public static aweXpect.Results.StringEqualityTypeResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> HaveNamespace(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject, string expected) { }
     }
 }

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_netstandard2.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_netstandard2.0.txt
@@ -134,7 +134,7 @@ namespace aweXpect.Reflection
     }
     public static class ThatAssemblies
     {
-        public static aweXpect.Results.StringEqualityTypeResult<System.Collections.Generic.IEnumerable<System.Reflection.Assembly>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.Assembly>>> HaveName(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.Assembly>> subject, string expected) { }
+        public static aweXpect.Results.StringEqualityTypeResult<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>>> HaveName(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>> subject, string expected) { }
     }
     public static class ThatAssembly
     {

--- a/Tests/aweXpect.Reflection.Tests/ThatAssemblies.HaveName.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatAssemblies.HaveName.Tests.cs
@@ -23,7 +23,7 @@ public sealed partial class ThatAssemblies
 					             Expected that in assembly containing type PublicAbstractClass
 					             all have name equal to "Reflection",
 					             but it contained not matching types [
-					               aweXpect.Reflection.Tests, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+					               aweXpect.Reflection.Tests, Version=*, Culture=neutral, PublicKeyToken=null
 					             ]
 					             """).AsWildcard();
 			}

--- a/Tests/aweXpect.Reflection.Tests/ThatAssemblies.HaveName.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatAssemblies.HaveName.Tests.cs
@@ -1,0 +1,65 @@
+﻿using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Tests.TestHelpers.Types;
+using Xunit.Sdk;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatAssemblies
+{
+	public sealed class HaveName
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenTypesContainTypeWithDifferentName_ShouldFail()
+			{
+				Filtered.Assemblies subject = In.AssemblyContaining<PublicAbstractClass>();
+
+				async Task Act()
+					=> await That(subject).HaveName("Reflection");
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that in assembly containing type PublicAbstractClass
+					             all have name equal to "Reflection",
+					             but it contained not matching types [
+					               aweXpect.Reflection.Tests, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+					             ]
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenTypesHaveName_ShouldSucceed()
+			{
+				Filtered.Assemblies subject = In.AssemblyContaining<PublicAbstractClass>();
+
+				async Task Act()
+					=> await That(subject).HaveName("aweXpect.Reflection.Tests");
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenTypesMatchIgnoringCase_ShouldSucceed()
+			{
+				Filtered.Assemblies subject = In.AssemblyContaining<PublicAbstractClass>();
+
+				async Task Act()
+					=> await That(subject).HaveName("AWExPECT.rEFLECTION.tESTS").IgnoringCase();
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenTypesMatchPrefix_ShouldSucceed()
+			{
+				Filtered.Assemblies subject = In.AssemblyContaining<PublicAbstractClass>();
+
+				async Task Act()
+					=> await That(subject).HaveName("aweXpect").AsPrefix();
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatAssemblies.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatAssemblies.cs
@@ -1,0 +1,5 @@
+﻿namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatAssemblies
+{
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatAssembly.HasName.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatAssembly.HasName.Tests.cs
@@ -1,0 +1,83 @@
+﻿using System.Reflection;
+using aweXpect.Reflection.Tests.TestHelpers.Types;
+using Xunit.Sdk;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatAssembly
+{
+	public sealed class HasName
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenExpectedValueIsOnlySubstring_ShouldFail()
+			{
+				Assembly subject = typeof(PublicAbstractClass).Assembly;
+
+				async Task Act()
+					=> await That(subject).HasName("Reflection");
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has name equal to "Reflection",
+					             but it was "aweXpect.Reflection.Tests" which differs at index 0:
+					                ↓ (actual)
+					               "aweXpect.Reflection.Tests"
+					               "Reflection"
+					                ↑ (expected)
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenTypeHasExpectedPrefix_ShouldSucceed()
+			{
+				Assembly subject = typeof(PublicAbstractClass).Assembly;
+
+				async Task Act()
+					=> await That(subject).HasName("aweXpect.Reflection").AsPrefix();
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenTypeHasMatchingName_ShouldSucceed()
+			{
+				Assembly subject = typeof(PublicAbstractClass).Assembly;
+
+				async Task Act()
+					=> await That(subject).HasName("aweXpect.Reflection.Tests");
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenTypeIsNull_ShouldFail()
+			{
+				Assembly? subject = null;
+
+				async Task Act()
+					=> await That(subject).HasName("foo");
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             has name equal to "foo",
+					             but it was <null>
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenTypeMatchesIgnoringCase_ShouldSucceed()
+			{
+				Assembly subject = typeof(PublicAbstractClass).Assembly;
+
+				async Task Act()
+					=> await That(subject).HasName("AWExPECT.rEFLECTION.tESTS").IgnoringCase();
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatAssembly.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatAssembly.cs
@@ -1,0 +1,3 @@
+﻿namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatAssembly;


### PR DESCRIPTION
Add expectation `HasName` for assemblies and make type collection expectation nullable.