### PR TITLE
feat: add property formatting

### DIFF
--- a/Source/aweXpect.Reflection/Formatting/FormatterRegistration.cs
+++ b/Source/aweXpect.Reflection/Formatting/FormatterRegistration.cs
@@ -26,7 +26,8 @@ internal sealed class FormatterRegistration : IAweXpectInitializer, IDisposable
 
 	public void Initialize() => _disposables =
 	[
-		ValueFormatter.Register(new ConstructorFormatter())
+		ValueFormatter.Register(new ConstructorFormatter()),
+		ValueFormatter.Register(new PropertyFormatter()),
 	];
 
 	public void Dispose()

--- a/Source/aweXpect.Reflection/Formatting/PropertyFormatter.cs
+++ b/Source/aweXpect.Reflection/Formatting/PropertyFormatter.cs
@@ -1,0 +1,48 @@
+﻿using System.Reflection;
+using System.Text;
+using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Helpers;
+
+namespace aweXpect.Reflection.Formatting;
+
+internal class PropertyFormatter : IValueFormatter
+{
+	public bool TryFormat(StringBuilder stringBuilder, object value, FormattingOptions? options)
+	{
+		if (value is PropertyInfo property)
+		{
+			var propertyAccess = property.GetAccessModifier();
+			stringBuilder.Append(propertyAccess.GetString(" "));
+			Formatter.Format(stringBuilder, property.PropertyType);
+			stringBuilder.Append(' ');
+			Formatter.Format(stringBuilder, property.DeclaringType);
+			stringBuilder.Append('.');
+			stringBuilder.Append(property.Name);
+			stringBuilder.Append(" { ");
+			if (property.CanRead)
+			{
+				var getAccess = property.GetMethod.GetAccessModifier();
+				if (propertyAccess != getAccess)
+				{
+					stringBuilder.Append(getAccess.GetString(" "));
+				}
+				stringBuilder.Append("get; ");
+			}
+
+			if (property.CanWrite)
+			{
+				var setAccess = property.SetMethod.GetAccessModifier();
+				if (propertyAccess != setAccess)
+				{
+					stringBuilder.Append(setAccess.GetString(" "));
+				}
+				stringBuilder.Append("set; ");
+			}
+
+			stringBuilder.Append('}');
+			return true;
+		}
+
+		return false;
+	}
+}

--- a/Source/aweXpect.Reflection/Helpers/MemberInfoHelpers.cs
+++ b/Source/aweXpect.Reflection/Helpers/MemberInfoHelpers.cs
@@ -37,9 +37,9 @@ internal static class MemberInfoHelpers
 			return AccessModifiers.Public;
 		}
 
-		if (memberInfo.HasAccessModifier(AccessModifiers.Private))
+		if (memberInfo.HasAccessModifier(AccessModifiers.ProtectedInternal))
 		{
-			return AccessModifiers.Private;
+			return AccessModifiers.ProtectedInternal;
 		}
 
 		if (memberInfo.HasAccessModifier(AccessModifiers.Protected))
@@ -56,10 +56,10 @@ internal static class MemberInfoHelpers
 		{
 			return AccessModifiers.PrivateProtected;
 		}
-
-		if (memberInfo.HasAccessModifier(AccessModifiers.ProtectedInternal))
+		
+		if (memberInfo.HasAccessModifier(AccessModifiers.Private))
 		{
-			return AccessModifiers.ProtectedInternal;
+			return AccessModifiers.Private;
 		}
 
 		return AccessModifiers.Any;

--- a/Source/aweXpect.Reflection/Helpers/PropertyInfoHelpers.cs
+++ b/Source/aweXpect.Reflection/Helpers/PropertyInfoHelpers.cs
@@ -28,7 +28,7 @@ internal static class PropertyInfoHelpers
 			return false;
 		}
 
-		return propertyInfo.GetMethod.HasAccessModifier(accessModifiers) &&
+		return propertyInfo.GetMethod.HasAccessModifier(accessModifiers) ||
 		       propertyInfo.SetMethod.HasAccessModifier(accessModifiers);
 	}
 

