### PR TITLE
feat: add `WhichAre` for methods and types

### DIFF
--- a/Source/aweXpect.Reflection/Filters/AssemblyFilters.WhichSatisfy.cs
+++ b/Source/aweXpect.Reflection/Filters/AssemblyFilters.WhichSatisfy.cs
@@ -8,7 +8,7 @@ namespace aweXpect.Reflection;
 public static partial class AssemblyFilters
 {
 	/// <summary>
-	///     Filters the assemblies according to the <paramref name="predicate" />.
+	///     Filters for assemblies that satisfy the <paramref name="predicate" />.
 	/// </summary>
 	public static Filtered.Assemblies WhichSatisfy(this Filtered.Assemblies @this,
 		Func<Assembly, bool> predicate,

--- a/Source/aweXpect.Reflection/Filters/MethodFilters.WhichAre.cs
+++ b/Source/aweXpect.Reflection/Filters/MethodFilters.WhichAre.cs
@@ -1,0 +1,26 @@
+﻿using System.Reflection;
+using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Helpers;
+
+namespace aweXpect.Reflection;
+
+public static partial class MethodFilters
+{
+	/// <summary>
+	///     Filters for methods that have the given <paramref name="accessModifier" />.
+	/// </summary>
+	public static Filtered.Methods WhichAre(this Filtered.Methods @this,
+		AccessModifiers accessModifier)
+		=> @this.Which(Filter.Prefix<MethodInfo>(
+			type => type.HasAccessModifier(accessModifier),
+			accessModifier.GetString(" ")));
+
+	/// <summary>
+	///     Filters for methods that do not have the given <paramref name="accessModifier" />.
+	/// </summary>
+	public static Filtered.Methods WhichAreNot(this Filtered.Methods @this,
+		AccessModifiers accessModifier)
+		=> @this.Which(Filter.Prefix<MethodInfo>(
+			type => !type.HasAccessModifier(accessModifier),
+			"non-" + accessModifier.GetString(" ")));
+}

--- a/Source/aweXpect.Reflection/Filters/TypeFilters.WhichAre.cs
+++ b/Source/aweXpect.Reflection/Filters/TypeFilters.WhichAre.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Helpers;
+
+namespace aweXpect.Reflection;
+
+public static partial class TypeFilters
+{
+	/// <summary>
+	///     Filters for types that have the given <paramref name="accessModifier" />.
+	/// </summary>
+	public static Filtered.Types WhichAre(this Filtered.Types @this,
+		AccessModifiers accessModifier)
+		=> @this.Which(Filter.Prefix<Type>(
+			type => type.HasAccessModifier(accessModifier),
+			accessModifier.GetString(" ")));
+
+	/// <summary>
+	///     Filters for types that do not have the given <paramref name="accessModifier" />.
+	/// </summary>
+	public static Filtered.Types WhichAreNot(this Filtered.Types @this,
+		AccessModifiers accessModifier)
+		=> @this.Which(Filter.Prefix<Type>(
+			type => !type.HasAccessModifier(accessModifier),
+			"non-" + accessModifier.GetString(" ")));
+}

--- a/Source/aweXpect.Reflection/Filters/TypeFilters.WhichSatisfy.cs
+++ b/Source/aweXpect.Reflection/Filters/TypeFilters.WhichSatisfy.cs
@@ -9,7 +9,7 @@ namespace aweXpect.Reflection;
 public static partial class TypeFilters
 {
 	/// <summary>
-	///     Filters the types according to the <paramref name="predicate" />.
+	///     Filters for types that satisfy the <paramref name="predicate" />.
 	/// </summary>
 	public static Filtered.Types WhichSatisfy(this Filtered.Types @this,
 		Func<Type, bool> predicate,

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net8.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net8.0.txt
@@ -20,6 +20,8 @@ namespace aweXpect.Reflection
     }
     public static class MethodFilters
     {
+        public static aweXpect.Reflection.Collections.Filtered.Methods WhichAre(this aweXpect.Reflection.Collections.Filtered.Methods @this, aweXpect.Reflection.Collections.AccessModifiers accessModifier) { }
+        public static aweXpect.Reflection.Collections.Filtered.Methods WhichAreNot(this aweXpect.Reflection.Collections.Filtered.Methods @this, aweXpect.Reflection.Collections.AccessModifiers accessModifier) { }
         public static aweXpect.Reflection.MethodFilters.MethodsWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Methods @this, bool inherit = true)
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.MethodFilters.MethodsWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Methods @this, System.Func<TAttribute, bool>? predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
@@ -133,6 +135,8 @@ namespace aweXpect.Reflection
     }
     public static class TypeFilters
     {
+        public static aweXpect.Reflection.Collections.Filtered.Types WhichAre(this aweXpect.Reflection.Collections.Filtered.Types @this, aweXpect.Reflection.Collections.AccessModifiers accessModifier) { }
+        public static aweXpect.Reflection.Collections.Filtered.Types WhichAreNot(this aweXpect.Reflection.Collections.Filtered.Types @this, aweXpect.Reflection.Collections.AccessModifiers accessModifier) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichInheritFrom(this aweXpect.Reflection.Collections.Filtered.Types @this, System.Type baseType, bool forceDirect = false) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichInheritFrom<TBaseType>(this aweXpect.Reflection.Collections.Filtered.Types @this, bool forceDirect = false) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichSatisfy(this aweXpect.Reflection.Collections.Filtered.Types @this, System.Func<System.Type, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_netstandard2.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_netstandard2.0.txt
@@ -20,6 +20,8 @@ namespace aweXpect.Reflection
     }
     public static class MethodFilters
     {
+        public static aweXpect.Reflection.Collections.Filtered.Methods WhichAre(this aweXpect.Reflection.Collections.Filtered.Methods @this, aweXpect.Reflection.Collections.AccessModifiers accessModifier) { }
+        public static aweXpect.Reflection.Collections.Filtered.Methods WhichAreNot(this aweXpect.Reflection.Collections.Filtered.Methods @this, aweXpect.Reflection.Collections.AccessModifiers accessModifier) { }
         public static aweXpect.Reflection.MethodFilters.MethodsWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Methods @this, bool inherit = true)
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.MethodFilters.MethodsWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Methods @this, System.Func<TAttribute, bool>? predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
@@ -133,6 +135,8 @@ namespace aweXpect.Reflection
     }
     public static class TypeFilters
     {
+        public static aweXpect.Reflection.Collections.Filtered.Types WhichAre(this aweXpect.Reflection.Collections.Filtered.Types @this, aweXpect.Reflection.Collections.AccessModifiers accessModifier) { }
+        public static aweXpect.Reflection.Collections.Filtered.Types WhichAreNot(this aweXpect.Reflection.Collections.Filtered.Types @this, aweXpect.Reflection.Collections.AccessModifiers accessModifier) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichInheritFrom(this aweXpect.Reflection.Collections.Filtered.Types @this, System.Type baseType, bool forceDirect = false) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichInheritFrom<TBaseType>(this aweXpect.Reflection.Collections.Filtered.Types @this, bool forceDirect = false) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichSatisfy(this aweXpect.Reflection.Collections.Filtered.Types @this, System.Func<System.Type, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }

--- a/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WhichAre.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WhichAre.Tests.cs
@@ -1,0 +1,56 @@
+﻿using aweXpect.Reflection.Collections;
+
+namespace aweXpect.Reflection.Tests.Filters;
+
+public sealed partial class MethodFilters
+{
+	public sealed class WhichAre
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task ShouldAllowFilteringForInternalTypes()
+			{
+				Filtered.Methods types = In.AssemblyContaining<AssemblyFilters>()
+					.Methods().WhichAre(AccessModifiers.Internal);
+
+				await That(types).AreInternal();
+				await That(types.GetDescription())
+					.IsEqualTo("internal methods in assembly").AsPrefix();
+			}
+
+			[Fact]
+			public async Task ShouldAllowFilteringForPrivateTypes()
+			{
+				Filtered.Methods types = In.AssemblyContaining<AssemblyFilters>()
+					.Methods().WhichAre(AccessModifiers.Private);
+
+				await That(types).ArePrivate();
+				await That(types.GetDescription())
+					.IsEqualTo("private methods in assembly").AsPrefix();
+			}
+
+			[Fact]
+			public async Task ShouldAllowFilteringForProtectedTypes()
+			{
+				Filtered.Methods types = In.AssemblyContaining<AssemblyFilters>()
+					.Methods().WhichAre(AccessModifiers.Protected);
+
+				await That(types).AreProtected();
+				await That(types.GetDescription())
+					.IsEqualTo("protected methods in assembly").AsPrefix();
+			}
+
+			[Fact]
+			public async Task ShouldAllowFilteringForPublicTypes()
+			{
+				Filtered.Methods types = In.AssemblyContaining<AssemblyFilters>()
+					.Methods().WhichAre(AccessModifiers.Public);
+
+				await That(types).ArePublic();
+				await That(types.GetDescription())
+					.IsEqualTo("public methods in assembly").AsPrefix();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WhichAreNot.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WhichAreNot.Tests.cs
@@ -1,0 +1,56 @@
+﻿using aweXpect.Reflection.Collections;
+
+namespace aweXpect.Reflection.Tests.Filters;
+
+public sealed partial class MethodFilters
+{
+	public sealed class WhichAreNot
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task ShouldAllowFilteringForInternalTypes()
+			{
+				Filtered.Methods types = In.AssemblyContaining<AssemblyFilters>()
+					.Methods().WhichAreNot(AccessModifiers.Internal);
+
+				await That(types).AreNotInternal();
+				await That(types.GetDescription())
+					.IsEqualTo("non-internal methods in assembly").AsPrefix();
+			}
+
+			[Fact]
+			public async Task ShouldAllowFilteringForPrivateTypes()
+			{
+				Filtered.Methods types = In.AssemblyContaining<AssemblyFilters>()
+					.Methods().WhichAreNot(AccessModifiers.Private);
+
+				await That(types).AreNotPrivate();
+				await That(types.GetDescription())
+					.IsEqualTo("non-private methods in assembly").AsPrefix();
+			}
+
+			[Fact]
+			public async Task ShouldAllowFilteringForProtectedTypes()
+			{
+				Filtered.Methods types = In.AssemblyContaining<AssemblyFilters>()
+					.Methods().WhichAreNot(AccessModifiers.Protected);
+
+				await That(types).AreNotProtected();
+				await That(types.GetDescription())
+					.IsEqualTo("non-protected methods in assembly").AsPrefix();
+			}
+
+			[Fact]
+			public async Task ShouldAllowFilteringForPublicTypes()
+			{
+				Filtered.Methods types = In.AssemblyContaining<AssemblyFilters>()
+					.Methods().WhichAreNot(AccessModifiers.Public);
+
+				await That(types).AreNotPublic();
+				await That(types.GetDescription())
+					.IsEqualTo("non-public methods in assembly").AsPrefix();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.With.AttributeTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.With.AttributeTests.cs
@@ -13,7 +13,7 @@ public sealed partial class MethodFilters
 			public async Task ShouldFilterForMethodsWithAttribute()
 			{
 				Filtered.Methods methods = In.AssemblyContaining<AssemblyFilters>()
-					.Types().Methods().With<BarAttribute>();
+					.Methods().With<BarAttribute>();
 
 				await That(methods).IsEqualTo([
 					typeof(Dummy).GetMethod(nameof(Dummy.MyBarMethod)),
@@ -28,7 +28,7 @@ public sealed partial class MethodFilters
 			public async Task WhenInheritIsSetToFalse_ShouldFilterForTypesWithAttributeDirectlySet()
 			{
 				Filtered.Methods methods = In.AssemblyContaining<AssemblyFilters>()
-					.Types().Methods().With<BarAttribute>(false);
+					.Methods().With<BarAttribute>(false);
 
 				await That(methods).HasSingle().Which.IsEqualTo(typeof(Dummy).GetMethod(nameof(Dummy.MyBarMethod)));
 				await That(methods.GetDescription())
@@ -42,7 +42,7 @@ public sealed partial class MethodFilters
 				MethodInfo?[] expectedTypes)
 			{
 				Filtered.Methods methods = In.AssemblyContaining<AssemblyFilters>()
-					.Types().Methods().With<FooAttribute>(foo => foo.Value == value);
+					.Methods().With<FooAttribute>(foo => foo.Value == value);
 
 				await That(methods).IsEqualTo(expectedTypes).InAnyOrder();
 				await That(methods.GetDescription())
@@ -55,7 +55,7 @@ public sealed partial class MethodFilters
 			public async Task WithPredicate_WhenInheritIsSetToFalse_ShouldFilterForTypesWithAttributeDirectlySet()
 			{
 				Filtered.Methods methods = In.AssemblyContaining<AssemblyFilters>()
-					.Types().Methods().With<FooAttribute>(foo => foo.Value == 2, false);
+					.Methods().With<FooAttribute>(foo => foo.Value == 2, false);
 
 				await That(methods).HasSingle().Which
 					.IsEqualTo(typeof(Dummy).GetMethod(nameof(Dummy.MyFooMethod2)));
@@ -86,7 +86,7 @@ public sealed partial class MethodFilters
 			public async Task ShouldFilterForMethodsWithAttribute()
 			{
 				Filtered.Methods methods = In.AssemblyContaining<AssemblyFilters>()
-					.Types().Methods().With<BarAttribute>().OrWith<FooAttribute>();
+					.Methods().With<BarAttribute>().OrWith<FooAttribute>();
 
 				await That(methods).IsEqualTo([
 					typeof(Dummy).GetMethod(nameof(Dummy.MyBarMethod)),
@@ -105,7 +105,7 @@ public sealed partial class MethodFilters
 			public async Task WhenInheritIsSetToFalse_ShouldFilterForTypesWithAttributeDirectlySet()
 			{
 				Filtered.Methods methods = In.AssemblyContaining<AssemblyFilters>()
-					.Types().Methods().With<BarAttribute>().OrWith<FooAttribute>(false);
+					.Methods().With<BarAttribute>().OrWith<FooAttribute>(false);
 
 				await That(methods).IsEqualTo([
 					typeof(Dummy).GetMethod(nameof(Dummy.MyBarMethod)),
@@ -125,7 +125,7 @@ public sealed partial class MethodFilters
 				MethodInfo?[] expectedTypes)
 			{
 				Filtered.Methods methods = In.AssemblyContaining<AssemblyFilters>()
-					.Types().Methods().With<BarAttribute>(false).OrWith<FooAttribute>(foo => foo.Value == value);
+					.Methods().With<BarAttribute>(false).OrWith<FooAttribute>(foo => foo.Value == value);
 
 				await That(methods).IsEqualTo(expectedTypes).InAnyOrder();
 				await That(methods.GetDescription())
@@ -138,7 +138,7 @@ public sealed partial class MethodFilters
 			public async Task WithPredicate_WhenInheritIsSetToFalse_ShouldFilterForTypesWithAttributeDirectlySet()
 			{
 				Filtered.Methods methods = In.AssemblyContaining<AssemblyFilters>()
-					.Types().Methods().With<BarAttribute>(_ => false)
+					.Methods().With<BarAttribute>(_ => false)
 					.OrWith<FooAttribute>(foo => foo.Value == 2, false);
 
 				await That(methods).HasSingle().Which

--- a/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAre.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAre.Tests.cs
@@ -1,0 +1,56 @@
+﻿using aweXpect.Reflection.Collections;
+
+namespace aweXpect.Reflection.Tests.Filters;
+
+public sealed partial class TypeFilters
+{
+	public sealed class WhichAre
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task ShouldAllowFilteringForInternalTypes()
+			{
+				Filtered.Types types = In.AssemblyContaining<AssemblyFilters>()
+					.Types().WhichAre(AccessModifiers.Internal);
+
+				await That(types).AreInternal();
+				await That(types.GetDescription())
+					.IsEqualTo("internal types in assembly").AsPrefix();
+			}
+
+			[Fact]
+			public async Task ShouldAllowFilteringForPrivateTypes()
+			{
+				Filtered.Types types = In.AssemblyContaining<AssemblyFilters>()
+					.Types().WhichAre(AccessModifiers.Private);
+
+				await That(types).ArePrivate();
+				await That(types.GetDescription())
+					.IsEqualTo("private types in assembly").AsPrefix();
+			}
+
+			[Fact]
+			public async Task ShouldAllowFilteringForProtectedTypes()
+			{
+				Filtered.Types types = In.AssemblyContaining<AssemblyFilters>()
+					.Types().WhichAre(AccessModifiers.Protected);
+
+				await That(types).AreProtected();
+				await That(types.GetDescription())
+					.IsEqualTo("protected types in assembly").AsPrefix();
+			}
+
+			[Fact]
+			public async Task ShouldAllowFilteringForPublicTypes()
+			{
+				Filtered.Types types = In.AssemblyContaining<AssemblyFilters>()
+					.Types().WhichAre(AccessModifiers.Public);
+
+				await That(types).ArePublic();
+				await That(types.GetDescription())
+					.IsEqualTo("public types in assembly").AsPrefix();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreNot.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreNot.Tests.cs
@@ -1,0 +1,56 @@
+﻿using aweXpect.Reflection.Collections;
+
+namespace aweXpect.Reflection.Tests.Filters;
+
+public sealed partial class TypeFilters
+{
+	public sealed class WhichAreNot
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task ShouldAllowFilteringForInternalTypes()
+			{
+				Filtered.Types types = In.AssemblyContaining<AssemblyFilters>()
+					.Types().WhichAreNot(AccessModifiers.Internal);
+
+				await That(types).AreNotInternal();
+				await That(types.GetDescription())
+					.IsEqualTo("non-internal types in assembly").AsPrefix();
+			}
+
+			[Fact]
+			public async Task ShouldAllowFilteringForPrivateTypes()
+			{
+				Filtered.Types types = In.AssemblyContaining<AssemblyFilters>()
+					.Types().WhichAreNot(AccessModifiers.Private);
+
+				await That(types).AreNotPrivate();
+				await That(types.GetDescription())
+					.IsEqualTo("non-private types in assembly").AsPrefix();
+			}
+
+			[Fact]
+			public async Task ShouldAllowFilteringForProtectedTypes()
+			{
+				Filtered.Types types = In.AssemblyContaining<AssemblyFilters>()
+					.Types().WhichAreNot(AccessModifiers.Protected);
+
+				await That(types).AreNotProtected();
+				await That(types.GetDescription())
+					.IsEqualTo("non-protected types in assembly").AsPrefix();
+			}
+
+			[Fact]
+			public async Task ShouldAllowFilteringForPublicTypes()
+			{
+				Filtered.Types types = In.AssemblyContaining<AssemblyFilters>()
+					.Types().WhichAreNot(AccessModifiers.Public);
+
+				await That(types).AreNotPublic();
+				await That(types.GetDescription())
+					.IsEqualTo("non-public types in assembly").AsPrefix();
+			}
+		}
+	}
+}


### PR DESCRIPTION
This PR adds access modifier filtering capabilities to both types and methods by introducing `WhichAre` and `WhichAreNot` extension methods. These methods allow filtering collections based on specific access modifiers (Public, Private, Protected, Internal).

- Adds `WhichAre` and `WhichAreNot` methods for both type and method filtering
- Updates test files to use direct method access instead of chaining through types
- Improves documentation consistency for filtering methods