### PR TITLE
refactor: trim common whitespace from predicate descriptions

### DIFF
--- a/Source/aweXpect.Reflection/Collections/Filtered.cs
+++ b/Source/aweXpect.Reflection/Collections/Filtered.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using aweXpect.Reflection.Helpers;
 
 namespace aweXpect.Reflection.Collections;
 
@@ -44,5 +45,5 @@ public abstract class Filtered<T, TFiltered>(IEnumerable<T> source, List<IFilter
 	public TFiltered Which(Func<T, bool> predicate,
 		[CallerArgumentExpression("predicate")]
 		string doNotPopulateThisValue = "")
-		=> Which(Filter.Suffix(predicate, $"matching {doNotPopulateThisValue} "));
+		=> Which(Filter.Suffix(predicate, $"matching {doNotPopulateThisValue.TrimCommonWhiteSpace()} "));
 }

--- a/Source/aweXpect.Reflection/Filters/AssemblyFilters.WhichSatisfy.cs
+++ b/Source/aweXpect.Reflection/Filters/AssemblyFilters.WhichSatisfy.cs
@@ -2,6 +2,7 @@
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Helpers;
 
 namespace aweXpect.Reflection;
 
@@ -14,5 +15,5 @@ public static partial class AssemblyFilters
 		Func<Assembly, bool> predicate,
 		[CallerArgumentExpression("predicate")]
 		string doNotPopulateThisValue = "")
-		=> @this.Which(Filter.Suffix(predicate, $" matching {doNotPopulateThisValue}"));
+		=> @this.Which(Filter.Suffix(predicate, $" matching {doNotPopulateThisValue.TrimCommonWhiteSpace()}"));
 }

--- a/Source/aweXpect.Reflection/Filters/ConstructorFilters.WhichSatisfy.cs
+++ b/Source/aweXpect.Reflection/Filters/ConstructorFilters.WhichSatisfy.cs
@@ -2,6 +2,7 @@
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Helpers;
 
 namespace aweXpect.Reflection;
 
@@ -14,5 +15,5 @@ public static partial class ConstructorFilters
 		Func<ConstructorInfo, bool> predicate,
 		[CallerArgumentExpression("predicate")]
 		string doNotPopulateThisValue = "")
-		=> @this.Which(Filter.Suffix(predicate, $"matching {doNotPopulateThisValue} "));
+		=> @this.Which(Filter.Suffix(predicate, $"matching {doNotPopulateThisValue.TrimCommonWhiteSpace()} "));
 }

--- a/Source/aweXpect.Reflection/Filters/ConstructorFilters.With.cs
+++ b/Source/aweXpect.Reflection/Filters/ConstructorFilters.With.cs
@@ -32,7 +32,7 @@ public static partial class ConstructorFilters
 	{
 		IChangeableFilter<ConstructorInfo> filter = Filter.Suffix<ConstructorInfo>(
 			constructorInfo => constructorInfo.HasAttribute(predicate),
-			$"with {Formatter.Format(typeof(TAttribute))} matching {doNotPopulateThisValue} ");
+			$"with {Formatter.Format(typeof(TAttribute))} matching {doNotPopulateThisValue.TrimCommonWhiteSpace()} ");
 		return new ConstructorsWith(@this.Which(filter), filter);
 	}
 
@@ -67,7 +67,7 @@ public static partial class ConstructorFilters
 			filter.UpdateFilter(
 				(result, constructorInfo) => result || constructorInfo.HasAttribute(predicate),
 				description
-					=> $"{description}or with {Formatter.Format(typeof(TAttribute))} matching {doNotPopulateThisValue} ");
+					=> $"{description}or with {Formatter.Format(typeof(TAttribute))} matching {doNotPopulateThisValue.TrimCommonWhiteSpace()} ");
 			return this;
 		}
 	}

--- a/Source/aweXpect.Reflection/Filters/EventFilters.WhichSatisfy.cs
+++ b/Source/aweXpect.Reflection/Filters/EventFilters.WhichSatisfy.cs
@@ -2,6 +2,7 @@
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Helpers;
 
 namespace aweXpect.Reflection;
 
