### PR TITLE
feat: add `Of{Exact}Type` filter for fields and properties

### DIFF
--- a/Source/aweXpect.Reflection/Filters/FieldFilters.OfExactType.cs
+++ b/Source/aweXpect.Reflection/Filters/FieldFilters.OfExactType.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Reflection;
+using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Helpers;
+
+namespace aweXpect.Reflection;
+
+public static partial class FieldFilters
+{
+	/// <summary>
+	///     Filter for fields of exact type <typeparamref name="TField" />.
+	/// </summary>
+	public static FieldsOfType OfExactType<TField>(this Filtered.Fields @this)
+		=> OfExactType(@this, typeof(TField));
+
+	/// <summary>
+	///     Filter for fields of exact type <paramref name="fieldType" />.
+	/// </summary>
+	public static FieldsOfType OfExactType(this Filtered.Fields @this,
+		Type fieldType)
+	{
+		IChangeableFilter<FieldInfo> filter = Filter.Suffix<FieldInfo>(
+			fieldInfo => fieldInfo.FieldType.IsOrInheritsFrom(fieldType, true),
+			$"of exact type {Formatter.Format(fieldType)} ");
+		return new FieldsOfType(@this.Which(filter), filter);
+	}
+
+	public partial class FieldsOfType
+	{
+		/// <summary>
+		///     Allow an alternative type <typeparamref name="TField" /> exactly.
+		/// </summary>
+		public FieldsOfType OrOfExactType<TField>()
+			=> OrOfExactType(typeof(TField));
+
+		/// <summary>
+		///     Allow an alternative type <paramref name="fieldType" /> exactly.
+		/// </summary>
+		public FieldsOfType OrOfExactType(Type fieldType)
+		{
+			filter.UpdateFilter(
+				(result, fieldInfo)
+					=> result || fieldInfo.FieldType.IsOrInheritsFrom(fieldType, true),
+				description
+					=> $"{description}or of exact type {Formatter.Format(fieldType)} ");
+			return this;
+		}
+	}
+}

--- a/Source/aweXpect.Reflection/Filters/FieldFilters.OfType.cs
+++ b/Source/aweXpect.Reflection/Filters/FieldFilters.OfType.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Reflection;
+using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Helpers;
+
+namespace aweXpect.Reflection;
+
+public static partial class FieldFilters
+{
+	/// <summary>
+	///     Filter for fields of type <typeparamref name="TField" />.
+	/// </summary>
+	public static FieldsOfType OfType<TField>(this Filtered.Fields @this)
+		=> OfType(@this, typeof(TField));
+
+	/// <summary>
+	///     Filter for fields of type <paramref name="fieldType" />.
+	/// </summary>
+	public static FieldsOfType OfType(this Filtered.Fields @this,
+		Type fieldType)
+	{
+		IChangeableFilter<FieldInfo> filter = Filter.Suffix<FieldInfo>(
+			fieldInfo => fieldInfo.FieldType.IsOrInheritsFrom(fieldType),
+			$"of type {Formatter.Format(fieldType)} ");
+		return new FieldsOfType(@this.Which(filter), filter);
+	}
+
+	public partial class FieldsOfType
+	{
+		/// <summary>
+		///     Allow an alternative type <typeparamref name="TField" />.
+		/// </summary>
+		public FieldsOfType OrOfType<TField>()
+			=> OrOfType(typeof(TField));
+
+		/// <summary>
+		///     Allow an alternative type <paramref name="fieldType" />.
+		/// </summary>
+		public FieldsOfType OrOfType(Type fieldType)
+		{
+			filter.UpdateFilter(
+				(result, fieldInfo)
+					=> result || fieldInfo.FieldType.IsOrInheritsFrom(fieldType),
+				description
+					=> $"{description}or of type {Formatter.Format(fieldType)} ");
+			return this;
+		}
+	}
+}

--- a/Source/aweXpect.Reflection/Filters/FieldFilters.cs
+++ b/Source/aweXpect.Reflection/Filters/FieldFilters.cs
@@ -1,4 +1,5 @@
-﻿using aweXpect.Reflection.Collections;
+﻿using System.Reflection;
+using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection;
 
@@ -7,4 +8,9 @@ namespace aweXpect.Reflection;
 /// </summary>
 public static partial class FieldFilters
 {
+	/// <summary>
+	///     Additional filters on fields of a specific type.
+	/// </summary>
+	public partial class FieldsOfType(Filtered.Fields inner, IChangeableFilter<FieldInfo> filter)
+		: Filtered.Fields(inner);
 }

--- a/Source/aweXpect.Reflection/Filters/PropertyFilters.OfExactType.cs
+++ b/Source/aweXpect.Reflection/Filters/PropertyFilters.OfExactType.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Reflection;
+using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Helpers;
+
+namespace aweXpect.Reflection;
+
+public static partial class PropertyFilters
+{
+	/// <summary>
+	///     Filter for properties of exact type <typeparamref name="TProperty" />.
+	/// </summary>
+	public static PropertiesOfType OfExactType<TProperty>(this Filtered.Properties @this)
+		=> OfExactType(@this, typeof(TProperty));
+
+	/// <summary>
+	///     Filter for properties of exact type <paramref name="propertyType" />.
+	/// </summary>
+	public static PropertiesOfType OfExactType(this Filtered.Properties @this,
+		Type propertyType)
+	{
+		IChangeableFilter<PropertyInfo> filter = Filter.Suffix<PropertyInfo>(
+			propertyInfo => propertyInfo.PropertyType.IsOrInheritsFrom(propertyType, true),
+			$"of exact type {Formatter.Format(propertyType)} ");
+		return new PropertiesOfType(@this.Which(filter), filter);
+	}
+
+	public partial class PropertiesOfType
+	{
+		/// <summary>
+		///     Allow an alternative type <typeparamref name="TProperty" /> exactly.
+		/// </summary>
+		public PropertiesOfType OrOfExactType<TProperty>()
+			=> OrOfExactType(typeof(TProperty));
+
+		/// <summary>
+		///     Allow an alternative type <paramref name="propertyType" /> exactly.
+		/// </summary>
+		public PropertiesOfType OrOfExactType(Type propertyType)
+		{
+			filter.UpdateFilter(
+				(result, propertyInfo)
+					=> result || propertyInfo.PropertyType.IsOrInheritsFrom(propertyType, true),
+				description
+					=> $"{description}or of exact type {Formatter.Format(propertyType)} ");
+			return this;
+		}
+	}
+}

