### PR TITLE
feat: add `WithName` and `WhichSatisfy` for methods

### DIFF
--- a/Source/aweXpect.Reflection/Collections/Filtered.Methods.cs
+++ b/Source/aweXpect.Reflection/Collections/Filtered.Methods.cs
@@ -1,6 +1,9 @@
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Text.RegularExpressions;
 using aweXpect.Core;
+using aweXpect.Options;
 using aweXpect.Reflection.Helpers;
 
 // ReSharper disable MemberHidesStaticFromOuterClass
@@ -60,5 +63,122 @@ public static partial class Filtered
 		///     Get all declaring types of the filtered methods.
 		/// </summary>
 		public Types DeclaringTypes() => new(this);
+
+		/// <summary>
+		///     A Container for a filterable collection of <see cref="MethodInfo" />,
+		///     that also allows specifying string equality options.
+		/// </summary>
+		public class StringEqualityResult : Methods
+		{
+			private readonly StringEqualityOptions _options;
+
+			internal StringEqualityResult(Methods inner, StringEqualityOptions options) : base(inner)
+			{
+				_options = options;
+			}
+
+			/// <summary>
+			///     Ignores casing when comparing the <see langword="string" />s,
+			///     according to the <paramref name="ignoreCase" /> parameter.
+			/// </summary>
+			public StringEqualityResult IgnoringCase(bool ignoreCase = true)
+			{
+				_options.IgnoringCase(ignoreCase);
+				return this;
+			}
+
+			/// <summary>
+			///     Ignores leading white-space when comparing <see langword="string" />s,
+			///     according to the <paramref name="ignoreLeadingWhiteSpace" /> parameter.
+			/// </summary>
+			/// <remarks>
+			///     Note:<br />
+			///     This affects the index of first mismatch, as the removed whitespace is also ignored for the index calculation!
+			/// </remarks>
+			public StringEqualityResult IgnoringLeadingWhiteSpace(bool ignoreLeadingWhiteSpace = true)
+			{
+				_options.IgnoringLeadingWhiteSpace(ignoreLeadingWhiteSpace);
+				return this;
+			}
+
+			/// <summary>
+			///     Ignores trailing white-space when comparing <see langword="string" />s,
+			///     according to the <paramref name="ignoreTrailingWhiteSpace" /> parameter.
+			/// </summary>
+			public StringEqualityResult IgnoringTrailingWhiteSpace(bool ignoreTrailingWhiteSpace = true)
+			{
+				_options.IgnoringTrailingWhiteSpace(ignoreTrailingWhiteSpace);
+				return this;
+			}
+
+			/// <summary>
+			///     Uses the provided <paramref name="comparer" /> for comparing <see langword="string" />s.
+			/// </summary>
+			public StringEqualityResult Using(IEqualityComparer<string> comparer)
+			{
+				_options.UsingComparer(comparer);
+				return this;
+			}
+		}
+
+		/// <summary>
+		///     A Container for a filterable collection of <see cref="MethodInfo" />,
+		///     that also allows specifying string equality options and types.
+		/// </summary>
+		public class StringEqualityResultType : StringEqualityResult
+		{
+			private readonly StringEqualityOptions _options;
+
+			internal StringEqualityResultType(Methods inner, StringEqualityOptions options) : base(inner, options)
+			{
+				_options = options;
+			}
+
+			/// <summary>
+			///     Interprets the expected <see langword="string" /> to be exactly equal.
+			/// </summary>
+			public StringEqualityResult Exactly()
+			{
+				_options.Exactly();
+				return this;
+			}
+
+			/// <summary>
+			///     Interprets the expected <see langword="string" /> as a prefix, so that the actual value starts with it.
+			/// </summary>
+			public StringEqualityResult AsPrefix()
+			{
+				_options.AsPrefix();
+				return this;
+			}
+
+			/// <summary>
+			///     Interprets the expected <see langword="string" /> as <see cref="Regex" /> pattern.
+			/// </summary>
+			public StringEqualityResult AsRegex()
+			{
+				_options.AsRegex();
+				return this;
+			}
+
+			/// <summary>
+			///     Interprets the expected <see langword="string" /> as a suffix, so that the actual value ends with it.
+			/// </summary>
+			public StringEqualityResult AsSuffix()
+			{
+				_options.AsSuffix();
+				return this;
+			}
+
+			/// <summary>
+			///     Interprets the expected <see langword="string" /> as wildcard pattern.<br />
+			///     Supports * to match zero or more characters and ? to match exactly one character.
+			/// </summary>
+			public StringEqualityResult AsWildcard()
+			{
+				_options.AsWildcard();
+				return this;
+			}
+		}
 	}
 }

