### PR TITLE
feat: add event formatting

### DIFF
--- a/Source/aweXpect.Reflection/Formatting/EventFormatter.cs
+++ b/Source/aweXpect.Reflection/Formatting/EventFormatter.cs
@@ -1,0 +1,23 @@
+﻿using System.Reflection;
+using System.Text;
+
+namespace aweXpect.Reflection.Formatting;
+
+internal class EventFormatter : IValueFormatter
+{
+	public bool TryFormat(StringBuilder stringBuilder, object value, FormattingOptions? options)
+	{
+		if (value is EventInfo @event)
+		{
+			stringBuilder.Append("event ");
+			Formatter.Format(stringBuilder, @event.EventHandlerType);
+			stringBuilder.Append(' ');
+			Formatter.Format(stringBuilder, @event.DeclaringType);
+			stringBuilder.Append('.');
+			stringBuilder.Append(@event.Name);
+			return true;
+		}
+
+		return false;
+	}
+}

--- a/Source/aweXpect.Reflection/Formatting/FormatterRegistration.cs
+++ b/Source/aweXpect.Reflection/Formatting/FormatterRegistration.cs
@@ -27,6 +27,7 @@ internal sealed class FormatterRegistration : IAweXpectInitializer, IDisposable
 	public void Initialize() => _disposables =
 	[
 		ValueFormatter.Register(new ConstructorFormatter()),
+		ValueFormatter.Register(new EventFormatter()),
 		ValueFormatter.Register(new PropertyFormatter()),
 	];
 

--- a/Tests/aweXpect.Reflection.Internal.Tests/Formatting/ConstructorFormatterTests.cs
+++ b/Tests/aweXpect.Reflection.Internal.Tests/Formatting/ConstructorFormatterTests.cs
@@ -52,7 +52,7 @@ public class ConstructorFormatterTests
 
 	// ReSharper disable UnusedMember.Local
 	// ReSharper disable UnusedParameter.Local
