### PR TITLE
feat: add constructor formatting

### DIFF
--- a/Source/aweXpect.Reflection/Formatting/ConstructorFormatter.cs
+++ b/Source/aweXpect.Reflection/Formatting/ConstructorFormatter.cs
@@ -1,0 +1,38 @@
+﻿using System.Reflection;
+using System.Text;
+
+namespace aweXpect.Reflection.Formatting;
+
+internal class ConstructorFormatter : IValueFormatter
+{
+	public bool TryFormat(StringBuilder stringBuilder, object value, FormattingOptions? options)
+	{
+		if (value is ConstructorInfo constructor)
+		{
+			Formatter.Format(stringBuilder, constructor.DeclaringType);
+			stringBuilder.Append('(');
+			int index = 0;
+			foreach (ParameterInfo? parameter in constructor.GetParameters())
+			{
+				if (index++ > 0)
+				{
+					stringBuilder.Append(", ");
+				}
+
+				Formatter.Format(stringBuilder, parameter.ParameterType);
+				stringBuilder.Append(' ');
+				stringBuilder.Append(parameter.Name);
+				if (parameter.HasDefaultValue)
+				{
+					stringBuilder.Append(" = ");
+					Formatter.Format(stringBuilder, parameter.DefaultValue);
+				}
+			}
+
+			stringBuilder.Append(')');
+			return true;
+		}
+
+		return false;
+	}
+}

--- a/Source/aweXpect.Reflection/Formatting/FormatterRegistration.cs
+++ b/Source/aweXpect.Reflection/Formatting/FormatterRegistration.cs
@@ -12,7 +12,7 @@ internal class FormatterRegistration : IAweXpectInitializer, IDisposable
 	{
 		if (_instance != null)
 		{
-			throw new InvalidOperationException("You have to first dispose the static instance");
+			throw new InvalidOperationException("A FormatterRegistration instance is already initialized. Dispose the existing instance before creating a new one.");
 		}
 
 		_instance = this;

--- a/Source/aweXpect.Reflection/Formatting/FormatterRegistration.cs
+++ b/Source/aweXpect.Reflection/Formatting/FormatterRegistration.cs
@@ -3,7 +3,7 @@ using aweXpect.Core.Initialization;
 
 namespace aweXpect.Reflection.Formatting;
 
-internal class FormatterRegistration : IAweXpectInitializer, IDisposable
+internal sealed class FormatterRegistration : IAweXpectInitializer, IDisposable
 {
 	private static FormatterRegistration? _instance;
 	private IDisposable[] _disposables = [];
@@ -12,10 +12,13 @@ internal class FormatterRegistration : IAweXpectInitializer, IDisposable
 	{
 		if (_instance != null)
 		{
-			throw new InvalidOperationException("A FormatterRegistration instance is already initialized. Dispose the existing instance before creating a new one.");
+			throw new InvalidOperationException(
+				"A FormatterRegistration instance is already initialized. Dispose the existing instance before creating a new one.");
 		}
 
+#pragma warning disable S3010
 		_instance = this;
+#pragma warning restore S3010
 	}
 
 	internal static FormatterRegistration Instance
@@ -23,7 +26,7 @@ internal class FormatterRegistration : IAweXpectInitializer, IDisposable
 
 	public void Initialize() => _disposables =
 	[
-		ValueFormatter.Register(new ConstructorFormatter()),
+		ValueFormatter.Register(new ConstructorFormatter())
 	];
 
 	public void Dispose()
@@ -33,6 +36,8 @@ internal class FormatterRegistration : IAweXpectInitializer, IDisposable
 			disposable.Dispose();
 		}
 
+#pragma warning disable S2696
 		_instance = null;
+#pragma warning restore S2696
 	}
 }

--- a/Source/aweXpect.Reflection/Formatting/FormatterRegistration.cs
+++ b/Source/aweXpect.Reflection/Formatting/FormatterRegistration.cs
@@ -1,0 +1,38 @@
+using System;
+using aweXpect.Core.Initialization;
+
+namespace aweXpect.Reflection.Formatting;
+
+internal class FormatterRegistration : IAweXpectInitializer, IDisposable
+{
+	private static FormatterRegistration? _instance;
+	private IDisposable[] _disposables = [];
+
+	public FormatterRegistration()
+	{
+		if (_instance != null)
+		{
+			throw new InvalidOperationException("You have to first dispose the static instance");
+		}
+
+		_instance = this;
+	}
+
+	internal static FormatterRegistration Instance
+		=> _instance ??= new FormatterRegistration();
+
+	public void Initialize() => _disposables =
+	[
+		ValueFormatter.Register(new ConstructorFormatter()),
+	];
+
+	public void Dispose()
+	{
+		foreach (IDisposable? disposable in _disposables)
+		{
+			disposable.Dispose();
+		}
+
+		_instance = null;
+	}
+}

