### PR TITLE
feat: add access modifier properties to filtered assemblies

### DIFF
--- a/Source/aweXpect.Reflection/Collections/Filtered.Assemblies.cs
+++ b/Source/aweXpect.Reflection/Collections/Filtered.Assemblies.cs
@@ -16,7 +16,8 @@ public static partial class Filtered
 	/// <summary>
 	///     Container for a filterable collection of <see cref="Assembly" />.
 	/// </summary>
-	public class Assemblies : Filtered<Assembly, Assemblies>, IDescribableSubject, ITypeAssemblies
+	public class Assemblies : Filtered<Assembly, Assemblies>, IDescribableSubject, ITypeAssemblies.IProtected,
+		ITypeAssemblies.IPrivate
 	{
 		private readonly string _description;
 		private readonly List<Func<Type, bool>> _typeFilters = [];
@@ -56,6 +57,62 @@ public static partial class Filtered
 			_description = inner._description;
 		}
 
+		/// <summary>
+		///     Filters for public types.
+		/// </summary>
+		public ITypeAssemblies Public
+		{
+			get
+			{
+				AccessModifiers accessModifier = AccessModifiers.Public;
+				_typeFilters.Add(type => type.HasAccessModifier(accessModifier));
+				_typeFilterDescription = accessModifier.GetString(" ") + (_typeFilterDescription ?? "");
+				return this;
+			}
+		}
+
+		/// <summary>
+		///     Filters for private types.
+		/// </summary>
+		public ITypeAssemblies.IPrivate Private
+		{
+			get
+			{
+				AccessModifiers accessModifier = AccessModifiers.Private;
+				_typeFilters.Add(type => type.HasAccessModifier(accessModifier));
+				_typeFilterDescription = accessModifier.GetString(" ") + (_typeFilterDescription ?? "");
+				return this;
+			}
+		}
+
+		/// <summary>
+		///     Filters for protected types.
+		/// </summary>
+		public ITypeAssemblies.IProtected Protected
+		{
+			get
+			{
+				AccessModifiers accessModifier = AccessModifiers.Protected;
+				_typeFilters.Add(type => type.HasAccessModifier(accessModifier));
+				_typeFilterDescription = accessModifier.GetString(" ") + (_typeFilterDescription ?? "");
+				return this;
+			}
+		}
+
+		/// <summary>
+		///     Filters for internal types.
+		/// </summary>
+		public ITypeAssemblies Internal
+		{
+			get
+			{
+				AccessModifiers accessModifier = AccessModifiers.Internal;
+				_typeFilters.Add(type => type.HasAccessModifier(accessModifier));
+				_typeFilterDescription = accessModifier.GetString(" ") + (_typeFilterDescription ?? "");
+				return this;
+			}
+		}
+
 		/// <inheritdoc />
 		public string GetDescription()
 		{
@@ -66,6 +123,30 @@ public static partial class Filtered
 			}
 
 			return description;
+		}
+
+		/// <inheritdoc cref="ITypeAssemblies.IPrivate.Protected" />
+		ITypeAssemblies ITypeAssemblies.IPrivate.Protected
+		{
+			get
+			{
+				AccessModifiers accessModifier = AccessModifiers.Protected;
+				_typeFilters.Add(type => type.HasAccessModifier(accessModifier));
+				_typeFilterDescription = (_typeFilterDescription ?? "") + accessModifier.GetString(" ");
+				return this;
+			}
+		}
+
+		/// <inheritdoc cref="ITypeAssemblies.IProtected.Internal" />
+		ITypeAssemblies ITypeAssemblies.IProtected.Internal
+		{
+			get
+			{
+				AccessModifiers accessModifier = AccessModifiers.Internal;
+				_typeFilters.Add(type => type.HasAccessModifier(accessModifier));
+				_typeFilterDescription = (_typeFilterDescription ?? "") + accessModifier.GetString(" ");
+				return this;
+			}
 		}
 
 		/// <inheritdoc cref="ITypeAssemblies.Abstract" />

--- a/Source/aweXpect.Reflection/Collections/Filtered.Assemblies.cs
+++ b/Source/aweXpect.Reflection/Collections/Filtered.Assemblies.cs
@@ -16,7 +16,9 @@ public static partial class Filtered
 	/// <summary>
 	///     Container for a filterable collection of <see cref="Assembly" />.
 	/// </summary>