--- a/Tests/aweXpect.Reflection.Internal.Tests/Formatting/PropertyFormatterTests.cs
+++ b/Tests/aweXpect.Reflection.Internal.Tests/Formatting/PropertyFormatterTests.cs
@@ -26,7 +26,8 @@ public class PropertyFormatterTests
 
 		string result = formatter.GetString(propertyInfo);
 
-		await That(result).IsEqualTo("internal string PropertyFormatterTests.MyTestClass.PropertyWithOnlyGetter { get; }");
+		await That(result)
+			.IsEqualTo("internal string PropertyFormatterTests.MyTestClass.PropertyWithOnlyGetter { get; }");
 	}
 
 	[Fact]
@@ -75,13 +76,16 @@ public class PropertyFormatterTests
 		return new TheoryData<PropertyInfo?, string>
 		{
 			{
-				GetProperty("MyProperty"), "public int PropertyFormatterTests.MyTestClass.MyProperty { get; private set; }"
+				GetProperty("MyProperty"),
+				"public int PropertyFormatterTests.MyTestClass.MyProperty { get; private set; }"
 			},
 			{
-				GetProperty("InternalProperty"), "internal int PropertyFormatterTests.MyTestClass.InternalProperty { get; private set; }"
+				GetProperty("InternalProperty"),
+				"internal int PropertyFormatterTests.MyTestClass.InternalProperty { get; private set; }"
 			},
 			{
-				GetProperty("ProtectedProperty"), "protected int PropertyFormatterTests.MyTestClass.ProtectedProperty { get; private protected set; }"
+				GetProperty("ProtectedProperty"),
+				"protected int PropertyFormatterTests.MyTestClass.ProtectedProperty { get; private protected set; }"
 			},
 			{
 				GetProperty("ProtectedInternalProperty"),
@@ -92,11 +96,13 @@ public class PropertyFormatterTests
 				"private protected int PropertyFormatterTests.MyTestClass.PrivateProtectedProperty { get; private set; }"
 			},
 			{
-				GetProperty("PrivateProperty"), "private int PropertyFormatterTests.MyTestClass.PrivateProperty { get; set; }"
+				GetProperty("PrivateProperty"),
+				"private int PropertyFormatterTests.MyTestClass.PrivateProperty { get; set; }"
 			}
 		};
 	}
 
+	// ReSharper disable UnusedMember.Local
 	private class MyTestClass
 	{
 		public int MyProperty { get; private set; }
@@ -105,7 +111,10 @@ public class PropertyFormatterTests
 		protected internal int ProtectedInternalProperty { get; internal set; }
 		private protected int PrivateProtectedProperty { get; private set; }
 		private int PrivateProperty { get; set; }
-		internal string PropertyWithOnlyGetter { get; }
+		// ReSharper disable once UnassignedGetOnlyAutoProperty
+#pragma warning disable CS8618
+		internal string? PropertyWithOnlyGetter { get; }
+#pragma warning restore CS8618
 
 		public int PropertyWithOnlySetter
 		{
@@ -116,4 +125,5 @@ public class PropertyFormatterTests
 
 		public int PropertyWithPrivateGetter { private get; set; }
 	}
+	// ReSharper restore UnusedMember.Local
 }

