### PR TITLE
chore: bump aweXpect and aweXpect.Core

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,8 +3,8 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="aweXpect" Version="2.18.0" />
-    <PackageVersion Include="aweXpect.Core" Version="2.13.0" />
+    <PackageVersion Include="aweXpect" Version="2.20.0" />
+    <PackageVersion Include="aweXpect.Core" Version="2.15.2" />
   </ItemGroup>
   <ItemGroup>
     <PackageVersion Include="Nullable" Version="1.3.1" />


### PR DESCRIPTION
This PR updates the two aweXpect packages to their latest versions:

- Update aweXpect package from v2.18.0 to v2.20.0
- Update aweXpect.Core package from v2.13.0 to v2.15.2