-	public class Assemblies : Filtered<Assembly, Assemblies>, IDescribableSubject, ITypeAssemblies.IProtected,
+	public class Assemblies : Filtered<Assembly, Assemblies>,
+		IDescribableSubject,
+		ITypeAssemblies.IProtected,
 		ITypeAssemblies.IPrivate
 	{
 		private readonly string _description;

--- a/Source/aweXpect.Reflection/Collections/ITypeAssemblies.cs
+++ b/Source/aweXpect.Reflection/Collections/ITypeAssemblies.cs
@@ -33,4 +33,34 @@ public interface ITypeAssemblies : ILimitedTypeAssemblies<ITypeAssemblies>
 	///     Get all enums in the filtered assemblies.
 	/// </summary>
 	Filtered.Types Enums(AccessModifiers accessModifier = AccessModifiers.Any);
+
+	/// <summary>
+	///     An interface to allow filtering for types in assemblies.
+	/// </summary>
+	/// <remarks>
+	///     In addition to the properties and methods in <see cref="ITypeAssemblies" /> it also
+	///     allows specifying a private protected access modifier.
+	/// </remarks>
+	public interface IPrivate : ITypeAssemblies
+	{
+		/// <summary>
+		///     Filters only for private protected types.
+		/// </summary>
+		ITypeAssemblies Protected { get; }
+	}
+
+	/// <summary>
+	///     An interface to allow filtering for types in assemblies.
+	/// </summary>
+	/// <remarks>
+	///     In addition to the properties and methods in <see cref="ITypeAssemblies" /> it also
+	///     allows specifying a protected internal access modifier.
+	/// </remarks>
+	public interface IProtected : ITypeAssemblies
+	{
+		/// <summary>
+		///     Filters only for protected internal types.
+		/// </summary>
+		ITypeAssemblies Internal { get; }
+	}
 }

--- a/Source/aweXpect.Reflection/Collections/ITypeAssemblies.cs
+++ b/Source/aweXpect.Reflection/Collections/ITypeAssemblies.cs
@@ -39,12 +39,12 @@ public interface ITypeAssemblies : ILimitedTypeAssemblies<ITypeAssemblies>
 	/// </summary>
 	/// <remarks>
 	///     In addition to the properties and methods in <see cref="ITypeAssemblies" /> it also
-	///     allows specifying a private protected access modifier.
+	///     allows filtering for a private protected access modifier.
 	/// </remarks>
 	public interface IPrivate : ITypeAssemblies
 	{
 		/// <summary>
-		///     Filters only for private protected types.
+		///     Filters for private protected types.
 		/// </summary>
 		ITypeAssemblies Protected { get; }
 	}
@@ -54,12 +54,12 @@ public interface ITypeAssemblies : ILimitedTypeAssemblies<ITypeAssemblies>
 	/// </summary>
 	/// <remarks>
 	///     In addition to the properties and methods in <see cref="ITypeAssemblies" /> it also