--- a/Source/aweXpect.Reflection/Filters/PropertyFilters.OfType.cs
+++ b/Source/aweXpect.Reflection/Filters/PropertyFilters.OfType.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Reflection;
+using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Helpers;
+
+namespace aweXpect.Reflection;
+
+public static partial class PropertyFilters
+{
+	/// <summary>
+	///     Filter for properties of type <typeparamref name="TProperty" />.
+	/// </summary>
+	public static PropertiesOfType OfType<TProperty>(this Filtered.Properties @this)
+		=> OfType(@this, typeof(TProperty));
+
+	/// <summary>
+	///     Filter for properties of type <paramref name="propertyType" />.
+	/// </summary>
+	public static PropertiesOfType OfType(this Filtered.Properties @this,
+		Type propertyType)
+	{
+		IChangeableFilter<PropertyInfo> filter = Filter.Suffix<PropertyInfo>(
+			propertyInfo => propertyInfo.PropertyType.IsOrInheritsFrom(propertyType),
+			$"of type {Formatter.Format(propertyType)} ");
+		return new PropertiesOfType(@this.Which(filter), filter);
+	}
+
+	public partial class PropertiesOfType
+	{
+		/// <summary>
+		///     Allow an alternative type <typeparamref name="TProperty" />.
+		/// </summary>
+		public PropertiesOfType OrOfType<TProperty>()
+			=> OrOfType(typeof(TProperty));
+
+		/// <summary>
+		///     Allow an alternative type <paramref name="propertyType" />.
+		/// </summary>
+		public PropertiesOfType OrOfType(Type propertyType)
+		{
+			filter.UpdateFilter(
+				(result, propertyInfo)
+					=> result || propertyInfo.PropertyType.IsOrInheritsFrom(propertyType),
+				description
+					=> $"{description}or of type {Formatter.Format(propertyType)} ");
+			return this;
+		}
+	}
+}

--- a/Source/aweXpect.Reflection/Filters/PropertyFilters.cs
+++ b/Source/aweXpect.Reflection/Filters/PropertyFilters.cs
@@ -1,4 +1,5 @@
-﻿using aweXpect.Reflection.Collections;
+﻿using System.Reflection;
+using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection;
 