@@ -14,5 +15,5 @@ public static partial class EventFilters
 		Func<EventInfo, bool> predicate,
 		[CallerArgumentExpression("predicate")]
 		string doNotPopulateThisValue = "")
-		=> @this.Which(Filter.Suffix(predicate, $"matching {doNotPopulateThisValue} "));
+		=> @this.Which(Filter.Suffix(predicate, $"matching {doNotPopulateThisValue.TrimCommonWhiteSpace()} "));
 }

--- a/Source/aweXpect.Reflection/Filters/EventFilters.With.cs
+++ b/Source/aweXpect.Reflection/Filters/EventFilters.With.cs
@@ -43,7 +43,7 @@ public static partial class EventFilters
 	{
 		IChangeableFilter<EventInfo> filter = Filter.Suffix<EventInfo>(
 			eventInfo => eventInfo.HasAttribute(predicate, inherit),
-			$"with {(inherit ? "" : DirectText)}{Formatter.Format(typeof(TAttribute))} matching {doNotPopulateThisValue} ");
+			$"with {(inherit ? "" : DirectText)}{Formatter.Format(typeof(TAttribute))} matching {doNotPopulateThisValue.TrimCommonWhiteSpace()} ");
 		return new EventsWith(@this.Which(filter), filter);
 	}
 
@@ -86,7 +86,7 @@ public static partial class EventFilters
 			filter.UpdateFilter(
 				(result, eventInfo) => result || eventInfo.HasAttribute(predicate, inherit),
 				description
-					=> $"{description}or with {(inherit ? "" : DirectText)}{Formatter.Format(typeof(TAttribute))} matching {doNotPopulateThisValue} ");
+					=> $"{description}or with {(inherit ? "" : DirectText)}{Formatter.Format(typeof(TAttribute))} matching {doNotPopulateThisValue.TrimCommonWhiteSpace()} ");
 			return this;
 		}
 	}

--- a/Source/aweXpect.Reflection/Filters/FieldFilters.WhichSatisfy.cs
+++ b/Source/aweXpect.Reflection/Filters/FieldFilters.WhichSatisfy.cs
@@ -2,6 +2,7 @@
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Helpers;
 
 namespace aweXpect.Reflection;
 
@@ -14,5 +15,5 @@ public static partial class FieldFilters
 		Func<FieldInfo, bool> predicate,
 		[CallerArgumentExpression("predicate")]
 		string doNotPopulateThisValue = "")
-		=> @this.Which(Filter.Suffix(predicate, $"matching {doNotPopulateThisValue} "));
+		=> @this.Which(Filter.Suffix(predicate, $"matching {doNotPopulateThisValue.TrimCommonWhiteSpace()} "));
 }

--- a/Source/aweXpect.Reflection/Filters/FieldFilters.With.cs
+++ b/Source/aweXpect.Reflection/Filters/FieldFilters.With.cs
@@ -32,7 +32,7 @@ public static partial class FieldFilters
 	{
 		IChangeableFilter<FieldInfo> filter = Filter.Suffix<FieldInfo>(
 			fieldInfo => fieldInfo.HasAttribute(predicate),
-			$"with {Formatter.Format(typeof(TAttribute))} matching {doNotPopulateThisValue} ");
+			$"with {Formatter.Format(typeof(TAttribute))} matching {doNotPopulateThisValue.TrimCommonWhiteSpace()} ");
 		return new FieldsWith(@this.Which(filter), filter);
 	}
 
@@ -66,7 +66,7 @@ public static partial class FieldFilters
 			filter.UpdateFilter(
 				(result, fieldInfo) => result || fieldInfo.HasAttribute(predicate),
 				description
-					=> $"{description}or with {Formatter.Format(typeof(TAttribute))} matching {doNotPopulateThisValue} ");
+					=> $"{description}or with {Formatter.Format(typeof(TAttribute))} matching {doNotPopulateThisValue.TrimCommonWhiteSpace()} ");
 			return this;
 		}
 	}

