### PR TITLE
coverage: improve test coverage for filtered assemblies and types

### DIFF
--- a/Source/aweXpect.Reflection/Collections/Filtered.Assemblies.cs
+++ b/Source/aweXpect.Reflection/Collections/Filtered.Assemblies.cs
@@ -73,7 +73,11 @@ public static partial class Filtered
 		{
 			get
 			{
-				_typeFilterDescription = "abstract " + (_typeFilterDescription ?? "");
+				_typeFilterDescription = _typeFilterDescription switch
+				{
+					null => "abstract ",
+					_ => _typeFilterDescription + "abstract ",
+				};
 				_typeFilters.Add(type => type.IsReallyAbstract());
 				return this;
 			}
@@ -84,7 +88,11 @@ public static partial class Filtered
 		{
 			get
 			{
-				_typeFilterDescription = "sealed " + (_typeFilterDescription ?? "");
+				_typeFilterDescription = _typeFilterDescription switch
+				{
+					null => "sealed ",
+					_ => _typeFilterDescription + "sealed ",
+				};
 				_typeFilters.Add(type => type.IsReallySealed());
 				return this;
 			}
@@ -95,7 +103,11 @@ public static partial class Filtered
 		{
 			get
 			{
-				_typeFilterDescription = "static " + (_typeFilterDescription ?? "");
+				_typeFilterDescription = _typeFilterDescription switch
+				{
+					null => "static ",
+					_ => _typeFilterDescription + "static ",
+				};
 				_typeFilters.Add(type => type.IsReallyStatic());
 				return this;
 			}
@@ -106,7 +118,11 @@ public static partial class Filtered
 		{
 			get
 			{
-				_typeFilterDescription = "generic " + (_typeFilterDescription ?? "");
+				_typeFilterDescription = _typeFilterDescription switch
+				{
+					null => "generic ",
+					_ => _typeFilterDescription + "generic ",
+				};
 				_typeFilters.Add(type => type.IsGenericType);
 				return this;
 			}
@@ -117,7 +133,11 @@ public static partial class Filtered
 		{
 			get
 			{
-				_typeFilterDescription = "nested " + (_typeFilterDescription ?? "");
+				_typeFilterDescription = _typeFilterDescription switch
+				{
+					null => "nested ",
+					_ => _typeFilterDescription + "nested ",
+				};
 				_typeFilters.Add(type => type.IsNested);
 				return this;
 			}

--- a/Tests/aweXpect.Reflection.Tests/Collections/Filtered.Assemblies.Classes.AbstractTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Collections/Filtered.Assemblies.Classes.AbstractTests.cs
@@ -1,4 +1,6 @@
-﻿namespace aweXpect.Reflection.Tests.Collections;
+﻿using aweXpect.Reflection.Collections;
+
+namespace aweXpect.Reflection.Tests.Collections;
 
 public sealed partial class Filtered
 {
@@ -13,7 +15,19 @@ public sealed partial class Filtered
 				{
 					Reflection.Collections.Filtered.Types types = In.AllLoadedAssemblies().Abstract.Classes();
 
-					await That(types).All().Satisfy(t => t is { IsClass: true, IsAbstract: true, });
+					await That(types).All().Satisfy(t => t is
+						{ IsClass: true, IsAbstract: true, IsSealed: false, IsInterface: false, });
+				}
+
+				[Fact]
+				public async Task ShouldConsiderAccessModifier()
+				{
+					Reflection.Collections.Filtered.Types types = In.AllLoadedAssemblies()
+						.Abstract.Classes(AccessModifiers.Public);
+
+					await That(types).All().Satisfy(type
+						=> type is { IsAbstract: true, IsSealed: false, IsInterface: false, IsClass: true, } &&
+						   (type.IsNested ? type.IsNestedPublic : type.IsPublic));
 				}
 
 				[Fact]

--- a/Tests/aweXpect.Reflection.Tests/Collections/Filtered.Assemblies.Classes.NestedTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Collections/Filtered.Assemblies.Classes.NestedTests.cs
@@ -1,4 +1,6 @@
-﻿namespace aweXpect.Reflection.Tests.Collections;
+﻿using aweXpect.Reflection.Collections;
+
+namespace aweXpect.Reflection.Tests.Collections;
 
 public sealed partial class Filtered
 {
@@ -14,6 +16,16 @@ public sealed partial class Filtered
 					Reflection.Collections.Filtered.Types types = In.AllLoadedAssemblies().Nested.Classes();
 
 					await That(types).All().Satisfy(t => t is { IsClass: true, IsNested: true, });
+				}
+
+				[Fact]
+				public async Task ShouldConsiderAccessModifier()
+				{
+					Reflection.Collections.Filtered.Types types = In.AllLoadedAssemblies()
+						.Nested.Classes(AccessModifiers.Public);
+
+					await That(types).All().Satisfy(type
+						=> type is { IsClass: true, IsNested: true, IsNestedPublic: true, });
 				}
 
 				[Fact]

--- a/Tests/aweXpect.Reflection.Tests/Collections/Filtered.Assemblies.Classes.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Collections/Filtered.Assemblies.Classes.Tests.cs
@@ -1,4 +1,6 @@
-﻿namespace aweXpect.Reflection.Tests.Collections;
+﻿using aweXpect.Reflection.Collections;
+
+namespace aweXpect.Reflection.Tests.Collections;
 
 public sealed partial class Filtered
 {
@@ -14,6 +16,16 @@ public sealed partial class Filtered
 					Reflection.Collections.Filtered.Types types = In.AllLoadedAssemblies().Classes();
 
 					await That(types).All().Satisfy(t => t.IsClass);
+				}
+
+				[Theory]
+				[MemberData(nameof(CheckAccessModifiers), MemberType = typeof(Assemblies))]
+				public async Task ShouldConsiderAccessModifier(AccessModifiers accessModifier, Func<Type, bool> check)
+				{
+					Reflection.Collections.Filtered.Types types = In.AllLoadedAssemblies()
+						.Classes(accessModifier);
+
+					await That(types).All().Satisfy(type => type.IsClass && check(type));
 				}
 
 				[Fact]

--- a/Tests/aweXpect.Reflection.Tests/Collections/Filtered.Assemblies.Enums.NestedTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Collections/Filtered.Assemblies.Enums.NestedTests.cs
@@ -1,4 +1,6 @@
-﻿namespace aweXpect.Reflection.Tests.Collections;
+﻿using aweXpect.Reflection.Collections;
+
+namespace aweXpect.Reflection.Tests.Collections;
 
 public sealed partial class Filtered
 {
@@ -14,6 +16,16 @@ public sealed partial class Filtered
 					Reflection.Collections.Filtered.Types types = In.AllLoadedAssemblies().Nested.Enums();
 
 					await That(types).All().Satisfy(t => t is { IsEnum: true, IsNested: true, });
+				}
+
+				[Fact]
+				public async Task ShouldConsiderAccessModifier()
+				{
+					Reflection.Collections.Filtered.Types types = In.AllLoadedAssemblies()
+						.Nested.Enums(AccessModifiers.Public);
+
+					await That(types).All().Satisfy(type
+						=> type is { IsEnum: true, IsNested: true, IsNestedPublic: true, });
 				}
 
 				[Fact]

--- a/Tests/aweXpect.Reflection.Tests/Collections/Filtered.Assemblies.Enums.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Collections/Filtered.Assemblies.Enums.Tests.cs
@@ -1,4 +1,6 @@
-﻿namespace aweXpect.Reflection.Tests.Collections;
+﻿using aweXpect.Reflection.Collections;
+
+namespace aweXpect.Reflection.Tests.Collections;
 
 public sealed partial class Filtered
 {
@@ -14,6 +16,16 @@ public sealed partial class Filtered
 					Reflection.Collections.Filtered.Types types = In.AllLoadedAssemblies().Enums();
 
 					await That(types).All().Satisfy(t => t.IsEnum);
+				}
+
+				[Theory]
+				[MemberData(nameof(CheckAccessModifiers), MemberType = typeof(Assemblies))]
+				public async Task ShouldConsiderAccessModifier(AccessModifiers accessModifier, Func<Type, bool> check)
+				{
+					Reflection.Collections.Filtered.Types types = In.AllLoadedAssemblies()
+						.Enums(accessModifier);
+
+					await That(types).All().Satisfy(type => type.IsEnum && check(type));
 				}
 
 				[Fact]

--- a/Tests/aweXpect.Reflection.Tests/Collections/Filtered.Assemblies.Interfaces.NestedTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Collections/Filtered.Assemblies.Interfaces.NestedTests.cs
@@ -1,4 +1,6 @@
-﻿namespace aweXpect.Reflection.Tests.Collections;
+﻿using aweXpect.Reflection.Collections;
+
+namespace aweXpect.Reflection.Tests.Collections;
 
 public sealed partial class Filtered
 {
@@ -14,6 +16,16 @@ public sealed partial class Filtered
 					Reflection.Collections.Filtered.Types types = In.AllLoadedAssemblies().Nested.Interfaces();
 
 					await That(types).All().Satisfy(t => t is { IsInterface: true, IsNested: true, });
+				}
+
+				[Fact]
+				public async Task ShouldConsiderAccessModifier()
+				{
+					Reflection.Collections.Filtered.Types types = In.AllLoadedAssemblies()
+						.Nested.Interfaces(AccessModifiers.Public);
+
+					await That(types).All().Satisfy(type
+						=> type is { IsInterface: true, IsNested: true, IsNestedPublic: true, });
 				}
 
 				[Fact]

--- a/Tests/aweXpect.Reflection.Tests/Collections/Filtered.Assemblies.Interfaces.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Collections/Filtered.Assemblies.Interfaces.Tests.cs
@@ -1,4 +1,6 @@
-﻿namespace aweXpect.Reflection.Tests.Collections;
+﻿using aweXpect.Reflection.Collections;
+
+namespace aweXpect.Reflection.Tests.Collections;
 
 public sealed partial class Filtered
 {
@@ -14,6 +16,16 @@ public sealed partial class Filtered
 					Reflection.Collections.Filtered.Types types = In.AllLoadedAssemblies().Interfaces();
 
 					await That(types).All().Satisfy(t => t.IsInterface);
+				}
+
+				[Theory]
+				[MemberData(nameof(CheckAccessModifiers), MemberType = typeof(Assemblies))]
+				public async Task ShouldConsiderAccessModifier(AccessModifiers accessModifier, Func<Type, bool> check)
+				{
+					Reflection.Collections.Filtered.Types types = In.AllLoadedAssemblies()
+						.Interfaces(accessModifier);
+
+					await That(types).All().Satisfy(type => type.IsInterface && check(type));
 				}
 
 				[Fact]

--- a/Tests/aweXpect.Reflection.Tests/Collections/Filtered.Assemblies.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Collections/Filtered.Assemblies.Tests.cs
@@ -1,0 +1,173 @@
+﻿using System.Reflection;
+
+namespace aweXpect.Reflection.Tests.Collections;
+
+public sealed partial class Filtered
+{
+	public sealed partial class Assemblies
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task Assembly_FromTypes_ShouldHaveExpectedDescription()
+			{
+				Assembly assembly = typeof(Tests).Assembly;
+
+				Reflection.Collections.Filtered.Assemblies assemblies =
+					new Reflection.Collections.Filtered.Assemblies(assembly, "in my assembly").Types().Assemblies();
+				string description = assemblies.GetDescription();
+
+				await That(assemblies).IsNotEmpty();
+				await That(description).IsEqualTo("assemblies containing types in my assembly");
+			}
+
+			[Fact]
+			public async Task CanCombineAbstractAndGeneric()
+			{
+				Reflection.Collections.Filtered.Types types = In.AllLoadedAssemblies().Abstract.Generic.Classes();
+				string description = types.GetDescription();
+
+				await That(description).IsEqualTo("abstract generic classes in all loaded assemblies");
+			}
+
+			[Fact]
+			public async Task CanCombineAbstractAndNested()
+			{
+				Reflection.Collections.Filtered.Types types = In.AllLoadedAssemblies().Abstract.Nested.Classes();
+				string description = types.GetDescription();
+
+				await That(description).IsEqualTo("abstract nested classes in all loaded assemblies");
+			}
+
+			[Fact]
+			public async Task CanCombineGenericAndAbstract()
+			{
+				Reflection.Collections.Filtered.Types types = In.AllLoadedAssemblies().Generic.Abstract.Classes();
+				string description = types.GetDescription();
+
+				await That(description).IsEqualTo("generic abstract classes in all loaded assemblies");
+			}
+
+			[Fact]
+			public async Task CanCombineGenericAndSealed()
+			{
+				Reflection.Collections.Filtered.Types types = In.AllLoadedAssemblies().Generic.Sealed.Classes();
+				string description = types.GetDescription();
+
+				await That(description).IsEqualTo("generic sealed classes in all loaded assemblies");
+			}
+
+			[Fact]
+			public async Task CanCombineGenericAndStatic()
+			{
+				Reflection.Collections.Filtered.Types types = In.AllLoadedAssemblies().Generic.Static.Classes();
+				string description = types.GetDescription();
+
+				await That(description).IsEqualTo("generic static classes in all loaded assemblies");
+			}
+
+			[Fact]
+			public async Task CanCombineGenericNestedAndAbstract()
+			{
+				Reflection.Collections.Filtered.Types
+					types = In.AllLoadedAssemblies().Generic.Nested.Abstract.Classes();
+				string description = types.GetDescription();
+
+				await That(description).IsEqualTo("generic nested abstract classes in all loaded assemblies");
+			}
+
+			[Fact]
+			public async Task CanCombineGenericStaticAndNested()
+			{
+				Reflection.Collections.Filtered.Types types = In.AllLoadedAssemblies().Generic.Static.Nested.Classes();
+				string description = types.GetDescription();
+
+				await That(description).IsEqualTo("generic static nested classes in all loaded assemblies");
+			}
+
+			[Fact]
+			public async Task CanCombineNestedAndAbstract()
+			{
+				Reflection.Collections.Filtered.Types types = In.AllLoadedAssemblies().Nested.Abstract.Classes();
+				string description = types.GetDescription();
+
+				await That(description).IsEqualTo("nested abstract classes in all loaded assemblies");
+			}
+
+			[Fact]
+			public async Task CanCombineNestedAndSealed()
+			{
+				Reflection.Collections.Filtered.Types types = In.AllLoadedAssemblies().Nested.Sealed.Classes();
+				string description = types.GetDescription();
+
+				await That(description).IsEqualTo("nested sealed classes in all loaded assemblies");
+			}
+
+			[Fact]
+			public async Task CanCombineNestedAndStatic()
+			{
+				Reflection.Collections.Filtered.Types types = In.AllLoadedAssemblies().Nested.Static.Classes();
+				string description = types.GetDescription();
+
+				await That(description).IsEqualTo("nested static classes in all loaded assemblies");
+			}
+
+			[Fact]
+			public async Task CanCombineNestedGenericAndSealed()
+			{
+				Reflection.Collections.Filtered.Types types = In.AllLoadedAssemblies().Nested.Generic.Sealed.Classes();
+				string description = types.GetDescription();
+
+				await That(description).IsEqualTo("nested generic sealed classes in all loaded assemblies");
+			}
+
+			[Fact]
+			public async Task CanCombineSealedAndGeneric()
+			{
+				Reflection.Collections.Filtered.Types types = In.AllLoadedAssemblies().Sealed.Generic.Classes();
+				string description = types.GetDescription();
+
+				await That(description).IsEqualTo("sealed generic classes in all loaded assemblies");
+			}
+
+			[Fact]
+			public async Task CanCombineSealedAndNested()
+			{
+				Reflection.Collections.Filtered.Types types = In.AllLoadedAssemblies().Sealed.Nested.Classes();
+				string description = types.GetDescription();
+
+				await That(description).IsEqualTo("sealed nested classes in all loaded assemblies");
+			}
+
+			[Fact]
+			public async Task CanCombineStaticAndGeneric()
+			{
+				Reflection.Collections.Filtered.Types types = In.AllLoadedAssemblies().Static.Generic.Classes();
+				string description = types.GetDescription();
+
+				await That(description).IsEqualTo("static generic classes in all loaded assemblies");
+			}
+
+			[Fact]
+			public async Task CanCombineStaticAndNested()
+			{
+				Reflection.Collections.Filtered.Types types = In.AllLoadedAssemblies().Static.Nested.Classes();
+				string description = types.GetDescription();
+
+				await That(description).IsEqualTo("static nested classes in all loaded assemblies");
+			}
+
+			[Fact]
+			public async Task NullAssembly_ShouldBeIgnored()
+			{
+				Assembly? assembly = null;
+
+				Reflection.Collections.Filtered.Assemblies assemblies = new(assembly, "in my assembly");
+				string description = assemblies.GetDescription();
+
+				await That(assemblies).IsEmpty();
+				await That(description).IsEqualTo("in my assembly");
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/Collections/Filtered.Assemblies.Types.AbstractTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Collections/Filtered.Assemblies.Types.AbstractTests.cs
@@ -19,6 +19,17 @@ public sealed partial class Filtered
 				}
 
 				[Fact]
+				public async Task ShouldConsiderAccessModifier()
+				{
+					Reflection.Collections.Filtered.Types types = In.AllLoadedAssemblies()
+						.Abstract.Types(AccessModifiers.Public);
+
+					await That(types).All().Satisfy(type
+						=> type is { IsAbstract: true, IsSealed: false, IsInterface: false, } &&
+						   (type.IsNested ? type.IsNestedPublic : type.IsPublic));
+				}
+
+				[Fact]
 				public async Task ShouldIncludeAbstractInformationInErrorMessage()
 				{
 					async Task Act()

--- a/Tests/aweXpect.Reflection.Tests/Collections/Filtered.Assemblies.Types.NestedTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Collections/Filtered.Assemblies.Types.NestedTests.cs
@@ -19,6 +19,16 @@ public sealed partial class Filtered
 				}
 
 				[Fact]
+				public async Task ShouldConsiderAccessModifier()
+				{
+					Reflection.Collections.Filtered.Types types = In.AllLoadedAssemblies()
+						.Nested.Types(AccessModifiers.Public);
+
+					await That(types).All().Satisfy(type
+						=> type is { IsNested: true, IsNestedPublic: true, });
+				}
+
+				[Fact]
 				public async Task ShouldIncludeNestedInformationInErrorMessage()
 				{
 					async Task Act()

--- a/Tests/aweXpect.Reflection.Tests/Collections/Filtered.Assemblies.Types.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Collections/Filtered.Assemblies.Types.Tests.cs
@@ -1,4 +1,6 @@
-﻿namespace aweXpect.Reflection.Tests.Collections;
+﻿using aweXpect.Reflection.Collections;
+
+namespace aweXpect.Reflection.Tests.Collections;
 
 public sealed partial class Filtered
 {
@@ -17,6 +19,26 @@ public sealed partial class Filtered
 						.AtLeast(1).Satisfy(t => t.IsClass).And
 						.AtLeast(1).Satisfy(t => t.IsInterface).And
 						.AtLeast(1).Satisfy(t => t.IsEnum);
+				}
+
+				[Theory]
+				[MemberData(nameof(CheckAccessModifiers), MemberType = typeof(Assemblies))]
+				public async Task ShouldConsiderAccessModifier(AccessModifiers accessModifier, Func<Type, bool> check)
+				{
+					Reflection.Collections.Filtered.Types types = In.AllLoadedAssemblies()
+						.Types(accessModifier);
+
+					await That(types).All().Satisfy(check);
+				}
+
+				[Fact]
+				public async Task ShouldConsiderPrivateAccessModifier()
+				{
+					Reflection.Collections.Filtered.Types types = In.AllLoadedAssemblies()
+						.Types(AccessModifiers.Private);
+
+					await That(types).All().Satisfy(type
+						=> type.IsNested ? type.IsNestedPrivate : type.IsNotPublic);
 				}
 
 				[Fact]

--- a/Tests/aweXpect.Reflection.Tests/Collections/Filtered.Assemblies.cs
+++ b/Tests/aweXpect.Reflection.Tests/Collections/Filtered.Assemblies.cs
@@ -32,5 +32,19 @@ public sealed partial class Filtered
 					"public, protected or internal "
 				},
 			};
+
+		public static TheoryData<AccessModifiers, Func<Type, bool>> CheckAccessModifiers()
+			=> new()
+			{
+				{
+					AccessModifiers.Public, type => type.IsNested ? type.IsNestedPublic : type.IsPublic
+				},
+				{
+					AccessModifiers.Private, type => type.IsNested ? type.IsNestedPrivate : type.IsNotPublic
+				},
+				{
+					AccessModifiers.Internal, type => type.IsNested ? type.IsNestedAssembly : !type.IsVisible
+				},
+			};
 	}
 }

--- a/Tests/aweXpect.Reflection.Tests/Collections/Filtered.Types.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Collections/Filtered.Types.Tests.cs
@@ -1,0 +1,88 @@
+﻿namespace aweXpect.Reflection.Tests.Collections;
+
+public sealed partial class Filtered
+{
+	public sealed class Types
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task Types_FromConstructors_ShouldHaveExpectedDescription()
+			{
+				Reflection.Collections.Filtered.Types types = In.AssemblyContaining<Tests>()
+					.Types().Constructors().DeclaringTypes();
+
+				string description = types.GetDescription();
+
+				await That(types).IsNotEmpty();
+				await That(description)
+					.IsEqualTo(
+						"declaring types of constructors in types in assembly containing type Filtered.Types.Tests");
+			}
+
+			[Fact]
+			public async Task Types_FromEvents_ShouldHaveExpectedDescription()
+			{
+				Reflection.Collections.Filtered.Types types = In.AssemblyContaining<Tests>()
+					.Types().Events().DeclaringTypes();
+
+				string description = types.GetDescription();
+
+				await That(types).IsNotEmpty();
+				await That(description)
+					.IsEqualTo("declaring types of events in types in assembly containing type Filtered.Types.Tests");
+			}
+
+			[Fact]
+			public async Task Types_FromFields_ShouldHaveExpectedDescription()
+			{
+				Reflection.Collections.Filtered.Types types = In.AssemblyContaining<Tests>()
+					.Types().Fields().DeclaringTypes();
+
+				string description = types.GetDescription();
+
+				await That(types).IsNotEmpty();
+				await That(description)
+					.IsEqualTo("declaring types of fields in types in assembly containing type Filtered.Types.Tests");
+			}
+
+			[Fact]
+			public async Task Types_FromMethods_ShouldHaveExpectedDescription()
+			{
+				Reflection.Collections.Filtered.Types types = In.AssemblyContaining<Tests>()
+					.Types().Methods().DeclaringTypes();
+
+				string description = types.GetDescription();
+
+				await That(types).IsNotEmpty();
+				await That(description)
+					.IsEqualTo("declaring types of methods in types in assembly containing type Filtered.Types.Tests");
+			}
+
+			[Fact]
+			public async Task Types_FromProperties_ShouldHaveExpectedDescription()
+			{
+				Reflection.Collections.Filtered.Types types = In.AssemblyContaining<Tests>()
+					.Types().Properties().DeclaringTypes();
+
+				string description = types.GetDescription();
+
+				await That(types).IsNotEmpty();
+				await That(description)
+					.IsEqualTo(
+						"declaring types of properties in types in assembly containing type Filtered.Types.Tests");
+			}
+
+			[Fact]
+			public async Task Types_InAssembly_ShouldHaveExpectedDescription()
+			{
+				Reflection.Collections.Filtered.Types types = In.AssemblyContaining<Tests>().Types();
+
+				string description = types.GetDescription();
+
+				await That(types).IsNotEmpty();
+				await That(description).IsEqualTo("types in assembly containing type Filtered.Types.Tests");
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/Filters/ConstructorFilters.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/ConstructorFilters.cs
@@ -7,13 +7,14 @@ public sealed partial class ConstructorFilters
 {
 	private static ConstructorInfo? ExpectedConstructorInfo()
 		=> typeof(SomeClassToVerifyTheConstructorNameOfIt)
-			.GetConstructors().Single();
+			.GetConstructors(
+				BindingFlags.DeclaredOnly | BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance)
+			.Single();
 
 	private class SomeClassToVerifyTheConstructorNameOfIt
 	{
-		public SomeClassToVerifyTheConstructorNameOfIt()
+		private SomeClassToVerifyTheConstructorNameOfIt()
 		{
-			
 		}
 	}
 }


### PR DESCRIPTION
This PR improves test coverage for filtered assemblies and types in the aweXpect.Reflection library by adding comprehensive test cases for various filtering scenarios.

- Enhanced test coverage for access modifier filtering across different type categories (classes, interfaces, enums)
- Added tests for combined type filters (abstract + generic, nested + sealed, etc.)
- Improved constructor filter tests to handle non-public constructors