### PR TITLE
feat: add `HasName` for missing reflection types

### DIFF
--- a/Source/aweXpect.Reflection/Collections/Filtered.Constructors.cs
+++ b/Source/aweXpect.Reflection/Collections/Filtered.Constructors.cs
@@ -40,7 +40,7 @@ public static partial class Filtered
 
 			if (_types is not null)
 			{
-				return description + _types.GetDescription();
+				return description + "in " + _types.GetDescription();
 			}
 
 			return description;

--- a/Source/aweXpect.Reflection/Collections/Filtered.Events.cs
+++ b/Source/aweXpect.Reflection/Collections/Filtered.Events.cs
@@ -40,7 +40,7 @@ public static partial class Filtered
 
 			if (_types is not null)
 			{
-				return description + _types.GetDescription();
+				return description + "in " + _types.GetDescription();
 			}
 
 			return description;

--- a/Source/aweXpect.Reflection/Collections/Filtered.Fields.cs
+++ b/Source/aweXpect.Reflection/Collections/Filtered.Fields.cs
@@ -40,7 +40,7 @@ public static partial class Filtered
 
 			if (_types is not null)
 			{
-				return description + _types.GetDescription();
+				return description + "in " + _types.GetDescription();
 			}
 
 			return description;

--- a/Source/aweXpect.Reflection/Collections/Filtered.Methods.cs
+++ b/Source/aweXpect.Reflection/Collections/Filtered.Methods.cs
@@ -49,7 +49,7 @@ public static partial class Filtered
 
 			if (_types is not null)
 			{
-				return description + _types.GetDescription();
+				return description + "in " + _types.GetDescription();
 			}
 
 			return description;

--- a/Source/aweXpect.Reflection/Collections/Filtered.Properties.cs
+++ b/Source/aweXpect.Reflection/Collections/Filtered.Properties.cs
@@ -40,7 +40,7 @@ public static partial class Filtered
 
 			if (_types is not null)
 			{
-				return description + _types.GetDescription();
+				return description + "in " + _types.GetDescription();
 			}
 
 			return description;