--- a/Source/aweXpect.Reflection/Filters/MethodFilters.WhichSatisfy.cs
+++ b/Source/aweXpect.Reflection/Filters/MethodFilters.WhichSatisfy.cs
@@ -2,6 +2,7 @@
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Helpers;
 
 namespace aweXpect.Reflection;
 
@@ -14,5 +15,5 @@ public static partial class MethodFilters
 		Func<MethodInfo, bool> predicate,
 		[CallerArgumentExpression("predicate")]
 		string doNotPopulateThisValue = "")
-		=> @this.Which(Filter.Suffix(predicate, $"matching {doNotPopulateThisValue} "));
+		=> @this.Which(Filter.Suffix(predicate, $"matching {doNotPopulateThisValue.TrimCommonWhiteSpace()} "));
 }

--- a/Source/aweXpect.Reflection/Filters/MethodFilters.With.cs
+++ b/Source/aweXpect.Reflection/Filters/MethodFilters.With.cs
@@ -43,7 +43,7 @@ public static partial class MethodFilters
 	{
 		IChangeableFilter<MethodInfo> filter = Filter.Suffix<MethodInfo>(
 			methodInfo => methodInfo.HasAttribute(predicate, inherit),
-			$"with {(inherit ? "" : DirectText)}{Formatter.Format(typeof(TAttribute))} matching {doNotPopulateThisValue} ");
+			$"with {(inherit ? "" : DirectText)}{Formatter.Format(typeof(TAttribute))} matching {doNotPopulateThisValue.TrimCommonWhiteSpace()} ");
 		return new MethodsWith(@this.Which(filter), filter);
 	}
 
@@ -86,7 +86,7 @@ public static partial class MethodFilters
 			filter.UpdateFilter(
 				(result, methodInfo) => result || methodInfo.HasAttribute(predicate, inherit),
 				description
-					=> $"{description}or with {(inherit ? "" : DirectText)}{Formatter.Format(typeof(TAttribute))} matching {doNotPopulateThisValue} ");
+					=> $"{description}or with {(inherit ? "" : DirectText)}{Formatter.Format(typeof(TAttribute))} matching {doNotPopulateThisValue.TrimCommonWhiteSpace()} ");
 			return this;
 		}
 	}

--- a/Source/aweXpect.Reflection/Filters/PropertyFilters.WhichSatisfy.cs
+++ b/Source/aweXpect.Reflection/Filters/PropertyFilters.WhichSatisfy.cs
@@ -2,6 +2,7 @@
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Helpers;
 
 namespace aweXpect.Reflection;
 
@@ -14,5 +15,5 @@ public static partial class PropertyFilters
 		Func<PropertyInfo, bool> predicate,
 		[CallerArgumentExpression("predicate")]
 		string doNotPopulateThisValue = "")
-		=> @this.Which(Filter.Suffix(predicate, $"matching {doNotPopulateThisValue} "));
+		=> @this.Which(Filter.Suffix(predicate, $"matching {doNotPopulateThisValue.TrimCommonWhiteSpace()} "));
 }

--- a/Source/aweXpect.Reflection/Filters/PropertyFilters.With.cs
+++ b/Source/aweXpect.Reflection/Filters/PropertyFilters.With.cs
@@ -43,7 +43,7 @@ public static partial class PropertyFilters
 	{
 		IChangeableFilter<PropertyInfo> filter = Filter.Suffix<PropertyInfo>(
 			propertyInfo => propertyInfo.HasAttribute(predicate, inherit),
-			$"with {(inherit ? "" : DirectText)}{Formatter.Format(typeof(TAttribute))} matching {doNotPopulateThisValue} ");
+			$"with {(inherit ? "" : DirectText)}{Formatter.Format(typeof(TAttribute))} matching {doNotPopulateThisValue.TrimCommonWhiteSpace()} ");
 		return new PropertiesWith(@this.Which(filter), filter);
 	}
 
