### PR TITLE
feat: Support property-based access modifier filters for other members

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,10 @@ In.AllLoadedAssemblies().Methods()
     .WhichArePrivate()
     .WhichAreProtected()
     .WhichAreInternal()
+	
+// Alternatively
+In.AllLoadedAssemblies().Public.Methods()
+In.AllLoadedAssemblies().Private.Protected.Methods()
 
 // Filter by return types
 In.AllLoadedAssemblies().Methods()
@@ -161,29 +165,25 @@ In.AllLoadedAssemblies().Methods()
 
 ```csharp
 // Properties
-In.AllLoadedAssemblies().Properties()
-    .WhichArePublic()
+In.AllLoadedAssemblies().Public.Properties()
     .OfType<string>()
     .OfExactType<List<int>>()
     .WithName("Id").AsSuffix()
     .With<RequiredAttribute>()
 
 // Fields
-In.AllLoadedAssemblies().Fields()
-    .WhichArePrivate()
+In.AllLoadedAssemblies().Private.Fields()
     .OfType<ILogger>()
     .WithName("_").AsPrefix()
     .With<NonSerializedAttribute>()
 
 // Events
-In.AllLoadedAssemblies().Events()
-    .WhichArePublic()
+In.AllLoadedAssemblies().Public.Events()
     .WithName("Changed").AsSuffix()
     .With<ObsoleteAttribute>()
 
 // Constructors
-In.AllLoadedAssemblies().Constructors()
-    .WhichArePublic()
+In.AllLoadedAssemblies().Public.Constructors()
     .WithoutParameters()
     .WithParameter<string>()
     .WithParameterCount(1)
@@ -220,7 +220,7 @@ Here are some practical examples of using the `In` helper:
 ```csharp
 // Verify all test classes follow naming convention
 await Expect.That(In.AllLoadedAssemblies()
-        .Methods().With<FactAttribute>().OrWith<TheoryAttribute>()
+        .Public.Methods().With<FactAttribute>().OrWith<TheoryAttribute>()
         .DeclaringTypes())
     .HaveName("Tests").AsSuffix();
 
@@ -234,21 +234,10 @@ await Expect.That(In.AssemblyContaining<MyClass>()
         .Methods().WithName("Async").AsSuffix())
     .Return<Task>().OrReturn<ValueTask>();
 
-// Verify all public classes have XML documentation
-await Expect.That(In.AllLoadedAssemblies()
-        .Types().WhichAreClasses().WhichArePublic())
-    .Have<DocumentationAttribute>();
-
 // Verify controllers follow naming convention
 await Expect.That(In.AllLoadedAssemblies()
         .Types().WhichInheritFrom<ControllerBase>())
     .HaveName("Controller").AsSuffix();