@@ -7,4 +8,9 @@ namespace aweXpect.Reflection;
 /// </summary>
 public static partial class PropertyFilters
 {
+	/// <summary>
+	///     Additional filters on properties of a specific type.
+	/// </summary>
+	public partial class PropertiesOfType(Filtered.Properties inner, IChangeableFilter<PropertyInfo> filter)
+		: Filtered.Properties(inner);
 }

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net8.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net8.0.txt
@@ -47,6 +47,10 @@ namespace aweXpect.Reflection
     }
     public static class FieldFilters
     {
+        public static aweXpect.Reflection.FieldFilters.FieldsOfType OfExactType(this aweXpect.Reflection.Collections.Filtered.Fields @this, System.Type fieldType) { }
+        public static aweXpect.Reflection.FieldFilters.FieldsOfType OfExactType<TField>(this aweXpect.Reflection.Collections.Filtered.Fields @this) { }
+        public static aweXpect.Reflection.FieldFilters.FieldsOfType OfType(this aweXpect.Reflection.Collections.Filtered.Fields @this, System.Type fieldType) { }
+        public static aweXpect.Reflection.FieldFilters.FieldsOfType OfType<TField>(this aweXpect.Reflection.Collections.Filtered.Fields @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Fields WhichAre(this aweXpect.Reflection.Collections.Filtered.Fields @this, aweXpect.Reflection.Collections.AccessModifiers accessModifier) { }
         public static aweXpect.Reflection.Collections.Filtered.Fields WhichAreNot(this aweXpect.Reflection.Collections.Filtered.Fields @this, aweXpect.Reflection.Collections.AccessModifiers accessModifier) { }
         public static aweXpect.Reflection.Collections.Filtered.Fields WhichSatisfy(this aweXpect.Reflection.Collections.Filtered.Fields @this, System.Func<System.Reflection.FieldInfo, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
@@ -55,6 +59,14 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.FieldFilters.FieldsWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Fields @this, System.Func<TAttribute, bool>? predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Collections.Filtered.Fields.StringEqualityResultType WithName(this aweXpect.Reflection.Collections.Filtered.Fields @this, string expected) { }
+        public class FieldsOfType : aweXpect.Reflection.Collections.Filtered.Fields
+        {
+            public FieldsOfType(aweXpect.Reflection.Collections.Filtered.Fields inner, aweXpect.Reflection.Collections.IChangeableFilter<System.Reflection.FieldInfo> filter) { }
+            public aweXpect.Reflection.FieldFilters.FieldsOfType OrOfExactType(System.Type fieldType) { }
+            public aweXpect.Reflection.FieldFilters.FieldsOfType OrOfExactType<TField>() { }
+            public aweXpect.Reflection.FieldFilters.FieldsOfType OrOfType(System.Type fieldType) { }
+            public aweXpect.Reflection.FieldFilters.FieldsOfType OrOfType<TField>() { }
+        }
         public class FieldsWith : aweXpect.Reflection.Collections.Filtered.Fields
         {
             public FieldsWith(aweXpect.Reflection.Collections.Filtered.Fields inner, aweXpect.Reflection.Collections.IChangeableFilter<System.Reflection.FieldInfo> filter) { }
@@ -95,6 +107,10 @@ namespace aweXpect.Reflection
     }
     public static class PropertyFilters
     {
+        public static aweXpect.Reflection.PropertyFilters.PropertiesOfType OfExactType(this aweXpect.Reflection.Collections.Filtered.Properties @this, System.Type propertyType) { }
+        public static aweXpect.Reflection.PropertyFilters.PropertiesOfType OfExactType<TProperty>(this aweXpect.Reflection.Collections.Filtered.Properties @this) { }
+        public static aweXpect.Reflection.PropertyFilters.PropertiesOfType OfType(this aweXpect.Reflection.Collections.Filtered.Properties @this, System.Type propertyType) { }
+        public static aweXpect.Reflection.PropertyFilters.PropertiesOfType OfType<TProperty>(this aweXpect.Reflection.Collections.Filtered.Properties @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Properties WhichAre(this aweXpect.Reflection.Collections.Filtered.Properties @this, aweXpect.Reflection.Collections.AccessModifiers accessModifier) { }
         public static aweXpect.Reflection.Collections.Filtered.Properties WhichAreNot(this aweXpect.Reflection.Collections.Filtered.Properties @this, aweXpect.Reflection.Collections.AccessModifiers accessModifier) { }
         public static aweXpect.Reflection.Collections.Filtered.Properties WhichSatisfy(this aweXpect.Reflection.Collections.Filtered.Properties @this, System.Func<System.Reflection.PropertyInfo, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
@@ -103,6 +119,14 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.PropertyFilters.PropertiesWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Properties @this, System.Func<TAttribute, bool>? predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Collections.Filtered.Properties.StringEqualityResultType WithName(this aweXpect.Reflection.Collections.Filtered.Properties @this, string expected) { }
+        public class PropertiesOfType : aweXpect.Reflection.Collections.Filtered.Properties
+        {
+            public PropertiesOfType(aweXpect.Reflection.Collections.Filtered.Properties inner, aweXpect.Reflection.Collections.IChangeableFilter<System.Reflection.PropertyInfo> filter) { }
+            public aweXpect.Reflection.PropertyFilters.PropertiesOfType OrOfExactType(System.Type propertyType) { }
+            public aweXpect.Reflection.PropertyFilters.PropertiesOfType OrOfExactType<TProperty>() { }
+            public aweXpect.Reflection.PropertyFilters.PropertiesOfType OrOfType(System.Type propertyType) { }
+            public aweXpect.Reflection.PropertyFilters.PropertiesOfType OrOfType<TProperty>() { }
+        }
         public class PropertiesWith : aweXpect.Reflection.Collections.Filtered.Properties
         {
             public PropertiesWith(aweXpect.Reflection.Collections.Filtered.Properties inner, aweXpect.Reflection.Collections.IChangeableFilter<System.Reflection.PropertyInfo> filter) { }

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_netstandard2.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_netstandard2.0.txt
@@ -47,6 +47,10 @@ namespace aweXpect.Reflection
     }
     public static class FieldFilters
     {
+        public static aweXpect.Reflection.FieldFilters.FieldsOfType OfExactType(this aweXpect.Reflection.Collections.Filtered.Fields @this, System.Type fieldType) { }
+        public static aweXpect.Reflection.FieldFilters.FieldsOfType OfExactType<TField>(this aweXpect.Reflection.Collections.Filtered.Fields @this) { }
+        public static aweXpect.Reflection.FieldFilters.FieldsOfType OfType(this aweXpect.Reflection.Collections.Filtered.Fields @this, System.Type fieldType) { }
+        public static aweXpect.Reflection.FieldFilters.FieldsOfType OfType<TField>(this aweXpect.Reflection.Collections.Filtered.Fields @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Fields WhichAre(this aweXpect.Reflection.Collections.Filtered.Fields @this, aweXpect.Reflection.Collections.AccessModifiers accessModifier) { }
         public static aweXpect.Reflection.Collections.Filtered.Fields WhichAreNot(this aweXpect.Reflection.Collections.Filtered.Fields @this, aweXpect.Reflection.Collections.AccessModifiers accessModifier) { }
         public static aweXpect.Reflection.Collections.Filtered.Fields WhichSatisfy(this aweXpect.Reflection.Collections.Filtered.Fields @this, System.Func<System.Reflection.FieldInfo, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
@@ -55,6 +59,14 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.FieldFilters.FieldsWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Fields @this, System.Func<TAttribute, bool>? predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Collections.Filtered.Fields.StringEqualityResultType WithName(this aweXpect.Reflection.Collections.Filtered.Fields @this, string expected) { }
+        public class FieldsOfType : aweXpect.Reflection.Collections.Filtered.Fields
+        {
+            public FieldsOfType(aweXpect.Reflection.Collections.Filtered.Fields inner, aweXpect.Reflection.Collections.IChangeableFilter<System.Reflection.FieldInfo> filter) { }
+            public aweXpect.Reflection.FieldFilters.FieldsOfType OrOfExactType(System.Type fieldType) { }
+            public aweXpect.Reflection.FieldFilters.FieldsOfType OrOfExactType<TField>() { }
+            public aweXpect.Reflection.FieldFilters.FieldsOfType OrOfType(System.Type fieldType) { }
+            public aweXpect.Reflection.FieldFilters.FieldsOfType OrOfType<TField>() { }
+        }
         public class FieldsWith : aweXpect.Reflection.Collections.Filtered.Fields
         {
             public FieldsWith(aweXpect.Reflection.Collections.Filtered.Fields inner, aweXpect.Reflection.Collections.IChangeableFilter<System.Reflection.FieldInfo> filter) { }
@@ -95,6 +107,10 @@ namespace aweXpect.Reflection
     }
     public static class PropertyFilters
     {
+        public static aweXpect.Reflection.PropertyFilters.PropertiesOfType OfExactType(this aweXpect.Reflection.Collections.Filtered.Properties @this, System.Type propertyType) { }
+        public static aweXpect.Reflection.PropertyFilters.PropertiesOfType OfExactType<TProperty>(this aweXpect.Reflection.Collections.Filtered.Properties @this) { }
+        public static aweXpect.Reflection.PropertyFilters.PropertiesOfType OfType(this aweXpect.Reflection.Collections.Filtered.Properties @this, System.Type propertyType) { }
+        public static aweXpect.Reflection.PropertyFilters.PropertiesOfType OfType<TProperty>(this aweXpect.Reflection.Collections.Filtered.Properties @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Properties WhichAre(this aweXpect.Reflection.Collections.Filtered.Properties @this, aweXpect.Reflection.Collections.AccessModifiers accessModifier) { }
         public static aweXpect.Reflection.Collections.Filtered.Properties WhichAreNot(this aweXpect.Reflection.Collections.Filtered.Properties @this, aweXpect.Reflection.Collections.AccessModifiers accessModifier) { }
         public static aweXpect.Reflection.Collections.Filtered.Properties WhichSatisfy(this aweXpect.Reflection.Collections.Filtered.Properties @this, System.Func<System.Reflection.PropertyInfo, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
@@ -103,6 +119,14 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.PropertyFilters.PropertiesWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Properties @this, System.Func<TAttribute, bool>? predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Collections.Filtered.Properties.StringEqualityResultType WithName(this aweXpect.Reflection.Collections.Filtered.Properties @this, string expected) { }
+        public class PropertiesOfType : aweXpect.Reflection.Collections.Filtered.Properties
+        {
+            public PropertiesOfType(aweXpect.Reflection.Collections.Filtered.Properties inner, aweXpect.Reflection.Collections.IChangeableFilter<System.Reflection.PropertyInfo> filter) { }
+            public aweXpect.Reflection.PropertyFilters.PropertiesOfType OrOfExactType(System.Type propertyType) { }
+            public aweXpect.Reflection.PropertyFilters.PropertiesOfType OrOfExactType<TProperty>() { }
+            public aweXpect.Reflection.PropertyFilters.PropertiesOfType OrOfType(System.Type propertyType) { }
+            public aweXpect.Reflection.PropertyFilters.PropertiesOfType OrOfType<TProperty>() { }
+        }
         public class PropertiesWith : aweXpect.Reflection.Collections.Filtered.Properties
         {
             public PropertiesWith(aweXpect.Reflection.Collections.Filtered.Properties inner, aweXpect.Reflection.Collections.IChangeableFilter<System.Reflection.PropertyInfo> filter) { }

--- a/Tests/aweXpect.Reflection.Tests/Filters/FieldFilters.OfExactlyType.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/FieldFilters.OfExactlyType.Tests.cs
@@ -1,0 +1,138 @@
+﻿using aweXpect.Reflection.Collections;
+
+namespace aweXpect.Reflection.Tests.Filters;
+
+public sealed partial class FieldFilters
+{
+	public sealed class OfExactType
+	{
+		public sealed class GenericTests
+		{
+			[Fact]
+			public async Task ShouldFilterForFieldsWithType()
+			{
+				Filtered.Fields fields = In.AssemblyContaining<AssemblyFilters>()
+					.Fields().OfExactType<DummyBase>();
+
+				await That(fields).IsEqualTo([
+					typeof(TestClass).GetField(nameof(TestClass.DummyBaseField))!,
+				]).InAnyOrder();
+				await That(fields.GetDescription())
+					.IsEqualTo("fields of exact type FieldFilters.OfExactType.DummyBase in assembly")
+					.AsPrefix();
+			}
+		}
+
+		public sealed class TypeTests
+		{
+			[Fact]
+			public async Task ShouldFilterForFieldsWithType()
+			{
+				Filtered.Fields fields = In.AssemblyContaining<AssemblyFilters>()
+					.Fields().OfExactType(typeof(DummyBase));
+
+				await That(fields).IsEqualTo([
+					typeof(TestClass).GetField(nameof(TestClass.DummyBaseField))!,
+				]).InAnyOrder();
+				await That(fields.GetDescription())
+					.IsEqualTo("fields of exact type FieldFilters.OfExactType.DummyBase in assembly")
+					.AsPrefix();
+			}
+		}
+
+		public sealed class OrOfTypeGenericTests
+		{
+			[Fact]
+			public async Task FirstCheckIsOfType_ShouldNotAllowDerivedTypes()
+			{
+				Filtered.Fields fields = In.AssemblyContaining<AssemblyFilters>()
+					.Fields().OfType(typeof(OtherDummy)).OrOfExactType<DummyBase>();
+
+				await That(fields).IsEqualTo([
+					typeof(TestClass).GetField(nameof(TestClass.DummyBaseField))!,
+					typeof(TestClass).GetField(nameof(TestClass.OtherDummyField))!,
+				]).InAnyOrder();
+				await That(fields.GetDescription())
+					.IsEqualTo(
+						"fields of type FieldFilters.OfExactType.OtherDummy or of exact type FieldFilters.OfExactType.DummyBase in assembly")
+					.AsPrefix();
+			}
+
+			[Fact]
+			public async Task ShouldFilterForFieldsWhichImplementAnyOfTheGivenTypes()
+			{
+				Filtered.Fields fields = In.AssemblyContaining<AssemblyFilters>()
+					.Fields().OfExactType<OtherDummy>().OrOfExactType<DummyBase>();
+
+				await That(fields).IsEqualTo([
+					typeof(TestClass).GetField(nameof(TestClass.DummyBaseField))!,
+					typeof(TestClass).GetField(nameof(TestClass.OtherDummyField))!,
+				]).InAnyOrder();
+				await That(fields.GetDescription())
+					.IsEqualTo(
+						"fields of exact type FieldFilters.OfExactType.OtherDummy or of exact type FieldFilters.OfExactType.DummyBase in assembly")
+					.AsPrefix();
+			}
+		}
+
+		public sealed class OrOfTypeTests
+		{
+			[Fact]
+			public async Task FirstCheckIsOfTypeExactly_ShouldAllowDerivedTypes()
+			{
+				Filtered.Fields fields = In.AssemblyContaining<AssemblyFilters>()
+					.Fields().OfExactType(typeof(OtherDummy)).OrOfType(typeof(DummyBase));
+
+				await That(fields).IsEqualTo([
+					typeof(TestClass).GetField(nameof(TestClass.DummyBaseField))!,
+					typeof(TestClass).GetField(nameof(TestClass.DummyField))!,
+					typeof(TestClass).GetField(nameof(TestClass.OtherDummyField))!,
+				]).InAnyOrder();
+				await That(fields.GetDescription())
+					.IsEqualTo(
+						"fields of exact type FieldFilters.OfExactType.OtherDummy or of type FieldFilters.OfExactType.DummyBase in assembly")
+					.AsPrefix();
+			}
+
+			[Fact]
+			public async Task ShouldFilterForFieldsWhichImplementAnyOfTheGivenTypes()
+			{
+				Filtered.Fields fields = In.AssemblyContaining<AssemblyFilters>()
+					.Fields().OfType<OtherDummy>().OrOfType(typeof(DummyBase));
+
+				await That(fields).IsEqualTo([
+					typeof(TestClass).GetField(nameof(TestClass.DummyBaseField))!,
+					typeof(TestClass).GetField(nameof(TestClass.DummyField))!,
+					typeof(TestClass).GetField(nameof(TestClass.OtherDummyField))!,
+				]).InAnyOrder();
+				await That(fields.GetDescription())
+					.IsEqualTo(
+						"fields of type FieldFilters.OfExactType.OtherDummy or of type FieldFilters.OfExactType.DummyBase in assembly")
+					.AsPrefix();
+			}
+		}
+
+		private class TestClass
+		{
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
+#pragma warning disable CS0649 // Field is never assigned to, and will always have its default value
+			public DummyBase DummyBaseField;
+			public Dummy DummyField;
+			public OtherDummy OtherDummyField;
+#pragma warning restore CS0649
+#pragma warning restore CS8618
+		}
+
+		private class DummyBase
+		{
+		}
+
+		private class Dummy : DummyBase
+		{
+		}
+
+		private class OtherDummy
+		{
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/Filters/FieldFilters.OfType.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/FieldFilters.OfType.Tests.cs
@@ -1,0 +1,142 @@
+﻿using aweXpect.Reflection.Collections;
+
+namespace aweXpect.Reflection.Tests.Filters;
+
+public sealed partial class FieldFilters
+{
+	public sealed class OfType
+	{
+		public sealed class GenericTests
+		{
+			[Fact]
+			public async Task ShouldFilterForFieldsWhichImplementType()
+			{
+				Filtered.Fields fields = In.AssemblyContaining<AssemblyFilters>()
+					.Fields().OfType<DummyBase>();
+
+				await That(fields).IsEqualTo([
+					typeof(TestClass).GetField(nameof(TestClass.DummyBaseField))!,
+					typeof(TestClass).GetField(nameof(TestClass.DummyField))!,
+				]).InAnyOrder();
+				await That(fields.GetDescription())
+					.IsEqualTo("fields of type FieldFilters.OfType.DummyBase in assembly")
+					.AsPrefix();
+			}
+		}
+
+		public sealed class TypeTests
+		{
+			[Fact]
+			public async Task ShouldFilterForFieldsWhichImplementType()
+			{
+				Filtered.Fields fields = In.AssemblyContaining<AssemblyFilters>()
+					.Fields().OfType(typeof(DummyBase));
+
+				await That(fields).IsEqualTo([
+					typeof(TestClass).GetField(nameof(TestClass.DummyBaseField))!,
+					typeof(TestClass).GetField(nameof(TestClass.DummyField))!,
+				]).InAnyOrder();
+				await That(fields.GetDescription())
+					.IsEqualTo("fields of type FieldFilters.OfType.DummyBase in assembly")
+					.AsPrefix();
+			}
+		}
+
+		public sealed class OrOfTypeGenericTests
+		{
+			[Fact]
+			public async Task FirstCheckIsOfTypeExactly_ShouldAllowDerivedTypes()
+			{
+				Filtered.Fields fields = In.AssemblyContaining<AssemblyFilters>()
+					.Fields().OfExactType(typeof(OtherDummy)).OrOfType<DummyBase>();
+
+				await That(fields).IsEqualTo([
+					typeof(TestClass).GetField(nameof(TestClass.DummyBaseField))!,
+					typeof(TestClass).GetField(nameof(TestClass.DummyField))!,
+					typeof(TestClass).GetField(nameof(TestClass.OtherDummyField))!,
+				]).InAnyOrder();
+				await That(fields.GetDescription())
+					.IsEqualTo(
+						"fields of exact type FieldFilters.OfType.OtherDummy or of type FieldFilters.OfType.DummyBase in assembly")
+					.AsPrefix();
+			}
+
+			[Fact]
+			public async Task ShouldFilterForFieldsWhichImplementAnyOfTheGivenTypes()
+			{
+				Filtered.Fields fields = In.AssemblyContaining<AssemblyFilters>()
+					.Fields().OfType<OtherDummy>().OrOfType<DummyBase>();
+
+				await That(fields).IsEqualTo([
+					typeof(TestClass).GetField(nameof(TestClass.DummyBaseField))!,
+					typeof(TestClass).GetField(nameof(TestClass.DummyField))!,
+					typeof(TestClass).GetField(nameof(TestClass.OtherDummyField))!,
+				]).InAnyOrder();
+				await That(fields.GetDescription())
+					.IsEqualTo(
+						"fields of type FieldFilters.OfType.OtherDummy or of type FieldFilters.OfType.DummyBase in assembly")
+					.AsPrefix();
+			}
+		}
+
+		public sealed class OrOfTypeTests
+		{
+			[Fact]
+			public async Task FirstCheckIsOfTypeExactly_ShouldAllowDerivedTypes()
+			{
+				Filtered.Fields fields = In.AssemblyContaining<AssemblyFilters>()
+					.Fields().OfExactType(typeof(OtherDummy)).OrOfType(typeof(DummyBase));
+
+				await That(fields).IsEqualTo([
+					typeof(TestClass).GetField(nameof(TestClass.DummyBaseField))!,
+					typeof(TestClass).GetField(nameof(TestClass.DummyField))!,
+					typeof(TestClass).GetField(nameof(TestClass.OtherDummyField))!,
+				]).InAnyOrder();
+				await That(fields.GetDescription())
+					.IsEqualTo(
+						"fields of exact type FieldFilters.OfType.OtherDummy or of type FieldFilters.OfType.DummyBase in assembly")
+					.AsPrefix();
+			}
+
+			[Fact]
+			public async Task ShouldFilterForFieldsWhichImplementAnyOfTheGivenTypes()
+			{
+				Filtered.Fields fields = In.AssemblyContaining<AssemblyFilters>()
+					.Fields().OfType<OtherDummy>().OrOfType(typeof(DummyBase));
+
+				await That(fields).IsEqualTo([
+					typeof(TestClass).GetField(nameof(TestClass.DummyBaseField))!,
+					typeof(TestClass).GetField(nameof(TestClass.DummyField))!,
+					typeof(TestClass).GetField(nameof(TestClass.OtherDummyField))!,
+				]).InAnyOrder();
+				await That(fields.GetDescription())
+					.IsEqualTo(
+						"fields of type FieldFilters.OfType.OtherDummy or of type FieldFilters.OfType.DummyBase in assembly")
+					.AsPrefix();
+			}
+		}
+
+		private class TestClass
+		{
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
+#pragma warning disable CS0649 // Field is never assigned to, and will always have its default value
+			public DummyBase DummyBaseField;
+			public Dummy DummyField;
+			public OtherDummy OtherDummyField;
+#pragma warning restore CS0649
+#pragma warning restore CS8618
+		}
+
+		private class DummyBase
+		{
+		}
+
+		private class Dummy : DummyBase
+		{
+		}
+
+		private class OtherDummy
+		{
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/Filters/PropertyFilters.OfExactlyType.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/PropertyFilters.OfExactlyType.Tests.cs
@@ -1,0 +1,136 @@
+﻿using aweXpect.Reflection.Collections;
+
+namespace aweXpect.Reflection.Tests.Filters;
+
+public sealed partial class PropertyFilters
+{
+	public sealed class OfExactType
+	{
+		public sealed class GenericTests
+		{
+			[Fact]
+			public async Task ShouldFilterForPropertiesWithType()
+			{
+				Filtered.Properties properties = In.AssemblyContaining<AssemblyFilters>()
+					.Properties().OfExactType<DummyBase>();
+
+				await That(properties).IsEqualTo([
+					typeof(TestClass).GetProperty(nameof(TestClass.DummyBaseProperty))!,
+				]).InAnyOrder();
+				await That(properties.GetDescription())
+					.IsEqualTo("properties of exact type PropertyFilters.OfExactType.DummyBase in assembly")
+					.AsPrefix();
+			}
+		}
+
+		public sealed class TypeTests
+		{
+			[Fact]
+			public async Task ShouldFilterForPropertiesWithType()
+			{
+				Filtered.Properties properties = In.AssemblyContaining<AssemblyFilters>()
+					.Properties().OfExactType(typeof(DummyBase));
+
+				await That(properties).IsEqualTo([
+					typeof(TestClass).GetProperty(nameof(TestClass.DummyBaseProperty))!,
+				]).InAnyOrder();
+				await That(properties.GetDescription())
+					.IsEqualTo("properties of exact type PropertyFilters.OfExactType.DummyBase in assembly")
+					.AsPrefix();
+			}
+		}
+
+		public sealed class OrOfTypeGenericTests
+		{
+			[Fact]
+			public async Task FirstCheckIsOfType_ShouldNotAllowDerivedTypes()
+			{
+				Filtered.Properties properties = In.AssemblyContaining<AssemblyFilters>()
+					.Properties().OfType(typeof(OtherDummy)).OrOfExactType<DummyBase>();
+
+				await That(properties).IsEqualTo([
+					typeof(TestClass).GetProperty(nameof(TestClass.DummyBaseProperty))!,
+					typeof(TestClass).GetProperty(nameof(TestClass.OtherDummyProperty))!,
+				]).InAnyOrder();
+				await That(properties.GetDescription())
+					.IsEqualTo(
+						"properties of type PropertyFilters.OfExactType.OtherDummy or of exact type PropertyFilters.OfExactType.DummyBase in assembly")
+					.AsPrefix();
+			}
+
+			[Fact]
+			public async Task ShouldFilterForPropertiesWhichImplementAnyOfTheGivenTypes()
+			{
+				Filtered.Properties properties = In.AssemblyContaining<AssemblyFilters>()
+					.Properties().OfExactType<OtherDummy>().OrOfExactType<DummyBase>();
+
+				await That(properties).IsEqualTo([
+					typeof(TestClass).GetProperty(nameof(TestClass.DummyBaseProperty))!,
+					typeof(TestClass).GetProperty(nameof(TestClass.OtherDummyProperty))!,
+				]).InAnyOrder();
+				await That(properties.GetDescription())
+					.IsEqualTo(
+						"properties of exact type PropertyFilters.OfExactType.OtherDummy or of exact type PropertyFilters.OfExactType.DummyBase in assembly")
+					.AsPrefix();
+			}
+		}
+
+		public sealed class OrOfTypeTests
+		{
+			[Fact]
+			public async Task FirstCheckIsOfTypeExactly_ShouldAllowDerivedTypes()
+			{
+				Filtered.Properties properties = In.AssemblyContaining<AssemblyFilters>()
+					.Properties().OfExactType(typeof(OtherDummy)).OrOfType(typeof(DummyBase));
+
+				await That(properties).IsEqualTo([
+					typeof(TestClass).GetProperty(nameof(TestClass.DummyBaseProperty))!,
+					typeof(TestClass).GetProperty(nameof(TestClass.DummyProperty))!,
+					typeof(TestClass).GetProperty(nameof(TestClass.OtherDummyProperty))!,
+				]).InAnyOrder();
+				await That(properties.GetDescription())
+					.IsEqualTo(
+						"properties of exact type PropertyFilters.OfExactType.OtherDummy or of type PropertyFilters.OfExactType.DummyBase in assembly")
+					.AsPrefix();
+			}
+
+			[Fact]
+			public async Task ShouldFilterForPropertiesWhichImplementAnyOfTheGivenTypes()
+			{
+				Filtered.Properties properties = In.AssemblyContaining<AssemblyFilters>()
+					.Properties().OfType<OtherDummy>().OrOfType(typeof(DummyBase));
+
+				await That(properties).IsEqualTo([
+					typeof(TestClass).GetProperty(nameof(TestClass.DummyBaseProperty))!,
+					typeof(TestClass).GetProperty(nameof(TestClass.DummyProperty))!,
+					typeof(TestClass).GetProperty(nameof(TestClass.OtherDummyProperty))!,
+				]).InAnyOrder();
+				await That(properties.GetDescription())
+					.IsEqualTo(
+						"properties of type PropertyFilters.OfExactType.OtherDummy or of type PropertyFilters.OfExactType.DummyBase in assembly")
+					.AsPrefix();
+			}
+		}
+
+		private class TestClass
+		{
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
+			public DummyBase DummyBaseProperty { get; set; }
+			public Dummy DummyProperty { get; set; }
+			public OtherDummy OtherDummyProperty { get; set; }
+#pragma warning restore CS8618
+		}
+
+		private class DummyBase
+		{
+		}
+
+		private class Dummy : DummyBase
+		{
+		}
+
+		private class OtherDummy
+		{
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/Filters/PropertyFilters.OfType.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/PropertyFilters.OfType.Tests.cs
@@ -1,0 +1,140 @@
+﻿using aweXpect.Reflection.Collections;
+
+namespace aweXpect.Reflection.Tests.Filters;
+
+public sealed partial class PropertyFilters
+{
+	public sealed class OfType
+	{
+		public sealed class GenericTests
+		{
+			[Fact]
+			public async Task ShouldFilterForPropertiesWhichImplementType()
+			{
+				Filtered.Properties properties = In.AssemblyContaining<AssemblyFilters>()
+					.Properties().OfType<DummyBase>();
+
+				await That(properties).IsEqualTo([
+					typeof(TestClass).GetProperty(nameof(TestClass.DummyBaseProperty))!,
+					typeof(TestClass).GetProperty(nameof(TestClass.DummyProperty))!,
+				]).InAnyOrder();
+				await That(properties.GetDescription())
+					.IsEqualTo("properties of type PropertyFilters.OfType.DummyBase in assembly")
+					.AsPrefix();
+			}
+		}
+
+		public sealed class TypeTests
+		{
+			[Fact]
+			public async Task ShouldFilterForPropertiesWhichImplementType()
+			{
+				Filtered.Properties properties = In.AssemblyContaining<AssemblyFilters>()
+					.Properties().OfType(typeof(DummyBase));
+
+				await That(properties).IsEqualTo([
+					typeof(TestClass).GetProperty(nameof(TestClass.DummyBaseProperty))!,
+					typeof(TestClass).GetProperty(nameof(TestClass.DummyProperty))!,
+				]).InAnyOrder();
+				await That(properties.GetDescription())
+					.IsEqualTo("properties of type PropertyFilters.OfType.DummyBase in assembly")
+					.AsPrefix();
+			}
+		}
+
+		public sealed class OrOfTypeGenericTests
+		{
+			[Fact]
+			public async Task FirstCheckIsOfTypeExactly_ShouldAllowDerivedTypes()
+			{
+				Filtered.Properties properties = In.AssemblyContaining<AssemblyFilters>()
+					.Properties().OfExactType(typeof(OtherDummy)).OrOfType<DummyBase>();
+
+				await That(properties).IsEqualTo([
+					typeof(TestClass).GetProperty(nameof(TestClass.DummyBaseProperty))!,
+					typeof(TestClass).GetProperty(nameof(TestClass.DummyProperty))!,
+					typeof(TestClass).GetProperty(nameof(TestClass.OtherDummyProperty))!,
+				]).InAnyOrder();
+				await That(properties.GetDescription())
+					.IsEqualTo(
+						"properties of exact type PropertyFilters.OfType.OtherDummy or of type PropertyFilters.OfType.DummyBase in assembly")
+					.AsPrefix();
+			}
+
+			[Fact]
+			public async Task ShouldFilterForPropertiesWhichImplementAnyOfTheGivenTypes()
+			{
+				Filtered.Properties properties = In.AssemblyContaining<AssemblyFilters>()
+					.Properties().OfType<OtherDummy>().OrOfType<DummyBase>();
+
+				await That(properties).IsEqualTo([
+					typeof(TestClass).GetProperty(nameof(TestClass.DummyBaseProperty))!,
+					typeof(TestClass).GetProperty(nameof(TestClass.DummyProperty))!,
+					typeof(TestClass).GetProperty(nameof(TestClass.OtherDummyProperty))!,
+				]).InAnyOrder();
+				await That(properties.GetDescription())
+					.IsEqualTo(
+						"properties of type PropertyFilters.OfType.OtherDummy or of type PropertyFilters.OfType.DummyBase in assembly")
+					.AsPrefix();
+			}
+		}
+
+		public sealed class OrOfTypeTests
+		{
+			[Fact]
+			public async Task FirstCheckIsOfTypeExactly_ShouldAllowDerivedTypes()
+			{
+				Filtered.Properties properties = In.AssemblyContaining<AssemblyFilters>()
+					.Properties().OfExactType(typeof(OtherDummy)).OrOfType(typeof(DummyBase));
+
+				await That(properties).IsEqualTo([
+					typeof(TestClass).GetProperty(nameof(TestClass.DummyBaseProperty))!,
+					typeof(TestClass).GetProperty(nameof(TestClass.DummyProperty))!,
+					typeof(TestClass).GetProperty(nameof(TestClass.OtherDummyProperty))!,
+				]).InAnyOrder();
+				await That(properties.GetDescription())
+					.IsEqualTo(
+						"properties of exact type PropertyFilters.OfType.OtherDummy or of type PropertyFilters.OfType.DummyBase in assembly")
+					.AsPrefix();
+			}
+
+			[Fact]
+			public async Task ShouldFilterForPropertiesWhichImplementAnyOfTheGivenTypes()
+			{
+				Filtered.Properties properties = In.AssemblyContaining<AssemblyFilters>()
+					.Properties().OfType<OtherDummy>().OrOfType(typeof(DummyBase));
+
+				await That(properties).IsEqualTo([
+					typeof(TestClass).GetProperty(nameof(TestClass.DummyBaseProperty))!,
+					typeof(TestClass).GetProperty(nameof(TestClass.DummyProperty))!,
+					typeof(TestClass).GetProperty(nameof(TestClass.OtherDummyProperty))!,
+				]).InAnyOrder();
+				await That(properties.GetDescription())
+					.IsEqualTo(
+						"properties of type PropertyFilters.OfType.OtherDummy or of type PropertyFilters.OfType.DummyBase in assembly")
+					.AsPrefix();
+			}
+		}
+
+		private class TestClass
+		{
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
+			public DummyBase DummyBaseProperty { get; set; }
+			public Dummy DummyProperty { get; set; }
+			public OtherDummy OtherDummyProperty { get; set; }
+#pragma warning restore CS8618
+		}
+
+		private class DummyBase
+		{
+		}
+
+		private class Dummy : DummyBase
+		{
+		}
+
+		private class OtherDummy
+		{
+		}
+	}
+}


### PR DESCRIPTION
This PR introduces type-based filtering capabilities for fields and properties in the reflection library. It adds `OfType` and `OfExactType` filter methods that allow filtering based on inheritance relationships and exact type matches respectively.

Key changes:
- Adds `OfType<T>()` and `OfType(Type)` methods for filtering fields/properties that are assignable from the specified type (including derived types)
- Adds `OfExactType<T>()` and `OfExactType(Type)` methods for filtering fields/properties that match the exact type
- Introduces chainable `OrOfType` and `OrOfExactType` methods for combining multiple type filters