--- a/Tests/aweXpect.Reflection.Internal.Tests/Formatting/ConstructorFormatterTests.cs
+++ b/Tests/aweXpect.Reflection.Internal.Tests/Formatting/ConstructorFormatterTests.cs
@@ -1,0 +1,75 @@
+﻿using System.Reflection;
+using aweXpect.Reflection.Formatting;
+using aweXpect.Reflection.Internal.Tests.TestHelpers;
+
+namespace aweXpect.Reflection.Internal.Tests.Formatting;
+
+public class ConstructorFormatterTests
+{
+	[Fact]
+	public async Task WithOneParameter_ShouldFormatCorrectly()
+	{
+		ConstructorInfo? constructorInfo = typeof(MyTestClass).GetConstructor([typeof(int),]);
+		ConstructorFormatter formatter = new();
+
+		string result = formatter.GetString(constructorInfo);
+
+		await That(result).IsEqualTo("ConstructorFormatterTests.MyTestClass(int parameter1)");
+	}
+
+	[Fact]
+	public async Task WithoutParameters_ShouldFormatCorrectly()
+	{
+		ConstructorInfo? constructorInfo = typeof(MyTestClass).GetConstructor(Type.EmptyTypes);
+		ConstructorFormatter formatter = new();
+
+		string result = formatter.GetString(constructorInfo);
+
+		await That(result).IsEqualTo("ConstructorFormatterTests.MyTestClass()");
+	}
+
+	[Fact]
+	public async Task WithParametersWithDefaultValues_ShouldFormatCorrectly()
+	{
+		ConstructorInfo? constructorInfo = typeof(MyTestClass).GetConstructor([typeof(string), typeof(int),]);
+		ConstructorFormatter formatter = new();
+
+		string result = formatter.GetString(constructorInfo);
+
+		await That(result).IsEqualTo("ConstructorFormatterTests.MyTestClass(string p1 = \"foo\", int p2 = 42)");
+	}
+
+	[Fact]
+	public async Task WithTwoParameters_ShouldFormatCorrectly()
+	{
+		ConstructorInfo? constructorInfo = typeof(MyTestClass).GetConstructor([typeof(int), typeof(string),]);
+		ConstructorFormatter formatter = new();
+
+		string result = formatter.GetString(constructorInfo);
+
+		await That(result).IsEqualTo("ConstructorFormatterTests.MyTestClass(int parameter1, string parameter2)");
+	}
+
+	// ReSharper disable UnusedMember.Local
+	// ReSharper disable UnusedParameter.Local
+	private class MyTestClass
+	{
+		public MyTestClass()
+		{
+		}
+
+		public MyTestClass(int parameter1)
+		{
+		}
+
+		public MyTestClass(int parameter1, string parameter2)
+		{
+		}
+
+		public MyTestClass(string p1 = "foo", int p2 = 42)
+		{
+		}
+	}
+	// ReSharper restore UnusedParameter.Local
+	// ReSharper restore UnusedMember.Local
+}

--- a/Tests/aweXpect.Reflection.Internal.Tests/Formatting/FormatterRegistrationTests.cs
+++ b/Tests/aweXpect.Reflection.Internal.Tests/Formatting/FormatterRegistrationTests.cs
@@ -1,0 +1,35 @@
+﻿using System.Linq;
+using System.Reflection;
+using aweXpect.Formatting;
+using aweXpect.Reflection.Formatting;
+
+namespace aweXpect.Reflection.Internal.Tests.Formatting;
+
+public class FormatterRegistrationTests
+{
+	[Fact]
+	public async Task Constructor_WhenNotDisposed_ShouldThrowInvalidOperationException()
+	{
+		void Act() => _ = new FormatterRegistration();
+
+		await That(Act).Throws<InvalidOperationException>()
+			.WithMessage("A FormatterRegistration instance is already initialized. Dispose the existing instance before creating a new one.");
+	}
+
+	[Fact]
+	public async Task Initialize_ShouldRegisterFormatterForConstructorInfo()
+	{
+		ConstructorInfo constructorInfo = typeof(FormatterRegistrationTests).GetConstructors().First();
+		await That(true).IsTrue();
+		string result1 = Format.Formatter.Format(constructorInfo);
+
+		FormatterRegistration.Instance.Dispose();
+		string result2 = Format.Formatter.Format(constructorInfo);
+		FormatterRegistration.Instance.Initialize();
+
+		string result3 = Format.Formatter.Format(constructorInfo);
+
+		await That(result1).IsEqualTo(result3);
+		await That(result2).IsNotEqualTo(result3);
+	}
+}