@@ -88,7 +88,7 @@ public static partial class PropertyFilters
 			filter.UpdateFilter(
 				(result, propertyInfo) => result || propertyInfo.HasAttribute(predicate, inherit),
 				description
-					=> $"{description}or with {(inherit ? "" : DirectText)}{Formatter.Format(typeof(TAttribute))} matching {doNotPopulateThisValue} ");
+					=> $"{description}or with {(inherit ? "" : DirectText)}{Formatter.Format(typeof(TAttribute))} matching {doNotPopulateThisValue.TrimCommonWhiteSpace()} ");
 			return this;
 		}
 	}

--- a/Source/aweXpect.Reflection/Filters/TypeFilters.WhichSatisfy.cs
+++ b/Source/aweXpect.Reflection/Filters/TypeFilters.WhichSatisfy.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Runtime.CompilerServices;
 using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Helpers;
 
 namespace aweXpect.Reflection;
 
@@ -13,5 +14,5 @@ public static partial class TypeFilters
 		Func<Type, bool> predicate,
 		[CallerArgumentExpression("predicate")]
 		string doNotPopulateThisValue = "")
-		=> @this.Which(Filter.Suffix(predicate, $"matching {doNotPopulateThisValue} "));
+		=> @this.Which(Filter.Suffix(predicate, $"matching {doNotPopulateThisValue.TrimCommonWhiteSpace()} "));
 }

--- a/Source/aweXpect.Reflection/Filters/TypeFilters.With.cs
+++ b/Source/aweXpect.Reflection/Filters/TypeFilters.With.cs
@@ -40,7 +40,7 @@ public static partial class TypeFilters
 		where TAttribute : Attribute
 	{
 		IChangeableFilter<Type> filter = Filter.Suffix<Type>(type => type.HasAttribute(predicate, inherit),
-			$"with {(inherit ? "" : DirectText)}{Formatter.Format(typeof(TAttribute))} matching {doNotPopulateThisValue} ");
+			$"with {(inherit ? "" : DirectText)}{Formatter.Format(typeof(TAttribute))} matching {doNotPopulateThisValue.TrimCommonWhiteSpace()} ");
 		return new TypesWith(@this.Which(filter), filter);
 	}
 
@@ -83,7 +83,7 @@ public static partial class TypeFilters
 			filter.UpdateFilter(
 				(result, type) => result || type.HasAttribute(predicate, inherit),
 				description
-					=> $"{description}or with {(inherit ? "" : DirectText)}{Formatter.Format(typeof(TAttribute))} matching {doNotPopulateThisValue} ");
+					=> $"{description}or with {(inherit ? "" : DirectText)}{Formatter.Format(typeof(TAttribute))} matching {doNotPopulateThisValue.TrimCommonWhiteSpace()} ");
 			return this;
 		}
 	}

--- a/Source/aweXpect.Reflection/Helpers/StringHelpers.cs
+++ b/Source/aweXpect.Reflection/Helpers/StringHelpers.cs
@@ -1,4 +1,8 @@
-﻿namespace aweXpect.Reflection.Helpers;
+﻿using System;
+using System.Linq;
+using System.Text;
+
+namespace aweXpect.Reflection.Helpers;
 
 internal static class StringHelpers
 {
@@ -10,5 +14,60 @@ internal static class StringHelpers
 		}
 
 		return "in " + description;