-	private class MyTestClass
+	internal class MyTestClass
 	{
 		public MyTestClass()
 		{

--- a/Tests/aweXpect.Reflection.Internal.Tests/Formatting/EventFormatterTests.cs
+++ b/Tests/aweXpect.Reflection.Internal.Tests/Formatting/EventFormatterTests.cs
@@ -1,0 +1,44 @@
+﻿using System.Reflection;
+using aweXpect.Formatting;
+using aweXpect.Reflection.Formatting;
+using aweXpect.Reflection.Internal.Tests.TestHelpers;
+
+namespace aweXpect.Reflection.Internal.Tests.Formatting;
+
+public class EventFormatterTests
+{
+	[Fact]
+	public async Task WithCustomEventHandler_ShouldFormatCorrectly()
+	{
+		EventInfo? eventInfo = typeof(MyTestClass).GetEvent(nameof(MyTestClass.MyEvent));
+		EventFormatter formatter = new();
+
+		string result = formatter.GetString(eventInfo);
+
+		await That(result).IsEqualTo("event EventFormatterTests.MyTestClass.MyEventHandler EventFormatterTests.MyTestClass.MyEvent");
+	}
+
+	[Fact]
+	public async Task WithEventHandler_ShouldFormatCorrectly()
+	{
+		EventInfo? eventInfo = typeof(MyTestClass).GetEvent(nameof(MyTestClass.PublicEvent));
+		EventFormatter formatter = new();
+
+		string result = formatter.GetString(eventInfo);
+
+		await That(result).IsEqualTo("event EventHandler EventFormatterTests.MyTestClass.PublicEvent");
+	}
+
+	internal class MyTestClass
+	{
+		public delegate void MyEventHandler(object? sender, MyEventArgs e);
+
+		public event EventHandler PublicEvent;
+		public event MyEventHandler MyEvent;
+
+		public class MyEventArgs : EventArgs
+		{
+			public int MyValue { get; set; }
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Internal.Tests/Formatting/EventFormatterTests.cs
+++ b/Tests/aweXpect.Reflection.Internal.Tests/Formatting/EventFormatterTests.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using aweXpect.Formatting;
 using aweXpect.Reflection.Formatting;
 using aweXpect.Reflection.Internal.Tests.TestHelpers;
 
@@ -15,7 +14,8 @@ public class EventFormatterTests
 
 		string result = formatter.GetString(eventInfo);
 
-		await That(result).IsEqualTo("event EventFormatterTests.MyTestClass.MyEventHandler EventFormatterTests.MyTestClass.MyEvent");
+		await That(result)
+			.IsEqualTo("event EventFormatterTests.MyTestClass.MyEventHandler EventFormatterTests.MyTestClass.MyEvent");
 	}
 
 	[Fact]
@@ -33,12 +33,14 @@ public class EventFormatterTests
 	{
 		public delegate void MyEventHandler(object? sender, MyEventArgs e);
 
-		public event EventHandler PublicEvent;
-		public event MyEventHandler MyEvent;
-
 		public class MyEventArgs : EventArgs
 		{
 			public int MyValue { get; set; }
 		}
+
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
+		public event EventHandler PublicEvent;
+		public event MyEventHandler MyEvent;
+#pragma warning restore CS8618
 	}
 }

--- a/Tests/aweXpect.Reflection.Internal.Tests/Formatting/EventFormatterTests.cs
+++ b/Tests/aweXpect.Reflection.Internal.Tests/Formatting/EventFormatterTests.cs
@@ -33,14 +33,12 @@ public class EventFormatterTests
 	{
 		public delegate void MyEventHandler(object? sender, MyEventArgs e);
 
+		public event EventHandler PublicEvent = delegate { };
+		public event MyEventHandler MyEvent = delegate { };
+
 		public class MyEventArgs : EventArgs
 		{
 			public int MyValue { get; set; }
 		}
-
-#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
-		public event EventHandler PublicEvent;
-		public event MyEventHandler MyEvent;
-#pragma warning restore CS8618
 	}
 }

--- a/Tests/aweXpect.Reflection.Internal.Tests/Formatting/FormatterRegistrationTests.cs
+++ b/Tests/aweXpect.Reflection.Internal.Tests/Formatting/FormatterRegistrationTests.cs
@@ -13,13 +13,14 @@ public class FormatterRegistrationTests
 		void Act() => _ = new FormatterRegistration();
 
 		await That(Act).Throws<InvalidOperationException>()
-			.WithMessage("A FormatterRegistration instance is already initialized. Dispose the existing instance before creating a new one.");
+			.WithMessage(
+				"A FormatterRegistration instance is already initialized. Dispose the existing instance before creating a new one.");
 	}
 
 	[Fact]
 	public async Task Initialize_ShouldRegisterFormatterForConstructorInfo()
 	{
-		ConstructorInfo constructorInfo = typeof(FormatterRegistrationTests).GetConstructors().First();
+		ConstructorInfo constructorInfo = typeof(ConstructorFormatterTests.MyTestClass).GetConstructors().First();
 		await That(true).IsTrue();
 		string result1 = Format.Formatter.Format(constructorInfo);
 
@@ -28,6 +29,40 @@ public class FormatterRegistrationTests
 		FormatterRegistration.Instance.Initialize();
 
 		string result3 = Format.Formatter.Format(constructorInfo);
+
+		await That(result1).IsEqualTo(result3);
+		await That(result2).IsNotEqualTo(result3);
+	}
+
+	[Fact]
+	public async Task Initialize_ShouldRegisterFormatterForEventInfo()
+	{
+		EventInfo eventInfo = typeof(EventFormatterTests.MyTestClass).GetEvents().First();
+		await That(true).IsTrue();
+		string result1 = Format.Formatter.Format(eventInfo);
+
+		FormatterRegistration.Instance.Dispose();
+		string result2 = Format.Formatter.Format(eventInfo);
+		FormatterRegistration.Instance.Initialize();
+
+		string result3 = Format.Formatter.Format(eventInfo);
+
+		await That(result1).IsEqualTo(result3);
+		await That(result2).IsNotEqualTo(result3);
+	}
+
+	[Fact]
+	public async Task Initialize_ShouldRegisterFormatterForPropertyInfo()
+	{
+		PropertyInfo propertyInfo = typeof(PropertyFormatterTests.MyTestClass).GetProperties().First();
+		await That(true).IsTrue();
+		string result1 = Format.Formatter.Format(propertyInfo);
+
+		FormatterRegistration.Instance.Dispose();
+		string result2 = Format.Formatter.Format(propertyInfo);
+		FormatterRegistration.Instance.Initialize();
+
+		string result3 = Format.Formatter.Format(propertyInfo);
 
 		await That(result1).IsEqualTo(result3);
 		await That(result2).IsNotEqualTo(result3);

--- a/Tests/aweXpect.Reflection.Internal.Tests/Formatting/PropertyFormatterTests.cs
+++ b/Tests/aweXpect.Reflection.Internal.Tests/Formatting/PropertyFormatterTests.cs
@@ -103,7 +103,7 @@ public class PropertyFormatterTests
 	}
 
 	// ReSharper disable UnusedMember.Local
-	private class MyTestClass
+	internal class MyTestClass
 	{
 		public int MyProperty { get; private set; }
 		internal int InternalProperty { get; private set; }

--- a/Tests/aweXpect.Reflection.Tests/ThatEvent.Has.AttributeTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatEvent.Has.AttributeTests.cs
@@ -21,7 +21,7 @@ public sealed partial class ThatEvent
 					.WithMessage("""
 					             Expected that subject
 					             has ThatEvent.Has.AttributeTests.TestAttribute,
-					             but it did not in System.Action NoAttributeEvent
+					             but it did not in event Action ThatEvent.Has.AttributeTests.TestClass.NoAttributeEvent
 					             """);
 			}
 
@@ -59,7 +59,7 @@ public sealed partial class ThatEvent
 					.WithMessage("""
 					             Expected that subject
 					             has ThatEvent.Has.AttributeTests.TestAttribute matching attr => attr.Value == 99,
-					             but it did not in System.Action TestEventWithValue
+					             but it did not in event Action ThatEvent.Has.AttributeTests.TestClass.TestEventWithValue
 					             """);
 			}
 