--- a/Source/aweXpect.Reflection/Filters/MethodFilters.WhichSatisfy.cs
+++ b/Source/aweXpect.Reflection/Filters/MethodFilters.WhichSatisfy.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using aweXpect.Reflection.Collections;
+
+namespace aweXpect.Reflection;
+
+public static partial class MethodFilters
+{
+	/// <summary>
+	///     Filters for methods that satisfy the <paramref name="predicate" />.
+	/// </summary>
+	public static Filtered.Methods WhichSatisfy(this Filtered.Methods @this,
+		Func<MethodInfo, bool> predicate,
+		[CallerArgumentExpression("predicate")]
+		string doNotPopulateThisValue = "")
+		=> @this.Which(Filter.Suffix(predicate, $"matching {doNotPopulateThisValue} "));
+}

--- a/Source/aweXpect.Reflection/Filters/MethodFilters.WithName.cs
+++ b/Source/aweXpect.Reflection/Filters/MethodFilters.WithName.cs
@@ -14,7 +14,7 @@ public static partial class MethodFilters
 	{
 		StringEqualityOptions options = new();
 		return new Filtered.Methods.StringEqualityResultType(@this.Which(Filter.Suffix<MethodInfo>(
-				type => options.AreConsideredEqual(type.Name, expected),
+				methodInfo => options.AreConsideredEqual(methodInfo.Name, expected),
 				() => $"with name {options.GetExpectation(expected, ExpectationGrammars.None)} ")),
 			options);
 	}

