### PR TITLE
feat: add support for structs, records and record structs

### DIFF
--- a/Source/aweXpect.Reflection/Collections/Filtered.Assemblies.cs
+++ b/Source/aweXpect.Reflection/Collections/Filtered.Assemblies.cs
@@ -141,7 +141,7 @@ public static partial class Filtered
 		}
 
 		/// <inheritdoc cref="ITypeAssemblies.Abstract" />
-		public ILimitedTypeAssemblies<ILimitedTypeAssemblies> Abstract
+		public ILimitedAbstractSealedTypeAssemblies<ILimitedAbstractSealedTypeAssemblies> Abstract
 		{
 			get
 			{
@@ -156,7 +156,7 @@ public static partial class Filtered
 		}
 
 		/// <inheritdoc cref="ITypeAssemblies.Sealed" />
-		public ILimitedTypeAssemblies<ILimitedTypeAssemblies> Sealed
+		public ILimitedAbstractSealedTypeAssemblies<ILimitedAbstractSealedTypeAssemblies> Sealed
 		{
 			get
 			{
@@ -171,7 +171,7 @@ public static partial class Filtered
 		}
 
 		/// <inheritdoc cref="ITypeAssemblies.Static" />
-		public ILimitedTypeAssemblies<ILimitedTypeAssemblies> Static
+		public ILimitedStaticTypeAssemblies<ILimitedStaticTypeAssemblies> Static
 		{
 			get
 			{
@@ -185,7 +185,7 @@ public static partial class Filtered
 			}
 		}
 
-		/// <inheritdoc cref="ILimitedTypeAssemblies{ITypeAssemblies}.Generic" />
+		/// <inheritdoc cref="ILimitedStaticTypeAssemblies{TLimitedTypeAssemblies}.Generic" />
 		public ITypeAssemblies Generic
 		{
 			get
@@ -200,7 +200,7 @@ public static partial class Filtered
 			}
 		}
 
-		/// <inheritdoc cref="ILimitedTypeAssemblies{ITypeAssemblies}.Nested" />
+		/// <inheritdoc cref="ILimitedStaticTypeAssemblies{TLimitedTypeAssemblies}.Nested" />
 		public ITypeAssemblies Nested
 		{
 			get
@@ -215,7 +215,7 @@ public static partial class Filtered
 			}
 		}
 
-		/// <inheritdoc cref="ILimitedTypeAssemblies.Types(AccessModifiers)" />
+		/// <inheritdoc cref="ILimitedStaticTypeAssemblies.Types(AccessModifiers)" />
 		public Types Types(AccessModifiers accessModifier = AccessModifiers.Any)
 		{
 			if (_implicitAccessModifier is not null)
@@ -241,10 +241,10 @@ public static partial class Filtered
 			return new Types(this, "types ");
 		}
 