-
-// Verify all properties with setters are not init-only
-await Expect.That(In.AllLoadedAssemblies()
-        .Properties().WhichSatisfy(p => p.SetMethod != null))
-    .Satisfy(p => !p.SetMethod.ReturnParameter.GetRequiredCustomModifiers()
-        .Contains(typeof(System.Runtime.CompilerServices.IsExternalInit)));
 ```
 
 ## Assemblies

--- a/Source/aweXpect.Reflection/Collections/ITypeAssemblies.cs
+++ b/Source/aweXpect.Reflection/Collections/ITypeAssemblies.cs
@@ -35,6 +35,31 @@ public interface ITypeAssemblies : ILimitedTypeAssemblies<ITypeAssemblies>
 	Filtered.Types Enums(AccessModifiers accessModifier = AccessModifiers.Any);
 
 	/// <summary>
+	///     Get all constructors in the filtered types.
+	/// </summary>
+	Filtered.Constructors Constructors();
+
+	/// <summary>
+	///     Get all events in the filtered types.
+	/// </summary>
+	Filtered.Events Events();
+
+	/// <summary>
+	///     Get all fields in the filtered types.
+	/// </summary>
+	Filtered.Fields Fields();
+
+	/// <summary>
+	///     Get all methods in the filtered types.
+	/// </summary>
+	Filtered.Methods Methods();
+
+	/// <summary>
+	///     Get all properties in the filtered types.
+	/// </summary>
+	Filtered.Properties Properties();
+
+	/// <summary>
 	///     An interface to allow filtering for types in assemblies.
 	/// </summary>
 	/// <remarks>

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net8.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net8.0.txt
@@ -697,8 +697,13 @@ namespace aweXpect.Reflection.Collections
         aweXpect.Reflection.Collections.ILimitedTypeAssemblies<aweXpect.Reflection.Collections.ILimitedTypeAssemblies> Abstract { get; }
         aweXpect.Reflection.Collections.ILimitedTypeAssemblies<aweXpect.Reflection.Collections.ILimitedTypeAssemblies> Sealed { get; }
         aweXpect.Reflection.Collections.ILimitedTypeAssemblies<aweXpect.Reflection.Collections.ILimitedTypeAssemblies> Static { get; }
+        aweXpect.Reflection.Collections.Filtered.Constructors Constructors();
         aweXpect.Reflection.Collections.Filtered.Types Enums(aweXpect.Reflection.Collections.AccessModifiers accessModifier = 15);
+        aweXpect.Reflection.Collections.Filtered.Events Events();
+        aweXpect.Reflection.Collections.Filtered.Fields Fields();
         aweXpect.Reflection.Collections.Filtered.Types Interfaces(aweXpect.Reflection.Collections.AccessModifiers accessModifier = 15);
+        aweXpect.Reflection.Collections.Filtered.Methods Methods();
+        aweXpect.Reflection.Collections.Filtered.Properties Properties();
         public interface IPrivate : aweXpect.Reflection.Collections.ILimitedTypeAssemblies, aweXpect.Reflection.Collections.ILimitedTypeAssemblies<aweXpect.Reflection.Collections.ITypeAssemblies>, aweXpect.Reflection.Collections.ITypeAssemblies
         {
             aweXpect.Reflection.Collections.ITypeAssemblies Protected { get; }

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_netstandard2.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_netstandard2.0.txt
@@ -697,8 +697,13 @@ namespace aweXpect.Reflection.Collections
         aweXpect.Reflection.Collections.ILimitedTypeAssemblies<aweXpect.Reflection.Collections.ILimitedTypeAssemblies> Abstract { get; }
         aweXpect.Reflection.Collections.ILimitedTypeAssemblies<aweXpect.Reflection.Collections.ILimitedTypeAssemblies> Sealed { get; }
         aweXpect.Reflection.Collections.ILimitedTypeAssemblies<aweXpect.Reflection.Collections.ILimitedTypeAssemblies> Static { get; }
+        aweXpect.Reflection.Collections.Filtered.Constructors Constructors();
         aweXpect.Reflection.Collections.Filtered.Types Enums(aweXpect.Reflection.Collections.AccessModifiers accessModifier = 15);
+        aweXpect.Reflection.Collections.Filtered.Events Events();
+        aweXpect.Reflection.Collections.Filtered.Fields Fields();
         aweXpect.Reflection.Collections.Filtered.Types Interfaces(aweXpect.Reflection.Collections.AccessModifiers accessModifier = 15);
+        aweXpect.Reflection.Collections.Filtered.Methods Methods();
+        aweXpect.Reflection.Collections.Filtered.Properties Properties();
         public interface IPrivate : aweXpect.Reflection.Collections.ILimitedTypeAssemblies, aweXpect.Reflection.Collections.ILimitedTypeAssemblies<aweXpect.Reflection.Collections.ITypeAssemblies>, aweXpect.Reflection.Collections.ITypeAssemblies
         {
             aweXpect.Reflection.Collections.ITypeAssemblies Protected { get; }

--- a/Tests/aweXpect.Reflection.Tests/Collections/Filtered.Assemblies.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Collections/Filtered.Assemblies.Tests.cs
@@ -158,6 +158,58 @@ public sealed partial class Filtered
 			}
 
 			[Fact]
+			public async Task CanFilterForInternalConstructors()
+			{
+				Reflection.Collections.Filtered.Constructors constructors =
+					In.AllLoadedAssemblies().Internal.Constructors();
+				string description = constructors.GetDescription();
+
+				await That(constructors).AreInternal();
+				await That(description).IsEqualTo("internal constructors in all loaded assemblies");
+			}
+
+			[Fact]
+			public async Task CanFilterForInternalEvents()
+			{
+				Reflection.Collections.Filtered.Events events = In.AllLoadedAssemblies().Internal.Events();
+				string description = events.GetDescription();
+
+				await That(events).AreInternal();
+				await That(description).IsEqualTo("internal events in all loaded assemblies");
+			}
+
+			[Fact]
+			public async Task CanFilterForInternalFields()
+			{
+				Reflection.Collections.Filtered.Fields fields = In.AllLoadedAssemblies().Internal.Fields();
+				string description = fields.GetDescription();
+
+				await That(fields).AreInternal();
+				await That(description).IsEqualTo("internal fields in all loaded assemblies");
+			}
+
+
+			[Fact]
+			public async Task CanFilterForInternalMethods()
+			{
+				Reflection.Collections.Filtered.Methods methods = In.AllLoadedAssemblies().Internal.Methods();
+				string description = methods.GetDescription();
+
+				await That(methods).AreInternal();
+				await That(description).IsEqualTo("internal methods in all loaded assemblies");
+			}
+
+			[Fact]
+			public async Task CanFilterForInternalProperties()
+			{
+				Reflection.Collections.Filtered.Properties properties = In.AllLoadedAssemblies().Internal.Properties();
+				string description = properties.GetDescription();
+
+				await That(properties).AreInternal();
+				await That(description).IsEqualTo("internal properties in all loaded assemblies");
+			}
+
+			[Fact]
 			public async Task CanFilterForInternalTypes()
 			{
 				Reflection.Collections.Filtered.Types types = In.AllLoadedAssemblies().Internal.Types();
@@ -165,6 +217,109 @@ public sealed partial class Filtered
 
 				await That(types).AreInternal();
 				await That(description).IsEqualTo("internal types in all loaded assemblies");
+			}
+
+			[Fact]
+			public async Task CanFilterForPrivateConstructors()
+			{
+				Reflection.Collections.Filtered.Constructors constructors =
+					In.AllLoadedAssemblies().Private.Constructors();
+				string description = constructors.GetDescription();
+
+				await That(constructors).ArePrivate();
+				await That(description).IsEqualTo("private constructors in all loaded assemblies");
+			}
+
+			[Fact]
+			public async Task CanFilterForPrivateEvents()
+			{
+				Reflection.Collections.Filtered.Events events = In.AllLoadedAssemblies().Private.Events();
+				string description = events.GetDescription();
+
+				await That(events).ArePrivate();
+				await That(description).IsEqualTo("private events in all loaded assemblies");
+			}
+
+			[Fact]
+			public async Task CanFilterForPrivateFields()
+			{
+				Reflection.Collections.Filtered.Fields fields = In.AllLoadedAssemblies().Private.Fields();
+				string description = fields.GetDescription();
+
+				await That(fields).ArePrivate();
+				await That(description).IsEqualTo("private fields in all loaded assemblies");
+			}
+
+			[Fact]
+			public async Task CanFilterForPrivateMethods()
+			{
+				Reflection.Collections.Filtered.Methods methods = In.AllLoadedAssemblies().Private.Methods();
+				string description = methods.GetDescription();
+
+				await That(methods).ArePrivate();
+				await That(description).IsEqualTo("private methods in all loaded assemblies");
+			}
+
+			[Fact]
+			public async Task CanFilterForPrivateProperties()
+			{
+				Reflection.Collections.Filtered.Properties properties = In.AllLoadedAssemblies().Private.Properties();
+				string description = properties.GetDescription();
+
+				await That(properties).ArePrivate();
+				await That(description).IsEqualTo("private properties in all loaded assemblies");
+			}
+
+			[Fact]
+			public async Task CanFilterForPrivateProtectedConstructors()
+			{
+				Reflection.Collections.Filtered.Constructors constructors =
+					In.AllLoadedAssemblies().Private.Protected.Constructors();
+				string description = constructors.GetDescription();
+
+				await That(constructors).ArePrivate();
+				await That(description).IsEqualTo("private protected constructors in all loaded assemblies");
+			}
+
+			[Fact]
+			public async Task CanFilterForPrivateProtectedEvents()
+			{
+				Reflection.Collections.Filtered.Events events = In.AllLoadedAssemblies().Private.Protected.Events();
+				string description = events.GetDescription();
+
+				await That(events).ArePrivate();
+				await That(description).IsEqualTo("private protected events in all loaded assemblies");
+			}
+
+			[Fact]
+			public async Task CanFilterForPrivateProtectedFields()
+			{
+				Reflection.Collections.Filtered.Fields fields = In.AllLoadedAssemblies().Private.Protected.Fields();
+				string description = fields.GetDescription();
+
+				await That(fields).ArePrivate();
+				await That(description).IsEqualTo("private protected fields in all loaded assemblies");
+			}
+
+			[Fact]
+			public async Task CanFilterForPrivateProtectedMethods()
+			{
+				Reflection.Collections.Filtered.Methods methods = In.AllLoadedAssemblies().Private.Protected.Methods();
+				string description = methods.GetDescription();
+
+				await That(methods).ArePrivate();
+				await That(description).IsEqualTo("private protected methods in all loaded assemblies");
+			}
+
+			[Fact]
+			public async Task CanFilterForPrivateProtectedProperties()
+			{
+				Reflection.Collections.Filtered.Properties properties =
+					In.AllLoadedAssemblies().Private.Protected.Properties();
+				string description = properties.GetDescription();
+
+				await That(properties).ArePrivate();
+				await That(description).IsEqualTo("private protected properties in all loaded assemblies");
 			}
 
 			[Fact]
@@ -188,6 +343,89 @@ public sealed partial class Filtered
 			}
 
 			[Fact]
+			public async Task CanFilterForProtectedConstructors()
+			{
+				Reflection.Collections.Filtered.Constructors constructors =
+					In.AllLoadedAssemblies().Protected.Constructors();
+				string description = constructors.GetDescription();
+
+				await That(constructors).AreProtected();
+				await That(description).IsEqualTo("protected constructors in all loaded assemblies");
+			}
+
+			[Fact]
+			public async Task CanFilterForProtectedEvents()
+			{
+				Reflection.Collections.Filtered.Events events = In.AllLoadedAssemblies().Protected.Events();
+				string description = events.GetDescription();
+
+				await That(events).AreProtected();
+				await That(description).IsEqualTo("protected events in all loaded assemblies");
+			}
+
+			[Fact]
+			public async Task CanFilterForProtectedFields()
+			{
+				Reflection.Collections.Filtered.Fields fields = In.AllLoadedAssemblies().Protected.Fields();
+				string description = fields.GetDescription();
+
+				await That(fields).AreProtected();
+				await That(description).IsEqualTo("protected fields in all loaded assemblies");
+			}
+
+			[Fact]
+			public async Task CanFilterForProtectedInternalConstructors()
+			{
+				Reflection.Collections.Filtered.Constructors constructors =
+					In.AllLoadedAssemblies().Protected.Internal.Constructors();
+				string description = constructors.GetDescription();
+
+				await That(constructors).AreProtected();
+				await That(description).IsEqualTo("protected internal constructors in all loaded assemblies");
+			}
+
+			[Fact]
+			public async Task CanFilterForProtectedInternalEvents()
+			{
+				Reflection.Collections.Filtered.Events events = In.AllLoadedAssemblies().Protected.Internal.Events();
+				string description = events.GetDescription();
+
+				await That(events).AreProtected();
+				await That(description).IsEqualTo("protected internal events in all loaded assemblies");
+			}
+
+			[Fact]
+			public async Task CanFilterForProtectedInternalFields()
+			{
+				Reflection.Collections.Filtered.Fields fields = In.AllLoadedAssemblies().Protected.Internal.Fields();
+				string description = fields.GetDescription();
+
+				await That(fields).AreProtected();
+				await That(description).IsEqualTo("protected internal fields in all loaded assemblies");
+			}
+
+			[Fact]
+			public async Task CanFilterForProtectedInternalMethods()
+			{
+				Reflection.Collections.Filtered.Methods methods = In.AllLoadedAssemblies().Protected.Internal.Methods();
+				string description = methods.GetDescription();
+
+				await That(methods).AreProtected();
+				await That(description).IsEqualTo("protected internal methods in all loaded assemblies");
+			}
+
+			[Fact]
+			public async Task CanFilterForProtectedInternalProperties()
+			{
+				Reflection.Collections.Filtered.Properties properties =
+					In.AllLoadedAssemblies().Protected.Internal.Properties();
+				string description = properties.GetDescription();
+
+				await That(properties).AreProtected();
+				await That(description).IsEqualTo("protected internal properties in all loaded assemblies");
+			}
+
+			[Fact]
 			public async Task CanFilterForProtectedInternalTypes()
 			{
 				Reflection.Collections.Filtered.Types types = In.AllLoadedAssemblies().Protected.Internal.Types();
@@ -198,6 +436,26 @@ public sealed partial class Filtered
 			}
 
 			[Fact]
+			public async Task CanFilterForProtectedMethods()
+			{
+				Reflection.Collections.Filtered.Methods methods = In.AllLoadedAssemblies().Protected.Methods();
+				string description = methods.GetDescription();
+
+				await That(methods).AreProtected();
+				await That(description).IsEqualTo("protected methods in all loaded assemblies");
+			}
+
+			[Fact]
+			public async Task CanFilterForProtectedProperties()
+			{
+				Reflection.Collections.Filtered.Properties properties = In.AllLoadedAssemblies().Protected.Properties();
+				string description = properties.GetDescription();
+
+				await That(properties).AreProtected();
+				await That(description).IsEqualTo("protected properties in all loaded assemblies");
+			}
+
+			[Fact]
 			public async Task CanFilterForProtectedTypes()
 			{
 				Reflection.Collections.Filtered.Types types = In.AllLoadedAssemblies().Protected.Types();
@@ -205,6 +463,57 @@ public sealed partial class Filtered
 
 				await That(types).AreProtected();
 				await That(description).IsEqualTo("protected types in all loaded assemblies");
+			}
+
+			[Fact]
+			public async Task CanFilterForPublicConstructors()
+			{
+				Reflection.Collections.Filtered.Constructors constructors =
+					In.AllLoadedAssemblies().Public.Constructors();
+				string description = constructors.GetDescription();
+
+				await That(constructors).ArePublic();
+				await That(description).IsEqualTo("public constructors in all loaded assemblies");
+			}
+
+			[Fact]
+			public async Task CanFilterForPublicEvents()
+			{
+				Reflection.Collections.Filtered.Events events = In.AllLoadedAssemblies().Public.Events();
+				string description = events.GetDescription();
+
+				await That(events).ArePublic();
+				await That(description).IsEqualTo("public events in all loaded assemblies");
+			}
+
+			[Fact]
+			public async Task CanFilterForPublicFields()
+			{
+				Reflection.Collections.Filtered.Fields fields = In.AllLoadedAssemblies().Public.Fields();
+				string description = fields.GetDescription();
+
+				await That(fields).ArePublic();
+				await That(description).IsEqualTo("public fields in all loaded assemblies");
+			}
+
+			[Fact]
+			public async Task CanFilterForPublicMethods()
+			{
+				Reflection.Collections.Filtered.Methods methods = In.AllLoadedAssemblies().Public.Methods();
+				string description = methods.GetDescription();
+
+				await That(methods).ArePublic();
+				await That(description).IsEqualTo("public methods in all loaded assemblies");
+			}
+
+			[Fact]
+			public async Task CanFilterForPublicProperties()
+			{
+				Reflection.Collections.Filtered.Properties properties = In.AllLoadedAssemblies().Public.Properties();
+				string description = properties.GetDescription();
+
+				await That(properties).ArePublic();
+				await That(description).IsEqualTo("public properties in all loaded assemblies");
 			}
 
 			[Fact]

--- a/Tests/aweXpect.Reflection.Tests/Collections/Filtered.Assemblies.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Collections/Filtered.Assemblies.Tests.cs
@@ -277,7 +277,7 @@ public sealed partial class Filtered
 					In.AllLoadedAssemblies().Private.Protected.Constructors();
 				string description = constructors.GetDescription();
 
-				await That(constructors).ArePrivate();
+				await That(constructors).ArePrivate().And.AreProtected();
 				await That(description).IsEqualTo("private protected constructors in all loaded assemblies");
 			}
 
@@ -287,7 +287,7 @@ public sealed partial class Filtered
 				Reflection.Collections.Filtered.Events events = In.AllLoadedAssemblies().Private.Protected.Events();
 				string description = events.GetDescription();
 
-				await That(events).ArePrivate();
+				await That(events).ArePrivate().And.AreProtected();
 				await That(description).IsEqualTo("private protected events in all loaded assemblies");
 			}
 
@@ -297,7 +297,7 @@ public sealed partial class Filtered
 				Reflection.Collections.Filtered.Fields fields = In.AllLoadedAssemblies().Private.Protected.Fields();
 				string description = fields.GetDescription();
 
-				await That(fields).ArePrivate();
+				await That(fields).ArePrivate().And.AreProtected();
 				await That(description).IsEqualTo("private protected fields in all loaded assemblies");
 			}
 
@@ -307,7 +307,7 @@ public sealed partial class Filtered
 				Reflection.Collections.Filtered.Methods methods = In.AllLoadedAssemblies().Private.Protected.Methods();
 				string description = methods.GetDescription();
 
-				await That(methods).ArePrivate();
+				await That(methods).ArePrivate().And.AreProtected();
 				await That(description).IsEqualTo("private protected methods in all loaded assemblies");
 			}
 
@@ -318,7 +318,7 @@ public sealed partial class Filtered
 					In.AllLoadedAssemblies().Private.Protected.Properties();
 				string description = properties.GetDescription();
 
-				await That(properties).ArePrivate();
+				await That(properties).ArePrivate().And.AreProtected();
 				await That(description).IsEqualTo("private protected properties in all loaded assemblies");
 			}
 
@@ -328,7 +328,7 @@ public sealed partial class Filtered
 				Reflection.Collections.Filtered.Types types = In.AllLoadedAssemblies().Private.Protected.Types();
 				string description = types.GetDescription();
 
-				await That(types).ArePrivate();
+				await That(types).ArePrivate().And.AreProtected();
 				await That(description).IsEqualTo("private protected types in all loaded assemblies");
 			}
 
@@ -380,7 +380,7 @@ public sealed partial class Filtered
 					In.AllLoadedAssemblies().Protected.Internal.Constructors();
 				string description = constructors.GetDescription();
 
-				await That(constructors).AreProtected();
+				await That(constructors).AreProtected().And.AreInternal();
 				await That(description).IsEqualTo("protected internal constructors in all loaded assemblies");
 			}
 
@@ -390,7 +390,7 @@ public sealed partial class Filtered
 				Reflection.Collections.Filtered.Events events = In.AllLoadedAssemblies().Protected.Internal.Events();
 				string description = events.GetDescription();
 
-				await That(events).AreProtected();
+				await That(events).AreProtected().And.AreInternal();
 				await That(description).IsEqualTo("protected internal events in all loaded assemblies");
 			}
 
@@ -400,7 +400,7 @@ public sealed partial class Filtered
 				Reflection.Collections.Filtered.Fields fields = In.AllLoadedAssemblies().Protected.Internal.Fields();
 				string description = fields.GetDescription();
 
-				await That(fields).AreProtected();
+				await That(fields).AreProtected().And.AreInternal();
 				await That(description).IsEqualTo("protected internal fields in all loaded assemblies");
 			}
 
@@ -410,7 +410,7 @@ public sealed partial class Filtered
 				Reflection.Collections.Filtered.Methods methods = In.AllLoadedAssemblies().Protected.Internal.Methods();
 				string description = methods.GetDescription();
 
-				await That(methods).AreProtected();
+				await That(methods).AreProtected().And.AreInternal();
 				await That(description).IsEqualTo("protected internal methods in all loaded assemblies");
 			}
 
@@ -421,7 +421,7 @@ public sealed partial class Filtered
 					In.AllLoadedAssemblies().Protected.Internal.Properties();
 				string description = properties.GetDescription();
 
-				await That(properties).AreProtected();
+				await That(properties).AreProtected().And.AreInternal();
 				await That(description).IsEqualTo("protected internal properties in all loaded assemblies");
 			}
 
@@ -431,7 +431,7 @@ public sealed partial class Filtered
 				Reflection.Collections.Filtered.Types types = In.AllLoadedAssemblies().Protected.Internal.Types();
 				string description = types.GetDescription();
 
-				await That(types).AreProtected();
+				await That(types).AreProtected().And.AreInternal();
 				await That(description).IsEqualTo("protected internal types in all loaded assemblies");
 			}
 


### PR DESCRIPTION
This PR extends the property-based access modifier filtering functionality in `Filtered.Assemblies` to support other reflection members beyond just types. The change allows developers to use convenient property-based syntax like `In.AllLoadedAssemblies().Public.Methods()` instead of the more verbose `In.AllLoadedAssemblies().Methods().WhichArePublic()`.

Key changes:
- Added support for access modifier filters on constructors, events, fields, methods, and properties
- Refactored access modifier handling to use an implicit accumulation pattern instead of immediate type filtering
- Updated interface and documentation to reflect the expanded capabilities