--- a/Source/aweXpect.Reflection/Filters/MethodFilters.WithName.cs
+++ b/Source/aweXpect.Reflection/Filters/MethodFilters.WithName.cs
@@ -1,0 +1,21 @@
+﻿using System.Reflection;
+using aweXpect.Core;
+using aweXpect.Options;
+using aweXpect.Reflection.Collections;
+
+namespace aweXpect.Reflection;
+
+public static partial class MethodFilters
+{
+	/// <summary>
+	///     Filter for methods with the <paramref name="expected" /> name.
+	/// </summary>
+	public static Filtered.Methods.StringEqualityResultType WithName(this Filtered.Methods @this, string expected)
+	{
+		StringEqualityOptions options = new();
+		return new Filtered.Methods.StringEqualityResultType(@this.Which(Filter.Suffix<MethodInfo>(
+				type => options.AreConsideredEqual(type.Name, expected),
+				() => $"with name {options.GetExpectation(expected, ExpectationGrammars.None)} ")),
+			options);
+	}
+}

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net8.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net8.0.txt
@@ -22,10 +22,12 @@ namespace aweXpect.Reflection
     {
         public static aweXpect.Reflection.Collections.Filtered.Methods WhichAre(this aweXpect.Reflection.Collections.Filtered.Methods @this, aweXpect.Reflection.Collections.AccessModifiers accessModifier) { }
         public static aweXpect.Reflection.Collections.Filtered.Methods WhichAreNot(this aweXpect.Reflection.Collections.Filtered.Methods @this, aweXpect.Reflection.Collections.AccessModifiers accessModifier) { }
+        public static aweXpect.Reflection.Collections.Filtered.Methods WhichSatisfy(this aweXpect.Reflection.Collections.Filtered.Methods @this, System.Func<System.Reflection.MethodInfo, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Reflection.MethodFilters.MethodsWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Methods @this, bool inherit = true)
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.MethodFilters.MethodsWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Methods @this, System.Func<TAttribute, bool>? predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
             where TAttribute : System.Attribute { }
+        public static aweXpect.Reflection.Collections.Filtered.Methods.StringEqualityResultType WithName(this aweXpect.Reflection.Collections.Filtered.Methods @this, string expected) { }
         public class MethodsWith : aweXpect.Reflection.Collections.Filtered.Methods
         {
             public MethodsWith(aweXpect.Reflection.Collections.Filtered.Methods inner, aweXpect.Reflection.Collections.IChangeableFilter<System.Reflection.MethodInfo> filter) { }
@@ -225,6 +227,21 @@ namespace aweXpect.Reflection.Collections
             protected Methods(aweXpect.Reflection.Collections.Filtered.Methods inner) { }
             public aweXpect.Reflection.Collections.Filtered.Types DeclaringTypes() { }
             public string GetDescription() { }
+            public class StringEqualityResult : aweXpect.Reflection.Collections.Filtered.Methods
+            {
+                public aweXpect.Reflection.Collections.Filtered.Methods.StringEqualityResult IgnoringCase(bool ignoreCase = true) { }
+                public aweXpect.Reflection.Collections.Filtered.Methods.StringEqualityResult IgnoringLeadingWhiteSpace(bool ignoreLeadingWhiteSpace = true) { }
+                public aweXpect.Reflection.Collections.Filtered.Methods.StringEqualityResult IgnoringTrailingWhiteSpace(bool ignoreTrailingWhiteSpace = true) { }
+                public aweXpect.Reflection.Collections.Filtered.Methods.StringEqualityResult Using(System.Collections.Generic.IEqualityComparer<string> comparer) { }
+            }
+            public class StringEqualityResultType : aweXpect.Reflection.Collections.Filtered.Methods.StringEqualityResult
+            {
+                public aweXpect.Reflection.Collections.Filtered.Methods.StringEqualityResult AsPrefix() { }
+                public aweXpect.Reflection.Collections.Filtered.Methods.StringEqualityResult AsRegex() { }
+                public aweXpect.Reflection.Collections.Filtered.Methods.StringEqualityResult AsSuffix() { }
+                public aweXpect.Reflection.Collections.Filtered.Methods.StringEqualityResult AsWildcard() { }
+                public aweXpect.Reflection.Collections.Filtered.Methods.StringEqualityResult Exactly() { }
+            }
         }
         public class Properties : aweXpect.Reflection.Collections.Filtered<System.Reflection.PropertyInfo, aweXpect.Reflection.Collections.Filtered.Properties>, aweXpect.Core.IDescribableSubject
         {

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_netstandard2.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_netstandard2.0.txt
@@ -22,10 +22,12 @@ namespace aweXpect.Reflection
     {
         public static aweXpect.Reflection.Collections.Filtered.Methods WhichAre(this aweXpect.Reflection.Collections.Filtered.Methods @this, aweXpect.Reflection.Collections.AccessModifiers accessModifier) { }
         public static aweXpect.Reflection.Collections.Filtered.Methods WhichAreNot(this aweXpect.Reflection.Collections.Filtered.Methods @this, aweXpect.Reflection.Collections.AccessModifiers accessModifier) { }
+        public static aweXpect.Reflection.Collections.Filtered.Methods WhichSatisfy(this aweXpect.Reflection.Collections.Filtered.Methods @this, System.Func<System.Reflection.MethodInfo, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Reflection.MethodFilters.MethodsWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Methods @this, bool inherit = true)
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.MethodFilters.MethodsWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Methods @this, System.Func<TAttribute, bool>? predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
             where TAttribute : System.Attribute { }
+        public static aweXpect.Reflection.Collections.Filtered.Methods.StringEqualityResultType WithName(this aweXpect.Reflection.Collections.Filtered.Methods @this, string expected) { }
         public class MethodsWith : aweXpect.Reflection.Collections.Filtered.Methods
         {
             public MethodsWith(aweXpect.Reflection.Collections.Filtered.Methods inner, aweXpect.Reflection.Collections.IChangeableFilter<System.Reflection.MethodInfo> filter) { }
@@ -225,6 +227,21 @@ namespace aweXpect.Reflection.Collections
             protected Methods(aweXpect.Reflection.Collections.Filtered.Methods inner) { }
             public aweXpect.Reflection.Collections.Filtered.Types DeclaringTypes() { }
             public string GetDescription() { }
+            public class StringEqualityResult : aweXpect.Reflection.Collections.Filtered.Methods
+            {
+                public aweXpect.Reflection.Collections.Filtered.Methods.StringEqualityResult IgnoringCase(bool ignoreCase = true) { }
+                public aweXpect.Reflection.Collections.Filtered.Methods.StringEqualityResult IgnoringLeadingWhiteSpace(bool ignoreLeadingWhiteSpace = true) { }
+                public aweXpect.Reflection.Collections.Filtered.Methods.StringEqualityResult IgnoringTrailingWhiteSpace(bool ignoreTrailingWhiteSpace = true) { }
+                public aweXpect.Reflection.Collections.Filtered.Methods.StringEqualityResult Using(System.Collections.Generic.IEqualityComparer<string> comparer) { }
+            }
+            public class StringEqualityResultType : aweXpect.Reflection.Collections.Filtered.Methods.StringEqualityResult
+            {
+                public aweXpect.Reflection.Collections.Filtered.Methods.StringEqualityResult AsPrefix() { }
+                public aweXpect.Reflection.Collections.Filtered.Methods.StringEqualityResult AsRegex() { }
+                public aweXpect.Reflection.Collections.Filtered.Methods.StringEqualityResult AsSuffix() { }
+                public aweXpect.Reflection.Collections.Filtered.Methods.StringEqualityResult AsWildcard() { }
+                public aweXpect.Reflection.Collections.Filtered.Methods.StringEqualityResult Exactly() { }
+            }
         }
         public class Properties : aweXpect.Reflection.Collections.Filtered<System.Reflection.PropertyInfo, aweXpect.Reflection.Collections.Filtered.Properties>, aweXpect.Core.IDescribableSubject
         {

--- a/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WhichSatisfy.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WhichSatisfy.Tests.cs
@@ -1,0 +1,25 @@
+﻿using aweXpect.Reflection.Collections;
+
+namespace aweXpect.Reflection.Tests.Filters;
+
+public sealed partial class MethodFilters
+{
+	public sealed class WhichSatisfy
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task ShouldFilterForMethodsWhichSatisfyThePredicate()
+			{
+				Filtered.Methods types = In.AssemblyContaining<AssemblyFilters>()
+					.Methods().WhichSatisfy(it => it.Name.Equals("SomeMethodToVerifyTheNameOfIt"));
+
+				await That(types).HasSingle().Which.IsEqualTo(ExpectedMethodInfo());
+				await That(types.GetDescription())
+					.IsEqualTo(
+						"methods matching it => it.Name.Equals(\"SomeMethodToVerifyTheNameOfIt\") in assembly")
+					.AsPrefix();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WhichSatisfy.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WhichSatisfy.Tests.cs
@@ -11,11 +11,11 @@ public sealed partial class MethodFilters
 			[Fact]
 			public async Task ShouldFilterForMethodsWhichSatisfyThePredicate()
 			{
-				Filtered.Methods types = In.AssemblyContaining<AssemblyFilters>()
+				Filtered.Methods methods = In.AssemblyContaining<AssemblyFilters>()
 					.Methods().WhichSatisfy(it => it.Name.Equals("SomeMethodToVerifyTheNameOfIt"));
 
-				await That(types).HasSingle().Which.IsEqualTo(ExpectedMethodInfo());
-				await That(types.GetDescription())
+				await That(methods).HasSingle().Which.IsEqualTo(ExpectedMethodInfo());
+				await That(methods.GetDescription())
 					.IsEqualTo(
 						"methods matching it => it.Name.Equals(\"SomeMethodToVerifyTheNameOfIt\") in assembly")
 					.AsPrefix();

--- a/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WithName.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WithName.Tests.cs
@@ -1,0 +1,142 @@
+﻿using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Tests.TestHelpers;
+
+namespace aweXpect.Reflection.Tests.Filters;
+
+public sealed partial class MethodFilters
+{
+	public sealed class WithName
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task ShouldFilterForTypesWithName()
+			{
+				Filtered.Methods Methods = In.AssemblyContaining<AssemblyFilters>()
+					.Methods().WithName(nameof(SomeClassToVerifyTheMethodNameOfIt.SomeMethodToVerifyTheNameOfIt));
+
+				await That(Methods).HasSingle().Which.IsEqualTo(ExpectedMethodInfo());
+				await That(Methods.GetDescription())
+					.IsEqualTo("methods with name equal to \"SomeMethodToVerifyTheNameOfIt\" in assembly")
+					.AsPrefix();
+			}
+
+			[Fact]
+			public async Task ShouldSupportAsPrefix()
+			{
+				Filtered.Methods Methods = In.AssemblyContaining<AssemblyFilters>()
+					.Methods().WithName("SomeMethodToVerifyTheNameOf").AsPrefix();
+
+				await That(Methods).HasSingle().Which.IsEqualTo(ExpectedMethodInfo());
+				await That(Methods.GetDescription())
+					.IsEqualTo("methods with name starting with \"SomeMethodToVerifyTheNameOf\" in assembly")
+					.AsPrefix();
+			}
+
+			[Fact]
+			public async Task ShouldSupportAsRegex()
+			{
+				Filtered.Methods Methods = In.AssemblyContaining<AssemblyFilters>()
+					.Methods().WithName("[a-zA-Z]*VerifyTheNameOfIt").AsRegex();
+
+				await That(Methods).HasSingle().Which.IsEqualTo(ExpectedMethodInfo());
+				await That(Methods.GetDescription())
+					.IsEqualTo("methods with name matching regex \"[a-zA-Z]*VerifyTheNameOfIt\" in assembly")
+					.AsPrefix();
+			}
+
+			[Fact]
+			public async Task ShouldSupportAsSuffix()
+			{
+				Filtered.Methods Methods = In.AssemblyContaining<AssemblyFilters>()
+					.Methods().WithName("MethodToVerifyTheNameOfIt").AsSuffix();
+
+				await That(Methods).HasSingle().Which.IsEqualTo(ExpectedMethodInfo());
+				await That(Methods.GetDescription())
+					.IsEqualTo("methods with name ending with \"MethodToVerifyTheNameOfIt\" in assembly").AsPrefix();
+			}
+
+			[Fact]
+			public async Task ShouldSupportAsWildcard()
+			{
+				Filtered.Methods Methods = In.AssemblyContaining<AssemblyFilters>()
+					.Methods().WithName("*ToVerifyTheNameOf*").AsWildcard();
+
+				await That(Methods).HasSingle().Which.IsEqualTo(ExpectedMethodInfo());
+				await That(Methods.GetDescription())
+					.IsEqualTo("methods with name matching \"*ToVerifyTheNameOf*\" in assembly").AsPrefix();
+			}
+
+			[Fact]
+			public async Task ShouldSupportExactly()
+			{
+				Filtered.Methods Methods = In.AssemblyContaining<AssemblyFilters>()
+					.Methods().WithName(nameof(SomeClassToVerifyTheMethodNameOfIt.SomeMethodToVerifyTheNameOfIt))
+					.Exactly();
+
+				await That(Methods).HasSingle().Which.IsEqualTo(ExpectedMethodInfo());
+				await That(Methods.GetDescription())
+					.IsEqualTo("methods with name equal to \"SomeMethodToVerifyTheNameOfIt\" in assembly")
+					.AsPrefix();
+			}
+
+			[Fact]
+			public async Task ShouldSupportIgnoringCase()
+			{
+				Filtered.Methods Methods = In.AssemblyContaining<AssemblyFilters>()
+					.Methods().WithName(nameof(SomeClassToVerifyTheMethodNameOfIt.SomeMethodToVerifyTheNameOfIt)
+						.ToLowerInvariant()).IgnoringCase();
+
+				await That(Methods).HasSingle().Which.IsEqualTo(ExpectedMethodInfo());
+				await That(Methods.GetDescription())
+					.IsEqualTo(
+						"methods with name equal to \"somemethodtoverifythenameofit\" ignoring case in assembly")
+					.AsPrefix();
+			}
+
+			[Fact]
+			public async Task ShouldSupportIgnoringLeadingWhiteSpace()
+			{
+				Filtered.Methods Methods = In.AssemblyContaining<AssemblyFilters>()
+					.Methods().WithName(
+						"\t " + nameof(SomeClassToVerifyTheMethodNameOfIt.SomeMethodToVerifyTheNameOfIt))
+					.IgnoringLeadingWhiteSpace();
+
+				await That(Methods).HasSingle().Which.IsEqualTo(ExpectedMethodInfo());
+				await That(Methods.GetDescription())
+					.IsEqualTo(
+						"methods with name equal to \"\\t SomeMethodToVerifyTheNameOfI…\" ignoring leading white-space in assembly")
+					.AsPrefix();
+			}
+
+			[Fact]
+			public async Task ShouldSupportIgnoringTrailingWhiteSpace()
+			{
+				Filtered.Methods Methods = In.AssemblyContaining<AssemblyFilters>()
+					.Methods().WithName(
+						nameof(SomeClassToVerifyTheMethodNameOfIt.SomeMethodToVerifyTheNameOfIt) + "\t ")
+					.IgnoringTrailingWhiteSpace();
+
+				await That(Methods).HasSingle().Which.IsEqualTo(ExpectedMethodInfo());
+				await That(Methods.GetDescription())
+					.IsEqualTo(
+						"methods with name equal to \"SomeMethodToVerifyTheNameOfIt\\t…\" ignoring trailing white-space in assembly")
+					.AsPrefix();
+			}
+
+			[Fact]
+			public async Task ShouldSupportUsingCustomComparer()
+			{
+				Filtered.Methods Methods = In.AssemblyContaining<AssemblyFilters>()
+					.Methods().WithName("SOmEMEthOdTOVErIfyThENAmEofit")
+					.Using(new IgnoreCaseForVocalsComparer());
+
+				await That(Methods).HasSingle().Which.IsEqualTo(ExpectedMethodInfo());
+				await That(Methods.GetDescription())
+					.IsEqualTo(
+						"methods with name equal to \"SOmEMEthOdTOVErIfyThENAmEofit\" using IgnoreCaseForVocalsComparer in assembly")
+					.AsPrefix();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WithName.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WithName.Tests.cs
@@ -12,11 +12,11 @@ public sealed partial class MethodFilters
 			[Fact]
 			public async Task ShouldFilterForTypesWithName()
 			{
-				Filtered.Methods Methods = In.AssemblyContaining<AssemblyFilters>()
+				Filtered.Methods methods = In.AssemblyContaining<AssemblyFilters>()
 					.Methods().WithName(nameof(SomeClassToVerifyTheMethodNameOfIt.SomeMethodToVerifyTheNameOfIt));
 
-				await That(Methods).HasSingle().Which.IsEqualTo(ExpectedMethodInfo());
-				await That(Methods.GetDescription())
+				await That(methods).HasSingle().Which.IsEqualTo(ExpectedMethodInfo());
+				await That(methods.GetDescription())
 					.IsEqualTo("methods with name equal to \"SomeMethodToVerifyTheNameOfIt\" in assembly")
 					.AsPrefix();
 			}
@@ -24,11 +24,11 @@ public sealed partial class MethodFilters
 			[Fact]
 			public async Task ShouldSupportAsPrefix()
 			{
-				Filtered.Methods Methods = In.AssemblyContaining<AssemblyFilters>()
+				Filtered.Methods methods = In.AssemblyContaining<AssemblyFilters>()
 					.Methods().WithName("SomeMethodToVerifyTheNameOf").AsPrefix();
 
-				await That(Methods).HasSingle().Which.IsEqualTo(ExpectedMethodInfo());
-				await That(Methods.GetDescription())
+				await That(methods).HasSingle().Which.IsEqualTo(ExpectedMethodInfo());
+				await That(methods.GetDescription())
 					.IsEqualTo("methods with name starting with \"SomeMethodToVerifyTheNameOf\" in assembly")
 					.AsPrefix();
 			}
@@ -36,11 +36,11 @@ public sealed partial class MethodFilters
 			[Fact]
 			public async Task ShouldSupportAsRegex()
 			{
-				Filtered.Methods Methods = In.AssemblyContaining<AssemblyFilters>()
+				Filtered.Methods methods = In.AssemblyContaining<AssemblyFilters>()
 					.Methods().WithName("[a-zA-Z]*VerifyTheNameOfIt").AsRegex();
 
-				await That(Methods).HasSingle().Which.IsEqualTo(ExpectedMethodInfo());
-				await That(Methods.GetDescription())
+				await That(methods).HasSingle().Which.IsEqualTo(ExpectedMethodInfo());
+				await That(methods.GetDescription())
 					.IsEqualTo("methods with name matching regex \"[a-zA-Z]*VerifyTheNameOfIt\" in assembly")
 					.AsPrefix();
 			}
@@ -48,34 +48,34 @@ public sealed partial class MethodFilters
 			[Fact]
 			public async Task ShouldSupportAsSuffix()
 			{
-				Filtered.Methods Methods = In.AssemblyContaining<AssemblyFilters>()
+				Filtered.Methods methods = In.AssemblyContaining<AssemblyFilters>()
 					.Methods().WithName("MethodToVerifyTheNameOfIt").AsSuffix();
 
-				await That(Methods).HasSingle().Which.IsEqualTo(ExpectedMethodInfo());
-				await That(Methods.GetDescription())
+				await That(methods).HasSingle().Which.IsEqualTo(ExpectedMethodInfo());
+				await That(methods.GetDescription())
 					.IsEqualTo("methods with name ending with \"MethodToVerifyTheNameOfIt\" in assembly").AsPrefix();
 			}
 
 			[Fact]
 			public async Task ShouldSupportAsWildcard()
 			{
-				Filtered.Methods Methods = In.AssemblyContaining<AssemblyFilters>()
+				Filtered.Methods methods = In.AssemblyContaining<AssemblyFilters>()
 					.Methods().WithName("*ToVerifyTheNameOf*").AsWildcard();
 
-				await That(Methods).HasSingle().Which.IsEqualTo(ExpectedMethodInfo());
-				await That(Methods.GetDescription())
+				await That(methods).HasSingle().Which.IsEqualTo(ExpectedMethodInfo());
+				await That(methods.GetDescription())
 					.IsEqualTo("methods with name matching \"*ToVerifyTheNameOf*\" in assembly").AsPrefix();
 			}
 
 			[Fact]
 			public async Task ShouldSupportExactly()
 			{
-				Filtered.Methods Methods = In.AssemblyContaining<AssemblyFilters>()
+				Filtered.Methods methods = In.AssemblyContaining<AssemblyFilters>()
 					.Methods().WithName(nameof(SomeClassToVerifyTheMethodNameOfIt.SomeMethodToVerifyTheNameOfIt))
 					.Exactly();
 
-				await That(Methods).HasSingle().Which.IsEqualTo(ExpectedMethodInfo());
-				await That(Methods.GetDescription())
+				await That(methods).HasSingle().Which.IsEqualTo(ExpectedMethodInfo());
+				await That(methods.GetDescription())
 					.IsEqualTo("methods with name equal to \"SomeMethodToVerifyTheNameOfIt\" in assembly")
 					.AsPrefix();
 			}
@@ -83,12 +83,12 @@ public sealed partial class MethodFilters
 			[Fact]
 			public async Task ShouldSupportIgnoringCase()
 			{
-				Filtered.Methods Methods = In.AssemblyContaining<AssemblyFilters>()
+				Filtered.Methods methods = In.AssemblyContaining<AssemblyFilters>()
 					.Methods().WithName(nameof(SomeClassToVerifyTheMethodNameOfIt.SomeMethodToVerifyTheNameOfIt)
 						.ToLowerInvariant()).IgnoringCase();
 
-				await That(Methods).HasSingle().Which.IsEqualTo(ExpectedMethodInfo());
-				await That(Methods.GetDescription())
+				await That(methods).HasSingle().Which.IsEqualTo(ExpectedMethodInfo());
+				await That(methods.GetDescription())
 					.IsEqualTo(
 						"methods with name equal to \"somemethodtoverifythenameofit\" ignoring case in assembly")
 					.AsPrefix();
@@ -97,13 +97,13 @@ public sealed partial class MethodFilters
 			[Fact]
 			public async Task ShouldSupportIgnoringLeadingWhiteSpace()
 			{
-				Filtered.Methods Methods = In.AssemblyContaining<AssemblyFilters>()
+				Filtered.Methods methods = In.AssemblyContaining<AssemblyFilters>()
 					.Methods().WithName(
 						"\t " + nameof(SomeClassToVerifyTheMethodNameOfIt.SomeMethodToVerifyTheNameOfIt))
 					.IgnoringLeadingWhiteSpace();
 
-				await That(Methods).HasSingle().Which.IsEqualTo(ExpectedMethodInfo());
-				await That(Methods.GetDescription())
+				await That(methods).HasSingle().Which.IsEqualTo(ExpectedMethodInfo());
+				await That(methods.GetDescription())
 					.IsEqualTo(
 						"methods with name equal to \"\\t SomeMethodToVerifyTheNameOfI…\" ignoring leading white-space in assembly")
 					.AsPrefix();
@@ -112,13 +112,13 @@ public sealed partial class MethodFilters
 			[Fact]
 			public async Task ShouldSupportIgnoringTrailingWhiteSpace()
 			{
-				Filtered.Methods Methods = In.AssemblyContaining<AssemblyFilters>()
+				Filtered.Methods methods = In.AssemblyContaining<AssemblyFilters>()
 					.Methods().WithName(
 						nameof(SomeClassToVerifyTheMethodNameOfIt.SomeMethodToVerifyTheNameOfIt) + "\t ")
 					.IgnoringTrailingWhiteSpace();
 
-				await That(Methods).HasSingle().Which.IsEqualTo(ExpectedMethodInfo());
-				await That(Methods.GetDescription())
+				await That(methods).HasSingle().Which.IsEqualTo(ExpectedMethodInfo());
+				await That(methods.GetDescription())
 					.IsEqualTo(
 						"methods with name equal to \"SomeMethodToVerifyTheNameOfIt\\t…\" ignoring trailing white-space in assembly")
 					.AsPrefix();
@@ -127,12 +127,12 @@ public sealed partial class MethodFilters
 			[Fact]
 			public async Task ShouldSupportUsingCustomComparer()
 			{
-				Filtered.Methods Methods = In.AssemblyContaining<AssemblyFilters>()
+				Filtered.Methods methods = In.AssemblyContaining<AssemblyFilters>()
 					.Methods().WithName("SOmEMEthOdTOVErIfyThENAmEofit")
 					.Using(new IgnoreCaseForVocalsComparer());
 
-				await That(Methods).HasSingle().Which.IsEqualTo(ExpectedMethodInfo());
-				await That(Methods.GetDescription())
+				await That(methods).HasSingle().Which.IsEqualTo(ExpectedMethodInfo());
+				await That(methods.GetDescription())
 					.IsEqualTo(
 						"methods with name equal to \"SOmEMEthOdTOVErIfyThENAmEofit\" using IgnoreCaseForVocalsComparer in assembly")
 					.AsPrefix();

--- a/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.cs
@@ -1,5 +1,17 @@
-﻿namespace aweXpect.Reflection.Tests.Filters;
+﻿using System.Reflection;
+
+namespace aweXpect.Reflection.Tests.Filters;
 
 public sealed partial class MethodFilters
 {
+	private static MethodInfo? ExpectedMethodInfo()
+		=> typeof(SomeClassToVerifyTheMethodNameOfIt)
+			.GetMethod(nameof(SomeClassToVerifyTheMethodNameOfIt.SomeMethodToVerifyTheNameOfIt));
+
+	private class SomeClassToVerifyTheMethodNameOfIt
+	{
+		public void SomeMethodToVerifyTheNameOfIt()
+		{
+		}
+	}
 }

--- a/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.cs
@@ -10,8 +10,10 @@ public sealed partial class MethodFilters
 
 	private class SomeClassToVerifyTheMethodNameOfIt
 	{
+#pragma warning disable CA1822
 		public void SomeMethodToVerifyTheNameOfIt()
 		{
 		}
+#pragma warning restore CA1822
 	}
 }


### PR DESCRIPTION
This PR adds two new filtering methods for method reflection: `WithName` for filtering methods by name with various string matching options, and `WhichSatisfy` for filtering methods using a custom predicate.

- Implements `WithName` method with fluent API for string equality options (exact, prefix, suffix, regex, wildcard, case sensitivity, whitespace handling)
- Adds `WhichSatisfy` method for custom predicate-based method filtering
- Introduces nested `StringEqualityResult` and `StringEqualityResultType` classes to support the fluent API