-		/// <inheritdoc cref="ILimitedTypeAssemblies.Classes(AccessModifiers)" />
+		/// <inheritdoc cref="ILimitedStaticTypeAssemblies.Classes(AccessModifiers)" />
 		public Types Classes(AccessModifiers accessModifier = AccessModifiers.Any)
 		{
-			_typeFilters.Add(type => type.IsClass);
+			_typeFilters.Add(type => type.IsReallyClass());
 			if (_implicitAccessModifier is not null)
 			{
 				_typeFilters.Add(type => type.HasAccessModifier(_implicitAccessModifier.Value));
@@ -258,6 +258,72 @@ public static partial class Filtered
 			}
 
 			return new Types(this, "classes ")
+				.Which(Filter.Prefix<Type>(
+					type => _typeFilters.All(predicate => predicate.Invoke(type)),
+					_typeFilterDescription ?? ""));
+		}
+
+		/// <inheritdoc cref="ILimitedAbstractSealedTypeAssemblies.Records(AccessModifiers)" />
+		public Types Records(AccessModifiers accessModifier = AccessModifiers.Any)
+		{
+			_typeFilters.Add(type => type.IsRecordClass());
+			if (_implicitAccessModifier is not null)
+			{
+				_typeFilters.Add(type => type.HasAccessModifier(_implicitAccessModifier.Value));
+				_typeFilterDescription = (_typeFilterDescription ?? "") + _implicitAccessModifier.Value.GetString(" ");
+			}
+
+			if (accessModifier != AccessModifiers.Any)
+			{
+				_typeFilters.Add(type => type.HasAccessModifier(accessModifier));
+				_typeFilterDescription = accessModifier.GetString(" ") + (_typeFilterDescription ?? "");
+			}
+
+			return new Types(this, "records ")
+				.Which(Filter.Prefix<Type>(
+					type => _typeFilters.All(predicate => predicate.Invoke(type)),
+					_typeFilterDescription ?? ""));
+		}
+
+		/// <inheritdoc cref="ITypeAssemblies.RecordStructs(AccessModifiers)" />
+		public Types RecordStructs(AccessModifiers accessModifier = AccessModifiers.Any)
+		{
+			_typeFilters.Add(type => type.IsRecordStruct());
+			if (_implicitAccessModifier is not null)
+			{
+				_typeFilters.Add(type => type.HasAccessModifier(_implicitAccessModifier.Value));
+				_typeFilterDescription = (_typeFilterDescription ?? "") + _implicitAccessModifier.Value.GetString(" ");
+			}
+
+			if (accessModifier != AccessModifiers.Any)
+			{
+				_typeFilters.Add(type => type.HasAccessModifier(accessModifier));
+				_typeFilterDescription = accessModifier.GetString(" ") + (_typeFilterDescription ?? "");
+			}
+
+			return new Types(this, "record structs ")
+				.Which(Filter.Prefix<Type>(
+					type => _typeFilters.All(predicate => predicate.Invoke(type)),
+					_typeFilterDescription ?? ""));
+		}
+
+		/// <inheritdoc cref="ITypeAssemblies.Structs(AccessModifiers)" />
+		public Types Structs(AccessModifiers accessModifier = AccessModifiers.Any)
+		{
+			_typeFilters.Add(type => type.IsReallyStruct());
+			if (_implicitAccessModifier is not null)
+			{
+				_typeFilters.Add(type => type.HasAccessModifier(_implicitAccessModifier.Value));
+				_typeFilterDescription = (_typeFilterDescription ?? "") + _implicitAccessModifier.Value.GetString(" ");
+			}
+
+			if (accessModifier != AccessModifiers.Any)
+			{
+				_typeFilters.Add(type => type.HasAccessModifier(accessModifier));
+				_typeFilterDescription = accessModifier.GetString(" ") + (_typeFilterDescription ?? "");
+			}
+
+			return new Types(this, "structs ")
 				.Which(Filter.Prefix<Type>(
 					type => _typeFilters.All(predicate => predicate.Invoke(type)),
 					_typeFilterDescription ?? ""));

--- a/Source/aweXpect.Reflection/Collections/ILimitedAbstractSealedTypeAssemblies.cs
+++ b/Source/aweXpect.Reflection/Collections/ILimitedAbstractSealedTypeAssemblies.cs
@@ -1,0 +1,29 @@
+namespace aweXpect.Reflection.Collections;
+
+/// <summary>
+///     A limited interface to allow basic filtering for types in assemblies.
+/// </summary>
+/// <remarks>
+///     In addition to the methods in <see cref="ILimitedStaticTypeAssemblies" /> it
+///     only supports accessing <see cref="Records" />.
+/// </remarks>
+public interface ILimitedAbstractSealedTypeAssemblies : ILimitedStaticTypeAssemblies
+{
+	/// <summary>
+	///     Get all records in the filtered assemblies.
+	/// </summary>
+	Filtered.Types Records(AccessModifiers accessModifier = AccessModifiers.Any);
+}
+
+/// <summary>
+///     A limited interface to allow basic filtering for types in assemblies.
+/// </summary>
+/// <remarks>
+///     In addition to the methods in <see cref="ILimitedStaticTypeAssemblies" /> it also
+///     supports adding a filter for generic or nested types.
+/// </remarks>
+public interface ILimitedAbstractSealedTypeAssemblies<out TLimitedTypeAssemblies>
+	: ILimitedAbstractSealedTypeAssemblies, ILimitedStaticTypeAssemblies<TLimitedTypeAssemblies>
+	where TLimitedTypeAssemblies : ILimitedAbstractSealedTypeAssemblies
+{
+}

--- a/Source/aweXpect.Reflection/Collections/ILimitedStaticTypeAssemblies.cs
+++ b/Source/aweXpect.Reflection/Collections/ILimitedStaticTypeAssemblies.cs
@@ -6,7 +6,7 @@ namespace aweXpect.Reflection.Collections;
 /// <remarks>
 ///     It only supports accessing <see cref="Types" /> or <see cref="Classes" />.
 /// </remarks>
-public interface ILimitedTypeAssemblies
+public interface ILimitedStaticTypeAssemblies
 {
 	/// <summary>
 	///     Get all types in the filtered assemblies.
@@ -23,11 +23,11 @@ public interface ILimitedTypeAssemblies
 ///     A limited interface to allow basic filtering for types in assemblies.
 /// </summary>
 /// <remarks>
-///     In addition to the methods in <see cref="ILimitedTypeAssemblies" /> it also
+///     In addition to the methods in <see cref="ILimitedAbstractSealedTypeAssemblies" /> it also
 ///     supports adding a filter for generic or nested types.
 /// </remarks>
-public interface ILimitedTypeAssemblies<out TLimitedTypeAssemblies> : ILimitedTypeAssemblies
-	where TLimitedTypeAssemblies : ILimitedTypeAssemblies
+public interface ILimitedStaticTypeAssemblies<out TLimitedTypeAssemblies> : ILimitedStaticTypeAssemblies
+	where TLimitedTypeAssemblies : ILimitedStaticTypeAssemblies
 {
 	/// <summary>
 	///     Filters only for generic types.

--- a/Source/aweXpect.Reflection/Collections/ITypeAssemblies.cs
+++ b/Source/aweXpect.Reflection/Collections/ITypeAssemblies.cs
@@ -9,8 +9,7 @@
 ///     supports adding a filter for abstract, sealed or static types as well as accessing interfaces or enums.
 /// </remarks>
 public interface ITypeAssemblies
-	: ILimitedAbstractSealedTypeAssemblies<ITypeAssemblies>,
-		ILimitedStaticTypeAssemblies<ITypeAssemblies>
+	: ILimitedAbstractSealedTypeAssemblies<ITypeAssemblies>
 {
 	/// <summary>
 	///     Filters only for abstract types.

--- a/Source/aweXpect.Reflection/Collections/ITypeAssemblies.cs
+++ b/Source/aweXpect.Reflection/Collections/ITypeAssemblies.cs
@@ -4,25 +4,28 @@
 ///     An interface to allow filtering for types in assemblies.
 /// </summary>
 /// <remarks>
-///     In addition to the properties and methods in <see cref="ILimitedTypeAssemblies{ITypeAssemblies}" /> it also
+///     In addition to the properties and methods in
+///     <see cref="ILimitedAbstractSealedTypeAssemblies{TLimitedTypeAssemblies}" /> it also
 ///     supports adding a filter for abstract, sealed or static types as well as accessing interfaces or enums.
 /// </remarks>
-public interface ITypeAssemblies : ILimitedTypeAssemblies<ITypeAssemblies>
+public interface ITypeAssemblies
+	: ILimitedAbstractSealedTypeAssemblies<ITypeAssemblies>,
+		ILimitedStaticTypeAssemblies<ITypeAssemblies>
 {
 	/// <summary>
 	///     Filters only for abstract types.
 	/// </summary>
-	ILimitedTypeAssemblies<ILimitedTypeAssemblies> Abstract { get; }
+	ILimitedAbstractSealedTypeAssemblies<ILimitedAbstractSealedTypeAssemblies> Abstract { get; }
 
 	/// <summary>
 	///     Filters only for sealed types.
 	/// </summary>
-	ILimitedTypeAssemblies<ILimitedTypeAssemblies> Sealed { get; }
+	ILimitedAbstractSealedTypeAssemblies<ILimitedAbstractSealedTypeAssemblies> Sealed { get; }
 
 	/// <summary>
 	///     Filters only for static types.
 	/// </summary>
-	ILimitedTypeAssemblies<ILimitedTypeAssemblies> Static { get; }
+	ILimitedStaticTypeAssemblies<ILimitedStaticTypeAssemblies> Static { get; }
 
 	/// <summary>
 	///     Get all interfaces in the filtered assemblies.
@@ -33,6 +36,16 @@ public interface ITypeAssemblies : ILimitedTypeAssemblies<ITypeAssemblies>
 	///     Get all enums in the filtered assemblies.
 	/// </summary>
 	Filtered.Types Enums(AccessModifiers accessModifier = AccessModifiers.Any);
+
+	/// <summary>
+	///     Get all record structs in the filtered assemblies.
+	/// </summary>
+	Filtered.Types RecordStructs(AccessModifiers accessModifier = AccessModifiers.Any);
+
+	/// <summary>
+	///     Get all structs in the filtered assemblies.
+	/// </summary>
+	Filtered.Types Structs(AccessModifiers accessModifier = AccessModifiers.Any);
 
 	/// <summary>
 	///     Get all constructors in the filtered types.

--- a/Source/aweXpect.Reflection/Filters/TypeFilters.WhichAreRecordStructs.cs
+++ b/Source/aweXpect.Reflection/Filters/TypeFilters.WhichAreRecordStructs.cs
@@ -1,0 +1,24 @@
+using System;
+using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Helpers;
+
+namespace aweXpect.Reflection;
+
+public static partial class TypeFilters
+{
+	/// <summary>
+	///     Filters for types that are record structs.
+	/// </summary>
+	public static Filtered.Types WhichAreRecordStructs(this Filtered.Types @this)
+		=> @this.Which(Filter.Suffix<Type>(
+			type => type.IsRecordStruct(),
+			"which are record structs "));
+
+	/// <summary>
+	///     Filters for types that are not record structs.
+	/// </summary>
+	public static Filtered.Types WhichAreNotRecordStructs(this Filtered.Types @this)
+		=> @this.Which(Filter.Suffix<Type>(
+			type => !type.IsRecordStruct(),
+			"which are not record structs "));
+}

--- a/Source/aweXpect.Reflection/Filters/TypeFilters.WhichAreRecords.cs
+++ b/Source/aweXpect.Reflection/Filters/TypeFilters.WhichAreRecords.cs
@@ -1,0 +1,24 @@
+using System;
+using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Helpers;
+
+namespace aweXpect.Reflection;
+
+public static partial class TypeFilters
+{
+	/// <summary>
+	///     Filters for types that are records.
+	/// </summary>
+	public static Filtered.Types WhichAreRecords(this Filtered.Types @this)
+		=> @this.Which(Filter.Suffix<Type>(
+			type => type.IsRecordClass(),
+			"which are records "));
+
+	/// <summary>
+	///     Filters for types that are not records.
+	/// </summary>
+	public static Filtered.Types WhichAreNotRecords(this Filtered.Types @this)
+		=> @this.Which(Filter.Suffix<Type>(
+			type => !type.IsRecordClass(),
+			"which are not records "));
+}

--- a/Source/aweXpect.Reflection/Filters/TypeFilters.WhichAreStructs.cs
+++ b/Source/aweXpect.Reflection/Filters/TypeFilters.WhichAreStructs.cs
@@ -1,0 +1,24 @@
+using System;
+using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Helpers;
+
+namespace aweXpect.Reflection;
+
+public static partial class TypeFilters
+{
+	/// <summary>
+	///     Filters for types that are structs.
+	/// </summary>
+	public static Filtered.Types WhichAreStructs(this Filtered.Types @this)
+		=> @this.Which(Filter.Suffix<Type>(
+			type => type.IsReallyStruct(),
+			"which are structs "));
+
+	/// <summary>
+	///     Filters for types that are not structs.
+	/// </summary>
+	public static Filtered.Types WhichAreNotStructs(this Filtered.Types @this)
+		=> @this.Which(Filter.Suffix<Type>(
+			type => !type.IsReallyStruct(),
+			"which are not structs "));
+}

--- a/Source/aweXpect.Reflection/Helpers/TypeHelpers.cs
+++ b/Source/aweXpect.Reflection/Helpers/TypeHelpers.cs
@@ -301,6 +301,10 @@ internal static class TypeHelpers
 			   .GetMethod?.HasAttribute<CompilerGeneratedAttribute>() == true;
 
 
+	public static bool IsReallyStruct(this Type? type) =>
+		type is { IsValueType: true, IsEnum: false, } &&
+		!IsRecordStruct(type);
+
 	public static bool IsRecordStruct(this Type? type) =>
 		// As noted here: https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-10.0/record-structs#open-questions
 		// recognizing record structs from metadata is an open point. The following check is based on common sense

--- a/Source/aweXpect.Reflection/ThatType.IsARecord.cs
+++ b/Source/aweXpect.Reflection/ThatType.IsARecord.cs
@@ -10,36 +10,36 @@ namespace aweXpect.Reflection;
 public static partial class ThatType
 {
 	/// <summary>
-	///     Verifies that the <see cref="Type" /> is a class.
+	///     Verifies that the <see cref="Type" /> is a record.
 	/// </summary>
-	public static AndOrResult<Type?, IThat<Type?>> IsAClass(
+	public static AndOrResult<Type?, IThat<Type?>> IsARecord(
 		this IThat<Type?> subject)
 		=> new(subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new IsAClassConstraint(it, grammars)),
+				=> new IsARecordConstraint(it, grammars)),
 			subject);
 
 	/// <summary>
-	///     Verifies that the <see cref="Type" /> is not a class.
+	///     Verifies that the <see cref="Type" /> is not a record.
 	/// </summary>
-	public static AndOrResult<Type?, IThat<Type?>> IsNotAClass(
+	public static AndOrResult<Type?, IThat<Type?>> IsNotARecord(
 		this IThat<Type?> subject)
 		=> new(subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new IsAClassConstraint(it, grammars).Invert()),
+				=> new IsARecordConstraint(it, grammars).Invert()),
 			subject);
 
-	private sealed class IsAClassConstraint(string it, ExpectationGrammars grammars)
+	private sealed class IsARecordConstraint(string it, ExpectationGrammars grammars)
 		: ConstraintResult.WithNotNullValue<Type?>(it, grammars),
 			IValueConstraint<Type?>
 	{
 		public ConstraintResult IsMetBy(Type? actual)
 		{
 			Actual = actual;
-			Outcome = actual.IsReallyClass() ? Outcome.Success : Outcome.Failure;
+			Outcome = actual.IsRecordClass() ? Outcome.Success : Outcome.Failure;
 			return this;
 		}
 
 		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
-			=> stringBuilder.Append("is a class");
+			=> stringBuilder.Append("is a record");
 
 		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
 		{
@@ -48,7 +48,7 @@ public static partial class ThatType
 		}
 
 		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
-			=> stringBuilder.Append("is not a class");
+			=> stringBuilder.Append("is not a record");
 
 		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
 			=> AppendNormalResult(stringBuilder, indentation);

--- a/Source/aweXpect.Reflection/ThatType.IsARecordStruct.cs
+++ b/Source/aweXpect.Reflection/ThatType.IsARecordStruct.cs
@@ -10,36 +10,36 @@ namespace aweXpect.Reflection;
 public static partial class ThatType
 {
 	/// <summary>
-	///     Verifies that the <see cref="Type" /> is a class.
+	///     Verifies that the <see cref="Type" /> is a record struct.
 	/// </summary>
-	public static AndOrResult<Type?, IThat<Type?>> IsAClass(
+	public static AndOrResult<Type?, IThat<Type?>> IsARecordStruct(
 		this IThat<Type?> subject)
 		=> new(subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new IsAClassConstraint(it, grammars)),
+				=> new IsARecordStructConstraint(it, grammars)),
 			subject);
 
 	/// <summary>
-	///     Verifies that the <see cref="Type" /> is not a class.
+	///     Verifies that the <see cref="Type" /> is not a record struct.
 	/// </summary>
-	public static AndOrResult<Type?, IThat<Type?>> IsNotAClass(
+	public static AndOrResult<Type?, IThat<Type?>> IsNotARecordStruct(
 		this IThat<Type?> subject)
 		=> new(subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new IsAClassConstraint(it, grammars).Invert()),
+				=> new IsARecordStructConstraint(it, grammars).Invert()),
 			subject);
 
-	private sealed class IsAClassConstraint(string it, ExpectationGrammars grammars)
+	private sealed class IsARecordStructConstraint(string it, ExpectationGrammars grammars)
 		: ConstraintResult.WithNotNullValue<Type?>(it, grammars),
 			IValueConstraint<Type?>
 	{
 		public ConstraintResult IsMetBy(Type? actual)
 		{
 			Actual = actual;
-			Outcome = actual.IsReallyClass() ? Outcome.Success : Outcome.Failure;
+			Outcome = actual.IsRecordStruct() ? Outcome.Success : Outcome.Failure;
 			return this;
 		}
 
 		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
-			=> stringBuilder.Append("is a class");
+			=> stringBuilder.Append("is a record struct");
 
 		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
 		{
@@ -48,7 +48,7 @@ public static partial class ThatType
 		}
 
 		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
-			=> stringBuilder.Append("is not a class");
+			=> stringBuilder.Append("is not a record struct");
 
 		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
 			=> AppendNormalResult(stringBuilder, indentation);

--- a/Source/aweXpect.Reflection/ThatType.IsAStruct.cs
+++ b/Source/aweXpect.Reflection/ThatType.IsAStruct.cs
@@ -10,36 +10,36 @@ namespace aweXpect.Reflection;
 public static partial class ThatType
 {
 	/// <summary>
-	///     Verifies that the <see cref="Type" /> is a class.
+	///     Verifies that the <see cref="Type" /> is a struct.
 	/// </summary>
-	public static AndOrResult<Type?, IThat<Type?>> IsAClass(
+	public static AndOrResult<Type?, IThat<Type?>> IsAStruct(
 		this IThat<Type?> subject)
 		=> new(subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new IsAClassConstraint(it, grammars)),
+				=> new IsAStructConstraint(it, grammars)),
 			subject);
 
 	/// <summary>
-	///     Verifies that the <see cref="Type" /> is not a class.
+	///     Verifies that the <see cref="Type" /> is not a struct.
 	/// </summary>
-	public static AndOrResult<Type?, IThat<Type?>> IsNotAClass(
+	public static AndOrResult<Type?, IThat<Type?>> IsNotAStruct(
 		this IThat<Type?> subject)
 		=> new(subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new IsAClassConstraint(it, grammars).Invert()),
+				=> new IsAStructConstraint(it, grammars).Invert()),
 			subject);
 
-	private sealed class IsAClassConstraint(string it, ExpectationGrammars grammars)
+	private sealed class IsAStructConstraint(string it, ExpectationGrammars grammars)
 		: ConstraintResult.WithNotNullValue<Type?>(it, grammars),
 			IValueConstraint<Type?>
 	{
 		public ConstraintResult IsMetBy(Type? actual)
 		{
 			Actual = actual;
-			Outcome = actual.IsReallyClass() ? Outcome.Success : Outcome.Failure;
+			Outcome = actual.IsReallyStruct() ? Outcome.Success : Outcome.Failure;
 			return this;
 		}
 
 		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
-			=> stringBuilder.Append("is a class");
+			=> stringBuilder.Append("is a struct");
 
 		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
 		{
@@ -48,7 +48,7 @@ public static partial class ThatType
 		}
 
 		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
-			=> stringBuilder.Append("is not a class");
+			=> stringBuilder.Append("is not a struct");
 
 		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
 			=> AppendNormalResult(stringBuilder, indentation);

--- a/Source/aweXpect.Reflection/ThatTypes.AreRecordStructs.cs
+++ b/Source/aweXpect.Reflection/ThatTypes.AreRecordStructs.cs
@@ -70,7 +70,7 @@ public static partial class ThatTypes
 		public ConstraintResult IsMetBy(IEnumerable<Type?> actual)
 		{
 			Actual = actual;
-			Outcome = actual.All(type => type.IsRecordStruct()) ? Outcome.Success : Outcome.Failure;
+			Outcome = actual.All(type => !type.IsRecordStruct()) ? Outcome.Success : Outcome.Failure;
 			return this;
 		}
 

--- a/Source/aweXpect.Reflection/ThatTypes.AreRecordStructs.cs
+++ b/Source/aweXpect.Reflection/ThatTypes.AreRecordStructs.cs
@@ -14,83 +14,83 @@ namespace aweXpect.Reflection;
 public static partial class ThatTypes
 {
 	/// <summary>
-	///     Verifies that all items in the filtered collection of <see cref="Type" /> are classes.
+	///     Verifies that all items in the filtered collection of <see cref="Type" /> are record structs.
 	/// </summary>
-	public static AndOrResult<IEnumerable<Type?>, IThat<IEnumerable<Type?>>> AreClasses(
+	public static AndOrResult<IEnumerable<Type?>, IThat<IEnumerable<Type?>>> AreRecordStructs(
 		this IThat<IEnumerable<Type?>> subject)
 		=> new(subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new AreClassesConstraint(it, grammars)),
+				=> new AreRecordStructsConstraint(it, grammars)),
 			subject);
 
 	/// <summary>
-	///     Verifies that all items in the filtered collection of <see cref="Type" /> are not classes.
+	///     Verifies that all items in the filtered collection of <see cref="Type" /> are not record structs.
 	/// </summary>
-	public static AndOrResult<IEnumerable<Type?>, IThat<IEnumerable<Type?>>> AreNotClasses(
+	public static AndOrResult<IEnumerable<Type?>, IThat<IEnumerable<Type?>>> AreNotRecordStructs(
 		this IThat<IEnumerable<Type?>> subject)
 		=> new(subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new AreNotClassesConstraint(it, grammars)),
+				=> new AreNotRecordStructsConstraint(it, grammars)),
 			subject);
 
-	private sealed class AreClassesConstraint(string it, ExpectationGrammars grammars)
+	private sealed class AreRecordStructsConstraint(string it, ExpectationGrammars grammars)
 		: ConstraintResult.WithValue<IEnumerable<Type?>>(grammars),
 			IValueConstraint<IEnumerable<Type?>>
 	{
 		public ConstraintResult IsMetBy(IEnumerable<Type?> actual)
 		{
 			Actual = actual;
-			Outcome = actual.All(type => type.IsReallyClass()) ? Outcome.Success : Outcome.Failure;
+			Outcome = actual.All(type => type.IsRecordStruct()) ? Outcome.Success : Outcome.Failure;
 			return this;
 		}
 
 		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
-			=> stringBuilder.Append("are all classes");
+			=> stringBuilder.Append("are all record structs");
 
 		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
 		{
 			stringBuilder.Append(it).Append(" contained other types ");
-			Formatter.Format(stringBuilder, Actual?.Where(type => !type.IsReallyClass()),
+			Formatter.Format(stringBuilder, Actual?.Where(type => !type.IsRecordStruct()),
 				FormattingOptions.Indented(indentation));
 		}
 
 		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
-			=> stringBuilder.Append("are not all classes");
+			=> stringBuilder.Append("are not all record structs");
 
 		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
 		{
-			stringBuilder.Append(it).Append(" only contained classes ");
-			Formatter.Format(stringBuilder, Actual?.Where(type => type.IsReallyClass()),
+			stringBuilder.Append(it).Append(" only contained record structs ");
+			Formatter.Format(stringBuilder, Actual?.Where(type => type.IsRecordStruct()),
 				FormattingOptions.Indented(indentation));
 		}
 	}
 
-	private sealed class AreNotClassesConstraint(string it, ExpectationGrammars grammars)
+	private sealed class AreNotRecordStructsConstraint(string it, ExpectationGrammars grammars)
 		: ConstraintResult.WithValue<IEnumerable<Type?>>(grammars),
 			IValueConstraint<IEnumerable<Type?>>
 	{
 		public ConstraintResult IsMetBy(IEnumerable<Type?> actual)
 		{
 			Actual = actual;
-			Outcome = actual.All(type => !type.IsReallyClass()) ? Outcome.Success : Outcome.Failure;
+			Outcome = actual.All(type => type.IsRecordStruct()) ? Outcome.Success : Outcome.Failure;
 			return this;
 		}
 
 		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
-			=> stringBuilder.Append("are all not classes");
+			=> stringBuilder.Append("are all not record structs");
 
 		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
 		{
-			stringBuilder.Append(it).Append(" contained classes ");
-			Formatter.Format(stringBuilder, Actual?.Where(type => type.IsReallyClass()),
+			stringBuilder.Append(it).Append(" contained record structs ");
+			Formatter.Format(stringBuilder, Actual?.Where(type => type.IsRecordStruct()),
 				FormattingOptions.Indented(indentation));
 		}
 
 		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
-			=> stringBuilder.Append("also contain a class");
+			=> stringBuilder.Append("also contain a record struct");
 
 		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
 		{
-			stringBuilder.Append(it).Append(" only contained not classes ");
-			Formatter.Format(stringBuilder, Actual?.Where(type => !type.IsReallyClass()),
+			stringBuilder.Append(it).Append(" only contained not record structs ");
+			Formatter.Format(stringBuilder, Actual?.Where(type => !type.IsRecordStruct()),
 				FormattingOptions.Indented(indentation));
 		}
 	}

--- a/Source/aweXpect.Reflection/ThatTypes.AreRecords.cs
+++ b/Source/aweXpect.Reflection/ThatTypes.AreRecords.cs
@@ -70,7 +70,7 @@ public static partial class ThatTypes
 		public ConstraintResult IsMetBy(IEnumerable<Type?> actual)
 		{
 			Actual = actual;
-			Outcome = actual.All(type => type.IsRecordClass()) ? Outcome.Success : Outcome.Failure;
+			Outcome = actual.All(type => !type.IsRecordClass()) ? Outcome.Success : Outcome.Failure;
 			return this;
 		}
 

--- a/Source/aweXpect.Reflection/ThatTypes.AreRecords.cs
+++ b/Source/aweXpect.Reflection/ThatTypes.AreRecords.cs
@@ -14,83 +14,83 @@ namespace aweXpect.Reflection;
 public static partial class ThatTypes
 {
 	/// <summary>
-	///     Verifies that all items in the filtered collection of <see cref="Type" /> are classes.
+	///     Verifies that all items in the filtered collection of <see cref="Type" /> are records.
 	/// </summary>
-	public static AndOrResult<IEnumerable<Type?>, IThat<IEnumerable<Type?>>> AreClasses(
+	public static AndOrResult<IEnumerable<Type?>, IThat<IEnumerable<Type?>>> AreRecords(
 		this IThat<IEnumerable<Type?>> subject)
 		=> new(subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new AreClassesConstraint(it, grammars)),
+				=> new AreRecordsConstraint(it, grammars)),
 			subject);
 
 	/// <summary>
-	///     Verifies that all items in the filtered collection of <see cref="Type" /> are not classes.
+	///     Verifies that all items in the filtered collection of <see cref="Type" /> are not records.
 	/// </summary>
-	public static AndOrResult<IEnumerable<Type?>, IThat<IEnumerable<Type?>>> AreNotClasses(
+	public static AndOrResult<IEnumerable<Type?>, IThat<IEnumerable<Type?>>> AreNotRecords(
 		this IThat<IEnumerable<Type?>> subject)
 		=> new(subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new AreNotClassesConstraint(it, grammars)),
+				=> new AreNotRecordsConstraint(it, grammars)),
 			subject);
 
-	private sealed class AreClassesConstraint(string it, ExpectationGrammars grammars)
+	private sealed class AreRecordsConstraint(string it, ExpectationGrammars grammars)
 		: ConstraintResult.WithValue<IEnumerable<Type?>>(grammars),
 			IValueConstraint<IEnumerable<Type?>>
 	{
 		public ConstraintResult IsMetBy(IEnumerable<Type?> actual)
 		{
 			Actual = actual;
-			Outcome = actual.All(type => type.IsReallyClass()) ? Outcome.Success : Outcome.Failure;
+			Outcome = actual.All(type => type.IsRecordClass()) ? Outcome.Success : Outcome.Failure;
 			return this;
 		}
 
 		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
-			=> stringBuilder.Append("are all classes");
+			=> stringBuilder.Append("are all records");
 
 		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
 		{
 			stringBuilder.Append(it).Append(" contained other types ");
-			Formatter.Format(stringBuilder, Actual?.Where(type => !type.IsReallyClass()),
+			Formatter.Format(stringBuilder, Actual?.Where(type => !type.IsRecordClass()),
 				FormattingOptions.Indented(indentation));
 		}
 
 		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
-			=> stringBuilder.Append("are not all classes");
+			=> stringBuilder.Append("are not all records");
 
 		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
 		{
-			stringBuilder.Append(it).Append(" only contained classes ");
-			Formatter.Format(stringBuilder, Actual?.Where(type => type.IsReallyClass()),
+			stringBuilder.Append(it).Append(" only contained records ");
+			Formatter.Format(stringBuilder, Actual?.Where(type => type.IsRecordClass()),
 				FormattingOptions.Indented(indentation));
 		}
 	}
 
-	private sealed class AreNotClassesConstraint(string it, ExpectationGrammars grammars)
+	private sealed class AreNotRecordsConstraint(string it, ExpectationGrammars grammars)
 		: ConstraintResult.WithValue<IEnumerable<Type?>>(grammars),
 			IValueConstraint<IEnumerable<Type?>>
 	{
 		public ConstraintResult IsMetBy(IEnumerable<Type?> actual)
 		{
 			Actual = actual;
-			Outcome = actual.All(type => !type.IsReallyClass()) ? Outcome.Success : Outcome.Failure;
+			Outcome = actual.All(type => type.IsRecordClass()) ? Outcome.Success : Outcome.Failure;
 			return this;
 		}
 
 		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
-			=> stringBuilder.Append("are all not classes");
+			=> stringBuilder.Append("are all not records");
 
 		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
 		{
-			stringBuilder.Append(it).Append(" contained classes ");
-			Formatter.Format(stringBuilder, Actual?.Where(type => type.IsReallyClass()),
+			stringBuilder.Append(it).Append(" contained records ");
+			Formatter.Format(stringBuilder, Actual?.Where(type => type.IsRecordClass()),
 				FormattingOptions.Indented(indentation));
 		}
 
 		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
-			=> stringBuilder.Append("also contain a class");
+			=> stringBuilder.Append("also contain a record");
 
 		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
 		{
-			stringBuilder.Append(it).Append(" only contained not classes ");
-			Formatter.Format(stringBuilder, Actual?.Where(type => !type.IsReallyClass()),
+			stringBuilder.Append(it).Append(" only contained not records ");
+			Formatter.Format(stringBuilder, Actual?.Where(type => !type.IsRecordClass()),
 				FormattingOptions.Indented(indentation));
 		}
 	}

--- a/Source/aweXpect.Reflection/ThatTypes.AreStructs.cs
+++ b/Source/aweXpect.Reflection/ThatTypes.AreStructs.cs
@@ -70,7 +70,7 @@ public static partial class ThatTypes
 		public ConstraintResult IsMetBy(IEnumerable<Type?> actual)
 		{
 			Actual = actual;
-			Outcome = actual.All(type => type.IsReallyStruct()) ? Outcome.Success : Outcome.Failure;
+			Outcome = actual.All(type => !type.IsReallyStruct()) ? Outcome.Success : Outcome.Failure;
 			return this;
 		}
 

--- a/Source/aweXpect.Reflection/ThatTypes.AreStructs.cs
+++ b/Source/aweXpect.Reflection/ThatTypes.AreStructs.cs
@@ -14,83 +14,83 @@ namespace aweXpect.Reflection;
 public static partial class ThatTypes
 {
 	/// <summary>
-	///     Verifies that all items in the filtered collection of <see cref="Type" /> are classes.
+	///     Verifies that all items in the filtered collection of <see cref="Type" /> are structs.
 	/// </summary>
-	public static AndOrResult<IEnumerable<Type?>, IThat<IEnumerable<Type?>>> AreClasses(
+	public static AndOrResult<IEnumerable<Type?>, IThat<IEnumerable<Type?>>> AreStructs(
 		this IThat<IEnumerable<Type?>> subject)
 		=> new(subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new AreClassesConstraint(it, grammars)),
+				=> new AreStructsConstraint(it, grammars)),
 			subject);
 
 	/// <summary>
-	///     Verifies that all items in the filtered collection of <see cref="Type" /> are not classes.
+	///     Verifies that all items in the filtered collection of <see cref="Type" /> are not structs.
 	/// </summary>
-	public static AndOrResult<IEnumerable<Type?>, IThat<IEnumerable<Type?>>> AreNotClasses(
+	public static AndOrResult<IEnumerable<Type?>, IThat<IEnumerable<Type?>>> AreNotStructs(
 		this IThat<IEnumerable<Type?>> subject)
 		=> new(subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new AreNotClassesConstraint(it, grammars)),
+				=> new AreNotStructsConstraint(it, grammars)),
 			subject);
 
-	private sealed class AreClassesConstraint(string it, ExpectationGrammars grammars)
+	private sealed class AreStructsConstraint(string it, ExpectationGrammars grammars)
 		: ConstraintResult.WithValue<IEnumerable<Type?>>(grammars),
 			IValueConstraint<IEnumerable<Type?>>
 	{
 		public ConstraintResult IsMetBy(IEnumerable<Type?> actual)
 		{
 			Actual = actual;
-			Outcome = actual.All(type => type.IsReallyClass()) ? Outcome.Success : Outcome.Failure;
+			Outcome = actual.All(type => type.IsReallyStruct()) ? Outcome.Success : Outcome.Failure;
 			return this;
 		}
 
 		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
-			=> stringBuilder.Append("are all classes");
+			=> stringBuilder.Append("are all structs");
 
 		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
 		{
 			stringBuilder.Append(it).Append(" contained other types ");
-			Formatter.Format(stringBuilder, Actual?.Where(type => !type.IsReallyClass()),
+			Formatter.Format(stringBuilder, Actual?.Where(type => !type.IsReallyStruct()),
 				FormattingOptions.Indented(indentation));
 		}
 
 		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
-			=> stringBuilder.Append("are not all classes");
+			=> stringBuilder.Append("are not all structs");
 
 		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
 		{
-			stringBuilder.Append(it).Append(" only contained classes ");
-			Formatter.Format(stringBuilder, Actual?.Where(type => type.IsReallyClass()),
+			stringBuilder.Append(it).Append(" only contained structs ");
+			Formatter.Format(stringBuilder, Actual?.Where(type => type.IsReallyStruct()),
 				FormattingOptions.Indented(indentation));
 		}
 	}
 
-	private sealed class AreNotClassesConstraint(string it, ExpectationGrammars grammars)
+	private sealed class AreNotStructsConstraint(string it, ExpectationGrammars grammars)
 		: ConstraintResult.WithValue<IEnumerable<Type?>>(grammars),
 			IValueConstraint<IEnumerable<Type?>>
 	{
 		public ConstraintResult IsMetBy(IEnumerable<Type?> actual)
 		{
 			Actual = actual;
-			Outcome = actual.All(type => !type.IsReallyClass()) ? Outcome.Success : Outcome.Failure;
+			Outcome = actual.All(type => type.IsReallyStruct()) ? Outcome.Success : Outcome.Failure;
 			return this;
 		}
 
 		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
-			=> stringBuilder.Append("are all not classes");
+			=> stringBuilder.Append("are all not structs");
 
 		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
 		{
-			stringBuilder.Append(it).Append(" contained classes ");
-			Formatter.Format(stringBuilder, Actual?.Where(type => type.IsReallyClass()),
+			stringBuilder.Append(it).Append(" contained structs ");
+			Formatter.Format(stringBuilder, Actual?.Where(type => type.IsReallyStruct()),
 				FormattingOptions.Indented(indentation));
 		}
 
 		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
-			=> stringBuilder.Append("also contain a class");
+			=> stringBuilder.Append("also contain a struct");
 
 		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
 		{
-			stringBuilder.Append(it).Append(" only contained not classes ");
-			Formatter.Format(stringBuilder, Actual?.Where(type => !type.IsReallyClass()),
+			stringBuilder.Append(it).Append(" only contained not structs ");
+			Formatter.Format(stringBuilder, Actual?.Where(type => !type.IsReallyStruct()),
 				FormattingOptions.Indented(indentation));
 		}
 	}

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net8.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net8.0.txt
@@ -535,12 +535,18 @@ namespace aweXpect.Reflection
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> InheritsFrom(this aweXpect.Core.IThat<System.Type?> subject, System.Type baseType, bool forceDirect = false) { }
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> InheritsFrom<TBaseType>(this aweXpect.Core.IThat<System.Type?> subject, bool forceDirect = false) { }
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsAClass(this aweXpect.Core.IThat<System.Type?> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsARecord(this aweXpect.Core.IThat<System.Type?> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsARecordStruct(this aweXpect.Core.IThat<System.Type?> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsAStruct(this aweXpect.Core.IThat<System.Type?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsAbstract(this aweXpect.Core.IThat<System.Type?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsAnEnum(this aweXpect.Core.IThat<System.Type?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsAnInterface(this aweXpect.Core.IThat<System.Type?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsGeneric(this aweXpect.Core.IThat<System.Type?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsNested(this aweXpect.Core.IThat<System.Type?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsNotAClass(this aweXpect.Core.IThat<System.Type?> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsNotARecord(this aweXpect.Core.IThat<System.Type?> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsNotARecordStruct(this aweXpect.Core.IThat<System.Type?> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsNotAStruct(this aweXpect.Core.IThat<System.Type?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsNotAbstract(this aweXpect.Core.IThat<System.Type?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsNotAnEnum(this aweXpect.Core.IThat<System.Type?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsNotAnInterface(this aweXpect.Core.IThat<System.Type?> subject) { }
@@ -565,10 +571,16 @@ namespace aweXpect.Reflection
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreNotGeneric(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreNotInterfaces(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreNotNested(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreNotRecordStructs(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreNotRecords(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreNotSealed(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreNotStatic(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreNotStructs(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreRecordStructs(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreRecords(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreSealed(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreStatic(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreStructs(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> DoNotInheritFrom(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject, System.Type baseType, bool forceDirect = false) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> DoNotInheritFrom<TBaseType>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject, bool forceDirect = false) { }
         public static aweXpect.Reflection.Results.HaveAttributeResult<System.Type?> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject, bool inherit = true)
@@ -602,15 +614,21 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreNotProtected(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreNotProtectedInternal(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreNotPublic(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
+        public static aweXpect.Reflection.Collections.Filtered.Types WhichAreNotRecordStructs(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
+        public static aweXpect.Reflection.Collections.Filtered.Types WhichAreNotRecords(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreNotSealed(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreNotStatic(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
+        public static aweXpect.Reflection.Collections.Filtered.Types WhichAreNotStructs(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichArePrivate(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichArePrivateProtected(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreProtected(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreProtectedInternal(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichArePublic(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
+        public static aweXpect.Reflection.Collections.Filtered.Types WhichAreRecordStructs(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
+        public static aweXpect.Reflection.Collections.Filtered.Types WhichAreRecords(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreSealed(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreStatic(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
+        public static aweXpect.Reflection.Collections.Filtered.Types WhichAreStructs(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichInheritFrom(this aweXpect.Reflection.Collections.Filtered.Types @this, System.Type baseType, bool forceDirect = false) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichInheritFrom<TBaseType>(this aweXpect.Reflection.Collections.Filtered.Types @this, bool forceDirect = false) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichSatisfy(this aweXpect.Reflection.Collections.Filtered.Types @this, System.Func<System.Type, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
@@ -645,20 +663,20 @@ namespace aweXpect.Reflection.Collections
     }
     public static class Filtered
     {
-        public class Assemblies : aweXpect.Reflection.Collections.Filtered<System.Reflection.Assembly, aweXpect.Reflection.Collections.Filtered.Assemblies>, aweXpect.Core.IDescribableSubject, aweXpect.Reflection.Collections.ILimitedTypeAssemblies, aweXpect.Reflection.Collections.ILimitedTypeAssemblies<aweXpect.Reflection.Collections.ITypeAssemblies>, aweXpect.Reflection.Collections.ITypeAssemblies, aweXpect.Reflection.Collections.ITypeAssemblies.IPrivate, aweXpect.Reflection.Collections.ITypeAssemblies.IProtected
+        public class Assemblies : aweXpect.Reflection.Collections.Filtered<System.Reflection.Assembly, aweXpect.Reflection.Collections.Filtered.Assemblies>, aweXpect.Core.IDescribableSubject, aweXpect.Reflection.Collections.ILimitedAbstractSealedTypeAssemblies, aweXpect.Reflection.Collections.ILimitedAbstractSealedTypeAssemblies<aweXpect.Reflection.Collections.ITypeAssemblies>, aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies, aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies<aweXpect.Reflection.Collections.ITypeAssemblies>, aweXpect.Reflection.Collections.ITypeAssemblies, aweXpect.Reflection.Collections.ITypeAssemblies.IPrivate, aweXpect.Reflection.Collections.ITypeAssemblies.IProtected
         {
             protected Assemblies(aweXpect.Reflection.Collections.Filtered.Assemblies inner) { }
             public Assemblies(System.Collections.Generic.IEnumerable<System.Reflection.Assembly?> source, string description) { }
             public Assemblies(System.Reflection.Assembly? source, string description) { }
-            public aweXpect.Reflection.Collections.ILimitedTypeAssemblies<aweXpect.Reflection.Collections.ILimitedTypeAssemblies> Abstract { get; }
+            public aweXpect.Reflection.Collections.ILimitedAbstractSealedTypeAssemblies<aweXpect.Reflection.Collections.ILimitedAbstractSealedTypeAssemblies> Abstract { get; }
             public aweXpect.Reflection.Collections.ITypeAssemblies Generic { get; }
             public aweXpect.Reflection.Collections.ITypeAssemblies Internal { get; }
             public aweXpect.Reflection.Collections.ITypeAssemblies Nested { get; }
             public aweXpect.Reflection.Collections.ITypeAssemblies.IPrivate Private { get; }
             public aweXpect.Reflection.Collections.ITypeAssemblies.IProtected Protected { get; }
             public aweXpect.Reflection.Collections.ITypeAssemblies Public { get; }
-            public aweXpect.Reflection.Collections.ILimitedTypeAssemblies<aweXpect.Reflection.Collections.ILimitedTypeAssemblies> Sealed { get; }
-            public aweXpect.Reflection.Collections.ILimitedTypeAssemblies<aweXpect.Reflection.Collections.ILimitedTypeAssemblies> Static { get; }
+            public aweXpect.Reflection.Collections.ILimitedAbstractSealedTypeAssemblies<aweXpect.Reflection.Collections.ILimitedAbstractSealedTypeAssemblies> Sealed { get; }
+            public aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies<aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies> Static { get; }
             public aweXpect.Reflection.Collections.Filtered.Types Classes(aweXpect.Reflection.Collections.AccessModifiers accessModifier = 63) { }
             public aweXpect.Reflection.Collections.Filtered.Constructors Constructors() { }
             public aweXpect.Reflection.Collections.Filtered.Types Enums(aweXpect.Reflection.Collections.AccessModifiers accessModifier = 63) { }
@@ -668,6 +686,9 @@ namespace aweXpect.Reflection.Collections
             public aweXpect.Reflection.Collections.Filtered.Types Interfaces(aweXpect.Reflection.Collections.AccessModifiers accessModifier = 63) { }
             public aweXpect.Reflection.Collections.Filtered.Methods Methods() { }
             public aweXpect.Reflection.Collections.Filtered.Properties Properties() { }
+            public aweXpect.Reflection.Collections.Filtered.Types RecordStructs(aweXpect.Reflection.Collections.AccessModifiers accessModifier = 63) { }
+            public aweXpect.Reflection.Collections.Filtered.Types Records(aweXpect.Reflection.Collections.AccessModifiers accessModifier = 63) { }
+            public aweXpect.Reflection.Collections.Filtered.Types Structs(aweXpect.Reflection.Collections.AccessModifiers accessModifier = 63) { }
             public aweXpect.Reflection.Collections.Filtered.Types Types(aweXpect.Reflection.Collections.AccessModifiers accessModifier = 63) { }
             public class StringEqualityResult : aweXpect.Reflection.Collections.Filtered.Assemblies
             {
@@ -821,22 +842,28 @@ namespace aweXpect.Reflection.Collections
         bool Applies(TEntity value);
         string Describes(string text);
     }
-    public interface ILimitedTypeAssemblies
+    public interface ILimitedAbstractSealedTypeAssemblies : aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies
+    {
+        aweXpect.Reflection.Collections.Filtered.Types Records(aweXpect.Reflection.Collections.AccessModifiers accessModifier = 63);
+    }
+    public interface ILimitedAbstractSealedTypeAssemblies<out TLimitedTypeAssemblies> : aweXpect.Reflection.Collections.ILimitedAbstractSealedTypeAssemblies, aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies, aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies<TLimitedTypeAssemblies>
+        where out TLimitedTypeAssemblies : aweXpect.Reflection.Collections.ILimitedAbstractSealedTypeAssemblies { }
+    public interface ILimitedStaticTypeAssemblies
     {
         aweXpect.Reflection.Collections.Filtered.Types Classes(aweXpect.Reflection.Collections.AccessModifiers accessModifier = 63);
         aweXpect.Reflection.Collections.Filtered.Types Types(aweXpect.Reflection.Collections.AccessModifiers accessModifier = 63);
     }
-    public interface ILimitedTypeAssemblies<out TLimitedTypeAssemblies> : aweXpect.Reflection.Collections.ILimitedTypeAssemblies
-        where out TLimitedTypeAssemblies : aweXpect.Reflection.Collections.ILimitedTypeAssemblies
+    public interface ILimitedStaticTypeAssemblies<out TLimitedTypeAssemblies> : aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies
+        where out TLimitedTypeAssemblies : aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies
     {
         TLimitedTypeAssemblies Generic { get; }
         TLimitedTypeAssemblies Nested { get; }
     }
-    public interface ITypeAssemblies : aweXpect.Reflection.Collections.ILimitedTypeAssemblies, aweXpect.Reflection.Collections.ILimitedTypeAssemblies<aweXpect.Reflection.Collections.ITypeAssemblies>
+    public interface ITypeAssemblies : aweXpect.Reflection.Collections.ILimitedAbstractSealedTypeAssemblies, aweXpect.Reflection.Collections.ILimitedAbstractSealedTypeAssemblies<aweXpect.Reflection.Collections.ITypeAssemblies>, aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies, aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies<aweXpect.Reflection.Collections.ITypeAssemblies>
     {
-        aweXpect.Reflection.Collections.ILimitedTypeAssemblies<aweXpect.Reflection.Collections.ILimitedTypeAssemblies> Abstract { get; }
-        aweXpect.Reflection.Collections.ILimitedTypeAssemblies<aweXpect.Reflection.Collections.ILimitedTypeAssemblies> Sealed { get; }
-        aweXpect.Reflection.Collections.ILimitedTypeAssemblies<aweXpect.Reflection.Collections.ILimitedTypeAssemblies> Static { get; }
+        aweXpect.Reflection.Collections.ILimitedAbstractSealedTypeAssemblies<aweXpect.Reflection.Collections.ILimitedAbstractSealedTypeAssemblies> Abstract { get; }
+        aweXpect.Reflection.Collections.ILimitedAbstractSealedTypeAssemblies<aweXpect.Reflection.Collections.ILimitedAbstractSealedTypeAssemblies> Sealed { get; }
+        aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies<aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies> Static { get; }
         aweXpect.Reflection.Collections.Filtered.Constructors Constructors();
         aweXpect.Reflection.Collections.Filtered.Types Enums(aweXpect.Reflection.Collections.AccessModifiers accessModifier = 63);
         aweXpect.Reflection.Collections.Filtered.Events Events();
@@ -844,11 +871,13 @@ namespace aweXpect.Reflection.Collections
         aweXpect.Reflection.Collections.Filtered.Types Interfaces(aweXpect.Reflection.Collections.AccessModifiers accessModifier = 63);
         aweXpect.Reflection.Collections.Filtered.Methods Methods();
         aweXpect.Reflection.Collections.Filtered.Properties Properties();
-        public interface IPrivate : aweXpect.Reflection.Collections.ILimitedTypeAssemblies, aweXpect.Reflection.Collections.ILimitedTypeAssemblies<aweXpect.Reflection.Collections.ITypeAssemblies>, aweXpect.Reflection.Collections.ITypeAssemblies
+        aweXpect.Reflection.Collections.Filtered.Types RecordStructs(aweXpect.Reflection.Collections.AccessModifiers accessModifier = 63);
+        aweXpect.Reflection.Collections.Filtered.Types Structs(aweXpect.Reflection.Collections.AccessModifiers accessModifier = 63);
+        public interface IPrivate : aweXpect.Reflection.Collections.ILimitedAbstractSealedTypeAssemblies, aweXpect.Reflection.Collections.ILimitedAbstractSealedTypeAssemblies<aweXpect.Reflection.Collections.ITypeAssemblies>, aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies, aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies<aweXpect.Reflection.Collections.ITypeAssemblies>, aweXpect.Reflection.Collections.ITypeAssemblies
         {
             aweXpect.Reflection.Collections.ITypeAssemblies Protected { get; }
         }
-        public interface IProtected : aweXpect.Reflection.Collections.ILimitedTypeAssemblies, aweXpect.Reflection.Collections.ILimitedTypeAssemblies<aweXpect.Reflection.Collections.ITypeAssemblies>, aweXpect.Reflection.Collections.ITypeAssemblies
+        public interface IProtected : aweXpect.Reflection.Collections.ILimitedAbstractSealedTypeAssemblies, aweXpect.Reflection.Collections.ILimitedAbstractSealedTypeAssemblies<aweXpect.Reflection.Collections.ITypeAssemblies>, aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies, aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies<aweXpect.Reflection.Collections.ITypeAssemblies>, aweXpect.Reflection.Collections.ITypeAssemblies
         {
             aweXpect.Reflection.Collections.ITypeAssemblies Internal { get; }
         }

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_netstandard2.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_netstandard2.0.txt
@@ -535,12 +535,18 @@ namespace aweXpect.Reflection
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> InheritsFrom(this aweXpect.Core.IThat<System.Type?> subject, System.Type baseType, bool forceDirect = false) { }
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> InheritsFrom<TBaseType>(this aweXpect.Core.IThat<System.Type?> subject, bool forceDirect = false) { }
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsAClass(this aweXpect.Core.IThat<System.Type?> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsARecord(this aweXpect.Core.IThat<System.Type?> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsARecordStruct(this aweXpect.Core.IThat<System.Type?> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsAStruct(this aweXpect.Core.IThat<System.Type?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsAbstract(this aweXpect.Core.IThat<System.Type?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsAnEnum(this aweXpect.Core.IThat<System.Type?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsAnInterface(this aweXpect.Core.IThat<System.Type?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsGeneric(this aweXpect.Core.IThat<System.Type?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsNested(this aweXpect.Core.IThat<System.Type?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsNotAClass(this aweXpect.Core.IThat<System.Type?> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsNotARecord(this aweXpect.Core.IThat<System.Type?> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsNotARecordStruct(this aweXpect.Core.IThat<System.Type?> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsNotAStruct(this aweXpect.Core.IThat<System.Type?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsNotAbstract(this aweXpect.Core.IThat<System.Type?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsNotAnEnum(this aweXpect.Core.IThat<System.Type?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsNotAnInterface(this aweXpect.Core.IThat<System.Type?> subject) { }
@@ -565,10 +571,16 @@ namespace aweXpect.Reflection
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreNotGeneric(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreNotInterfaces(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreNotNested(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreNotRecordStructs(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreNotRecords(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreNotSealed(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreNotStatic(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreNotStructs(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreRecordStructs(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreRecords(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreSealed(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreStatic(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreStructs(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> DoNotInheritFrom(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject, System.Type baseType, bool forceDirect = false) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> DoNotInheritFrom<TBaseType>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject, bool forceDirect = false) { }
         public static aweXpect.Reflection.Results.HaveAttributeResult<System.Type?> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject, bool inherit = true)
@@ -602,15 +614,21 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreNotProtected(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreNotProtectedInternal(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreNotPublic(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
+        public static aweXpect.Reflection.Collections.Filtered.Types WhichAreNotRecordStructs(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
+        public static aweXpect.Reflection.Collections.Filtered.Types WhichAreNotRecords(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreNotSealed(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreNotStatic(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
+        public static aweXpect.Reflection.Collections.Filtered.Types WhichAreNotStructs(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichArePrivate(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichArePrivateProtected(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreProtected(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreProtectedInternal(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichArePublic(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
+        public static aweXpect.Reflection.Collections.Filtered.Types WhichAreRecordStructs(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
+        public static aweXpect.Reflection.Collections.Filtered.Types WhichAreRecords(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreSealed(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreStatic(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
+        public static aweXpect.Reflection.Collections.Filtered.Types WhichAreStructs(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichInheritFrom(this aweXpect.Reflection.Collections.Filtered.Types @this, System.Type baseType, bool forceDirect = false) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichInheritFrom<TBaseType>(this aweXpect.Reflection.Collections.Filtered.Types @this, bool forceDirect = false) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichSatisfy(this aweXpect.Reflection.Collections.Filtered.Types @this, System.Func<System.Type, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
@@ -645,20 +663,20 @@ namespace aweXpect.Reflection.Collections
     }
     public static class Filtered
     {
-        public class Assemblies : aweXpect.Reflection.Collections.Filtered<System.Reflection.Assembly, aweXpect.Reflection.Collections.Filtered.Assemblies>, aweXpect.Core.IDescribableSubject, aweXpect.Reflection.Collections.ILimitedTypeAssemblies, aweXpect.Reflection.Collections.ILimitedTypeAssemblies<aweXpect.Reflection.Collections.ITypeAssemblies>, aweXpect.Reflection.Collections.ITypeAssemblies, aweXpect.Reflection.Collections.ITypeAssemblies.IPrivate, aweXpect.Reflection.Collections.ITypeAssemblies.IProtected
+        public class Assemblies : aweXpect.Reflection.Collections.Filtered<System.Reflection.Assembly, aweXpect.Reflection.Collections.Filtered.Assemblies>, aweXpect.Core.IDescribableSubject, aweXpect.Reflection.Collections.ILimitedAbstractSealedTypeAssemblies, aweXpect.Reflection.Collections.ILimitedAbstractSealedTypeAssemblies<aweXpect.Reflection.Collections.ITypeAssemblies>, aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies, aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies<aweXpect.Reflection.Collections.ITypeAssemblies>, aweXpect.Reflection.Collections.ITypeAssemblies, aweXpect.Reflection.Collections.ITypeAssemblies.IPrivate, aweXpect.Reflection.Collections.ITypeAssemblies.IProtected
         {
             protected Assemblies(aweXpect.Reflection.Collections.Filtered.Assemblies inner) { }
             public Assemblies(System.Collections.Generic.IEnumerable<System.Reflection.Assembly?> source, string description) { }
             public Assemblies(System.Reflection.Assembly? source, string description) { }
-            public aweXpect.Reflection.Collections.ILimitedTypeAssemblies<aweXpect.Reflection.Collections.ILimitedTypeAssemblies> Abstract { get; }
+            public aweXpect.Reflection.Collections.ILimitedAbstractSealedTypeAssemblies<aweXpect.Reflection.Collections.ILimitedAbstractSealedTypeAssemblies> Abstract { get; }
             public aweXpect.Reflection.Collections.ITypeAssemblies Generic { get; }
             public aweXpect.Reflection.Collections.ITypeAssemblies Internal { get; }
             public aweXpect.Reflection.Collections.ITypeAssemblies Nested { get; }
             public aweXpect.Reflection.Collections.ITypeAssemblies.IPrivate Private { get; }
             public aweXpect.Reflection.Collections.ITypeAssemblies.IProtected Protected { get; }
             public aweXpect.Reflection.Collections.ITypeAssemblies Public { get; }
-            public aweXpect.Reflection.Collections.ILimitedTypeAssemblies<aweXpect.Reflection.Collections.ILimitedTypeAssemblies> Sealed { get; }
-            public aweXpect.Reflection.Collections.ILimitedTypeAssemblies<aweXpect.Reflection.Collections.ILimitedTypeAssemblies> Static { get; }
+            public aweXpect.Reflection.Collections.ILimitedAbstractSealedTypeAssemblies<aweXpect.Reflection.Collections.ILimitedAbstractSealedTypeAssemblies> Sealed { get; }
+            public aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies<aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies> Static { get; }
             public aweXpect.Reflection.Collections.Filtered.Types Classes(aweXpect.Reflection.Collections.AccessModifiers accessModifier = 63) { }
             public aweXpect.Reflection.Collections.Filtered.Constructors Constructors() { }
             public aweXpect.Reflection.Collections.Filtered.Types Enums(aweXpect.Reflection.Collections.AccessModifiers accessModifier = 63) { }
@@ -668,6 +686,9 @@ namespace aweXpect.Reflection.Collections
             public aweXpect.Reflection.Collections.Filtered.Types Interfaces(aweXpect.Reflection.Collections.AccessModifiers accessModifier = 63) { }
             public aweXpect.Reflection.Collections.Filtered.Methods Methods() { }
             public aweXpect.Reflection.Collections.Filtered.Properties Properties() { }
+            public aweXpect.Reflection.Collections.Filtered.Types RecordStructs(aweXpect.Reflection.Collections.AccessModifiers accessModifier = 63) { }
+            public aweXpect.Reflection.Collections.Filtered.Types Records(aweXpect.Reflection.Collections.AccessModifiers accessModifier = 63) { }
+            public aweXpect.Reflection.Collections.Filtered.Types Structs(aweXpect.Reflection.Collections.AccessModifiers accessModifier = 63) { }
             public aweXpect.Reflection.Collections.Filtered.Types Types(aweXpect.Reflection.Collections.AccessModifiers accessModifier = 63) { }
             public class StringEqualityResult : aweXpect.Reflection.Collections.Filtered.Assemblies
             {
@@ -821,22 +842,28 @@ namespace aweXpect.Reflection.Collections
         bool Applies(TEntity value);
         string Describes(string text);
     }
-    public interface ILimitedTypeAssemblies
+    public interface ILimitedAbstractSealedTypeAssemblies : aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies
+    {
+        aweXpect.Reflection.Collections.Filtered.Types Records(aweXpect.Reflection.Collections.AccessModifiers accessModifier = 63);
+    }
+    public interface ILimitedAbstractSealedTypeAssemblies<out TLimitedTypeAssemblies> : aweXpect.Reflection.Collections.ILimitedAbstractSealedTypeAssemblies, aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies, aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies<TLimitedTypeAssemblies>
+        where out TLimitedTypeAssemblies : aweXpect.Reflection.Collections.ILimitedAbstractSealedTypeAssemblies { }
+    public interface ILimitedStaticTypeAssemblies
     {
         aweXpect.Reflection.Collections.Filtered.Types Classes(aweXpect.Reflection.Collections.AccessModifiers accessModifier = 63);
         aweXpect.Reflection.Collections.Filtered.Types Types(aweXpect.Reflection.Collections.AccessModifiers accessModifier = 63);
     }
-    public interface ILimitedTypeAssemblies<out TLimitedTypeAssemblies> : aweXpect.Reflection.Collections.ILimitedTypeAssemblies
-        where out TLimitedTypeAssemblies : aweXpect.Reflection.Collections.ILimitedTypeAssemblies
+    public interface ILimitedStaticTypeAssemblies<out TLimitedTypeAssemblies> : aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies
+        where out TLimitedTypeAssemblies : aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies
     {
         TLimitedTypeAssemblies Generic { get; }
         TLimitedTypeAssemblies Nested { get; }
     }
-    public interface ITypeAssemblies : aweXpect.Reflection.Collections.ILimitedTypeAssemblies, aweXpect.Reflection.Collections.ILimitedTypeAssemblies<aweXpect.Reflection.Collections.ITypeAssemblies>
+    public interface ITypeAssemblies : aweXpect.Reflection.Collections.ILimitedAbstractSealedTypeAssemblies, aweXpect.Reflection.Collections.ILimitedAbstractSealedTypeAssemblies<aweXpect.Reflection.Collections.ITypeAssemblies>, aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies, aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies<aweXpect.Reflection.Collections.ITypeAssemblies>
     {
-        aweXpect.Reflection.Collections.ILimitedTypeAssemblies<aweXpect.Reflection.Collections.ILimitedTypeAssemblies> Abstract { get; }
-        aweXpect.Reflection.Collections.ILimitedTypeAssemblies<aweXpect.Reflection.Collections.ILimitedTypeAssemblies> Sealed { get; }
-        aweXpect.Reflection.Collections.ILimitedTypeAssemblies<aweXpect.Reflection.Collections.ILimitedTypeAssemblies> Static { get; }
+        aweXpect.Reflection.Collections.ILimitedAbstractSealedTypeAssemblies<aweXpect.Reflection.Collections.ILimitedAbstractSealedTypeAssemblies> Abstract { get; }
+        aweXpect.Reflection.Collections.ILimitedAbstractSealedTypeAssemblies<aweXpect.Reflection.Collections.ILimitedAbstractSealedTypeAssemblies> Sealed { get; }
+        aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies<aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies> Static { get; }
         aweXpect.Reflection.Collections.Filtered.Constructors Constructors();
         aweXpect.Reflection.Collections.Filtered.Types Enums(aweXpect.Reflection.Collections.AccessModifiers accessModifier = 63);
         aweXpect.Reflection.Collections.Filtered.Events Events();
@@ -844,11 +871,13 @@ namespace aweXpect.Reflection.Collections
         aweXpect.Reflection.Collections.Filtered.Types Interfaces(aweXpect.Reflection.Collections.AccessModifiers accessModifier = 63);
         aweXpect.Reflection.Collections.Filtered.Methods Methods();
         aweXpect.Reflection.Collections.Filtered.Properties Properties();
-        public interface IPrivate : aweXpect.Reflection.Collections.ILimitedTypeAssemblies, aweXpect.Reflection.Collections.ILimitedTypeAssemblies<aweXpect.Reflection.Collections.ITypeAssemblies>, aweXpect.Reflection.Collections.ITypeAssemblies
+        aweXpect.Reflection.Collections.Filtered.Types RecordStructs(aweXpect.Reflection.Collections.AccessModifiers accessModifier = 63);
+        aweXpect.Reflection.Collections.Filtered.Types Structs(aweXpect.Reflection.Collections.AccessModifiers accessModifier = 63);
+        public interface IPrivate : aweXpect.Reflection.Collections.ILimitedAbstractSealedTypeAssemblies, aweXpect.Reflection.Collections.ILimitedAbstractSealedTypeAssemblies<aweXpect.Reflection.Collections.ITypeAssemblies>, aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies, aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies<aweXpect.Reflection.Collections.ITypeAssemblies>, aweXpect.Reflection.Collections.ITypeAssemblies
         {
             aweXpect.Reflection.Collections.ITypeAssemblies Protected { get; }
         }
-        public interface IProtected : aweXpect.Reflection.Collections.ILimitedTypeAssemblies, aweXpect.Reflection.Collections.ILimitedTypeAssemblies<aweXpect.Reflection.Collections.ITypeAssemblies>, aweXpect.Reflection.Collections.ITypeAssemblies
+        public interface IProtected : aweXpect.Reflection.Collections.ILimitedAbstractSealedTypeAssemblies, aweXpect.Reflection.Collections.ILimitedAbstractSealedTypeAssemblies<aweXpect.Reflection.Collections.ITypeAssemblies>, aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies, aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies<aweXpect.Reflection.Collections.ITypeAssemblies>, aweXpect.Reflection.Collections.ITypeAssemblies
         {
             aweXpect.Reflection.Collections.ITypeAssemblies Internal { get; }
         }

--- a/Tests/aweXpect.Reflection.Tests/Collections/Filtered.Assemblies.Classes.NestedTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Collections/Filtered.Assemblies.Classes.NestedTests.cs
@@ -15,7 +15,7 @@ public sealed partial class Filtered
 				{
 					Reflection.Collections.Filtered.Types types = In.AllLoadedAssemblies().Nested.Classes();
 
-					await That(types).All().Satisfy(t => t is { IsClass: true, IsNested: true, });
+					await That(types).All().Satisfy(t => t is { IsClass: true, IsNested: true, }).And.IsNotEmpty();
 				}
 
 				[Fact]
@@ -25,7 +25,7 @@ public sealed partial class Filtered
 						.Nested.Classes(AccessModifiers.Public);
 
 					await That(types).All().Satisfy(type
-						=> type is { IsClass: true, IsNested: true, IsNestedPublic: true, });
+						=> type is { IsClass: true, IsNested: true, IsNestedPublic: true, }).And.IsNotEmpty();
 				}
 
 				[Fact]

--- a/Tests/aweXpect.Reflection.Tests/Collections/Filtered.Assemblies.Classes.StaticTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Collections/Filtered.Assemblies.Classes.StaticTests.cs
@@ -15,7 +15,7 @@ public sealed partial class Filtered
 				{
 					Reflection.Collections.Filtered.Types types = In.AllLoadedAssemblies().Static.Classes();
 
-					await That(types).All().Satisfy(t => t.IsClass && t.IsStatic());
+					await That(types).All().Satisfy(t => t.IsClass && t.IsStatic()).And.IsNotEmpty();
 				}
 
 				[Fact]

--- a/Tests/aweXpect.Reflection.Tests/Collections/Filtered.Assemblies.RecordStructs.GenericTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Collections/Filtered.Assemblies.RecordStructs.GenericTests.cs
@@ -6,28 +6,28 @@ public sealed partial class Filtered
 {
 	public sealed partial class Assemblies
 	{
-		public sealed partial class Classes
+		public sealed partial class RecordStructs
 		{
 			public sealed class GenericTests
 			{
 				[Fact]
 				public async Task ShouldApplyFilterForGenericTypes()
 				{
-					Reflection.Collections.Filtered.Types types = In.AllLoadedAssemblies().Generic.Classes();
+					Reflection.Collections.Filtered.Types types = In.AllLoadedAssemblies().Generic.RecordStructs();
 
-					await That(types).All().Satisfy(t => t is { IsClass: true, IsGenericType: true, }).And.IsNotEmpty();
+					await That(types).All().Satisfy(t => t is { IsClass: false, IsEnum: false, IsValueType: true, IsGenericType: true, }).And.IsNotEmpty();
 				}
 
 				[Fact]
 				public async Task ShouldIncludeNestedInformationInErrorMessage()
 				{
 					async Task Act()
-						=> await That(In.AllLoadedAssemblies().Generic.Classes())
+						=> await That(In.AllLoadedAssemblies().Generic.RecordStructs())
 							.AreNotGeneric();
 
 					await That(Act).ThrowsException()
 						.WithMessage("""
-						             Expected that generic classes in all loaded assemblies
+						             Expected that generic record structs in all loaded assemblies
 						             are all not generic,
 						             but it contained generic types [
 						               *
@@ -42,12 +42,12 @@ public sealed partial class Filtered
 					AccessModifiers accessModifier, string expectedString)
 				{
 					async Task Act()
-						=> await That(In.AllLoadedAssemblies().Generic.Classes(accessModifier))
+						=> await That(In.AllLoadedAssemblies().Generic.RecordStructs(accessModifier))
 							.AreNotGeneric();
 
 					await That(Act).ThrowsException()
 						.WithMessage($"""
-						              Expected that {expectedString}generic classes in all loaded assemblies
+						              Expected that {expectedString}generic record structs in all loaded assemblies
 						              are all not generic,
 						              but it contained generic types [
 						                *

--- a/Tests/aweXpect.Reflection.Tests/Collections/Filtered.Assemblies.RecordStructs.NestedTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Collections/Filtered.Assemblies.RecordStructs.NestedTests.cs
@@ -6,40 +6,38 @@ public sealed partial class Filtered
 {
 	public sealed partial class Assemblies
 	{
-		public sealed partial class Classes
+		public sealed partial class RecordStructs
 		{
-			public sealed class AbstractTests
+			public sealed class NestedTests
 			{
 				[Fact]
-				public async Task ShouldApplyFilterForClasses()
+				public async Task ShouldApplyFilterForRecordStructs()
 				{
-					Reflection.Collections.Filtered.Types types = In.AllLoadedAssemblies().Abstract.Classes();
+					Reflection.Collections.Filtered.Types types = In.AllLoadedAssemblies().Nested.RecordStructs();
 
-					await That(types).All().Satisfy(t => t is
-						{ IsClass: true, IsAbstract: true, IsSealed: false, IsInterface: false, }).And.IsNotEmpty();
+					await That(types).All().Satisfy(t => t is { IsClass: false, IsEnum: false, IsValueType: true, IsNested: true, }).And.IsNotEmpty();
 				}
 
 				[Fact]
 				public async Task ShouldConsiderAccessModifier()
 				{
 					Reflection.Collections.Filtered.Types types = In.AllLoadedAssemblies()
-						.Abstract.Classes(AccessModifiers.Public);
+						.Nested.RecordStructs(AccessModifiers.Protected);
 
 					await That(types).All().Satisfy(type
-						=> type is { IsAbstract: true, IsSealed: false, IsInterface: false, IsClass: true, } &&
-						   (type.IsNested ? type.IsNestedPublic : type.IsPublic)).And.IsNotEmpty();
+						=> type is { IsClass: false, IsEnum: false, IsValueType: true, IsNested: true, IsNestedFamily: true, }).And.IsNotEmpty();
 				}
 
 				[Fact]
 				public async Task ShouldIncludeAbstractInformationInErrorMessage()
 				{
 					async Task Act()
-						=> await That(In.AllLoadedAssemblies().Abstract.Classes())
+						=> await That(In.AllLoadedAssemblies().Nested.RecordStructs())
 							.AreInternal();
 
 					await That(Act).ThrowsException()
 						.WithMessage("""
-						             Expected that abstract classes in all loaded assemblies
+						             Expected that nested record structs in all loaded assemblies
 						             all are internal,
 						             but it contained not matching items [
 						               *

--- a/Tests/aweXpect.Reflection.Tests/Collections/Filtered.Assemblies.RecordStructs.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Collections/Filtered.Assemblies.RecordStructs.Tests.cs
@@ -6,16 +6,17 @@ public sealed partial class Filtered
 {
 	public sealed partial class Assemblies
 	{
-		public sealed partial class Classes
+		public sealed partial class RecordStructs
 		{
 			public sealed class Tests
 			{
 				[Fact]
-				public async Task ShouldApplyFilterForClasses()
+				public async Task ShouldApplyFilterForRecordStructs()
 				{
-					Reflection.Collections.Filtered.Types types = In.AllLoadedAssemblies().Classes();
+					Reflection.Collections.Filtered.Types types = In.AllLoadedAssemblies().RecordStructs();
 
-					await That(types).All().Satisfy(t => t.IsClass).And.IsNotEmpty();
+					await That(types).All().Satisfy(t => t is { IsClass: false, IsEnum: false, IsValueType: true, }).And
+						.IsNotEmpty();
 				}
 
 				[Theory]
@@ -23,21 +24,23 @@ public sealed partial class Filtered
 				public async Task ShouldConsiderAccessModifier(AccessModifiers accessModifier, Func<Type, bool> check)
 				{
 					Reflection.Collections.Filtered.Types types = In.AllLoadedAssemblies()
-						.Classes(accessModifier);
+						.RecordStructs(accessModifier);
 
-					await That(types).All().Satisfy(type => type.IsClass && check(type)).And.IsNotEmpty();
+					await That(types).All().Satisfy(type
+							=> type is { IsClass: false, IsEnum: false, IsValueType: true, } && check(type)).And
+						.IsNotEmpty();
 				}
 
 				[Fact]
 				public async Task ShouldIncludeAbstractInformationInErrorMessage()
 				{
 					async Task Act()
-						=> await That(In.AllLoadedAssemblies().Classes())
+						=> await That(In.AllLoadedAssemblies().RecordStructs())
 							.AreAbstract();
 
 					await That(Act).ThrowsException()
 						.WithMessage("""
-						             Expected that classes in all loaded assemblies
+						             Expected that record structs in all loaded assemblies
 						             are all abstract,
 						             but it contained non-abstract types [
 						               *

--- a/Tests/aweXpect.Reflection.Tests/Collections/Filtered.Assemblies.Records.AbstractTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Collections/Filtered.Assemblies.Records.AbstractTests.cs
@@ -1,4 +1,5 @@
 ﻿using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Tests.TestHelpers;
 
 namespace aweXpect.Reflection.Tests.Collections;
 
@@ -6,27 +7,26 @@ public sealed partial class Filtered
 {
 	public sealed partial class Assemblies
 	{
-		public sealed partial class Classes
+		public sealed partial class Records
 		{
 			public sealed class AbstractTests
 			{
 				[Fact]
-				public async Task ShouldApplyFilterForClasses()
+				public async Task ShouldApplyFilterForRecords()
 				{
-					Reflection.Collections.Filtered.Types types = In.AllLoadedAssemblies().Abstract.Classes();
+					Reflection.Collections.Filtered.Types types = In.AllLoadedAssemblies().Abstract.Records();
 
-					await That(types).All().Satisfy(t => t is
-						{ IsClass: true, IsAbstract: true, IsSealed: false, IsInterface: false, }).And.IsNotEmpty();
+					await That(types).All().Satisfy(t => t.IsRecordClass()).And.IsNotEmpty();
 				}
 
 				[Fact]
 				public async Task ShouldConsiderAccessModifier()
 				{
 					Reflection.Collections.Filtered.Types types = In.AllLoadedAssemblies()
-						.Abstract.Classes(AccessModifiers.Public);
+						.Abstract.Records(AccessModifiers.Public);
 
 					await That(types).All().Satisfy(type
-						=> type is { IsAbstract: true, IsSealed: false, IsInterface: false, IsClass: true, } &&
+						=> type.IsAbstract && type.IsRecordClass() &&
 						   (type.IsNested ? type.IsNestedPublic : type.IsPublic)).And.IsNotEmpty();
 				}
 
@@ -34,12 +34,12 @@ public sealed partial class Filtered
 				public async Task ShouldIncludeAbstractInformationInErrorMessage()
 				{
 					async Task Act()
-						=> await That(In.AllLoadedAssemblies().Abstract.Classes())
+						=> await That(In.AllLoadedAssemblies().Abstract.Records())
 							.AreInternal();
 
 					await That(Act).ThrowsException()
 						.WithMessage("""
-						             Expected that abstract classes in all loaded assemblies
+						             Expected that abstract records in all loaded assemblies
 						             all are internal,
 						             but it contained not matching items [
 						               *

--- a/Tests/aweXpect.Reflection.Tests/Collections/Filtered.Assemblies.Records.GenericTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Collections/Filtered.Assemblies.Records.GenericTests.cs
@@ -6,14 +6,14 @@ public sealed partial class Filtered
 {
 	public sealed partial class Assemblies
 	{
-		public sealed partial class Classes
+		public sealed partial class Records
 		{
 			public sealed class GenericTests
 			{
 				[Fact]
 				public async Task ShouldApplyFilterForGenericTypes()
 				{
-					Reflection.Collections.Filtered.Types types = In.AllLoadedAssemblies().Generic.Classes();
+					Reflection.Collections.Filtered.Types types = In.AllLoadedAssemblies().Generic.Records();
 
 					await That(types).All().Satisfy(t => t is { IsClass: true, IsGenericType: true, }).And.IsNotEmpty();
 				}
@@ -22,12 +22,12 @@ public sealed partial class Filtered
 				public async Task ShouldIncludeNestedInformationInErrorMessage()
 				{
 					async Task Act()
-						=> await That(In.AllLoadedAssemblies().Generic.Classes())
+						=> await That(In.AllLoadedAssemblies().Generic.Records())
 							.AreNotGeneric();
 
 					await That(Act).ThrowsException()
 						.WithMessage("""
-						             Expected that generic classes in all loaded assemblies
+						             Expected that generic records in all loaded assemblies
 						             are all not generic,
 						             but it contained generic types [
 						               *
@@ -42,12 +42,12 @@ public sealed partial class Filtered
 					AccessModifiers accessModifier, string expectedString)
 				{
 					async Task Act()
-						=> await That(In.AllLoadedAssemblies().Generic.Classes(accessModifier))
+						=> await That(In.AllLoadedAssemblies().Generic.Records(accessModifier))
 							.AreNotGeneric();
 
 					await That(Act).ThrowsException()
 						.WithMessage($"""
-						              Expected that {expectedString}generic classes in all loaded assemblies
+						              Expected that {expectedString}generic records in all loaded assemblies
 						              are all not generic,
 						              but it contained generic types [
 						                *

--- a/Tests/aweXpect.Reflection.Tests/Collections/Filtered.Assemblies.Records.NestedTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Collections/Filtered.Assemblies.Records.NestedTests.cs
@@ -6,40 +6,38 @@ public sealed partial class Filtered
 {
 	public sealed partial class Assemblies
 	{
-		public sealed partial class Classes
+		public sealed partial class Records
 		{
-			public sealed class AbstractTests
+			public sealed class NestedTests
 			{
 				[Fact]
-				public async Task ShouldApplyFilterForClasses()
+				public async Task ShouldApplyFilterForRecords()
 				{
-					Reflection.Collections.Filtered.Types types = In.AllLoadedAssemblies().Abstract.Classes();
+					Reflection.Collections.Filtered.Types types = In.AllLoadedAssemblies().Nested.Records();
 
-					await That(types).All().Satisfy(t => t is
-						{ IsClass: true, IsAbstract: true, IsSealed: false, IsInterface: false, }).And.IsNotEmpty();
+					await That(types).All().Satisfy(t => t is { IsClass: true, IsNested: true, }).And.IsNotEmpty();
 				}
 
 				[Fact]
 				public async Task ShouldConsiderAccessModifier()
 				{
 					Reflection.Collections.Filtered.Types types = In.AllLoadedAssemblies()
-						.Abstract.Classes(AccessModifiers.Public);
+						.Nested.Records(AccessModifiers.Public);
 
 					await That(types).All().Satisfy(type
-						=> type is { IsAbstract: true, IsSealed: false, IsInterface: false, IsClass: true, } &&
-						   (type.IsNested ? type.IsNestedPublic : type.IsPublic)).And.IsNotEmpty();
+						=> type is { IsClass: true, IsNested: true, IsNestedPublic: true, }).And.IsNotEmpty();
 				}
 
 				[Fact]
 				public async Task ShouldIncludeAbstractInformationInErrorMessage()
 				{
 					async Task Act()
-						=> await That(In.AllLoadedAssemblies().Abstract.Classes())
+						=> await That(In.AllLoadedAssemblies().Nested.Records())
 							.AreInternal();
 
 					await That(Act).ThrowsException()
 						.WithMessage("""
-						             Expected that abstract classes in all loaded assemblies
+						             Expected that nested records in all loaded assemblies
 						             all are internal,
 						             but it contained not matching items [
 						               *

--- a/Tests/aweXpect.Reflection.Tests/Collections/Filtered.Assemblies.Records.SealedTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Collections/Filtered.Assemblies.Records.SealedTests.cs
@@ -4,14 +4,14 @@ public sealed partial class Filtered
 {
 	public sealed partial class Assemblies
 	{
-		public sealed partial class Classes
+		public sealed partial class Records
 		{
 			public sealed class SealedTests
 			{
 				[Fact]
-				public async Task ShouldApplyFilterForClasses()
+				public async Task ShouldApplyFilterForRecords()
 				{
-					Reflection.Collections.Filtered.Types types = In.AllLoadedAssemblies().Sealed.Classes();
+					Reflection.Collections.Filtered.Types types = In.AllLoadedAssemblies().Sealed.Records();
 
 					await That(types).All().Satisfy(t => t is
 						{ IsClass: true, IsAbstract: false, IsSealed: true, IsInterface: false, }).And.IsNotEmpty();
@@ -21,12 +21,12 @@ public sealed partial class Filtered
 				public async Task ShouldIncludeAbstractInformationInErrorMessage()
 				{
 					async Task Act()
-						=> await That(In.AllLoadedAssemblies().Sealed.Classes())
+						=> await That(In.AllLoadedAssemblies().Sealed.Records())
 							.AreInternal();
 
 					await That(Act).ThrowsException()
 						.WithMessage("""
-						             Expected that sealed classes in all loaded assemblies
+						             Expected that sealed records in all loaded assemblies
 						             all are internal,
 						             but it contained not matching items [
 						               *

--- a/Tests/aweXpect.Reflection.Tests/Collections/Filtered.Assemblies.Records.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Collections/Filtered.Assemblies.Records.Tests.cs
@@ -6,14 +6,14 @@ public sealed partial class Filtered
 {
 	public sealed partial class Assemblies
 	{
-		public sealed partial class Classes
+		public sealed partial class Records
 		{
 			public sealed class Tests
 			{
 				[Fact]
-				public async Task ShouldApplyFilterForClasses()
+				public async Task ShouldApplyFilterForRecords()
 				{
-					Reflection.Collections.Filtered.Types types = In.AllLoadedAssemblies().Classes();
+					Reflection.Collections.Filtered.Types types = In.AllLoadedAssemblies().Records();
 
 					await That(types).All().Satisfy(t => t.IsClass).And.IsNotEmpty();
 				}
@@ -23,7 +23,7 @@ public sealed partial class Filtered
 				public async Task ShouldConsiderAccessModifier(AccessModifiers accessModifier, Func<Type, bool> check)
 				{
 					Reflection.Collections.Filtered.Types types = In.AllLoadedAssemblies()
-						.Classes(accessModifier);
+						.Records(accessModifier);
 
 					await That(types).All().Satisfy(type => type.IsClass && check(type)).And.IsNotEmpty();
 				}
@@ -32,12 +32,12 @@ public sealed partial class Filtered
 				public async Task ShouldIncludeAbstractInformationInErrorMessage()
 				{
 					async Task Act()
-						=> await That(In.AllLoadedAssemblies().Classes())
+						=> await That(In.AllLoadedAssemblies().Records())
 							.AreAbstract();
 
 					await That(Act).ThrowsException()
 						.WithMessage("""
-						             Expected that classes in all loaded assemblies
+						             Expected that records in all loaded assemblies
 						             are all abstract,
 						             but it contained non-abstract types [
 						               *

--- a/Tests/aweXpect.Reflection.Tests/Collections/Filtered.Assemblies.Structs.GenericTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Collections/Filtered.Assemblies.Structs.GenericTests.cs
@@ -6,28 +6,28 @@ public sealed partial class Filtered
 {
 	public sealed partial class Assemblies
 	{
-		public sealed partial class Classes
+		public sealed partial class Structs
 		{
 			public sealed class GenericTests
 			{
 				[Fact]
 				public async Task ShouldApplyFilterForGenericTypes()
 				{
-					Reflection.Collections.Filtered.Types types = In.AllLoadedAssemblies().Generic.Classes();
+					Reflection.Collections.Filtered.Types types = In.AllLoadedAssemblies().Generic.Structs();
 
-					await That(types).All().Satisfy(t => t is { IsClass: true, IsGenericType: true, }).And.IsNotEmpty();
+					await That(types).All().Satisfy(t => t is { IsClass: false, IsEnum: false, IsValueType: true, IsGenericType: true, }).And.IsNotEmpty();
 				}
 
 				[Fact]
 				public async Task ShouldIncludeNestedInformationInErrorMessage()
 				{
 					async Task Act()
-						=> await That(In.AllLoadedAssemblies().Generic.Classes())
+						=> await That(In.AllLoadedAssemblies().Generic.Structs())
 							.AreNotGeneric();
 
 					await That(Act).ThrowsException()
 						.WithMessage("""
-						             Expected that generic classes in all loaded assemblies
+						             Expected that generic structs in all loaded assemblies
 						             are all not generic,
 						             but it contained generic types [
 						               *
@@ -42,12 +42,12 @@ public sealed partial class Filtered
 					AccessModifiers accessModifier, string expectedString)
 				{
 					async Task Act()
-						=> await That(In.AllLoadedAssemblies().Generic.Classes(accessModifier))
+						=> await That(In.AllLoadedAssemblies().Generic.Structs(accessModifier))
 							.AreNotGeneric();
 
 					await That(Act).ThrowsException()
 						.WithMessage($"""
-						              Expected that {expectedString}generic classes in all loaded assemblies
+						              Expected that {expectedString}generic structs in all loaded assemblies
 						              are all not generic,
 						              but it contained generic types [
 						                *

--- a/Tests/aweXpect.Reflection.Tests/Collections/Filtered.Assemblies.Structs.NestedTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Collections/Filtered.Assemblies.Structs.NestedTests.cs
@@ -6,40 +6,38 @@ public sealed partial class Filtered
 {
 	public sealed partial class Assemblies
 	{
-		public sealed partial class Classes
+		public sealed partial class Structs
 		{
-			public sealed class AbstractTests
+			public sealed class NestedTests
 			{
 				[Fact]
-				public async Task ShouldApplyFilterForClasses()
+				public async Task ShouldApplyFilterForStructs()
 				{
-					Reflection.Collections.Filtered.Types types = In.AllLoadedAssemblies().Abstract.Classes();
+					Reflection.Collections.Filtered.Types types = In.AllLoadedAssemblies().Nested.Structs();
 
-					await That(types).All().Satisfy(t => t is
-						{ IsClass: true, IsAbstract: true, IsSealed: false, IsInterface: false, }).And.IsNotEmpty();
+					await That(types).All().Satisfy(t => t is { IsClass: false, IsEnum: false, IsValueType: true, IsNested: true, }).And.IsNotEmpty();
 				}
 
 				[Fact]
 				public async Task ShouldConsiderAccessModifier()
 				{
 					Reflection.Collections.Filtered.Types types = In.AllLoadedAssemblies()
-						.Abstract.Classes(AccessModifiers.Public);
+						.Nested.Structs(AccessModifiers.Protected);
 
 					await That(types).All().Satisfy(type
-						=> type is { IsAbstract: true, IsSealed: false, IsInterface: false, IsClass: true, } &&
-						   (type.IsNested ? type.IsNestedPublic : type.IsPublic)).And.IsNotEmpty();
+						=> type is { IsClass: false, IsEnum: false, IsValueType: true, IsNested: true, IsNestedFamily: true, }).And.IsNotEmpty();
 				}
 
 				[Fact]
 				public async Task ShouldIncludeAbstractInformationInErrorMessage()
 				{
 					async Task Act()
-						=> await That(In.AllLoadedAssemblies().Abstract.Classes())
+						=> await That(In.AllLoadedAssemblies().Nested.Structs())
 							.AreInternal();
 
 					await That(Act).ThrowsException()
 						.WithMessage("""
-						             Expected that abstract classes in all loaded assemblies
+						             Expected that nested structs in all loaded assemblies
 						             all are internal,
 						             but it contained not matching items [
 						               *

--- a/Tests/aweXpect.Reflection.Tests/Collections/Filtered.Assemblies.Structs.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Collections/Filtered.Assemblies.Structs.Tests.cs
@@ -6,16 +6,17 @@ public sealed partial class Filtered
 {
 	public sealed partial class Assemblies
 	{
-		public sealed partial class Classes
+		public sealed partial class Structs
 		{
 			public sealed class Tests
 			{
 				[Fact]
-				public async Task ShouldApplyFilterForClasses()
+				public async Task ShouldApplyFilterForStructs()
 				{
-					Reflection.Collections.Filtered.Types types = In.AllLoadedAssemblies().Classes();
+					Reflection.Collections.Filtered.Types types = In.AllLoadedAssemblies().Structs();
 
-					await That(types).All().Satisfy(t => t.IsClass).And.IsNotEmpty();
+					await That(types).All().Satisfy(t => t is { IsClass: false, IsEnum: false, IsValueType: true, }).And
+						.IsNotEmpty();
 				}
 
 				[Theory]
@@ -23,21 +24,23 @@ public sealed partial class Filtered
 				public async Task ShouldConsiderAccessModifier(AccessModifiers accessModifier, Func<Type, bool> check)
 				{
 					Reflection.Collections.Filtered.Types types = In.AllLoadedAssemblies()
-						.Classes(accessModifier);
+						.Structs(accessModifier);
 
-					await That(types).All().Satisfy(type => type.IsClass && check(type)).And.IsNotEmpty();
+					await That(types).All().Satisfy(type
+							=> type is { IsClass: false, IsEnum: false, IsValueType: true, } && check(type)).And
+						.IsNotEmpty();
 				}
 
 				[Fact]
 				public async Task ShouldIncludeAbstractInformationInErrorMessage()
 				{
 					async Task Act()
-						=> await That(In.AllLoadedAssemblies().Classes())
+						=> await That(In.AllLoadedAssemblies().Structs())
 							.AreAbstract();
 
 					await That(Act).ThrowsException()
 						.WithMessage("""
-						             Expected that classes in all loaded assemblies
+						             Expected that structs in all loaded assemblies
 						             are all abstract,
 						             but it contained non-abstract types [
 						               *

--- a/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreNotRecordStructs.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreNotRecordStructs.Tests.cs
@@ -1,0 +1,30 @@
+using aweXpect.Reflection.Collections;
+
+namespace aweXpect.Reflection.Tests.Filters;
+
+public sealed partial class TypeFilters
+{
+	public sealed class WhichAreNotRecordStructs
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task ShouldFilterOnlyNonRecordStructTypes()
+			{
+				Filtered.Types subject = In.AssemblyContaining<WhichAreNotRecordStructs>().Types()
+					.WhichAreNotRecordStructs();
+
+				await That(subject).AreNotRecordStructs().And.IsNotEmpty();
+			}
+
+			[Fact]
+			public async Task ShouldUpdateDescription()
+			{
+				Filtered.Types subject = In.AssemblyContaining<WhichAreNotRecordStructs>().Types()
+					.WhichAreNotRecordStructs();
+
+				await That(subject.GetDescription()).Contains("types which are not record structs in");
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreNotRecords.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreNotRecords.Tests.cs
@@ -1,0 +1,30 @@
+using aweXpect.Reflection.Collections;
+
+namespace aweXpect.Reflection.Tests.Filters;
+
+public sealed partial class TypeFilters
+{
+	public sealed class WhichAreNotRecords
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task ShouldFilterOnlyNonRecordTypes()
+			{
+				Filtered.Types subject = In.AssemblyContaining<WhichAreNotRecords>().Types()
+					.WhichAreNotRecords();
+
+				await That(subject).AreNotRecords().And.IsNotEmpty();
+			}
+
+			[Fact]
+			public async Task ShouldUpdateDescription()
+			{
+				Filtered.Types subject = In.AssemblyContaining<WhichAreNotRecords>().Types()
+					.WhichAreNotRecords();
+
+				await That(subject.GetDescription()).Contains("types which are not records in");
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreNotStructs.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreNotStructs.Tests.cs
@@ -1,0 +1,30 @@
+using aweXpect.Reflection.Collections;
+
+namespace aweXpect.Reflection.Tests.Filters;
+
+public sealed partial class TypeFilters
+{
+	public sealed class WhichAreNotStructs
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task ShouldFilterOnlyNonStructTypes()
+			{
+				Filtered.Types subject = In.AssemblyContaining<WhichAreNotStructs>().Types()
+					.WhichAreNotStructs();
+
+				await That(subject).AreNotStructs().And.IsNotEmpty();
+			}
+
+			[Fact]
+			public async Task ShouldUpdateDescription()
+			{
+				Filtered.Types subject = In.AssemblyContaining<WhichAreNotStructs>().Types()
+					.WhichAreNotStructs();
+
+				await That(subject.GetDescription()).Contains("types which are not structs in");
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreRecordStructs.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreRecordStructs.Tests.cs
@@ -1,0 +1,30 @@
+using aweXpect.Reflection.Collections;
+
+namespace aweXpect.Reflection.Tests.Filters;
+
+public sealed partial class TypeFilters
+{
+	public sealed class WhichAreRecordStructs
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task ShouldFilterOnlyRecordStructTypes()
+			{
+				Filtered.Types subject = In.AssemblyContaining<WhichAreRecordStructs>().Types()
+					.WhichAreRecordStructs();
+
+				await That(subject).AreRecordStructs().And.IsNotEmpty();
+			}
+
+			[Fact]
+			public async Task ShouldUpdateDescription()
+			{
+				Filtered.Types subject = In.AssemblyContaining<WhichAreRecordStructs>().Types()
+					.WhichAreRecordStructs();
+
+				await That(subject.GetDescription()).Contains("types which are record structs in");
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreRecords.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreRecords.Tests.cs
@@ -1,0 +1,30 @@
+using aweXpect.Reflection.Collections;
+
+namespace aweXpect.Reflection.Tests.Filters;
+
+public sealed partial class TypeFilters
+{
+	public sealed class WhichAreRecords
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task ShouldFilterOnlyRecordTypes()
+			{
+				Filtered.Types subject = In.AssemblyContaining<WhichAreRecords>().Types()
+					.WhichAreRecords();
+
+				await That(subject).AreRecords().And.IsNotEmpty();
+			}
+
+			[Fact]
+			public async Task ShouldUpdateDescription()
+			{
+				Filtered.Types subject = In.AssemblyContaining<WhichAreRecords>().Types()
+					.WhichAreRecords();
+
+				await That(subject.GetDescription()).Contains("types which are records in");
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreStructs.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreStructs.Tests.cs
@@ -1,0 +1,30 @@
+using aweXpect.Reflection.Collections;
+
+namespace aweXpect.Reflection.Tests.Filters;
+
+public sealed partial class TypeFilters
+{
+	public sealed class WhichAreStructs
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task ShouldFilterOnlyStructTypes()
+			{
+				Filtered.Types subject = In.AssemblyContaining<WhichAreStructs>().Types()
+					.WhichAreStructs();
+
+				await That(subject).AreStructs().And.IsNotEmpty();
+			}
+
+			[Fact]
+			public async Task ShouldUpdateDescription()
+			{
+				Filtered.Types subject = In.AssemblyContaining<WhichAreStructs>().Types()
+					.WhichAreStructs();
+
+				await That(subject.GetDescription()).Contains("types which are structs in");
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/TestHelpers/TypeExtensions.cs
+++ b/Tests/aweXpect.Reflection.Tests/TestHelpers/TypeExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Text;
 
 namespace aweXpect.Reflection.Tests.TestHelpers;
 
@@ -21,6 +22,17 @@ internal static class TypeExtensions
 				   BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly)?
 			   .GetMethod?.HasAttribute<CompilerGeneratedAttribute>() == true;
 
+	public static bool IsRecordStruct(this Type? type) =>
+		// As noted here: https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-10.0/record-structs#open-questions
+		// recognizing record structs from metadata is an open point. The following check is based on common sense
+		// and heuristic testing, apparently giving good results but not supported by official documentation.
+		type?.BaseType == typeof(ValueType) &&
+		type.GetMethod("PrintMembers", BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly, null,
+			[typeof(StringBuilder),], null) is not null &&
+		type.GetMethod("op_Equality", BindingFlags.Static | BindingFlags.Public | BindingFlags.DeclaredOnly, null,
+				[type, type,], null)?
+			.HasAttribute<CompilerGeneratedAttribute>() == true;
+	
 	public static bool HasAttribute<TAttribute>(
 		this MethodInfo methodInfo,
 		Func<TAttribute, bool>? predicate = null,

--- a/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/InternalGenericRecord.cs
+++ b/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/InternalGenericRecord.cs
@@ -1,0 +1,3 @@
+namespace aweXpect.Reflection.Tests.TestHelpers.Types;
+
+internal record InternalGenericRecord<T>;

--- a/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/InternalGenericRecordStruct.cs
+++ b/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/InternalGenericRecordStruct.cs
@@ -1,0 +1,3 @@
+namespace aweXpect.Reflection.Tests.TestHelpers.Types;
+
+internal record struct InternalGenericRecordStruct<T>;

--- a/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/InternalGenericStruct.cs
+++ b/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/InternalGenericStruct.cs
@@ -1,0 +1,3 @@
+namespace aweXpect.Reflection.Tests.TestHelpers.Types;
+
+internal struct InternalGenericStruct<T>;

--- a/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/ProtectedGenericRecord.cs
+++ b/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/ProtectedGenericRecord.cs
@@ -1,0 +1,6 @@
+namespace aweXpect.Reflection.Tests.TestHelpers.Types;
+
+public partial class Container
+{
+	protected record ProtectedGenericRecord<T>;
+}

--- a/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/ProtectedGenericRecordStruct.cs
+++ b/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/ProtectedGenericRecordStruct.cs
@@ -1,0 +1,6 @@
+namespace aweXpect.Reflection.Tests.TestHelpers.Types;
+
+public partial class Container
+{
+	protected record struct ProtectedGenericRecordStruct<T>;
+}

--- a/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/ProtectedGenericStruct.cs
+++ b/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/ProtectedGenericStruct.cs
@@ -1,0 +1,6 @@
+namespace aweXpect.Reflection.Tests.TestHelpers.Types;
+
+public partial class Container
+{
+	protected struct ProtectedGenericStruct<T>;
+}

--- a/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/PublicAbstractRecord.cs
+++ b/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/PublicAbstractRecord.cs
@@ -1,0 +1,3 @@
+namespace aweXpect.Reflection.Tests.TestHelpers.Types;
+
+public abstract record PublicAbstractRecord;

--- a/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/PublicGenericRecord.cs
+++ b/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/PublicGenericRecord.cs
@@ -1,0 +1,3 @@
+﻿namespace aweXpect.Reflection.Tests.TestHelpers.Types;
+
+public record PublicGenericRecord<T>;

--- a/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/PublicGenericRecordStruct.cs
+++ b/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/PublicGenericRecordStruct.cs
@@ -1,0 +1,3 @@
+﻿namespace aweXpect.Reflection.Tests.TestHelpers.Types;
+
+public record struct PublicGenericRecordStruct<T>;

--- a/Tests/aweXpect.Reflection.Tests/ThatType.IsARecord.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatType.IsARecord.Tests.cs
@@ -1,0 +1,76 @@
+﻿using aweXpect.Reflection.Tests.TestHelpers.Types;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatType
+{
+	public sealed class IsARecord
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenTypeIsARecord_ShouldSucceed()
+			{
+				Type subject = typeof(PublicRecord);
+
+				async Task Act()
+					=> await That(subject).IsARecord();
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
+			[MemberData(nameof(NonRecordType))]
+			public async Task WhenTypeIsNotARecord_ShouldFail(Type? subject, string name)
+			{
+				async Task Act()
+					=> await That(subject).IsARecord();
+
+				await That(Act).ThrowsException()
+					.WithMessage($"""
+					              Expected that subject
+					              is a record,
+					              but it was {name}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenTypeIsNull_ShouldFail()
+			{
+				Type? subject = null;
+
+				async Task Act()
+					=> await That(subject).IsARecord();
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             is a record,
+					             but it was <null>
+					             """);
+			}
+
+			public static TheoryData<Type?, string> NonRecordType() => new()
+			{
+				{
+					null, "<null>"
+				},
+				{
+					typeof(PublicClass), "class PublicClass"
+				},
+				{
+					typeof(IPublicInterface), "interface IPublicInterface"
+				},
+				{
+					typeof(PublicEnum), "enum PublicEnum"
+				},
+				{
+					typeof(PublicStruct), "struct PublicStruct"
+				},
+				{
+					typeof(PublicRecordStruct), "record struct PublicRecordStruct"
+				},
+			};
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatType.IsARecordStruct.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatType.IsARecordStruct.Tests.cs
@@ -1,0 +1,76 @@
+﻿using aweXpect.Reflection.Tests.TestHelpers.Types;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatType
+{
+	public sealed class IsARecordStruct
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenTypeIsARecordStruct_ShouldSucceed()
+			{
+				Type subject = typeof(PublicRecordStruct);
+
+				async Task Act()
+					=> await That(subject).IsARecordStruct();
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
+			[MemberData(nameof(NonRecordStructType))]
+			public async Task WhenTypeIsNotARecordStruct_ShouldFail(Type? subject, string name)
+			{
+				async Task Act()
+					=> await That(subject).IsARecordStruct();
+
+				await That(Act).ThrowsException()
+					.WithMessage($"""
+					              Expected that subject
+					              is a record struct,
+					              but it was {name}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenTypeIsNull_ShouldFail()
+			{
+				Type? subject = null;
+
+				async Task Act()
+					=> await That(subject).IsARecordStruct();
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             is a record struct,
+					             but it was <null>
+					             """);
+			}
+
+			public static TheoryData<Type?, string> NonRecordStructType() => new()
+			{
+				{
+					null, "<null>"
+				},
+				{
+					typeof(PublicClass), "class PublicClass"
+				},
+				{
+					typeof(IPublicInterface), "interface IPublicInterface"
+				},
+				{
+					typeof(PublicEnum), "enum PublicEnum"
+				},
+				{
+					typeof(PublicRecord), "record PublicRecord"
+				},
+				{
+					typeof(PublicStruct), "struct PublicStruct"
+				},
+			};
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatType.IsAStruct.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatType.IsAStruct.Tests.cs
@@ -1,0 +1,76 @@
+﻿using aweXpect.Reflection.Tests.TestHelpers.Types;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatType
+{
+	public sealed class IsAStruct
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenTypeIsAStruct_ShouldSucceed()
+			{
+				Type subject = typeof(PublicStruct);
+
+				async Task Act()
+					=> await That(subject).IsAStruct();
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
+			[MemberData(nameof(NonStructType))]
+			public async Task WhenTypeIsNotAStruct_ShouldFail(Type? subject, string name)
+			{
+				async Task Act()
+					=> await That(subject).IsAStruct();
+
+				await That(Act).ThrowsException()
+					.WithMessage($"""
+					              Expected that subject
+					              is a struct,
+					              but it was {name}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenTypeIsNull_ShouldFail()
+			{
+				Type? subject = null;
+
+				async Task Act()
+					=> await That(subject).IsAStruct();
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             is a struct,
+					             but it was <null>
+					             """);
+			}
+
+			public static TheoryData<Type?, string> NonStructType() => new()
+			{
+				{
+					null, "<null>"
+				},
+				{
+					typeof(PublicClass), "class PublicClass"
+				},
+				{
+					typeof(IPublicInterface), "interface IPublicInterface"
+				},
+				{
+					typeof(PublicEnum), "enum PublicEnum"
+				},
+				{
+					typeof(PublicRecord), "record PublicRecord"
+				},
+				{
+					typeof(PublicRecordStruct), "record struct PublicRecordStruct"
+				},
+			};
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatType.IsNotARecord.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatType.IsNotARecord.Tests.cs
@@ -1,0 +1,64 @@
+﻿using aweXpect.Reflection.Tests.TestHelpers.Types;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatType
+{
+	public sealed class IsNotARecord
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenTypeIsARecord_ShouldFail()
+			{
+				Type subject = typeof(PublicRecord);
+
+				async Task Act()
+					=> await That(subject).IsNotARecord();
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             is not a record,
+					             but it was record PublicRecord
+					             """);
+			}
+
+			[Theory]
+			[MemberData(nameof(NonRecordTypes))]
+			public async Task WhenTypeIsNotARecord_ShouldSucceed(Type subject)
+			{
+				async Task Act()
+					=> await That(subject).IsNotARecord();
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenTypeIsNull_ShouldFail()
+			{
+				Type? subject = null;
+
+				async Task Act()
+					=> await That(subject).IsNotARecord();
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             is not a record,
+					             but it was <null>
+					             """);
+			}
+
+			public static TheoryData<Type> NonRecordTypes()
+				=>
+				[
+					typeof(IPublicInterface),
+					typeof(PublicEnum),
+					typeof(PublicClass),
+					typeof(PublicStruct),
+					typeof(PublicRecordStruct),
+				];
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatType.IsNotARecordStruct.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatType.IsNotARecordStruct.Tests.cs
@@ -1,0 +1,64 @@
+﻿using aweXpect.Reflection.Tests.TestHelpers.Types;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatType
+{
+	public sealed class IsNotARecordStruct
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenTypeIsARecordStruct_ShouldFail()
+			{
+				Type subject = typeof(PublicRecordStruct);
+
+				async Task Act()
+					=> await That(subject).IsNotARecordStruct();
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             is not a record struct,
+					             but it was record struct PublicRecordStruct
+					             """);
+			}
+
+			[Theory]
+			[MemberData(nameof(NonRecordStructTypes))]
+			public async Task WhenTypeIsNotARecordStruct_ShouldSucceed(Type subject)
+			{
+				async Task Act()
+					=> await That(subject).IsNotARecordStruct();
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenTypeIsNull_ShouldFail()
+			{
+				Type? subject = null;
+
+				async Task Act()
+					=> await That(subject).IsNotARecordStruct();
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             is not a record struct,
+					             but it was <null>
+					             """);
+			}
+
+			public static TheoryData<Type> NonRecordStructTypes()
+				=>
+				[
+					typeof(IPublicInterface),
+					typeof(PublicEnum),
+					typeof(PublicClass),
+					typeof(PublicRecord),
+					typeof(PublicStruct),
+				];
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatType.IsNotAStruct.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatType.IsNotAStruct.Tests.cs
@@ -1,0 +1,64 @@
+﻿using aweXpect.Reflection.Tests.TestHelpers.Types;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatType
+{
+	public sealed class IsNotAStruct
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenTypeIsAStruct_ShouldFail()
+			{
+				Type subject = typeof(PublicStruct);
+
+				async Task Act()
+					=> await That(subject).IsNotAStruct();
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             is not a struct,
+					             but it was struct PublicStruct
+					             """);
+			}
+
+			[Theory]
+			[MemberData(nameof(NonStructTypes))]
+			public async Task WhenTypeIsNotAStruct_ShouldSucceed(Type subject)
+			{
+				async Task Act()
+					=> await That(subject).IsNotAStruct();
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenTypeIsNull_ShouldFail()
+			{
+				Type? subject = null;
+
+				async Task Act()
+					=> await That(subject).IsNotAStruct();
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             is not a struct,
+					             but it was <null>
+					             """);
+			}
+
+			public static TheoryData<Type> NonStructTypes()
+				=>
+				[
+					typeof(IPublicInterface),
+					typeof(PublicEnum),
+					typeof(PublicClass),
+					typeof(PublicRecord),
+					typeof(PublicRecordStruct),
+				];
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.AreNotClasses.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.AreNotClasses.Tests.cs
@@ -1,4 +1,5 @@
 ﻿using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Tests.TestHelpers;
 
 namespace aweXpect.Reflection.Tests;
 
@@ -23,14 +24,14 @@ public sealed partial class ThatTypes
 			public async Task WhenFilteringOnlyClasses_ShouldFail()
 			{
 				Filtered.Types subject = In.AssemblyContaining<AreNotClasses>().Types()
-					.WhichSatisfy(type => type.IsClass);
+					.WhichSatisfy(type => type.IsClass && !type.IsRecordClass());
 
 				async Task Act()
 					=> await That(subject).AreNotClasses();
 
 				await That(Act).ThrowsException()
 					.WithMessage("""
-					             Expected that types matching type => type.IsClass in assembly containing type ThatTypes.AreNotClasses
+					             Expected that types matching type => type.IsClass && !type.IsRecordClass() in assembly containing type ThatTypes.AreNotClasses
 					             are all not classes,
 					             but it contained classes [
 					               *

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.AreNotRecordStructs.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.AreNotRecordStructs.Tests.cs
@@ -1,0 +1,43 @@
+﻿using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Tests.TestHelpers;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatTypes
+{
+	public sealed class AreNotRecordStructs
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenAssembliesContainOnlyInterfaceTypes_ShouldSucceed()
+			{
+				Filtered.Types subject = In.AssemblyContaining<AreNotRecordStructs>().Interfaces();
+
+				async Task Act()
+					=> await That(subject).AreNotRecordStructs();
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenFilteringOnlyRecordStructs_ShouldFail()
+			{
+				Filtered.Types subject = In.AssemblyContaining<AreNotRecordStructs>().Types()
+					.WhichSatisfy(type => type.IsRecordStruct());
+
+				async Task Act()
+					=> await That(subject).AreNotRecordStructs();
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that types matching type => type.IsRecordStruct() in assembly containing type ThatTypes.AreNotRecordStructs
+					             are all not record structs,
+					             but it contained record structs [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.AreNotRecords.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.AreNotRecords.Tests.cs
@@ -1,0 +1,43 @@
+﻿using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Tests.TestHelpers;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatTypes
+{
+	public sealed class AreNotRecords
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenAssembliesContainOnlyInterfaceTypes_ShouldSucceed()
+			{
+				Filtered.Types subject = In.AssemblyContaining<AreNotRecords>().Interfaces();
+
+				async Task Act()
+					=> await That(subject).AreNotRecords();
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenFilteringOnlyRecords_ShouldFail()
+			{
+				Filtered.Types subject = In.AssemblyContaining<AreNotRecords>().Types()
+					.WhichSatisfy(type => type.IsRecordClass());
+
+				async Task Act()
+					=> await That(subject).AreNotRecords();
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that types matching type => type.IsRecordClass() in assembly containing type ThatTypes.AreNotRecords
+					             are all not records,
+					             but it contained records [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.AreNotStructs.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.AreNotStructs.Tests.cs
@@ -1,0 +1,43 @@
+﻿using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Tests.TestHelpers;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatTypes
+{
+	public sealed class AreNotStructs
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenAssembliesContainOnlyInterfaceTypes_ShouldSucceed()
+			{
+				Filtered.Types subject = In.AssemblyContaining<AreNotStructs>().Interfaces();
+
+				async Task Act()
+					=> await That(subject).AreNotStructs();
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenFilteringOnlyStructs_ShouldFail()
+			{
+				Filtered.Types subject = In.AssemblyContaining<AreNotStructs>().Types()
+					.WhichSatisfy(type => type.IsValueType && !type.IsRecordStruct() && !type.IsEnum);
+
+				async Task Act()
+					=> await That(subject).AreNotStructs();
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that types matching type => type.IsValueType && !type.IsRecordStruct() && !type.IsEnum in assembly containing type ThatTypes.AreNotStructs
+					             are all not structs,
+					             but it contained structs [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.AreRecordStructs.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.AreRecordStructs.Tests.cs
@@ -1,0 +1,43 @@
+﻿using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Tests.TestHelpers;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatTypes
+{
+	public sealed class AreRecordStructs
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenAssembliesContainNonRecordStructTypes_ShouldFail()
+			{
+				Filtered.Types subject = In.AssemblyContaining<AreRecordStructs>().Types();
+
+				async Task Act()
+					=> await That(subject).AreRecordStructs();
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that types in assembly containing type ThatTypes.AreRecordStructs
+					             are all record structs,
+					             but it contained other types [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenFilteringOnlyRecordStructs_ShouldSucceed()
+			{
+				Filtered.Types subject = In.AssemblyContaining<AreRecordStructs>().Types()
+					.WhichSatisfy(type => type.IsRecordStruct());
+
+				async Task Act()
+					=> await That(subject).AreRecordStructs();
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.AreRecords.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.AreRecords.Tests.cs
@@ -1,0 +1,43 @@
+﻿using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Tests.TestHelpers;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatTypes
+{
+	public sealed class AreRecords
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenAssembliesContainNonRecordTypes_ShouldFail()
+			{
+				Filtered.Types subject = In.AssemblyContaining<AreRecords>().Types();
+
+				async Task Act()
+					=> await That(subject).AreRecords();
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that types in assembly containing type ThatTypes.AreRecords
+					             are all records,
+					             but it contained other types [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenFilteringOnlyRecords_ShouldSucceed()
+			{
+				Filtered.Types subject = In.AssemblyContaining<AreRecords>().Types()
+					.WhichSatisfy(type => type.IsRecordClass());
+
+				async Task Act()
+					=> await That(subject).AreRecords();
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.AreStructs.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.AreStructs.Tests.cs
@@ -1,0 +1,43 @@
+﻿using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Tests.TestHelpers;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatTypes
+{
+	public sealed class AreStructs
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenAssembliesContainNonStructTypes_ShouldFail()
+			{
+				Filtered.Types subject = In.AssemblyContaining<AreStructs>().Types();
+
+				async Task Act()
+					=> await That(subject).AreStructs();
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that types in assembly containing type ThatTypes.AreStructs
+					             are all structs,
+					             but it contained other types [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenFilteringOnlyStructs_ShouldSucceed()
+			{
+				Filtered.Types subject = In.AssemblyContaining<AreStructs>().Types()
+					.WhichSatisfy(type => type.IsValueType && !type.IsRecordStruct() && !type.IsEnum);
+
+				async Task Act()
+					=> await That(subject).AreStructs();
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}


### PR DESCRIPTION
This PR adds comprehensive support for structs, records and record structs in the aweXpect.Reflection testing framework. It introduces new assertions for verifying single types and collections of types, along with filters for narrowing down type collections based on these categories.

- Adds assertion methods for individual types (`IsAStruct`, `IsARecord`, `IsARecordStruct` and their negations)
- Adds collection assertions for verifying all types in a collection are/aren't structs, records, or record structs
- Introduces type filters to narrow collections to specific type categories