@@ -158,7 +158,7 @@ public sealed partial class ThatEvent
 						.WithMessage("""
 						             Expected that subject
 						             has ThatEvent.Has.OrHas.AttributeTests.FooAttribute or ThatEvent.Has.OrHas.AttributeTests.BarAttribute,
-						             but it did not in System.Action BazEvent
+						             but it did not in event Action ThatEvent.Has.OrHas.AttributeTests.BazClass.BazEvent
 						             """);
 				}
 
@@ -186,7 +186,7 @@ public sealed partial class ThatEvent
 						.WithMessage("""
 						             Expected that subject
 						             has ThatEvent.Has.OrHas.AttributeTests.FooAttribute matching foo => foo.Value == 5 or ThatEvent.Has.OrHas.AttributeTests.BarAttribute matching bar => bar.Name == "test",
-						             but it did not in System.Action FooEvent2
+						             but it did not in event Action ThatEvent.Has.OrHas.AttributeTests.FooClass2.FooEvent2
 						             """);
 				}
 
@@ -278,7 +278,7 @@ public sealed partial class ThatEvent
 					.WithMessage("""
 					             Expected that subject
 					             has no ThatEvent.Has.NegatedTests.TestAttribute,
-					             but it did in System.Action TestEvent
+					             but it did in event Action ThatEvent.Has.NegatedTests.TestClass.TestEvent
 					             """);
 			}
 

--- a/Tests/aweXpect.Reflection.Tests/ThatEvent.IsAbstract.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatEvent.IsAbstract.Tests.cs
@@ -71,7 +71,7 @@ public sealed partial class ThatEvent
 					.WithMessage("""
 					             Expected that subject
 					             is not abstract,
-					             but it was abstract System.EventHandler AbstractEvent
+					             but it was abstract event EventHandler AbstractClassWithMembers.AbstractEvent
 					             """);
 			}
 

--- a/Tests/aweXpect.Reflection.Tests/ThatEvent.IsNotAbstract.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatEvent.IsNotAbstract.Tests.cs
@@ -83,7 +83,7 @@ public sealed partial class ThatEvent
 					.WithMessage("""
 					             Expected that subject
 					             is abstract,
-					             but it was non-abstract System.EventHandler VirtualEvent
+					             but it was non-abstract event EventHandler AbstractClassWithMembers.VirtualEvent
 					             """);
 			}
 		}