+	}
+
+	public static string TrimCommonWhiteSpace(this string value)
+	{
+		string[] lines = value.Split('\n');
+		if (lines.Length <= 1)
+		{
+			return value;
+		}
+
+		StringBuilder sb = new();
+		foreach (char c in lines[1])
+		{
+			if (char.IsWhiteSpace(c))
+			{
+				sb.Append(c);
+			}
+			else
+			{
+				break;
+			}
+		}
+
+		string commonWhiteSpace = sb.ToString();
+
+		for (int l = 2; l < lines.Length; l++)
+		{
+			if (lines[l].StartsWith(commonWhiteSpace))
+			{
+				continue;
+			}
+
+			for (int i = 0; i < Math.Min(lines[l].Length, commonWhiteSpace.Length); i++)
+			{
+				if (lines[l][i] != commonWhiteSpace[i])
+				{
+					commonWhiteSpace = commonWhiteSpace[..i];
+					break;
+				}
+			}
+		}
+
+		sb.Clear();
+		sb.Append(lines[0]);
+		foreach (string? line in lines.Skip(1))
+		{
+			sb.Append('\n').Append(line[commonWhiteSpace.Length..]);
+		}
+
+		if (lines.Length == 2)
+		{
+			sb.Replace(Environment.NewLine, " ");
+		}
+
+		return sb.ToString();
 	}
 }

--- a/Source/aweXpect.Reflection/Results/HasAttributeResult.cs
+++ b/Source/aweXpect.Reflection/Results/HasAttributeResult.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Runtime.CompilerServices;
 using aweXpect.Core;
+using aweXpect.Reflection.Helpers;
 using aweXpect.Reflection.Options;
 using aweXpect.Results;
 
@@ -49,7 +50,7 @@ public sealed class HasAttributeResult<TMember>(
 		string doNotPopulateThisValue = "")
 		where TAttribute : Attribute
 	{
-		attributeFilterOptions.RegisterAttribute(inherit, predicate, doNotPopulateThisValue);
+		attributeFilterOptions.RegisterAttribute(inherit, predicate, doNotPopulateThisValue.TrimCommonWhiteSpace());
 		return this;
 	}
 }

--- a/Source/aweXpect.Reflection/Results/HaveAttributeResult.cs
+++ b/Source/aweXpect.Reflection/Results/HaveAttributeResult.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using aweXpect.Core;
+using aweXpect.Reflection.Helpers;
 using aweXpect.Reflection.Options;
 using aweXpect.Results;
 
@@ -50,7 +51,7 @@ public sealed class HaveAttributeResult<TMember>(
 		string doNotPopulateThisValue = "")
 		where TAttribute : Attribute
 	{
-		attributeFilterOptions.RegisterAttribute(inherit, predicate, doNotPopulateThisValue);
+		attributeFilterOptions.RegisterAttribute(inherit, predicate, doNotPopulateThisValue.TrimCommonWhiteSpace());
 		return this;
 	}
 }