-	///     allows specifying a protected internal access modifier.
+	///     allows filtering for a protected internal access modifier.
 	/// </remarks>
 	public interface IProtected : ITypeAssemblies
 	{
 		/// <summary>
-		///     Filters only for protected internal types.
+		///     Filters for protected internal types.
 		/// </summary>
 		ITypeAssemblies Internal { get; }
 	}

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net8.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net8.0.txt
@@ -275,14 +275,18 @@ namespace aweXpect.Reflection.Collections
     }
     public static class Filtered
     {
-        public class Assemblies : aweXpect.Reflection.Collections.Filtered<System.Reflection.Assembly, aweXpect.Reflection.Collections.Filtered.Assemblies>, aweXpect.Core.IDescribableSubject, aweXpect.Reflection.Collections.ILimitedTypeAssemblies, aweXpect.Reflection.Collections.ILimitedTypeAssemblies<aweXpect.Reflection.Collections.ITypeAssemblies>, aweXpect.Reflection.Collections.ITypeAssemblies
+        public class Assemblies : aweXpect.Reflection.Collections.Filtered<System.Reflection.Assembly, aweXpect.Reflection.Collections.Filtered.Assemblies>, aweXpect.Core.IDescribableSubject, aweXpect.Reflection.Collections.ILimitedTypeAssemblies, aweXpect.Reflection.Collections.ILimitedTypeAssemblies<aweXpect.Reflection.Collections.ITypeAssemblies>, aweXpect.Reflection.Collections.ITypeAssemblies, aweXpect.Reflection.Collections.ITypeAssemblies.IPrivate, aweXpect.Reflection.Collections.ITypeAssemblies.IProtected
         {
             protected Assemblies(aweXpect.Reflection.Collections.Filtered.Assemblies inner) { }
             public Assemblies(System.Collections.Generic.IEnumerable<System.Reflection.Assembly?> source, string description) { }
             public Assemblies(System.Reflection.Assembly? source, string description) { }
             public aweXpect.Reflection.Collections.ILimitedTypeAssemblies<aweXpect.Reflection.Collections.ILimitedTypeAssemblies> Abstract { get; }
             public aweXpect.Reflection.Collections.ITypeAssemblies Generic { get; }
+            public aweXpect.Reflection.Collections.ITypeAssemblies Internal { get; }
             public aweXpect.Reflection.Collections.ITypeAssemblies Nested { get; }
+            public aweXpect.Reflection.Collections.ITypeAssemblies.IPrivate Private { get; }
+            public aweXpect.Reflection.Collections.ITypeAssemblies.IProtected Protected { get; }
+            public aweXpect.Reflection.Collections.ITypeAssemblies Public { get; }
             public aweXpect.Reflection.Collections.ILimitedTypeAssemblies<aweXpect.Reflection.Collections.ILimitedTypeAssemblies> Sealed { get; }
             public aweXpect.Reflection.Collections.ILimitedTypeAssemblies<aweXpect.Reflection.Collections.ILimitedTypeAssemblies> Static { get; }
             public aweXpect.Reflection.Collections.Filtered.Types Classes(aweXpect.Reflection.Collections.AccessModifiers accessModifier = 15) { }
@@ -465,5 +469,13 @@ namespace aweXpect.Reflection.Collections
         aweXpect.Reflection.Collections.ILimitedTypeAssemblies<aweXpect.Reflection.Collections.ILimitedTypeAssemblies> Static { get; }
         aweXpect.Reflection.Collections.Filtered.Types Enums(aweXpect.Reflection.Collections.AccessModifiers accessModifier = 15);
         aweXpect.Reflection.Collections.Filtered.Types Interfaces(aweXpect.Reflection.Collections.AccessModifiers accessModifier = 15);
+        public interface IPrivate : aweXpect.Reflection.Collections.ILimitedTypeAssemblies, aweXpect.Reflection.Collections.ILimitedTypeAssemblies<aweXpect.Reflection.Collections.ITypeAssemblies>, aweXpect.Reflection.Collections.ITypeAssemblies
+        {
+            aweXpect.Reflection.Collections.ITypeAssemblies Protected { get; }
+        }
+        public interface IProtected : aweXpect.Reflection.Collections.ILimitedTypeAssemblies, aweXpect.Reflection.Collections.ILimitedTypeAssemblies<aweXpect.Reflection.Collections.ITypeAssemblies>, aweXpect.Reflection.Collections.ITypeAssemblies
+        {
+            aweXpect.Reflection.Collections.ITypeAssemblies Internal { get; }
+        }
     }
 }

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_netstandard2.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_netstandard2.0.txt
@@ -275,14 +275,18 @@ namespace aweXpect.Reflection.Collections
     }
     public static class Filtered
     {
-        public class Assemblies : aweXpect.Reflection.Collections.Filtered<System.Reflection.Assembly, aweXpect.Reflection.Collections.Filtered.Assemblies>, aweXpect.Core.IDescribableSubject, aweXpect.Reflection.Collections.ILimitedTypeAssemblies, aweXpect.Reflection.Collections.ILimitedTypeAssemblies<aweXpect.Reflection.Collections.ITypeAssemblies>, aweXpect.Reflection.Collections.ITypeAssemblies
+        public class Assemblies : aweXpect.Reflection.Collections.Filtered<System.Reflection.Assembly, aweXpect.Reflection.Collections.Filtered.Assemblies>, aweXpect.Core.IDescribableSubject, aweXpect.Reflection.Collections.ILimitedTypeAssemblies, aweXpect.Reflection.Collections.ILimitedTypeAssemblies<aweXpect.Reflection.Collections.ITypeAssemblies>, aweXpect.Reflection.Collections.ITypeAssemblies, aweXpect.Reflection.Collections.ITypeAssemblies.IPrivate, aweXpect.Reflection.Collections.ITypeAssemblies.IProtected
         {
             protected Assemblies(aweXpect.Reflection.Collections.Filtered.Assemblies inner) { }
             public Assemblies(System.Collections.Generic.IEnumerable<System.Reflection.Assembly?> source, string description) { }
             public Assemblies(System.Reflection.Assembly? source, string description) { }
             public aweXpect.Reflection.Collections.ILimitedTypeAssemblies<aweXpect.Reflection.Collections.ILimitedTypeAssemblies> Abstract { get; }
             public aweXpect.Reflection.Collections.ITypeAssemblies Generic { get; }
+            public aweXpect.Reflection.Collections.ITypeAssemblies Internal { get; }
             public aweXpect.Reflection.Collections.ITypeAssemblies Nested { get; }
+            public aweXpect.Reflection.Collections.ITypeAssemblies.IPrivate Private { get; }
+            public aweXpect.Reflection.Collections.ITypeAssemblies.IProtected Protected { get; }
+            public aweXpect.Reflection.Collections.ITypeAssemblies Public { get; }
             public aweXpect.Reflection.Collections.ILimitedTypeAssemblies<aweXpect.Reflection.Collections.ILimitedTypeAssemblies> Sealed { get; }
             public aweXpect.Reflection.Collections.ILimitedTypeAssemblies<aweXpect.Reflection.Collections.ILimitedTypeAssemblies> Static { get; }
             public aweXpect.Reflection.Collections.Filtered.Types Classes(aweXpect.Reflection.Collections.AccessModifiers accessModifier = 15) { }
@@ -465,5 +469,13 @@ namespace aweXpect.Reflection.Collections
         aweXpect.Reflection.Collections.ILimitedTypeAssemblies<aweXpect.Reflection.Collections.ILimitedTypeAssemblies> Static { get; }
         aweXpect.Reflection.Collections.Filtered.Types Enums(aweXpect.Reflection.Collections.AccessModifiers accessModifier = 15);
         aweXpect.Reflection.Collections.Filtered.Types Interfaces(aweXpect.Reflection.Collections.AccessModifiers accessModifier = 15);
+        public interface IPrivate : aweXpect.Reflection.Collections.ILimitedTypeAssemblies, aweXpect.Reflection.Collections.ILimitedTypeAssemblies<aweXpect.Reflection.Collections.ITypeAssemblies>, aweXpect.Reflection.Collections.ITypeAssemblies
+        {
+            aweXpect.Reflection.Collections.ITypeAssemblies Protected { get; }
+        }
+        public interface IProtected : aweXpect.Reflection.Collections.ILimitedTypeAssemblies, aweXpect.Reflection.Collections.ILimitedTypeAssemblies<aweXpect.Reflection.Collections.ITypeAssemblies>, aweXpect.Reflection.Collections.ITypeAssemblies
+        {
+            aweXpect.Reflection.Collections.ITypeAssemblies Internal { get; }
+        }
     }
 }