--- a/Tests/aweXpect.Reflection.Tests/ThatEvent.IsNotSealed.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatEvent.IsNotSealed.Tests.cs
@@ -71,7 +71,7 @@ public sealed partial class ThatEvent
 					.WithMessage("""
 					             Expected that subject
 					             is sealed,
-					             but it was non-sealed System.EventHandler VirtualEvent
+					             but it was non-sealed event EventHandler AbstractClassWithMembers.VirtualEvent
 					             """);
 			}
 

--- a/Tests/aweXpect.Reflection.Tests/ThatEvent.IsSealed.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatEvent.IsSealed.Tests.cs
@@ -83,7 +83,7 @@ public sealed partial class ThatEvent
 					.WithMessage("""
 					             Expected that subject
 					             is not sealed,
-					             but it was sealed System.EventHandler VirtualEvent
+					             but it was sealed event EventHandler ClassWithSealedMembers.VirtualEvent
 					             """);
 			}
 		}

--- a/Tests/aweXpect.Reflection.Tests/ThatEvents.Have.AttributeTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatEvents.Have.AttributeTests.cs
@@ -54,7 +54,7 @@ public sealed partial class ThatEvents
 					             Expected that subject
 					             all have ThatEvents.Have.AttributeTests.TestAttribute,
 					             but it contained not matching events [
-					               System.Action NoAttributeEvent
+					               event Action ThatEvents.Have.AttributeTests.TestClass.NoAttributeEvent
 					             ]
 					             """);
 			}
@@ -75,8 +75,8 @@ public sealed partial class ThatEvents
 					             Expected that subject
 					             all have ThatEvents.Have.AttributeTests.TestAttribute matching attr => attr.Value == "WrongValue",
 					             but it contained not matching events [
-					               System.Action TestEvent1,
-					               System.Action TestEvent2
+					               event Action ThatEvents.Have.AttributeTests.TestClass.TestEvent1,
+					               event Action ThatEvents.Have.AttributeTests.TestClass.TestEvent2
 					             ]
 					             """);
 			}
@@ -177,7 +177,7 @@ public sealed partial class ThatEvents
 						             Expected that subject
 						             all have ThatEvents.Have.OrHave.AttributeTests.TestAttribute or ThatEvents.Have.OrHave.AttributeTests.BarAttribute,
 						             but it contained not matching events [
-						               System.Action NoAttributeEvent
+						               event Action ThatEvents.Have.OrHave.AttributeTests.TestClass.NoAttributeEvent
 						             ]
 						             """);
 				}
@@ -213,7 +213,7 @@ public sealed partial class ThatEvents
 						             Expected that subject
 						             all have ThatEvents.Have.OrHave.AttributeTests.TestAttribute matching attr => attr.Value == "WrongValue" or ThatEvents.Have.OrHave.AttributeTests.BarAttribute matching attr => attr.Name == "wrong",
 						             but it contained not matching events [
-						               System.Action TestEvent1
+						               event Action ThatEvents.Have.OrHave.AttributeTests.TestClass.TestEvent1
 						             ]
 						             """);
 				}
@@ -295,7 +295,7 @@ public sealed partial class ThatEvents
 					             Expected that subjects
 					             not all have ThatEvents.Have.NegatedTests.TestAttribute or ThatEvents.Have.NegatedTests.TestAttribute matching x => x.Value == "foo",
 					             but it only contained matching events [
-					               System.Action TestEvent1
+					               event Action ThatEvents.Have.NegatedTests.TestClass.TestEvent1
 					             ]
 					             """);
 			}


### PR DESCRIPTION
This PR adds event formatting to the aweXpect.Reflection library by implementing an EventFormatter that provides more descriptive string representations of EventInfo objects in test assertions and error messages.

- Implements EventFormatter class to format EventInfo objects with "event" prefix, handler type, declaring type, and event name
- Registers EventFormatter in FormatterRegistration to integrate with the existing formatting system
- Updates all test expectations to use the new event formatting

---

- *Implements part of #136*