### PR TITLE
chore: bump the aweXpect group

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,8 +3,8 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="aweXpect" Version="2.20.0" />
-    <PackageVersion Include="aweXpect.Core" Version="2.15.2" />
+    <PackageVersion Include="aweXpect" Version="2.21.1" />
+    <PackageVersion Include="aweXpect.Core" Version="2.16.1" />
   </ItemGroup>
   <ItemGroup>
     <PackageVersion Include="Nullable" Version="1.3.1" />


### PR DESCRIPTION
This PR updates the aweXpect library dependencies to newer versions, specifically bumping aweXpect from 2.20.0 to 2.21.1 and aweXpect.Core from 2.15.2 to 2.16.1.

- Updated aweXpect package version from 2.20.0 to 2.21.1
- Updated aweXpect.Core package version from 2.15.2 to 2.16.1