--- a/Tests/aweXpect.Reflection.Tests/Collections/Filtered.Assemblies.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Collections/Filtered.Assemblies.Tests.cs
@@ -163,6 +163,7 @@ public sealed partial class Filtered
 				Reflection.Collections.Filtered.Types types = In.AllLoadedAssemblies().Internal.Types();
 				string description = types.GetDescription();
 
+				await That(types).AreInternal();
 				await That(description).IsEqualTo("internal types in all loaded assemblies");
 			}
 
@@ -172,6 +173,7 @@ public sealed partial class Filtered
 				Reflection.Collections.Filtered.Types types = In.AllLoadedAssemblies().Private.Protected.Types();
 				string description = types.GetDescription();
 
+				await That(types).ArePrivate();
 				await That(description).IsEqualTo("private protected types in all loaded assemblies");
 			}
 
@@ -181,6 +183,7 @@ public sealed partial class Filtered
 				Reflection.Collections.Filtered.Types types = In.AllLoadedAssemblies().Private.Types();
 				string description = types.GetDescription();
 
+				await That(types).ArePrivate();
 				await That(description).IsEqualTo("private types in all loaded assemblies");
 			}
 
@@ -190,6 +193,7 @@ public sealed partial class Filtered
 				Reflection.Collections.Filtered.Types types = In.AllLoadedAssemblies().Protected.Internal.Types();
 				string description = types.GetDescription();
 