--- a/Source/aweXpect.Reflection/ThatAssemblies.Have.cs
+++ b/Source/aweXpect.Reflection/ThatAssemblies.Have.cs
@@ -55,7 +55,7 @@ public static partial class ThatAssemblies
 	{
 		AttributeFilterOptions<Assembly?> attributeFilterOptions =
 			new((a, attributeType, p, i) => a.HasAttribute(attributeType, p, i));
-		attributeFilterOptions.RegisterAttribute(inherit, predicate, doNotPopulateThisValue);
+		attributeFilterOptions.RegisterAttribute(inherit, predicate, doNotPopulateThisValue.TrimCommonWhiteSpace());
 		return new HaveAttributeResult<Assembly?>(subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
 				=> new HaveAttributeConstraint(it, grammars | ExpectationGrammars.Plural, attributeFilterOptions)),
 			subject,

--- a/Source/aweXpect.Reflection/ThatAssembly.Has.cs
+++ b/Source/aweXpect.Reflection/ThatAssembly.Has.cs
@@ -49,7 +49,7 @@ public static partial class ThatAssembly
 	{
 		AttributeFilterOptions<Assembly?> attributeFilterOptions =
 			new((a, attributeType, p, i) => a.HasAttribute(attributeType, p, i));
-		attributeFilterOptions.RegisterAttribute(inherit, predicate, doNotPopulateThisValue);
+		attributeFilterOptions.RegisterAttribute(inherit, predicate, doNotPopulateThisValue.TrimCommonWhiteSpace());
 		return new HasAttributeResult<Assembly?>(subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
 				=> new HasAttributeConstraint(it, grammars, attributeFilterOptions)),
 			subject,

--- a/Source/aweXpect.Reflection/ThatEvent.Has.cs
+++ b/Source/aweXpect.Reflection/ThatEvent.Has.cs
@@ -49,7 +49,7 @@ public static partial class ThatEvent
 	{
 		AttributeFilterOptions<EventInfo?> attributeFilterOptions =
 			new((a, attributeType, p, i) => a.HasAttribute(attributeType, p, i));
-		attributeFilterOptions.RegisterAttribute(inherit, predicate, doNotPopulateThisValue);
+		attributeFilterOptions.RegisterAttribute(inherit, predicate, doNotPopulateThisValue.TrimCommonWhiteSpace());
 		return new HasAttributeResult<EventInfo?>(subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
 				=> new HasAttributeConstraint(it, grammars, attributeFilterOptions)),
 			subject,

--- a/Source/aweXpect.Reflection/ThatEvents.Have.cs
+++ b/Source/aweXpect.Reflection/ThatEvents.Have.cs
@@ -55,7 +55,7 @@ public static partial class ThatEvents
 	{
 		AttributeFilterOptions<EventInfo?> attributeFilterOptions =
 			new((a, attributeType, p, i) => a.HasAttribute(attributeType, p, i));
-		attributeFilterOptions.RegisterAttribute(inherit, predicate, doNotPopulateThisValue);
+		attributeFilterOptions.RegisterAttribute(inherit, predicate, doNotPopulateThisValue.TrimCommonWhiteSpace());
 		return new HaveAttributeResult<EventInfo?>(subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
 				=> new HaveAttributeConstraint(it, grammars | ExpectationGrammars.Plural, attributeFilterOptions)),
 			subject,

--- a/Source/aweXpect.Reflection/ThatField.Has.cs
+++ b/Source/aweXpect.Reflection/ThatField.Has.cs
@@ -49,7 +49,7 @@ public static partial class ThatField
 	{
 		AttributeFilterOptions<FieldInfo?> attributeFilterOptions =
 			new((a, attributeType, p, i) => a.HasAttribute(attributeType, p, i));
-		attributeFilterOptions.RegisterAttribute(inherit, predicate, doNotPopulateThisValue);
+		attributeFilterOptions.RegisterAttribute(inherit, predicate, doNotPopulateThisValue.TrimCommonWhiteSpace());
 		return new HasAttributeResult<FieldInfo?>(subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
 				=> new HasAttributeConstraint(it, grammars, attributeFilterOptions)),
 			subject,

--- a/Source/aweXpect.Reflection/ThatFields.Have.cs
+++ b/Source/aweXpect.Reflection/ThatFields.Have.cs
@@ -55,7 +55,7 @@ public static partial class ThatFields
 	{
 		AttributeFilterOptions<FieldInfo?> attributeFilterOptions =
 			new((a, attributeType, p, i) => a.HasAttribute(attributeType, p, i));
-		attributeFilterOptions.RegisterAttribute(inherit, predicate, doNotPopulateThisValue);
+		attributeFilterOptions.RegisterAttribute(inherit, predicate, doNotPopulateThisValue.TrimCommonWhiteSpace());
 		return new HaveAttributeResult<FieldInfo?>(subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
 				=> new HaveAttributeConstraint(it, grammars | ExpectationGrammars.Plural, attributeFilterOptions)),
 			subject,

--- a/Source/aweXpect.Reflection/ThatMethod.Has.cs
+++ b/Source/aweXpect.Reflection/ThatMethod.Has.cs
@@ -49,7 +49,7 @@ public static partial class ThatMethod
 	{
 		AttributeFilterOptions<MethodInfo?> attributeFilterOptions =
 			new((a, attributeType, p, i) => a.HasAttribute(attributeType, p, i));
-		attributeFilterOptions.RegisterAttribute(inherit, predicate, doNotPopulateThisValue);
+		attributeFilterOptions.RegisterAttribute(inherit, predicate, doNotPopulateThisValue.TrimCommonWhiteSpace());
 		return new HasAttributeResult<MethodInfo?>(subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
 				=> new HasAttributeConstraint(it, grammars, attributeFilterOptions)),
 			subject,

--- a/Source/aweXpect.Reflection/ThatMethods.Have.cs
+++ b/Source/aweXpect.Reflection/ThatMethods.Have.cs
@@ -55,7 +55,7 @@ public static partial class ThatMethods
 	{
 		AttributeFilterOptions<MethodInfo?> attributeFilterOptions =
 			new((a, attributeType, p, i) => a.HasAttribute(attributeType, p, i));
-		attributeFilterOptions.RegisterAttribute(inherit, predicate, doNotPopulateThisValue);
+		attributeFilterOptions.RegisterAttribute(inherit, predicate, doNotPopulateThisValue.TrimCommonWhiteSpace());
 		return new HaveAttributeResult<MethodInfo?>(subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
 				=> new HaveAttributeConstraint(it, grammars | ExpectationGrammars.Plural, attributeFilterOptions)),
 			subject,

--- a/Source/aweXpect.Reflection/ThatProperties.Have.cs
+++ b/Source/aweXpect.Reflection/ThatProperties.Have.cs
@@ -55,7 +55,7 @@ public static partial class ThatProperties
 	{
 		AttributeFilterOptions<PropertyInfo?> attributeFilterOptions =
 			new((a, attributeType, p, i) => a.HasAttribute(attributeType, p, i));
-		attributeFilterOptions.RegisterAttribute(inherit, predicate, doNotPopulateThisValue);
+		attributeFilterOptions.RegisterAttribute(inherit, predicate, doNotPopulateThisValue.TrimCommonWhiteSpace());
 		return new HaveAttributeResult<PropertyInfo?>(subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
 				=> new HaveAttributeConstraint(it, grammars | ExpectationGrammars.Plural, attributeFilterOptions)),
 			subject,

--- a/Source/aweXpect.Reflection/ThatProperty.Has.cs
+++ b/Source/aweXpect.Reflection/ThatProperty.Has.cs
@@ -50,7 +50,7 @@ public static partial class ThatProperty
 	{
 		AttributeFilterOptions<PropertyInfo?> attributeFilterOptions =
 			new((a, attributeType, p, i) => a.HasAttribute(attributeType, p, i));
-		attributeFilterOptions.RegisterAttribute(inherit, predicate, doNotPopulateThisValue);
+		attributeFilterOptions.RegisterAttribute(inherit, predicate, doNotPopulateThisValue.TrimCommonWhiteSpace());
 		return new HasAttributeResult<PropertyInfo?>(subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
 				=> new HasAttributeConstraint(it, grammars, attributeFilterOptions)),
 			subject,

--- a/Source/aweXpect.Reflection/ThatType.Has.cs
+++ b/Source/aweXpect.Reflection/ThatType.Has.cs
@@ -48,7 +48,7 @@ public static partial class ThatType
 	{
 		AttributeFilterOptions<Type?> attributeFilterOptions =
 			new((a, attributeType, p, i) => a.HasAttribute(attributeType, p, i));
-		attributeFilterOptions.RegisterAttribute(inherit, predicate, doNotPopulateThisValue);
+		attributeFilterOptions.RegisterAttribute(inherit, predicate, doNotPopulateThisValue.TrimCommonWhiteSpace());
 		return new HasAttributeResult<Type?>(subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
 				=> new HasAttributeConstraint(it, grammars, attributeFilterOptions)),
 			subject,

--- a/Source/aweXpect.Reflection/ThatTypes.Have.cs
+++ b/Source/aweXpect.Reflection/ThatTypes.Have.cs
@@ -54,7 +54,7 @@ public static partial class ThatTypes
 	{
 		AttributeFilterOptions<Type?> attributeFilterOptions =
 			new((a, attributeType, p, i) => a.HasAttribute(attributeType, p, i));
-		attributeFilterOptions.RegisterAttribute(inherit, predicate, doNotPopulateThisValue);
+		attributeFilterOptions.RegisterAttribute(inherit, predicate, doNotPopulateThisValue.TrimCommonWhiteSpace());
 		return new HaveAttributeResult<Type?>(subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
 				=> new HaveAttributeConstraint(it, grammars | ExpectationGrammars.Plural, attributeFilterOptions)),
 			subject,

--- a/Tests/aweXpect.Reflection.Internal.Tests/Helpers/StringHelperTests.cs
+++ b/Tests/aweXpect.Reflection.Internal.Tests/Helpers/StringHelperTests.cs
@@ -1,0 +1,94 @@
+﻿using aweXpect.Reflection.Helpers;
+
+namespace aweXpect.Reflection.Internal.Tests.Helpers;
+
+public class StringHelperTests
+{
+	[Fact]
+	public async Task WhenAnyLaterLineHasNoWhiteSpace_ShouldReturnUnchangedInput()
+	{
+		string input = """
+		               foo
+		                   bar
+		               baz
+		                  bay
+		               """;
+
+		string result = input.TrimCommonWhiteSpace();
+
+		await That(result).IsEqualTo(input);
+	}
+
+	[Fact]
+	public async Task WhenEmpty_ShouldReturnEmptyString()
+	{
+		string input = string.Empty;
+
+		string result = input.TrimCommonWhiteSpace();
+
+		await That(result).IsEmpty();
+	}
+
+	[Fact]
+	public async Task WhenLinesHaveDifferentWhiteSpace_ShouldKeepAllWhiteSpace()
+	{
+		string input = """
+		               foo
+		                   bar
+		               	baz
+		               """;
+
+		string result = input.TrimCommonWhiteSpace();
+
+		await That(result).IsEqualTo("""
+		                             foo
+		                                 bar
+		                             	baz
+		                             """);
+	}
+
+	[Fact]
+	public async Task WhenLinesHaveSomeCommonWhiteSpace_ShouldTrim()
+	{
+		string input = """
+		               foo
+		                   bar
+		                 baz
+		                  bay
+		               """;
+
+		string result = input.TrimCommonWhiteSpace();
+
+		await That(result).IsEqualTo("""
+		                             foo
+		                               bar
+		                             baz
+		                              bay
+		                             """);
+	}
+
+	[Fact]
+	public async Task WhenOnlyHasOneLine_ShouldReturnLine()
+	{
+		string input = "foo";
+
+		string result = input.TrimCommonWhiteSpace();
+
+		await That(result).IsEqualTo(input);
+	}
+
+	[Fact]
+	public async Task WhenTwoLines_ShouldTrimSecondLineAndKeepOnOneLine()
+	{
+		string input = """
+		               foo
+		                	 bar
+		               """;
+
+		string result = input.TrimCommonWhiteSpace();
+
+		await That(result).IsEqualTo("""
+		                             foo bar
+		                             """);
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/Filters/ConstructorFilters.WhichSatisfy.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/ConstructorFilters.WhichSatisfy.Tests.cs
@@ -12,7 +12,8 @@ public sealed partial class ConstructorFilters
 			public async Task ShouldFilterForConstructorsWhichSatisfyThePredicate()
 			{
 				Filtered.Constructors constructors = In.AssemblyContaining<AssemblyFilters>()
-					.Constructors().WhichSatisfy(it => it.DeclaringType == typeof(SomeClassToVerifyTheConstructorNameOfIt));
+					.Constructors().WhichSatisfy(it
+						=> it.DeclaringType == typeof(SomeClassToVerifyTheConstructorNameOfIt));
 
 				await That(constructors).HasSingle().Which.IsEqualTo(ExpectedConstructorInfo());
 				await That(constructors.GetDescription())


### PR DESCRIPTION
This PR applies the `TrimCommonWhiteSpace()` helper method to all predicate descriptions from `[CallerArgumentExpression("predicate")]`.
The helper method removes common leading whitespace when the text contains multipe lines. Additionally for text that consists of only two lines, the two lines are concatenated by a single blank, which leads to much improved readability of the resulting expectation texts.