--- a/Tests/aweXpect.Reflection.Internal.Tests/Formatting/PropertyFormatterTests.cs
+++ b/Tests/aweXpect.Reflection.Internal.Tests/Formatting/PropertyFormatterTests.cs
@@ -1,0 +1,119 @@
+﻿using System.Reflection;
+using aweXpect.Reflection.Formatting;
+using aweXpect.Reflection.Internal.Tests.TestHelpers;
+
+namespace aweXpect.Reflection.Internal.Tests.Formatting;
+
+public class PropertyFormatterTests
+{
+	[Theory]
+	[MemberData(nameof(GetTestCases))]
+	public async Task ShouldFormatCorrectly(PropertyInfo? propertyInfo, string expectedResult)
+	{
+		PropertyFormatter formatter = new();
+
+		string result = formatter.GetString(propertyInfo);
+
+		await That(result).IsEqualTo(expectedResult);
+	}
+
+	[Fact]
+	public async Task WithOnlyGetter_ShouldFormatCorrectly()
+	{
+		PropertyInfo? propertyInfo = typeof(MyTestClass).GetProperty(nameof(MyTestClass.PropertyWithOnlyGetter),
+			BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+		PropertyFormatter formatter = new();
+
+		string result = formatter.GetString(propertyInfo);
+
+		await That(result).IsEqualTo("internal string PropertyFormatterTests.MyTestClass.PropertyWithOnlyGetter { get; }");
+	}
+
+	[Fact]
+	public async Task WithOnlySetter_ShouldFormatCorrectly()
+	{
+		PropertyInfo? propertyInfo = typeof(MyTestClass).GetProperty(nameof(MyTestClass.PropertyWithOnlySetter),
+			BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+		PropertyFormatter formatter = new();
+
+		string result = formatter.GetString(propertyInfo);
+
+		await That(result).IsEqualTo("public int PropertyFormatterTests.MyTestClass.PropertyWithOnlySetter { set; }");
+	}
+
+	[Fact]
+	public async Task WithPrivateGetter_ShouldFormatCorrectly()
+	{
+		PropertyInfo? propertyInfo = typeof(MyTestClass).GetProperty(nameof(MyTestClass.PropertyWithPrivateGetter),
+			BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+		PropertyFormatter formatter = new();
+
+		string result = formatter.GetString(propertyInfo);
+
+		await That(result)
+			.IsEqualTo("public int PropertyFormatterTests.MyTestClass.PropertyWithPrivateGetter { private get; set; }");
+	}
+
+	[Fact]
+	public async Task WithPrivateSetter_ShouldFormatCorrectly()
+	{
+		PropertyInfo? propertyInfo = typeof(MyTestClass).GetProperty(nameof(MyTestClass.PropertyWithPrivateSetter),
+			BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+		PropertyFormatter formatter = new();
+
+		string result = formatter.GetString(propertyInfo);
+
+		await That(result)
+			.IsEqualTo("public int PropertyFormatterTests.MyTestClass.PropertyWithPrivateSetter { get; private set; }");
+	}
+
+	public static TheoryData<PropertyInfo?, string> GetTestCases()
+	{
+		static PropertyInfo? GetProperty(string name) => typeof(MyTestClass).GetProperty(name,
+			BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+
+		return new TheoryData<PropertyInfo?, string>
+		{
+			{
+				GetProperty("MyProperty"), "public int PropertyFormatterTests.MyTestClass.MyProperty { get; private set; }"
+			},
+			{
+				GetProperty("InternalProperty"), "internal int PropertyFormatterTests.MyTestClass.InternalProperty { get; private set; }"
+			},
+			{
+				GetProperty("ProtectedProperty"), "protected int PropertyFormatterTests.MyTestClass.ProtectedProperty { get; private protected set; }"
+			},
+			{
+				GetProperty("ProtectedInternalProperty"),
+				"protected internal int PropertyFormatterTests.MyTestClass.ProtectedInternalProperty { get; internal set; }"
+			},
+			{
+				GetProperty("PrivateProtectedProperty"),
+				"private protected int PropertyFormatterTests.MyTestClass.PrivateProtectedProperty { get; private set; }"
+			},
+			{
+				GetProperty("PrivateProperty"), "private int PropertyFormatterTests.MyTestClass.PrivateProperty { get; set; }"
+			}
+		};
+	}
+
+	private class MyTestClass
+	{
+		public int MyProperty { get; private set; }
+		internal int InternalProperty { get; private set; }
+		protected int ProtectedProperty { get; private protected set; }
+		protected internal int ProtectedInternalProperty { get; internal set; }
+		private protected int PrivateProtectedProperty { get; private set; }
+		private int PrivateProperty { get; set; }
+		internal string PropertyWithOnlyGetter { get; }
+
+		public int PropertyWithOnlySetter
+		{
+			set => PropertyWithPrivateSetter = value;
+		}
+
+		public int PropertyWithPrivateSetter { get; private set; }
+
+		public int PropertyWithPrivateGetter { private get; set; }
+	}
+}

--- a/Tests/aweXpect.Reflection.Internal.Tests/Helpers/PropertyInfoHelpersTests.cs
+++ b/Tests/aweXpect.Reflection.Internal.Tests/Helpers/PropertyInfoHelpersTests.cs
@@ -22,16 +22,16 @@ public sealed class PropertyInfoHelpersTests
 	[Theory]
 	[InlineData(nameof(AccessModifierTestClass.PublicPropertyWithPrivateGetter))]
 	[InlineData(nameof(AccessModifierTestClass.PublicPropertyWithPrivateSetter))]
-	public async Task HasAccessModifier_MixedAccessConditionsForGetterAndSetter_ShouldNotMatch(string propertyName)
+	public async Task HasAccessModifier_MixedAccessConditionsForGetterAndSetter_ShouldMatchBoth(string propertyName)
 	{
 		PropertyInfo propertyInfo = typeof(AccessModifierTestClass).GetDeclaredProperties()
 			.Single(c => c.Name == propertyName);
 
 		await That(propertyInfo).IsNotNull();
 		await That(propertyInfo.HasAccessModifier(AccessModifiers.Internal)).IsFalse();
-		await That(propertyInfo.HasAccessModifier(AccessModifiers.Private)).IsFalse();
+		await That(propertyInfo.HasAccessModifier(AccessModifiers.Private)).IsTrue();
 		await That(propertyInfo.HasAccessModifier(AccessModifiers.Protected)).IsFalse();
-		await That(propertyInfo.HasAccessModifier(AccessModifiers.Public)).IsFalse();
+		await That(propertyInfo.HasAccessModifier(AccessModifiers.Public)).IsTrue();
 	}
 
 	[Fact]

--- a/Tests/aweXpect.Reflection.Tests/ThatProperties.Have.AttributeTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatProperties.Have.AttributeTests.cs
@@ -55,7 +55,7 @@ public sealed partial class ThatProperties
 					             Expected that subject
 					             all have ThatProperties.Have.AttributeTests.TestAttribute,
 					             but it contained not matching properties [
-					               System.String NoAttributeProperty
+					               public string ThatProperties.Have.AttributeTests.TestClass.NoAttributeProperty { get; set; }
 					             ]
 					             """);
 			}
@@ -76,8 +76,8 @@ public sealed partial class ThatProperties
 					             Expected that subject
 					             all have ThatProperties.Have.AttributeTests.TestAttribute matching attr => attr.Value == "WrongValue",
 					             but it contained not matching properties [
-					               System.String TestProperty1,
-					               System.String TestProperty2
+					               public string ThatProperties.Have.AttributeTests.TestClass.TestProperty1 { get; set; },
+					               public string ThatProperties.Have.AttributeTests.TestClass.TestProperty2 { get; set; }
 					             ]
 					             """);
 			}
@@ -178,7 +178,7 @@ public sealed partial class ThatProperties
 						             Expected that subject
 						             all have ThatProperties.Have.OrHave.AttributeTests.TestAttribute or ThatProperties.Have.OrHave.AttributeTests.BarAttribute,
 						             but it contained not matching properties [
-						               System.String NoAttributeProperty
+						               public string ThatProperties.Have.OrHave.AttributeTests.TestClass.NoAttributeProperty { get; set; }
 						             ]
 						             """);
 				}
@@ -214,7 +214,7 @@ public sealed partial class ThatProperties
 						             Expected that subject
 						             all have ThatProperties.Have.OrHave.AttributeTests.TestAttribute matching attr => attr.Value == "WrongValue" or ThatProperties.Have.OrHave.AttributeTests.BarAttribute matching attr => attr.Name == "wrong",
 						             but it contained not matching properties [
-						               System.String TestProperty1
+						               public string ThatProperties.Have.OrHave.AttributeTests.TestClass.TestProperty1 { get; set; }
 						             ]
 						             """);
 				}
@@ -296,7 +296,7 @@ public sealed partial class ThatProperties
 					             Expected that subjects
 					             not all have ThatProperties.Have.NegatedTests.TestAttribute or ThatProperties.Have.NegatedTests.TestAttribute matching x => x.Value == "foo",
 					             but it only contained matching properties [
-					               System.String TestProperty1
+					               public string ThatProperties.Have.NegatedTests.TestClass.TestProperty1 { get; set; }
 					             ]
 					             """);
 			}

--- a/Tests/aweXpect.Reflection.Tests/ThatProperty.Has.AttributeTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatProperty.Has.AttributeTests.cs
@@ -21,7 +21,7 @@ public sealed partial class ThatProperty
 					.WithMessage("""
 					             Expected that subject
 					             has ThatProperty.Has.AttributeTests.TestAttribute,
-					             but it did not in System.String NoAttributeProperty
+					             but it did not in public string ThatProperty.Has.AttributeTests.TestClass.NoAttributeProperty { get; set; }
 					             """);
 			}
 
@@ -59,7 +59,7 @@ public sealed partial class ThatProperty
 					.WithMessage("""
 					             Expected that subject
 					             has ThatProperty.Has.AttributeTests.TestAttribute matching attr => attr.Value == "WrongValue",
-					             but it did not in System.String TestProperty
+					             but it did not in public string ThatProperty.Has.AttributeTests.TestClass.TestProperty { get; set; }
 					             """);
 			}
 
@@ -132,7 +132,7 @@ public sealed partial class ThatProperty
 					.WithMessage("""
 					             Expected that subject
 					             has no ThatProperty.Has.NegatedTests.TestAttribute,
-					             but it did in System.String TestProperty
+					             but it did in public string ThatProperty.Has.NegatedTests.TestClass.TestProperty { get; set; }
 					             """);
 			}
 

--- a/Tests/aweXpect.Reflection.Tests/ThatProperty.IsAbstract.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatProperty.IsAbstract.Tests.cs
@@ -71,7 +71,7 @@ public sealed partial class ThatProperty
 					.WithMessage("""
 					             Expected that subject
 					             is not abstract,
-					             but it was abstract System.String AbstractProperty
+					             but it was abstract public string AbstractClassWithMembers.AbstractProperty { get; set; }
 					             """);
 			}
 

--- a/Tests/aweXpect.Reflection.Tests/ThatProperty.IsNotAbstract.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatProperty.IsNotAbstract.Tests.cs
@@ -83,7 +83,7 @@ public sealed partial class ThatProperty
 					.WithMessage("""
 					             Expected that subject
 					             is abstract,
-					             but it was non-abstract System.String VirtualProperty
+					             but it was non-abstract public string AbstractClassWithMembers.VirtualProperty { get; set; }
 					             """);
 			}
 		}

--- a/Tests/aweXpect.Reflection.Tests/ThatProperty.IsNotSealed.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatProperty.IsNotSealed.Tests.cs
@@ -71,7 +71,7 @@ public sealed partial class ThatProperty
 					.WithMessage("""
 					             Expected that subject
 					             is sealed,
-					             but it was non-sealed System.String VirtualProperty
+					             but it was non-sealed public string AbstractClassWithMembers.VirtualProperty { get; set; }
 					             """);
 			}
 

--- a/Tests/aweXpect.Reflection.Tests/ThatProperty.IsSealed.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatProperty.IsSealed.Tests.cs
@@ -83,7 +83,7 @@ public sealed partial class ThatProperty
 					.WithMessage("""
 					             Expected that subject
 					             is not sealed,
-					             but it was sealed System.String VirtualProperty
+					             but it was sealed public string ClassWithSealedMembers.VirtualProperty { get; set; }
 					             """);
 			}
 		}


### PR DESCRIPTION
This PR adds property formatting functionality to the aweXpect.Reflection library, improving the display of property information in test assertions and error messages.

### Key Changes:
- Adds a new `PropertyFormatter` class to format `PropertyInfo` objects with complete syntax including access modifiers, type, and accessor details
- Updates property access modifier logic to use OR instead of AND for mixed getter/setter access levels
- Fixes access modifier detection order to properly handle `ProtectedInternal` vs `Private` precedence

---

- *Implements part of #136*