+				await That(types).AreProtected();
 				await That(description).IsEqualTo("protected internal types in all loaded assemblies");
 			}
 
@@ -199,6 +203,7 @@ public sealed partial class Filtered
 				Reflection.Collections.Filtered.Types types = In.AllLoadedAssemblies().Protected.Types();
 				string description = types.GetDescription();
 
+				await That(types).AreProtected();
 				await That(description).IsEqualTo("protected types in all loaded assemblies");
 			}
 
@@ -208,6 +213,7 @@ public sealed partial class Filtered
 				Reflection.Collections.Filtered.Types types = In.AllLoadedAssemblies().Public.Types();
 				string description = types.GetDescription();
 
+				await That(types).ArePublic();
 				await That(description).IsEqualTo("public types in all loaded assemblies");
 			}
 

--- a/Tests/aweXpect.Reflection.Tests/Collections/Filtered.Assemblies.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Collections/Filtered.Assemblies.Tests.cs
@@ -158,6 +158,60 @@ public sealed partial class Filtered
 			}
 
 			[Fact]
+			public async Task CanFilterForInternalTypes()
+			{
+				Reflection.Collections.Filtered.Types types = In.AllLoadedAssemblies().Internal.Types();
+				string description = types.GetDescription();
+
+				await That(description).IsEqualTo("internal types in all loaded assemblies");
+			}
+
+			[Fact]
+			public async Task CanFilterForPrivateProtectedTypes()
+			{
+				Reflection.Collections.Filtered.Types types = In.AllLoadedAssemblies().Private.Protected.Types();
+				string description = types.GetDescription();
+
+				await That(description).IsEqualTo("private protected types in all loaded assemblies");
+			}
+
+			[Fact]
+			public async Task CanFilterForPrivateTypes()
+			{
+				Reflection.Collections.Filtered.Types types = In.AllLoadedAssemblies().Private.Types();
+				string description = types.GetDescription();
+
+				await That(description).IsEqualTo("private types in all loaded assemblies");
+			}
+
+			[Fact]
+			public async Task CanFilterForProtectedInternalTypes()
+			{
+				Reflection.Collections.Filtered.Types types = In.AllLoadedAssemblies().Protected.Internal.Types();
+				string description = types.GetDescription();
+
+				await That(description).IsEqualTo("protected internal types in all loaded assemblies");
+			}
+
+			[Fact]
+			public async Task CanFilterForProtectedTypes()
+			{
+				Reflection.Collections.Filtered.Types types = In.AllLoadedAssemblies().Protected.Types();
+				string description = types.GetDescription();
+
+				await That(description).IsEqualTo("protected types in all loaded assemblies");
+			}
+
+			[Fact]
+			public async Task CanFilterForPublicTypes()
+			{
+				Reflection.Collections.Filtered.Types types = In.AllLoadedAssemblies().Public.Types();
+				string description = types.GetDescription();
+
+				await That(description).IsEqualTo("public types in all loaded assemblies");
+			}
+
+			[Fact]
 			public async Task NullAssembly_ShouldBeIgnored()
 			{
 				Assembly? assembly = null;


### PR DESCRIPTION
This PR adds access modifier filtering properties to the `Filtered.Assemblies` class, enabling developers to filter types by their access modifiers (public, private, protected, internal, and their combinations).

- Adds new properties `Public`, `Private`, `Protected`, and `Internal` to filter types by access modifiers
- Introduces nested interfaces `IPrivate` and `IProtected` to support complex access modifier combinations like "private protected" and "protected internal"
- Updates API surface tests to reflect the new public interfaces and properties

--
- *Fixes #52*