--- a/Source/aweXpect.Reflection/ThatAssemblies.HaveName.cs
+++ b/Source/aweXpect.Reflection/ThatAssemblies.HaveName.cs
@@ -52,7 +52,8 @@ public static partial class ThatAssemblies
 		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
 		{
 			stringBuilder.Append(it).Append(" contained not matching types ");
-			Formatter.Format(stringBuilder, Actual?.Where(type => !options.AreConsideredEqual(type?.GetName().Name, expected)),
+			Formatter.Format(stringBuilder,
+				Actual?.Where(type => !options.AreConsideredEqual(type?.GetName().Name, expected)),
 				FormattingOptions.Indented(indentation));
 		}
 
@@ -62,7 +63,8 @@ public static partial class ThatAssemblies
 		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
 		{
 			stringBuilder.Append(it).Append(" only contained matching types ");
-			Formatter.Format(stringBuilder, Actual?.Where(type => options.AreConsideredEqual(type?.GetName().Name, expected)),
+			Formatter.Format(stringBuilder,
+				Actual?.Where(type => options.AreConsideredEqual(type?.GetName().Name, expected)),
 				FormattingOptions.Indented(indentation));
 		}
 	}

--- a/Source/aweXpect.Reflection/ThatEvent.HasName.cs
+++ b/Source/aweXpect.Reflection/ThatEvent.HasName.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Reflection;
+using System.Text;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Options;
+using aweXpect.Reflection.Extensions;
+using aweXpect.Results;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Reflection;
+
+public static partial class ThatEvent
+{
+	/// <summary>
+	///     Verifies that the <see cref="EventInfo" /> has the <paramref name="expected" /> name.
+	/// </summary>
+	public static StringEqualityTypeResult<EventInfo?, IThat<EventInfo?>> HasName(
+		this IThat<EventInfo?> subject, string expected)
+	{
+		StringEqualityOptions options = new();
+		return new StringEqualityTypeResult<EventInfo?, IThat<EventInfo?>>(subject.Get().ExpectationBuilder.AddConstraint(
+				(it, grammars)
+					=> new HasNameConstraint(it, grammars, expected, options)),
+			subject,
+			options);
+	}
+
+	private sealed class HasNameConstraint(
+		string it,
+		ExpectationGrammars grammars,
+		string expected,
+		StringEqualityOptions options)
+		: ConstraintResult.WithNotNullValue<EventInfo?>(it, grammars),
+			IValueConstraint<EventInfo?>
+	{
+		public ConstraintResult IsMetBy(EventInfo? actual)
+		{
+			Actual = actual;
+			Outcome = options.AreConsideredEqual(actual?.Name, expected) ? Outcome.Success : Outcome.Failure;
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("has name ").Append(options.GetExpectation(expected, Grammars));
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append(options.GetExtendedFailure(It, Grammars, Actual?.Name, expected));
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("does not have name ").Append(options.GetExpectation(expected, Grammars));
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+			=> AppendNormalResult(stringBuilder, indentation);
+	}
+}

--- a/Source/aweXpect.Reflection/ThatEvent.HasName.cs
+++ b/Source/aweXpect.Reflection/ThatEvent.HasName.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using System.Text;
 using aweXpect.Core;
 using aweXpect.Core.Constraints;
@@ -20,9 +19,9 @@ public static partial class ThatEvent
 		this IThat<EventInfo?> subject, string expected)
 	{
 		StringEqualityOptions options = new();
-		return new StringEqualityTypeResult<EventInfo?, IThat<EventInfo?>>(subject.Get().ExpectationBuilder.AddConstraint(
-				(it, grammars)
-					=> new HasNameConstraint(it, grammars, expected, options)),
+		return new StringEqualityTypeResult<EventInfo?, IThat<EventInfo?>>(
+			subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new HasNameConstraint(it, grammars, expected, options)),
 			subject,
 			options);
 	}

--- a/Source/aweXpect.Reflection/ThatEvent.cs
+++ b/Source/aweXpect.Reflection/ThatEvent.cs
@@ -1,0 +1,8 @@
+﻿using System.Reflection;
+
+namespace aweXpect.Reflection;
+
+/// <summary>
+///     Expectations on <see cref="EventInfo" />.
+/// </summary>
+public static partial class ThatEvent;

--- a/Source/aweXpect.Reflection/ThatEvents.HaveName.cs
+++ b/Source/aweXpect.Reflection/ThatEvents.HaveName.cs
@@ -1,0 +1,69 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Options;
+using aweXpect.Reflection.Extensions;
+using aweXpect.Results;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Reflection;
+
+public static partial class ThatEvents
+{
+	/// <summary>
+	///     Verifies that all items in the filtered collection of <see cref="EventInfo" /> have
+	///     the <paramref name="expected" /> name.
+	/// </summary>
+	public static StringEqualityTypeResult<IEnumerable<EventInfo?>, IThat<IEnumerable<EventInfo?>>> HaveName(
+		this IThat<IEnumerable<EventInfo?>> subject, string expected)
+	{
+		StringEqualityOptions options = new();
+		return new StringEqualityTypeResult<IEnumerable<EventInfo?>, IThat<IEnumerable<EventInfo?>>>(subject.Get()
+				.ExpectationBuilder.AddConstraint((it, grammars)
+					=> new HaveNameConstraint(it, grammars, expected, options)),
+			subject,
+			options);
+	}
+
+	private sealed class HaveNameConstraint(
+		string it,
+		ExpectationGrammars grammars,
+		string expected,
+		StringEqualityOptions options)
+		: ConstraintResult.WithValue<IEnumerable<EventInfo?>>(grammars),
+			IValueConstraint<IEnumerable<EventInfo?>>
+	{
+		public ConstraintResult IsMetBy(IEnumerable<EventInfo?> actual)
+		{
+			Actual = actual;
+			Outcome = actual.All(type => options.AreConsideredEqual(type?.Name, expected))
+				? Outcome.Success
+				: Outcome.Failure;
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("all have name ").Append(options.GetExpectation(expected, Grammars));
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(it).Append(" contained not matching types ");
+			Formatter.Format(stringBuilder, Actual?.Where(type => !options.AreConsideredEqual(type?.Name, expected)),
+				FormattingOptions.Indented(indentation));
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("all have name ").Append(options.GetExpectation(expected, Grammars));
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(it).Append(" only contained matching types ");
+			Formatter.Format(stringBuilder, Actual?.Where(type => options.AreConsideredEqual(type?.Name, expected)),
+				FormattingOptions.Indented(indentation));
+		}
+	}
+}

--- a/Source/aweXpect.Reflection/ThatEvents.cs
+++ b/Source/aweXpect.Reflection/ThatEvents.cs
@@ -1,0 +1,10 @@
+﻿using System.Reflection;
+
+namespace aweXpect.Reflection;
+
+/// <summary>
+///     Expectations on a collection of <see cref="EventInfo" />.
+/// </summary>
+public static partial class ThatEvents
+{
+}

--- a/Source/aweXpect.Reflection/ThatField.HasName.cs
+++ b/Source/aweXpect.Reflection/ThatField.HasName.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Reflection;
+using System.Text;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Options;
+using aweXpect.Reflection.Extensions;
+using aweXpect.Results;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Reflection;
+
+public static partial class ThatField
+{
+	/// <summary>
+	///     Verifies that the <see cref="FieldInfo" /> has the <paramref name="expected" /> name.
+	/// </summary>
+	public static StringEqualityTypeResult<FieldInfo?, IThat<FieldInfo?>> HasName(
+		this IThat<FieldInfo?> subject, string expected)
+	{
+		StringEqualityOptions options = new();
+		return new StringEqualityTypeResult<FieldInfo?, IThat<FieldInfo?>>(subject.Get().ExpectationBuilder.AddConstraint(
+				(it, grammars)
+					=> new HasNameConstraint(it, grammars, expected, options)),
+			subject,
+			options);
+	}
+
+	private sealed class HasNameConstraint(
+		string it,
+		ExpectationGrammars grammars,
+		string expected,
+		StringEqualityOptions options)
+		: ConstraintResult.WithNotNullValue<FieldInfo?>(it, grammars),
+			IValueConstraint<FieldInfo?>
+	{
+		public ConstraintResult IsMetBy(FieldInfo? actual)
+		{
+			Actual = actual;
+			Outcome = options.AreConsideredEqual(actual?.Name, expected) ? Outcome.Success : Outcome.Failure;
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("has name ").Append(options.GetExpectation(expected, Grammars));
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append(options.GetExtendedFailure(It, Grammars, Actual?.Name, expected));
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("does not have name ").Append(options.GetExpectation(expected, Grammars));
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+			=> AppendNormalResult(stringBuilder, indentation);
+	}
+}

--- a/Source/aweXpect.Reflection/ThatField.HasName.cs
+++ b/Source/aweXpect.Reflection/ThatField.HasName.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using System.Text;
 using aweXpect.Core;
 using aweXpect.Core.Constraints;
@@ -20,9 +19,9 @@ public static partial class ThatField
 		this IThat<FieldInfo?> subject, string expected)
 	{
 		StringEqualityOptions options = new();
-		return new StringEqualityTypeResult<FieldInfo?, IThat<FieldInfo?>>(subject.Get().ExpectationBuilder.AddConstraint(
-				(it, grammars)
-					=> new HasNameConstraint(it, grammars, expected, options)),
+		return new StringEqualityTypeResult<FieldInfo?, IThat<FieldInfo?>>(
+			subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new HasNameConstraint(it, grammars, expected, options)),
 			subject,
 			options);
 	}

--- a/Source/aweXpect.Reflection/ThatField.cs
+++ b/Source/aweXpect.Reflection/ThatField.cs
@@ -1,0 +1,8 @@
+﻿using System.Reflection;
+
+namespace aweXpect.Reflection;
+
+/// <summary>
+///     Expectations on <see cref="FieldInfo" />.
+/// </summary>
+public static partial class ThatField;

--- a/Source/aweXpect.Reflection/ThatFields.HaveName.cs
+++ b/Source/aweXpect.Reflection/ThatFields.HaveName.cs
@@ -1,0 +1,69 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Options;
+using aweXpect.Reflection.Extensions;
+using aweXpect.Results;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Reflection;
+
+public static partial class ThatFields
+{
+	/// <summary>
+	///     Verifies that all items in the filtered collection of <see cref="FieldInfo" /> have
+	///     the <paramref name="expected" /> name.
+	/// </summary>
+	public static StringEqualityTypeResult<IEnumerable<FieldInfo?>, IThat<IEnumerable<FieldInfo?>>> HaveName(
+		this IThat<IEnumerable<FieldInfo?>> subject, string expected)
+	{
+		StringEqualityOptions options = new();
+		return new StringEqualityTypeResult<IEnumerable<FieldInfo?>, IThat<IEnumerable<FieldInfo?>>>(subject.Get()
+				.ExpectationBuilder.AddConstraint((it, grammars)
+					=> new HaveNameConstraint(it, grammars, expected, options)),
+			subject,
+			options);
+	}
+
+	private sealed class HaveNameConstraint(
+		string it,
+		ExpectationGrammars grammars,
+		string expected,
+		StringEqualityOptions options)
+		: ConstraintResult.WithValue<IEnumerable<FieldInfo?>>(grammars),
+			IValueConstraint<IEnumerable<FieldInfo?>>
+	{
+		public ConstraintResult IsMetBy(IEnumerable<FieldInfo?> actual)
+		{
+			Actual = actual;
+			Outcome = actual.All(type => options.AreConsideredEqual(type?.Name, expected))
+				? Outcome.Success
+				: Outcome.Failure;
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("all have name ").Append(options.GetExpectation(expected, Grammars));
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(it).Append(" contained not matching types ");
+			Formatter.Format(stringBuilder, Actual?.Where(type => !options.AreConsideredEqual(type?.Name, expected)),
+				FormattingOptions.Indented(indentation));
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("all have name ").Append(options.GetExpectation(expected, Grammars));
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(it).Append(" only contained matching types ");
+			Formatter.Format(stringBuilder, Actual?.Where(type => options.AreConsideredEqual(type?.Name, expected)),
+				FormattingOptions.Indented(indentation));
+		}
+	}
+}

--- a/Source/aweXpect.Reflection/ThatFields.cs
+++ b/Source/aweXpect.Reflection/ThatFields.cs
@@ -1,0 +1,10 @@
+﻿using System.Reflection;
+
+namespace aweXpect.Reflection;
+
+/// <summary>
+///     Expectations on a collection of <see cref="FieldInfo" />.
+/// </summary>
+public static partial class ThatFields
+{
+}

--- a/Source/aweXpect.Reflection/ThatMethod.HasName.cs
+++ b/Source/aweXpect.Reflection/ThatMethod.HasName.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Reflection;
+using System.Text;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Options;
+using aweXpect.Reflection.Extensions;
+using aweXpect.Results;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Reflection;
+
+public static partial class ThatMethod
+{
+	/// <summary>
+	///     Verifies that the <see cref="MethodInfo" /> has the <paramref name="expected" /> name.
+	/// </summary>
+	public static StringEqualityTypeResult<MethodInfo?, IThat<MethodInfo?>> HasName(
+		this IThat<MethodInfo?> subject, string expected)
+	{
+		StringEqualityOptions options = new();
+		return new StringEqualityTypeResult<MethodInfo?, IThat<MethodInfo?>>(subject.Get().ExpectationBuilder.AddConstraint(
+				(it, grammars)
+					=> new HasNameConstraint(it, grammars, expected, options)),
+			subject,
+			options);
+	}
+
+	private sealed class HasNameConstraint(
+		string it,
+		ExpectationGrammars grammars,
+		string expected,
+		StringEqualityOptions options)
+		: ConstraintResult.WithNotNullValue<MethodInfo?>(it, grammars),
+			IValueConstraint<MethodInfo?>
+	{
+		public ConstraintResult IsMetBy(MethodInfo? actual)
+		{
+			Actual = actual;
+			Outcome = options.AreConsideredEqual(actual?.Name, expected) ? Outcome.Success : Outcome.Failure;
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("has name ").Append(options.GetExpectation(expected, Grammars));
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append(options.GetExtendedFailure(It, Grammars, Actual?.Name, expected));
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("does not have name ").Append(options.GetExpectation(expected, Grammars));
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+			=> AppendNormalResult(stringBuilder, indentation);
+	}
+}

--- a/Source/aweXpect.Reflection/ThatMethod.HasName.cs
+++ b/Source/aweXpect.Reflection/ThatMethod.HasName.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using System.Text;
 using aweXpect.Core;
 using aweXpect.Core.Constraints;
@@ -20,9 +19,9 @@ public static partial class ThatMethod
 		this IThat<MethodInfo?> subject, string expected)
 	{
 		StringEqualityOptions options = new();
-		return new StringEqualityTypeResult<MethodInfo?, IThat<MethodInfo?>>(subject.Get().ExpectationBuilder.AddConstraint(
-				(it, grammars)
-					=> new HasNameConstraint(it, grammars, expected, options)),
+		return new StringEqualityTypeResult<MethodInfo?, IThat<MethodInfo?>>(
+			subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new HasNameConstraint(it, grammars, expected, options)),
 			subject,
 			options);
 	}

--- a/Source/aweXpect.Reflection/ThatMethod.cs
+++ b/Source/aweXpect.Reflection/ThatMethod.cs
@@ -1,0 +1,8 @@
+﻿using System.Reflection;
+
+namespace aweXpect.Reflection;
+
+/// <summary>
+///     Expectations on <see cref="MethodInfo" />.
+/// </summary>
+public static partial class ThatMethod;

--- a/Source/aweXpect.Reflection/ThatMethods.HaveName.cs
+++ b/Source/aweXpect.Reflection/ThatMethods.HaveName.cs
@@ -1,0 +1,69 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Options;
+using aweXpect.Reflection.Extensions;
+using aweXpect.Results;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Reflection;
+
+public static partial class ThatMethods
+{
+	/// <summary>
+	///     Verifies that all items in the filtered collection of <see cref="MethodInfo" /> have
+	///     the <paramref name="expected" /> name.
+	/// </summary>
+	public static StringEqualityTypeResult<IEnumerable<MethodInfo?>, IThat<IEnumerable<MethodInfo?>>> HaveName(
+		this IThat<IEnumerable<MethodInfo?>> subject, string expected)
+	{
+		StringEqualityOptions options = new();
+		return new StringEqualityTypeResult<IEnumerable<MethodInfo?>, IThat<IEnumerable<MethodInfo?>>>(subject.Get()
+				.ExpectationBuilder.AddConstraint((it, grammars)
+					=> new HaveNameConstraint(it, grammars, expected, options)),
+			subject,
+			options);
+	}
+
+	private sealed class HaveNameConstraint(
+		string it,
+		ExpectationGrammars grammars,
+		string expected,
+		StringEqualityOptions options)
+		: ConstraintResult.WithValue<IEnumerable<MethodInfo?>>(grammars),
+			IValueConstraint<IEnumerable<MethodInfo?>>
+	{
+		public ConstraintResult IsMetBy(IEnumerable<MethodInfo?> actual)
+		{
+			Actual = actual;
+			Outcome = actual.All(type => options.AreConsideredEqual(type?.Name, expected))
+				? Outcome.Success
+				: Outcome.Failure;
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("all have name ").Append(options.GetExpectation(expected, Grammars));
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(it).Append(" contained not matching types ");
+			Formatter.Format(stringBuilder, Actual?.Where(type => !options.AreConsideredEqual(type?.Name, expected)),
+				FormattingOptions.Indented(indentation));
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("all have name ").Append(options.GetExpectation(expected, Grammars));
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(it).Append(" only contained matching types ");
+			Formatter.Format(stringBuilder, Actual?.Where(type => options.AreConsideredEqual(type?.Name, expected)),
+				FormattingOptions.Indented(indentation));
+		}
+	}
+}

--- a/Source/aweXpect.Reflection/ThatMethods.cs
+++ b/Source/aweXpect.Reflection/ThatMethods.cs
@@ -1,0 +1,10 @@
+﻿using System.Reflection;
+
+namespace aweXpect.Reflection;
+
+/// <summary>
+///     Expectations on a collection of <see cref="MethodInfo" />.
+/// </summary>
+public static partial class ThatMethods
+{
+}

--- a/Source/aweXpect.Reflection/ThatProperties.HaveName.cs
+++ b/Source/aweXpect.Reflection/ThatProperties.HaveName.cs
@@ -1,0 +1,69 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Options;
+using aweXpect.Reflection.Extensions;
+using aweXpect.Results;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Reflection;
+
+public static partial class ThatProperties
+{
+	/// <summary>
+	///     Verifies that all items in the filtered collection of <see cref="PropertyInfo" /> have
+	///     the <paramref name="expected" /> name.
+	/// </summary>
+	public static StringEqualityTypeResult<IEnumerable<PropertyInfo?>, IThat<IEnumerable<PropertyInfo?>>> HaveName(
+		this IThat<IEnumerable<PropertyInfo?>> subject, string expected)
+	{
+		StringEqualityOptions options = new();
+		return new StringEqualityTypeResult<IEnumerable<PropertyInfo?>, IThat<IEnumerable<PropertyInfo?>>>(subject.Get()
+				.ExpectationBuilder.AddConstraint((it, grammars)
+					=> new HaveNameConstraint(it, grammars, expected, options)),
+			subject,
+			options);
+	}
+
+	private sealed class HaveNameConstraint(
+		string it,
+		ExpectationGrammars grammars,
+		string expected,
+		StringEqualityOptions options)
+		: ConstraintResult.WithValue<IEnumerable<PropertyInfo?>>(grammars),
+			IValueConstraint<IEnumerable<PropertyInfo?>>
+	{
+		public ConstraintResult IsMetBy(IEnumerable<PropertyInfo?> actual)
+		{
+			Actual = actual;
+			Outcome = actual.All(type => options.AreConsideredEqual(type?.Name, expected))
+				? Outcome.Success
+				: Outcome.Failure;
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("all have name ").Append(options.GetExpectation(expected, Grammars));
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(it).Append(" contained not matching types ");
+			Formatter.Format(stringBuilder, Actual?.Where(type => !options.AreConsideredEqual(type?.Name, expected)),
+				FormattingOptions.Indented(indentation));
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("all have name ").Append(options.GetExpectation(expected, Grammars));
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(it).Append(" only contained matching types ");
+			Formatter.Format(stringBuilder, Actual?.Where(type => options.AreConsideredEqual(type?.Name, expected)),
+				FormattingOptions.Indented(indentation));
+		}
+	}
+}

--- a/Source/aweXpect.Reflection/ThatProperties.cs
+++ b/Source/aweXpect.Reflection/ThatProperties.cs
@@ -1,0 +1,10 @@
+﻿using System.Reflection;
+
+namespace aweXpect.Reflection;
+
+/// <summary>
+///     Expectations on a collection of <see cref="PropertyInfo" />.
+/// </summary>
+public static partial class ThatProperties
+{
+}

--- a/Source/aweXpect.Reflection/ThatProperty.HasName.cs
+++ b/Source/aweXpect.Reflection/ThatProperty.HasName.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Reflection;
+using System.Text;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Options;
+using aweXpect.Reflection.Extensions;
+using aweXpect.Results;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Reflection;
+
+public static partial class ThatProperty
+{
+	/// <summary>
+	///     Verifies that the <see cref="PropertyInfo" /> has the <paramref name="expected" /> name.
+	/// </summary>
+	public static StringEqualityTypeResult<PropertyInfo?, IThat<PropertyInfo?>> HasName(
+		this IThat<PropertyInfo?> subject, string expected)
+	{
+		StringEqualityOptions options = new();
+		return new StringEqualityTypeResult<PropertyInfo?, IThat<PropertyInfo?>>(subject.Get().ExpectationBuilder.AddConstraint(
+				(it, grammars)
+					=> new HasNameConstraint(it, grammars, expected, options)),
+			subject,
+			options);
+	}
+
+	private sealed class HasNameConstraint(
+		string it,
+		ExpectationGrammars grammars,
+		string expected,
+		StringEqualityOptions options)
+		: ConstraintResult.WithNotNullValue<PropertyInfo?>(it, grammars),
+			IValueConstraint<PropertyInfo?>
+	{
+		public ConstraintResult IsMetBy(PropertyInfo? actual)
+		{
+			Actual = actual;
+			Outcome = options.AreConsideredEqual(actual?.Name, expected) ? Outcome.Success : Outcome.Failure;
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("has name ").Append(options.GetExpectation(expected, Grammars));
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append(options.GetExtendedFailure(It, Grammars, Actual?.Name, expected));
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("does not have name ").Append(options.GetExpectation(expected, Grammars));
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+			=> AppendNormalResult(stringBuilder, indentation);
+	}
+}

--- a/Source/aweXpect.Reflection/ThatProperty.HasName.cs
+++ b/Source/aweXpect.Reflection/ThatProperty.HasName.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Reflection;
+﻿using System.Reflection;
 using System.Text;
 using aweXpect.Core;
 using aweXpect.Core.Constraints;
@@ -20,9 +19,9 @@ public static partial class ThatProperty
 		this IThat<PropertyInfo?> subject, string expected)
 	{
 		StringEqualityOptions options = new();
-		return new StringEqualityTypeResult<PropertyInfo?, IThat<PropertyInfo?>>(subject.Get().ExpectationBuilder.AddConstraint(
-				(it, grammars)
-					=> new HasNameConstraint(it, grammars, expected, options)),
+		return new StringEqualityTypeResult<PropertyInfo?, IThat<PropertyInfo?>>(
+			subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new HasNameConstraint(it, grammars, expected, options)),
 			subject,
 			options);
 	}

--- a/Source/aweXpect.Reflection/ThatProperty.cs
+++ b/Source/aweXpect.Reflection/ThatProperty.cs
@@ -1,0 +1,8 @@
+﻿using System.Reflection;
+
+namespace aweXpect.Reflection;
+
+/// <summary>
+///     Expectations on <see cref="PropertyInfo" />.
+/// </summary>
+public static partial class ThatProperty;

--- a/Source/aweXpect.Reflection/ThatTypes.HaveNamespace.cs
+++ b/Source/aweXpect.Reflection/ThatTypes.HaveNamespace.cs
@@ -63,7 +63,8 @@ public static partial class ThatTypes
 		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
 		{
 			stringBuilder.Append(it).Append(" only contained matching types ");
-			Formatter.Format(stringBuilder, Actual?.Where(type => options.AreConsideredEqual(type?.Namespace, expected)),
+			Formatter.Format(stringBuilder,
+				Actual?.Where(type => options.AreConsideredEqual(type?.Namespace, expected)),
 				FormattingOptions.Indented(indentation));
 		}
 	}

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net8.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net8.0.txt
@@ -166,6 +166,14 @@ namespace aweXpect.Reflection
     {
         public static aweXpect.Results.StringEqualityTypeResult<System.Reflection.Assembly?, aweXpect.Core.IThat<System.Reflection.Assembly?>> HasName(this aweXpect.Core.IThat<System.Reflection.Assembly?> subject, string expected) { }
     }
+    public static class ThatProperties
+    {
+        public static aweXpect.Results.StringEqualityTypeResult<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>>> HaveName(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>> subject, string expected) { }
+    }
+    public static class ThatProperty
+    {
+        public static aweXpect.Results.StringEqualityTypeResult<System.Reflection.PropertyInfo?, aweXpect.Core.IThat<System.Reflection.PropertyInfo?>> HasName(this aweXpect.Core.IThat<System.Reflection.PropertyInfo?> subject, string expected) { }
+    }
     public static class ThatType
     {
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> Has<TAttribute>(this aweXpect.Core.IThat<System.Type?> subject, bool inherit = true)

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net8.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net8.0.txt
@@ -166,6 +166,30 @@ namespace aweXpect.Reflection
     {
         public static aweXpect.Results.StringEqualityTypeResult<System.Reflection.Assembly?, aweXpect.Core.IThat<System.Reflection.Assembly?>> HasName(this aweXpect.Core.IThat<System.Reflection.Assembly?> subject, string expected) { }
     }
+    public static class ThatEvent
+    {
+        public static aweXpect.Results.StringEqualityTypeResult<System.Reflection.EventInfo?, aweXpect.Core.IThat<System.Reflection.EventInfo?>> HasName(this aweXpect.Core.IThat<System.Reflection.EventInfo?> subject, string expected) { }
+    }
+    public static class ThatEvents
+    {
+        public static aweXpect.Results.StringEqualityTypeResult<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>>> HaveName(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>> subject, string expected) { }
+    }
+    public static class ThatField
+    {
+        public static aweXpect.Results.StringEqualityTypeResult<System.Reflection.FieldInfo?, aweXpect.Core.IThat<System.Reflection.FieldInfo?>> HasName(this aweXpect.Core.IThat<System.Reflection.FieldInfo?> subject, string expected) { }
+    }
+    public static class ThatFields
+    {
+        public static aweXpect.Results.StringEqualityTypeResult<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>>> HaveName(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>> subject, string expected) { }
+    }
+    public static class ThatMethod
+    {
+        public static aweXpect.Results.StringEqualityTypeResult<System.Reflection.MethodInfo?, aweXpect.Core.IThat<System.Reflection.MethodInfo?>> HasName(this aweXpect.Core.IThat<System.Reflection.MethodInfo?> subject, string expected) { }
+    }
+    public static class ThatMethods
+    {
+        public static aweXpect.Results.StringEqualityTypeResult<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo?>>> HaveName(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo?>> subject, string expected) { }
+    }
     public static class ThatProperties
     {
         public static aweXpect.Results.StringEqualityTypeResult<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>>> HaveName(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>> subject, string expected) { }

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_netstandard2.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_netstandard2.0.txt
@@ -166,6 +166,14 @@ namespace aweXpect.Reflection
     {
         public static aweXpect.Results.StringEqualityTypeResult<System.Reflection.Assembly?, aweXpect.Core.IThat<System.Reflection.Assembly?>> HasName(this aweXpect.Core.IThat<System.Reflection.Assembly?> subject, string expected) { }
     }
+    public static class ThatProperties
+    {
+        public static aweXpect.Results.StringEqualityTypeResult<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>>> HaveName(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>> subject, string expected) { }
+    }
+    public static class ThatProperty
+    {
+        public static aweXpect.Results.StringEqualityTypeResult<System.Reflection.PropertyInfo?, aweXpect.Core.IThat<System.Reflection.PropertyInfo?>> HasName(this aweXpect.Core.IThat<System.Reflection.PropertyInfo?> subject, string expected) { }
+    }
     public static class ThatType
     {
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> Has<TAttribute>(this aweXpect.Core.IThat<System.Type?> subject, bool inherit = true)

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_netstandard2.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_netstandard2.0.txt
@@ -166,6 +166,30 @@ namespace aweXpect.Reflection
     {
         public static aweXpect.Results.StringEqualityTypeResult<System.Reflection.Assembly?, aweXpect.Core.IThat<System.Reflection.Assembly?>> HasName(this aweXpect.Core.IThat<System.Reflection.Assembly?> subject, string expected) { }
     }
+    public static class ThatEvent
+    {
+        public static aweXpect.Results.StringEqualityTypeResult<System.Reflection.EventInfo?, aweXpect.Core.IThat<System.Reflection.EventInfo?>> HasName(this aweXpect.Core.IThat<System.Reflection.EventInfo?> subject, string expected) { }
+    }
+    public static class ThatEvents
+    {
+        public static aweXpect.Results.StringEqualityTypeResult<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>>> HaveName(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>> subject, string expected) { }
+    }
+    public static class ThatField
+    {
+        public static aweXpect.Results.StringEqualityTypeResult<System.Reflection.FieldInfo?, aweXpect.Core.IThat<System.Reflection.FieldInfo?>> HasName(this aweXpect.Core.IThat<System.Reflection.FieldInfo?> subject, string expected) { }
+    }
+    public static class ThatFields
+    {
+        public static aweXpect.Results.StringEqualityTypeResult<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>>> HaveName(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>> subject, string expected) { }
+    }
+    public static class ThatMethod
+    {
+        public static aweXpect.Results.StringEqualityTypeResult<System.Reflection.MethodInfo?, aweXpect.Core.IThat<System.Reflection.MethodInfo?>> HasName(this aweXpect.Core.IThat<System.Reflection.MethodInfo?> subject, string expected) { }
+    }
+    public static class ThatMethods
+    {
+        public static aweXpect.Results.StringEqualityTypeResult<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo?>>> HaveName(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo?>> subject, string expected) { }
+    }
     public static class ThatProperties
     {
         public static aweXpect.Results.StringEqualityTypeResult<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>>> HaveName(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>> subject, string expected) { }

--- a/Tests/aweXpect.Reflection.Tests/Collections/FilteredExtensions.Types.WithName.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Collections/FilteredExtensions.Types.WithName.Tests.cs
@@ -30,7 +30,8 @@ public sealed partial class FilteredExtensions
 
 					await That(types).HasSingle().Which.IsEqualTo(typeof(SomeClassToVerifyTheNameOfIt));
 					await That(types.GetDescription())
-						.IsEqualTo("types with name starting with \"SomeClassToVerifyTheNameOf\" in assembly").AsPrefix();
+						.IsEqualTo("types with name starting with \"SomeClassToVerifyTheNameOf\" in assembly")
+						.AsPrefix();
 				}
 
 				[Fact]

--- a/Tests/aweXpect.Reflection.Tests/Collections/FilteredExtensions.Types.WithNamespace.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Collections/FilteredExtensions.Types.WithNamespace.Tests.cs
@@ -16,22 +16,26 @@ public sealed partial class FilteredExtensions
 				public async Task ShouldFilterForTypesWithNamespace()
 				{
 					Reflection.Collections.Filtered.Types types = In.AssemblyContaining<FilteredExtensions>()
-						.Types().WithNamespace("aweXpect.Reflection.Tests.TestHelpers.Types.ToVerifyingTheNamespaceOfIt");
+						.Types().WithNamespace(
+							"aweXpect.Reflection.Tests.TestHelpers.Types.ToVerifyingTheNamespaceOfIt");
 
 					await That(types).HasSingle().Which.IsEqualTo(typeof(SomeClassToVerifyTheNamespaceOfIt));
 					await That(types.GetDescription())
-						.IsEqualTo("types with namespace equal to \"aweXpect.Reflection.Tests.Test…\" in assembly").AsPrefix();
+						.IsEqualTo("types with namespace equal to \"aweXpect.Reflection.Tests.Test…\" in assembly")
+						.AsPrefix();
 				}
 
 				[Fact]
 				public async Task ShouldSupportAsPrefix()
 				{
 					Reflection.Collections.Filtered.Types types = In.AssemblyContaining<FilteredExtensions>()
-						.Types().WithNamespace("aweXpect.Reflection.Tests.TestHelpers.Types.ToVerifyingTheNamespaceOf").AsPrefix();
+						.Types().WithNamespace("aweXpect.Reflection.Tests.TestHelpers.Types.ToVerifyingTheNamespaceOf")
+						.AsPrefix();
 
 					await That(types).HasSingle().Which.IsEqualTo(typeof(SomeClassToVerifyTheNamespaceOfIt));
 					await That(types.GetDescription())
-						.IsEqualTo("types with namespace starting with \"aweXpect.Reflection.Tests.Test…\" in assembly").AsPrefix();
+						.IsEqualTo("types with namespace starting with \"aweXpect.Reflection.Tests.Test…\" in assembly")
+						.AsPrefix();
 				}
 
 				[Fact]
@@ -42,7 +46,8 @@ public sealed partial class FilteredExtensions
 
 					await That(types).HasSingle().Which.IsEqualTo(typeof(SomeClassToVerifyTheNamespaceOfIt));
 					await That(types.GetDescription())
-						.IsEqualTo("types with namespace matching regex \"[a-zA-Z\\.]*VerifyingTheNamespa…\" in assembly")
+						.IsEqualTo(
+							"types with namespace matching regex \"[a-zA-Z\\.]*VerifyingTheNamespa…\" in assembly")
 						.AsPrefix();
 				}
 
@@ -54,7 +59,8 @@ public sealed partial class FilteredExtensions
 
 					await That(types).HasSingle().Which.IsEqualTo(typeof(SomeClassToVerifyTheNamespaceOfIt));
 					await That(types.GetDescription())
-						.IsEqualTo("types with namespace ending with \"VerifyingTheNamespaceOfIt\" in assembly").AsPrefix();
+						.IsEqualTo("types with namespace ending with \"VerifyingTheNamespaceOfIt\" in assembly")
+						.AsPrefix();
 				}
 
 				[Fact]
@@ -65,25 +71,29 @@ public sealed partial class FilteredExtensions
 
 					await That(types).HasSingle().Which.IsEqualTo(typeof(SomeClassToVerifyTheNamespaceOfIt));
 					await That(types.GetDescription())
-						.IsEqualTo("types with namespace matching \"*ToVerifyingTheNamespaceOf*\" in assembly").AsPrefix();
+						.IsEqualTo("types with namespace matching \"*ToVerifyingTheNamespaceOf*\" in assembly")
+						.AsPrefix();
 				}
 
 				[Fact]
 				public async Task ShouldSupportExactly()
 				{
 					Reflection.Collections.Filtered.Types types = In.AssemblyContaining<FilteredExtensions>()
-						.Types().WithNamespace("aweXpect.Reflection.Tests.TestHelpers.Types.ToVerifyingTheNamespaceOfIt").Exactly();
+						.Types().WithNamespace(
+							"aweXpect.Reflection.Tests.TestHelpers.Types.ToVerifyingTheNamespaceOfIt").Exactly();
 
 					await That(types).HasSingle().Which.IsEqualTo(typeof(SomeClassToVerifyTheNamespaceOfIt));
 					await That(types.GetDescription())
-						.IsEqualTo("types with namespace equal to \"aweXpect.Reflection.Tests.Test…\" in assembly").AsPrefix();
+						.IsEqualTo("types with namespace equal to \"aweXpect.Reflection.Tests.Test…\" in assembly")
+						.AsPrefix();
 				}
 
 				[Fact]
 				public async Task ShouldSupportIgnoringCase()
 				{
 					Reflection.Collections.Filtered.Types types = In.AssemblyContaining<FilteredExtensions>()
-						.Types().WithNamespace("aweXpect.Reflection.Tests.TestHelpers.Types.ToVerifyingTheNamespaceOfIt".ToLowerInvariant()).IgnoringCase();
+						.Types().WithNamespace("aweXpect.Reflection.Tests.TestHelpers.Types.ToVerifyingTheNamespaceOfIt"
+							.ToLowerInvariant()).IgnoringCase();
 
 					await That(types).HasSingle().Which.IsEqualTo(typeof(SomeClassToVerifyTheNamespaceOfIt));
 					await That(types.GetDescription())
@@ -96,7 +106,8 @@ public sealed partial class FilteredExtensions
 				public async Task ShouldSupportIgnoringLeadingWhiteSpace()
 				{
 					Reflection.Collections.Filtered.Types types = In.AssemblyContaining<FilteredExtensions>()
-						.Types().WithNamespace("\t aweXpect.Reflection.Tests.TestHelpers.Types.ToVerifyingTheNamespaceOfIt")
+						.Types().WithNamespace(
+							"\t aweXpect.Reflection.Tests.TestHelpers.Types.ToVerifyingTheNamespaceOfIt")
 						.IgnoringLeadingWhiteSpace();
 
 					await That(types).HasSingle().Which.IsEqualTo(typeof(SomeClassToVerifyTheNamespaceOfIt));
@@ -110,7 +121,8 @@ public sealed partial class FilteredExtensions
 				public async Task ShouldSupportIgnoringTrailingWhiteSpace()
 				{
 					Reflection.Collections.Filtered.Types types = In.AssemblyContaining<FilteredExtensions>()
-						.Types().WithNamespace("aweXpect.Reflection.Tests.TestHelpers.Types.ToVerifyingTheNamespaceOfIt\t ")
+						.Types().WithNamespace(
+							"aweXpect.Reflection.Tests.TestHelpers.Types.ToVerifyingTheNamespaceOfIt\t ")
 						.IgnoringTrailingWhiteSpace();
 
 					await That(types).HasSingle().Which.IsEqualTo(typeof(SomeClassToVerifyTheNamespaceOfIt));
@@ -124,7 +136,8 @@ public sealed partial class FilteredExtensions
 				public async Task ShouldSupportUsingCustomComparer()
 				{
 					Reflection.Collections.Filtered.Types types = In.AssemblyContaining<FilteredExtensions>()
-						.Types().WithNamespace("AwEXpEct.REflEctIOn.TEsts.TEstHelpers.Types.ToVerifyingTheNamespaceOfIt")
+						.Types().WithNamespace(
+							"AwEXpEct.REflEctIOn.TEsts.TEstHelpers.Types.ToVerifyingTheNamespaceOfIt")
 						.Using(new IgnoreCaseForVocalsComparer());
 
 					await That(types).HasSingle().Which.IsEqualTo(typeof(SomeClassToVerifyTheNamespaceOfIt));

--- a/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/SomeClassToVerifyTheNamespaceOfIt.cs
+++ b/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/SomeClassToVerifyTheNamespaceOfIt.cs
@@ -1,4 +1,5 @@
 ﻿// ReSharper disable once CheckNamespace
+
 namespace aweXpect.Reflection.Tests.TestHelpers.Types.ToVerifyingTheNamespaceOfIt;
 
 public class SomeClassToVerifyTheNamespaceOfIt;

--- a/Tests/aweXpect.Reflection.Tests/ThatEvent.HasName.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatEvent.HasName.Tests.cs
@@ -10,27 +10,6 @@ public sealed partial class ThatEvent
 		public sealed class Tests
 		{
 			[Fact]
-			public async Task WhenExpectedValueIsOnlySubstring_ShouldFail()
-			{
-				EventInfo? subject =
-					typeof(ClassWithEvents).GetEvent(nameof(ClassWithEvents.PublicEvent));
-
-				async Task Act()
-					=> await That(subject).HasName("Event");
-
-				await That(Act).Throws<XunitException>()
-					.WithMessage("""
-					             Expected that subject
-					             has name equal to "Event",
-					             but it was "PublicEvent" which differs at index 0:
-					                ↓ (actual)
-					               "PublicEvent"
-					               "Event"
-					                ↑ (expected)
-					             """);
-			}
-
-			[Fact]
 			public async Task WhenEventInfoHasExpectedPrefix_ShouldSucceed()
 			{
 				EventInfo? subject =
@@ -80,6 +59,27 @@ public sealed partial class ThatEvent
 					=> await That(subject).HasName("pUBLICevent").IgnoringCase();
 
 				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenExpectedValueIsOnlySubstring_ShouldFail()
+			{
+				EventInfo? subject =
+					typeof(ClassWithEvents).GetEvent(nameof(ClassWithEvents.PublicEvent));
+
+				async Task Act()
+					=> await That(subject).HasName("Event");
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has name equal to "Event",
+					             but it was "PublicEvent" which differs at index 0:
+					                ↓ (actual)
+					               "PublicEvent"
+					               "Event"
+					                ↑ (expected)
+					             """);
 			}
 		}
 	}

--- a/Tests/aweXpect.Reflection.Tests/ThatEvent.HasName.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatEvent.HasName.Tests.cs
@@ -1,0 +1,86 @@
+﻿using System.Reflection;
+using Xunit.Sdk;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatEvent
+{
+	public sealed class HasName
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenExpectedValueIsOnlySubstring_ShouldFail()
+			{
+				EventInfo? subject =
+					typeof(ClassWithEvents).GetEvent(nameof(ClassWithEvents.PublicEvent));
+
+				async Task Act()
+					=> await That(subject).HasName("Event");
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has name equal to "Event",
+					             but it was "PublicEvent" which differs at index 0:
+					                ↓ (actual)
+					               "PublicEvent"
+					               "Event"
+					                ↑ (expected)
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenEventInfoHasExpectedPrefix_ShouldSucceed()
+			{
+				EventInfo? subject =
+					typeof(ClassWithEvents).GetEvent(nameof(ClassWithEvents.PublicEvent));
+
+				async Task Act()
+					=> await That(subject).HasName("Public").AsPrefix();
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenEventInfoHasMatchingName_ShouldSucceed()
+			{
+				EventInfo? subject =
+					typeof(ClassWithEvents).GetEvent(nameof(ClassWithEvents.PublicEvent));
+
+				async Task Act()
+					=> await That(subject).HasName("PublicEvent");
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenEventInfoIsNull_ShouldFail()
+			{
+				EventInfo? subject = null;
+
+				async Task Act()
+					=> await That(subject).HasName("foo");
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             has name equal to "foo",
+					             but it was <null>
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenEventInfoMatchesIgnoringCase_ShouldSucceed()
+			{
+				EventInfo? subject =
+					typeof(ClassWithEvents).GetEvent(nameof(ClassWithEvents.PublicEvent));
+
+				async Task Act()
+					=> await That(subject).HasName("pUBLICevent").IgnoringCase();
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatEvent.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatEvent.cs
@@ -2,6 +2,8 @@
 
 public sealed partial class ThatEvent
 {
+#pragma warning disable CS8618
+#pragma warning disable CS0067
 	public class ClassWithEvents
 	{
 		public event EventHandler PublicEvent;
@@ -14,4 +16,6 @@ public sealed partial class ThatEvent
 	{
 		public event EventHandler MyEvent;
 	}
+#pragma warning restore CS0067
+#pragma warning restore CS8618
 }

--- a/Tests/aweXpect.Reflection.Tests/ThatEvent.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatEvent.cs
@@ -9,6 +9,7 @@ public sealed partial class ThatEvent
 		protected event EventHandler ProtectedEvent;
 		private event EventHandler PrivateEvent;
 	}
+
 	public class ClassWithSingleEvent
 	{
 		public event EventHandler MyEvent;

--- a/Tests/aweXpect.Reflection.Tests/ThatEvent.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatEvent.cs
@@ -1,0 +1,16 @@
+﻿namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatEvent
+{
+	public class ClassWithEvents
+	{
+		public event EventHandler PublicEvent;
+		internal event EventHandler InternalEvent;
+		protected event EventHandler ProtectedEvent;
+		private event EventHandler PrivateEvent;
+	}
+	public class ClassWithSingleEvent
+	{
+		public event EventHandler MyEvent;
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatEvents.HaveName.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatEvents.HaveName.Tests.cs
@@ -1,0 +1,64 @@
+﻿using aweXpect.Reflection.Collections;
+using Xunit.Sdk;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatEvents
+{
+	public sealed class HaveName
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenEventInfosContainEventInfoWithDifferentName_ShouldFail()
+			{
+				Filtered.Events subject = GetTypes<ThatEvent.ClassWithEvents>().Events();
+
+				async Task Act()
+					=> await That(subject).HaveName("PublicEvent");
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that events in types matching t => t == typeof(T) in assembly containing type ThatEvent.ClassWithEvents
+					             all have name equal to "PublicEvent",
+					             but it contained not matching types [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenEventInfosHaveName_ShouldSucceed()
+			{
+				Filtered.Events subject = GetTypes<ThatEvent.ClassWithSingleEvent>().Events();
+
+				async Task Act()
+					=> await That(subject).HaveName("MyEvent");
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenEventInfosMatchIgnoringCase_ShouldSucceed()
+			{
+				Filtered.Events subject = GetTypes<ThatEvent.ClassWithSingleEvent>().Events();
+
+				async Task Act()
+					=> await That(subject).HaveName("mYevent").IgnoringCase();
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenEventInfosMatchSuffix_ShouldSucceed()
+			{
+				Filtered.Events subject = GetTypes<ThatEvent.ClassWithEvents>().Events();
+
+				async Task Act()
+					=> await That(subject).HaveName("Event").AsSuffix();
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatEvents.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatEvents.cs
@@ -1,0 +1,9 @@
+﻿using aweXpect.Reflection.Collections;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatEvents
+{
+	public static Filtered.Types GetTypes<T>()
+		=> In.AssemblyContaining<T>().Types().Which(t => t == typeof(T));
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatField.HasName.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatField.HasName.Tests.cs
@@ -1,0 +1,86 @@
+﻿using System.Reflection;
+using Xunit.Sdk;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatField
+{
+	public sealed class HasName
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenExpectedValueIsOnlySubstring_ShouldFail()
+			{
+				FieldInfo? subject =
+					typeof(ClassWithFields).GetField(nameof(ClassWithFields.PublicField));
+
+				async Task Act()
+					=> await That(subject).HasName("Field");
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has name equal to "Field",
+					             but it was "PublicField" which differs at index 0:
+					                ↓ (actual)
+					               "PublicField"
+					               "Field"
+					                ↑ (expected)
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenFieldInfoHasExpectedPrefix_ShouldSucceed()
+			{
+				FieldInfo? subject =
+					typeof(ClassWithFields).GetField(nameof(ClassWithFields.PublicField));
+
+				async Task Act()
+					=> await That(subject).HasName("Public").AsPrefix();
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenFieldInfoHasMatchingName_ShouldSucceed()
+			{
+				FieldInfo? subject =
+					typeof(ClassWithFields).GetField(nameof(ClassWithFields.PublicField));
+
+				async Task Act()
+					=> await That(subject).HasName("PublicField");
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenFieldInfoIsNull_ShouldFail()
+			{
+				FieldInfo? subject = null;
+
+				async Task Act()
+					=> await That(subject).HasName("foo");
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             has name equal to "foo",
+					             but it was <null>
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenFieldInfoMatchesIgnoringCase_ShouldSucceed()
+			{
+				FieldInfo? subject =
+					typeof(ClassWithFields).GetField(nameof(ClassWithFields.PublicField));
+
+				async Task Act()
+					=> await That(subject).HasName("pUBLICfIELD").IgnoringCase();
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatField.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatField.cs
@@ -2,6 +2,8 @@
 
 public sealed partial class ThatField
 {
+#pragma warning disable CS0169
+#pragma warning disable CS0649
 	public class ClassWithFields
 	{
 		internal int InternalField;
@@ -14,4 +16,6 @@ public sealed partial class ThatField
 	{
 		public int MyField;
 	}
+#pragma warning restore CS0649
+#pragma warning restore CS0169
 }

--- a/Tests/aweXpect.Reflection.Tests/ThatField.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatField.cs
@@ -4,11 +4,12 @@ public sealed partial class ThatField
 {
 	public class ClassWithFields
 	{
-		public int PublicField;
 		internal int InternalField;
-		protected int ProtectedField;
 		private int PrivateField;
+		protected int ProtectedField;
+		public int PublicField;
 	}
+
 	public class ClassWithSingleField
 	{
 		public int MyField;

--- a/Tests/aweXpect.Reflection.Tests/ThatField.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatField.cs
@@ -1,0 +1,16 @@
+﻿namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatField
+{
+	public class ClassWithFields
+	{
+		public int PublicField;
+		internal int InternalField;
+		protected int ProtectedField;
+		private int PrivateField;
+	}
+	public class ClassWithSingleField
+	{
+		public int MyField;
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatFields.HaveName.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatFields.HaveName.Tests.cs
@@ -1,0 +1,64 @@
+﻿using aweXpect.Reflection.Collections;
+using Xunit.Sdk;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatFields
+{
+	public sealed class HaveName
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenFieldInfosContainFieldInfoWithDifferentName_ShouldFail()
+			{
+				Filtered.Fields subject = GetTypes<ThatField.ClassWithFields>().Fields();
+
+				async Task Act()
+					=> await That(subject).HaveName("PublicField");
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that fields in types matching t => t == typeof(T) in assembly containing type ThatField.ClassWithFields
+					             all have name equal to "PublicField",
+					             but it contained not matching types [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenFieldInfosHaveName_ShouldSucceed()
+			{
+				Filtered.Fields subject = GetTypes<ThatField.ClassWithSingleField>().Fields();
+
+				async Task Act()
+					=> await That(subject).HaveName("MyField");
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenFieldInfosMatchIgnoringCase_ShouldSucceed()
+			{
+				Filtered.Fields subject = GetTypes<ThatField.ClassWithSingleField>().Fields();
+
+				async Task Act()
+					=> await That(subject).HaveName("mYfIELD").IgnoringCase();
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenFieldInfosMatchSuffix_ShouldSucceed()
+			{
+				Filtered.Fields subject = GetTypes<ThatField.ClassWithFields>().Fields();
+
+				async Task Act()
+					=> await That(subject).HaveName("Field").AsSuffix();
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatFields.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatFields.cs
@@ -1,0 +1,9 @@
+﻿using aweXpect.Reflection.Collections;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatFields
+{
+	public static Filtered.Types GetTypes<T>()
+		=> In.AssemblyContaining<T>().Types().Which(t => t == typeof(T));
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatMethod.HasName.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethod.HasName.Tests.cs
@@ -1,0 +1,86 @@
+﻿using System.Reflection;
+using Xunit.Sdk;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatMethod
+{
+	public sealed class HasName
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenExpectedValueIsOnlySubstring_ShouldFail()
+			{
+				MethodInfo? subject =
+					typeof(ClassWithMethods).GetMethod(nameof(ClassWithMethods.PublicMethod));
+
+				async Task Act()
+					=> await That(subject).HasName("Method");
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has name equal to "Method",
+					             but it was "PublicMethod" which differs at index 0:
+					                ↓ (actual)
+					               "PublicMethod"
+					               "Method"
+					                ↑ (expected)
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenMethodInfoHasExpectedPrefix_ShouldSucceed()
+			{
+				MethodInfo? subject =
+					typeof(ClassWithMethods).GetMethod(nameof(ClassWithMethods.PublicMethod));
+
+				async Task Act()
+					=> await That(subject).HasName("Public").AsPrefix();
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenMethodInfoHasMatchingName_ShouldSucceed()
+			{
+				MethodInfo? subject =
+					typeof(ClassWithMethods).GetMethod(nameof(ClassWithMethods.PublicMethod));
+
+				async Task Act()
+					=> await That(subject).HasName("PublicMethod");
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenMethodInfoIsNull_ShouldFail()
+			{
+				MethodInfo? subject = null;
+
+				async Task Act()
+					=> await That(subject).HasName("foo");
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             has name equal to "foo",
+					             but it was <null>
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenMethodInfoMatchesIgnoringCase_ShouldSucceed()
+			{
+				MethodInfo? subject =
+					typeof(ClassWithMethods).GetMethod(nameof(ClassWithMethods.PublicMethod));
+
+				async Task Act()
+					=> await That(subject).HasName("pUBLICmethod").IgnoringCase();
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatMethod.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethod.cs
@@ -1,0 +1,16 @@
+﻿namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatMethod
+{
+	public class ClassWithMethods
+	{
+		public int PublicMethod() => 0;
+		internal int InternalMethod() => 0;
+		protected int ProtectedMethod() => 0;
+		private int PrivateMethod() => 0;
+	}
+	public class ClassWithSingleMethod
+	{
+		public int MyMethod() => 0;
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatMethod.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethod.cs
@@ -2,6 +2,7 @@
 
 public sealed partial class ThatMethod
 {
+#pragma warning disable CA1822
 	public class ClassWithMethods
 	{
 		public int PublicMethod() => 0;
@@ -14,4 +15,5 @@ public sealed partial class ThatMethod
 	{
 		public int MyMethod() => 0;
 	}
+#pragma warning restore CA1822
 }

--- a/Tests/aweXpect.Reflection.Tests/ThatMethod.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethod.cs
@@ -9,6 +9,7 @@ public sealed partial class ThatMethod
 		protected int ProtectedMethod() => 0;
 		private int PrivateMethod() => 0;
 	}
+
 	public class ClassWithSingleMethod
 	{
 		public int MyMethod() => 0;

--- a/Tests/aweXpect.Reflection.Tests/ThatMethods.HaveName.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethods.HaveName.Tests.cs
@@ -1,0 +1,64 @@
+﻿using aweXpect.Reflection.Collections;
+using Xunit.Sdk;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatMethods
+{
+	public sealed class HaveName
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenMethodInfosContainMethodInfoWithDifferentName_ShouldFail()
+			{
+				Filtered.Methods subject = GetTypes<ThatMethod.ClassWithMethods>().Methods();
+
+				async Task Act()
+					=> await That(subject).HaveName("PublicMethod");
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methods in types matching t => t == typeof(T) in assembly containing type ThatMethod.ClassWithMethods
+					             all have name equal to "PublicMethod",
+					             but it contained not matching types [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenMethodInfosHaveName_ShouldSucceed()
+			{
+				Filtered.Methods subject = GetTypes<ThatMethod.ClassWithSingleMethod>().Methods();
+
+				async Task Act()
+					=> await That(subject).HaveName("MyMethod");
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenMethodInfosMatchIgnoringCase_ShouldSucceed()
+			{
+				Filtered.Methods subject = GetTypes<ThatMethod.ClassWithSingleMethod>().Methods();
+
+				async Task Act()
+					=> await That(subject).HaveName("mYmethod").IgnoringCase();
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenMethodInfosMatchSuffix_ShouldSucceed()
+			{
+				Filtered.Methods subject = GetTypes<ThatMethod.ClassWithMethods>().Methods();
+
+				async Task Act()
+					=> await That(subject).HaveName("Method").AsSuffix();
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatMethods.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethods.cs
@@ -1,0 +1,9 @@
+﻿using aweXpect.Reflection.Collections;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatMethods
+{
+	public static Filtered.Types GetTypes<T>()
+		=> In.AssemblyContaining<T>().Types().Which(t => t == typeof(T));
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatProperties.HaveName.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatProperties.HaveName.Tests.cs
@@ -1,0 +1,64 @@
+﻿using aweXpect.Reflection.Collections;
+using Xunit.Sdk;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatProperties
+{
+	public sealed class HaveName
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenPropertyInfosContainPropertyInfoWithDifferentName_ShouldFail()
+			{
+				Filtered.Properties subject = GetTypes<ThatProperty.ClassWithProperties>().Properties();
+
+				async Task Act()
+					=> await That(subject).HaveName("PublicProperty");
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that properties in types matching t => t == typeof(T) in assembly containing type ThatProperty.ClassWithProperties
+					             all have name equal to "PublicProperty",
+					             but it contained not matching types [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenPropertyInfosHaveName_ShouldSucceed()
+			{
+				Filtered.Properties subject = GetTypes<ThatProperty.ClassWithSingleProperty>().Properties();
+
+				async Task Act()
+					=> await That(subject).HaveName("MyProperty");
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenPropertyInfosMatchIgnoringCase_ShouldSucceed()
+			{
+				Filtered.Properties subject = GetTypes<ThatProperty.ClassWithSingleProperty>().Properties();
+
+				async Task Act()
+					=> await That(subject).HaveName("mYpROPERTY").IgnoringCase();
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenPropertyInfosMatchSuffix_ShouldSucceed()
+			{
+				Filtered.Properties subject = GetTypes<ThatProperty.ClassWithProperties>().Properties();
+
+				async Task Act()
+					=> await That(subject).HaveName("Property").AsSuffix();
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatProperties.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatProperties.cs
@@ -1,0 +1,9 @@
+﻿using aweXpect.Reflection.Collections;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatProperties
+{
+	public static Filtered.Types GetTypes<T>()
+		=> In.AssemblyContaining<T>().Types().Which(t => t == typeof(T));
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatProperty.HasName.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatProperty.HasName.Tests.cs
@@ -1,0 +1,86 @@
+﻿using System.Reflection;
+using Xunit.Sdk;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatProperty
+{
+	public sealed class HasName
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenExpectedValueIsOnlySubstring_ShouldFail()
+			{
+				PropertyInfo? subject =
+					typeof(ClassWithProperties).GetProperty(nameof(ClassWithProperties.PublicProperty));
+
+				async Task Act()
+					=> await That(subject).HasName("Property");
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has name equal to "Property",
+					             but it was "PublicProperty" which differs at index 1:
+					                 ↓ (actual)
+					               "PublicProperty"
+					               "Property"
+					                 ↑ (expected)
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenPropertyInfoHasExpectedPrefix_ShouldSucceed()
+			{
+				PropertyInfo? subject =
+					typeof(ClassWithProperties).GetProperty(nameof(ClassWithProperties.PublicProperty));
+
+				async Task Act()
+					=> await That(subject).HasName("Public").AsPrefix();
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenPropertyInfoHasMatchingName_ShouldSucceed()
+			{
+				PropertyInfo? subject =
+					typeof(ClassWithProperties).GetProperty(nameof(ClassWithProperties.PublicProperty));
+
+				async Task Act()
+					=> await That(subject).HasName("PublicProperty");
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenPropertyInfoIsNull_ShouldFail()
+			{
+				PropertyInfo? subject = null;
+
+				async Task Act()
+					=> await That(subject).HasName("foo");
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             has name equal to "foo",
+					             but it was <null>
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenPropertyInfoMatchesIgnoringCase_ShouldSucceed()
+			{
+				PropertyInfo? subject =
+					typeof(ClassWithProperties).GetProperty(nameof(ClassWithProperties.PublicProperty));
+
+				async Task Act()
+					=> await That(subject).HasName("pUBLICpROPERTY").IgnoringCase();
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatProperty.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatProperty.cs
@@ -9,6 +9,7 @@ public sealed partial class ThatProperty
 		protected int ProtectedProperty { get; set; }
 		private int PrivateProperty { get; set; }
 	}
+
 	public class ClassWithSingleProperty
 	{
 		public int MyProperty { get; set; }

--- a/Tests/aweXpect.Reflection.Tests/ThatProperty.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatProperty.cs
@@ -1,0 +1,16 @@
+﻿namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatProperty
+{
+	public class ClassWithProperties
+	{
+		public int PublicProperty { get; set; }
+		internal int InternalProperty { get; set; }
+		protected int ProtectedProperty { get; set; }
+		private int PrivateProperty { get; set; }
+	}
+	public class ClassWithSingleProperty
+	{
+		public int MyProperty { get; set; }
+	}
+}


### PR DESCRIPTION
Add the `HasName`/`HaveName` expectation for
- `PropertyInfo`
- `FieldInfo`
- `MethodInfo`
- `EventInfo`