--- a/Tests/aweXpect.Reflection.Internal.Tests/TestHelpers/ValueFormatterHelper.cs
+++ b/Tests/aweXpect.Reflection.Internal.Tests/TestHelpers/ValueFormatterHelper.cs
@@ -1,0 +1,18 @@
+using System.Text;
+using aweXpect.Formatting;
+
+namespace aweXpect.Reflection.Internal.Tests.TestHelpers;
+
+internal static class ValueFormatterHelpers
+{
+	public static string GetString<T>(this IValueFormatter formatter, T value, FormattingOptions? options = null)
+	{
+		StringBuilder sb = new();
+		if (!formatter.TryFormat(sb, value!, options))
+		{
+			throw new NotSupportedException($"Formatter doesn't support formatting of type {typeof(T)}");
+		}
+
+		return sb.ToString();
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatConstructor.Has.AttributeTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatConstructor.Has.AttributeTests.cs
@@ -21,7 +21,7 @@ public sealed partial class ThatConstructor
 					.WithMessage("""
 					             Expected that subject
 					             has ThatConstructor.Has.AttributeTests.TestAttribute,
-					             but it did not in Void .ctor()
+					             but it did not in ThatConstructor.Has.AttributeTests.TestClass()
 					             """);
 			}
 
@@ -59,7 +59,7 @@ public sealed partial class ThatConstructor
 					.WithMessage("""
 					             Expected that subject
 					             has ThatConstructor.Has.AttributeTests.TestAttribute matching attr => attr.Value == "WrongValue",
-					             but it did not in Void .ctor(System.String)
+					             but it did not in ThatConstructor.Has.AttributeTests.TestClass(string value)
 					             """);
 			}
 
@@ -159,7 +159,7 @@ public sealed partial class ThatConstructor
 						.WithMessage("""
 						             Expected that subject
 						             has ThatConstructor.Has.OrHas.AttributeTests.FooAttribute or ThatConstructor.Has.OrHas.AttributeTests.BarAttribute,
-						             but it did not in Void .ctor()
+						             but it did not in ThatConstructor.Has.OrHas.AttributeTests.TestClass()
 						             """);
 				}
 
@@ -187,7 +187,7 @@ public sealed partial class ThatConstructor
 						.WithMessage("""
 						             Expected that subject
 						             has ThatConstructor.Has.OrHas.AttributeTests.FooAttribute matching foo => foo.Value == 42 or ThatConstructor.Has.OrHas.AttributeTests.BarAttribute matching bar => bar.Name == "does-not-match",
-						             but it did not in Void .ctor(Int32, System.String)
+						             but it did not in ThatConstructor.Has.OrHas.AttributeTests.TestClass(int value, string name)
 						             """);
 				}
 
@@ -261,7 +261,7 @@ public sealed partial class ThatConstructor
 					.WithMessage("""
 					             Expected that subject
 					             has no ThatConstructor.Has.NegatedTests.TestAttribute,
-					             but it did in Void .ctor(System.String)
+					             but it did in ThatConstructor.Has.NegatedTests.TestClass(string value)
 					             """);
 			}
 

--- a/Tests/aweXpect.Reflection.Tests/ThatConstructors.Have.AttributeTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatConstructors.Have.AttributeTests.cs
@@ -57,7 +57,7 @@ public sealed partial class ThatConstructors
 					             Expected that subject
 					             all have ThatConstructors.Have.AttributeTests.TestAttribute,
 					             but it contained not matching constructors [
-					               Void .ctor()
+					               ThatConstructors.Have.AttributeTests.TestClass()
 					             ]
 					             """);
 			}
@@ -79,8 +79,8 @@ public sealed partial class ThatConstructors
 					             Expected that subject
 					             all have ThatConstructors.Have.AttributeTests.TestAttribute matching attr => attr.Value == "WrongValue",
 					             but it contained not matching constructors [
-					               Void .ctor(System.String),
-					               Void .ctor(Int32)
+					               ThatConstructors.Have.AttributeTests.TestClass(string value),
+					               ThatConstructors.Have.AttributeTests.TestClass(int value)
 					             ]
 					             """);
 			}
@@ -186,7 +186,7 @@ public sealed partial class ThatConstructors
 						             Expected that subject
 						             all have ThatConstructors.Have.OrHave.AttributeTests.TestAttribute or ThatConstructors.Have.OrHave.AttributeTests.BarAttribute,
 						             but it contained not matching constructors [
-						               Void .ctor()
+						               ThatConstructors.Have.OrHave.AttributeTests.TestClass()
 						             ]
 						             """);
 				}
@@ -278,8 +278,8 @@ public sealed partial class ThatConstructors
 					             Expected that subject
 					             not all have ThatConstructors.Have.NegatedTests.TestAttribute,
 					             but it only contained matching constructors [
-					               Void .ctor(System.String),
-					               Void .ctor(Int32)
+					               ThatConstructors.Have.NegatedTests.TestClass(string value),
+					               ThatConstructors.Have.NegatedTests.TestClass(int value)
 					             ]
 					             """);
 			}


### PR DESCRIPTION
This PR adds constructor formatting functionality to the aweXpect.Reflection library, improving the readability of constructor representations in test error messages and assertions.

- Implements a new `ConstructorFormatter` class that formats constructor information with type names, parameters, and default values
- Replaces the default .NET constructor format (`Void .ctor(...)`) with a more readable format (`TypeName(parameters)`)
- Adds comprehensive test coverage for the new formatting functionality

---

- *Implements part of #136*