### PR TITLE
feat: add method formatting

### DIFF
--- a/Source/aweXpect.Reflection/Formatting/FormatterRegistration.cs
+++ b/Source/aweXpect.Reflection/Formatting/FormatterRegistration.cs
@@ -28,8 +28,9 @@ internal sealed class FormatterRegistration : IAweXpectInitializer, IDisposable
 	[
 		ValueFormatter.Register(new ConstructorFormatter()),
 		ValueFormatter.Register(new EventFormatter()),
-		ValueFormatter.Register(new PropertyFormatter()),
 		ValueFormatter.Register(new FieldFormatter()),
+		ValueFormatter.Register(new MethodFormatter()),
+		ValueFormatter.Register(new PropertyFormatter())
 	];
 
 	public void Dispose()

--- a/Source/aweXpect.Reflection/Formatting/MethodFormatter.cs
+++ b/Source/aweXpect.Reflection/Formatting/MethodFormatter.cs
@@ -1,0 +1,70 @@
+﻿using System.Linq;
+using System.Reflection;
+using System.Text;
+
+namespace aweXpect.Reflection.Formatting;
+
+internal class MethodFormatter : IValueFormatter
+{
+	public bool TryFormat(StringBuilder stringBuilder, object value, FormattingOptions? options)
+	{
+		if (value is MethodInfo methodInfo)
+		{
+			if (methodInfo.ReturnType == typeof(void))
+			{
+				stringBuilder.Append("void");
+			}
+			else if (methodInfo.ReturnType.IsGenericParameter)
+			{
+				stringBuilder.Append(methodInfo.ReturnType.Name);
+			}
+			else
+			{
+				Formatter.Format(stringBuilder, methodInfo.ReturnType);
+			}
+
+			stringBuilder.Append(' ');
+			Formatter.Format(stringBuilder, methodInfo.DeclaringType);
+			stringBuilder.Append('.');
+			stringBuilder.Append(methodInfo.Name);
+			if (methodInfo.IsGenericMethod)
+			{
+				stringBuilder.Append('<');
+				stringBuilder.Append(string.Join(", ", methodInfo.GetGenericArguments().Select(x => x.Name)));
+				stringBuilder.Append('>');
+			}
+
+			stringBuilder.Append('(');
+			int index = 0;
+			foreach (ParameterInfo? parameter in methodInfo.GetParameters())
+			{
+				if (index++ > 0)
+				{
+					stringBuilder.Append(", ");
+				}
+
+				if (parameter.ParameterType.IsGenericParameter)
+				{
+					stringBuilder.Append(parameter.ParameterType.Name);
+				}
+				else
+				{
+					Formatter.Format(stringBuilder, parameter.ParameterType);
+				}
+
+				stringBuilder.Append(' ');
+				stringBuilder.Append(parameter.Name);
+				if (parameter.HasDefaultValue)
+				{
+					stringBuilder.Append(" = ");
+					Formatter.Format(stringBuilder, parameter.DefaultValue);
+				}
+			}
+
+			stringBuilder.Append(')');
+			return true;
+		}
+
+		return false;
+	}
+}

--- a/Tests/aweXpect.Reflection.Internal.Tests/Formatting/FormatterRegistrationTests.cs
+++ b/Tests/aweXpect.Reflection.Internal.Tests/Formatting/FormatterRegistrationTests.cs
@@ -69,6 +69,23 @@ public class FormatterRegistrationTests
 	}
 
 	[Fact]
+	public async Task Initialize_ShouldRegisterFormatterForMethodInfo()
+	{
+		MethodInfo methodInfo = typeof(MethodFormatterTests.MyTestClass).GetMethods().First();
+		await That(true).IsTrue();
+		string result1 = Format.Formatter.Format(methodInfo);
+
+		FormatterRegistration.Instance.Dispose();
+		string result2 = Format.Formatter.Format(methodInfo);
+		FormatterRegistration.Instance.Initialize();
+
+		string result3 = Format.Formatter.Format(methodInfo);
+
+		await That(result1).IsEqualTo(result3);
+		await That(result2).IsNotEqualTo(result3);
+	}
+
+	[Fact]
 	public async Task Initialize_ShouldRegisterFormatterForPropertyInfo()
 	{
 		PropertyInfo propertyInfo = typeof(PropertyFormatterTests.MyTestClass).GetProperties().First();

--- a/Tests/aweXpect.Reflection.Internal.Tests/Formatting/MethodFormatterTests.cs
+++ b/Tests/aweXpect.Reflection.Internal.Tests/Formatting/MethodFormatterTests.cs
@@ -107,6 +107,8 @@ public class MethodFormatterTests
 				"void MethodFormatterTests.MyTestClass.MyMethodWithTwoParameters(int parameter1, string parameter2)");
 	}
 
+#pragma warning disable CS1822
+	// ReSharper disable UnusedParameter.Global
 	internal abstract class MyTestClass
 	{
 		public void MyParameterlessMethod()
@@ -135,4 +137,6 @@ public class MethodFormatterTests
 		public string MyMethodWithParametersAndReturnValue(string p1, int p2 = 42)
 			=> p1 + p2;
 	}
+	// ReSharper restore UnusedParameter.Global
+#pragma warning restore CS1822
 }

--- a/Tests/aweXpect.Reflection.Internal.Tests/Formatting/MethodFormatterTests.cs
+++ b/Tests/aweXpect.Reflection.Internal.Tests/Formatting/MethodFormatterTests.cs
@@ -1,0 +1,138 @@
+﻿using System.Reflection;
+using aweXpect.Reflection.Formatting;
+using aweXpect.Reflection.Internal.Tests.TestHelpers;
+
+namespace aweXpect.Reflection.Internal.Tests.Formatting;
+
+public class MethodFormatterTests
+{
+	[Fact]
+	public async Task GenericMethodWithParameterAndReturnValue_ShouldFormatCorrectly()
+	{
+		MethodInfo? methodInfo =
+			typeof(MyTestClass).GetMethod(nameof(MyTestClass.MyGenericMethodWithParameterAndReturnValue));
+		MethodFormatter formatter = new();
+
+		string result = formatter.GetString(methodInfo);
+
+		await That(result)
+			.IsEqualTo(
+				"T1 MethodFormatterTests.MyTestClass.MyGenericMethodWithParameterAndReturnValue<T1, T2>(MethodFormatterTests.MyTestClass p1, T2 p2)");
+	}
+
+	[Fact]
+	public async Task GenericMethodWithReturnValue_ShouldFormatCorrectly()
+	{
+		MethodInfo? methodInfo = typeof(MyTestClass).GetMethod(nameof(MyTestClass.MyGenericMethodWithReturnValue));
+		MethodFormatter formatter = new();
+
+		string result = formatter.GetString(methodInfo);
+
+		await That(result)
+			.IsEqualTo(
+				"T MethodFormatterTests.MyTestClass.MyGenericMethodWithReturnValue<T>()");
+	}
+
+	[Fact]
+	public async Task WithOneParameter_ShouldFormatCorrectly()
+	{
+		MethodInfo? methodInfo = typeof(MyTestClass).GetMethod(nameof(MyTestClass.MyMethodWithOneParameter));
+		MethodFormatter formatter = new();
+
+		string result = formatter.GetString(methodInfo);
+
+		await That(result).IsEqualTo("void MethodFormatterTests.MyTestClass.MyMethodWithOneParameter(int parameter1)");
+	}
+
+	[Fact]
+	public async Task WithoutParameters_ShouldFormatCorrectly()
+	{
+		MethodInfo? methodInfo = typeof(MyTestClass).GetMethod(nameof(MyTestClass.MyParameterlessMethod));
+		MethodFormatter formatter = new();
+
+		string result = formatter.GetString(methodInfo);
+
+		await That(result).IsEqualTo("void MethodFormatterTests.MyTestClass.MyParameterlessMethod()");
+	}
+
+	[Fact]
+	public async Task WithoutParameters_WithReturnValue_ShouldFormatCorrectly()
+	{
+		MethodInfo? methodInfo =
+			typeof(MyTestClass).GetMethod(nameof(MyTestClass.MyParameterlessMethodWithReturnValue));
+		MethodFormatter formatter = new();
+
+		string result = formatter.GetString(methodInfo);
+
+		await That(result).IsEqualTo("int MethodFormatterTests.MyTestClass.MyParameterlessMethodWithReturnValue()");
+	}
+
+	[Fact]
+	public async Task WithParameters_WithReturnValue_ShouldFormatCorrectly()
+	{
+		MethodInfo? methodInfo =
+			typeof(MyTestClass).GetMethod(nameof(MyTestClass.MyMethodWithParametersAndReturnValue));
+		MethodFormatter formatter = new();
+
+		string result = formatter.GetString(methodInfo);
+
+		await That(result)
+			.IsEqualTo(
+				"string MethodFormatterTests.MyTestClass.MyMethodWithParametersAndReturnValue(string p1, int p2 = 42)");
+	}
+
+	[Fact]
+	public async Task WithParametersWithDefaultValues_ShouldFormatCorrectly()
+	{
+		MethodInfo? methodInfo = typeof(MyTestClass).GetMethod(nameof(MyTestClass.MyMethodWithDefaultValues));
+		MethodFormatter formatter = new();
+
+		string result = formatter.GetString(methodInfo);
+
+		await That(result)
+			.IsEqualTo(
+				"void MethodFormatterTests.MyTestClass.MyMethodWithDefaultValues(string p1 = \"foo\", int p2 = 42)");
+	}
+
+	[Fact]
+	public async Task WithTwoParameters_ShouldFormatCorrectly()
+	{
+		MethodInfo? methodInfo = typeof(MyTestClass).GetMethod(nameof(MyTestClass.MyMethodWithTwoParameters));
+		MethodFormatter formatter = new();
+
+		string result = formatter.GetString(methodInfo);
+
+		await That(result)
+			.IsEqualTo(
+				"void MethodFormatterTests.MyTestClass.MyMethodWithTwoParameters(int parameter1, string parameter2)");
+	}
+
+	internal abstract class MyTestClass
+	{
+		public void MyParameterlessMethod()
+		{
+		}
+
+		public void MyMethodWithOneParameter(int parameter1)
+		{
+		}
+
+		public void MyMethodWithTwoParameters(int parameter1, string parameter2)
+		{
+		}
+
+		public void MyMethodWithDefaultValues(string p1 = "foo", int p2 = 42)
+		{
+		}
+
+		public int MyParameterlessMethodWithReturnValue()
+			=> 42;
+
+		public abstract T MyGenericMethodWithReturnValue<T>();
+
+		public abstract T1 MyGenericMethodWithParameterAndReturnValue<T1, T2>(MyTestClass p1, T2 p2);
+
+		public string MyMethodWithParametersAndReturnValue(string p1, int p2 = 42)
+			=> p1 + p2;
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatMethod.Has.AttributeTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethod.Has.AttributeTests.cs
@@ -21,7 +21,7 @@ public sealed partial class ThatMethod
 					.WithMessage("""
 					             Expected that subject
 					             has ThatMethod.Has.AttributeTests.TestAttribute,
-					             but it did not in Void NoAttributeMethod()
+					             but it did not in void ThatMethod.Has.AttributeTests.TestClass.NoAttributeMethod()
 					             """);
 			}
 
@@ -59,7 +59,7 @@ public sealed partial class ThatMethod
 					.WithMessage("""
 					             Expected that subject
 					             has ThatMethod.Has.AttributeTests.TestAttribute matching attr => attr.Value == "WrongValue",
-					             but it did not in Void TestMethod()
+					             but it did not in void ThatMethod.Has.AttributeTests.TestClass.TestMethod()
 					             """);
 			}
 
@@ -133,7 +133,7 @@ public sealed partial class ThatMethod
 					.WithMessage("""
 					             Expected that subject
 					             has no ThatMethod.Has.NegatedTests.TestAttribute,
-					             but it did in Void TestMethod()
+					             but it did in void ThatMethod.Has.NegatedTests.TestClass.TestMethod()
 					             """);
 			}
 

--- a/Tests/aweXpect.Reflection.Tests/ThatMethod.IsAbstract.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethod.IsAbstract.Tests.cs
@@ -71,7 +71,7 @@ public sealed partial class ThatMethod
 					.WithMessage("""
 					             Expected that subject
 					             is not abstract,
-					             but it was abstract Void AbstractMethod()
+					             but it was abstract void AbstractClassWithMembers.AbstractMethod()
 					             """);
 			}
 

--- a/Tests/aweXpect.Reflection.Tests/ThatMethod.IsGeneric.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethod.IsGeneric.Tests.cs
@@ -31,7 +31,7 @@ public sealed partial class ThatMethod
 					.WithMessage("""
 					             Expected that subject
 					             is generic,
-					             but it was non-generic Int32 NonGenericMethod()
+					             but it was non-generic int ThatMethod.ClassWithMethods.NonGenericMethod()
 					             """);
 			}
 
@@ -66,7 +66,7 @@ public sealed partial class ThatMethod
 					.WithMessage("""
 					             Expected that subject
 					             is not generic,
-					             but it was generic T GenericMethod[T](T)
+					             but it was generic T ThatMethod.ClassWithMethods.GenericMethod<T>(T value)
 					             """);
 			}
 

--- a/Tests/aweXpect.Reflection.Tests/ThatMethod.IsNotAbstract.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethod.IsNotAbstract.Tests.cs
@@ -83,7 +83,7 @@ public sealed partial class ThatMethod
 					.WithMessage("""
 					             Expected that subject
 					             is abstract,
-					             but it was non-abstract Void VirtualMethod()
+					             but it was non-abstract void AbstractClassWithMembers.VirtualMethod()
 					             """);
 			}
 		}

--- a/Tests/aweXpect.Reflection.Tests/ThatMethod.IsNotGeneric.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethod.IsNotGeneric.Tests.cs
@@ -20,7 +20,7 @@ public sealed partial class ThatMethod
 					.WithMessage("""
 					             Expected that subject
 					             is not generic,
-					             but it was generic T GenericMethod[T](T)
+					             but it was generic T ThatMethod.ClassWithMethods.GenericMethod<T>(T value)
 					             """);
 			}
 
@@ -77,7 +77,7 @@ public sealed partial class ThatMethod
 					.WithMessage("""
 					             Expected that subject
 					             is generic,
-					             but it was non-generic Int32 NonGenericMethod()
+					             but it was non-generic int ThatMethod.ClassWithMethods.NonGenericMethod()
 					             """);
 			}
 		}

--- a/Tests/aweXpect.Reflection.Tests/ThatMethod.IsNotSealed.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethod.IsNotSealed.Tests.cs
@@ -71,7 +71,7 @@ public sealed partial class ThatMethod
 					.WithMessage("""
 					             Expected that subject
 					             is sealed,
-					             but it was non-sealed Void VirtualMethod()
+					             but it was non-sealed void AbstractClassWithMembers.VirtualMethod()
 					             """);
 			}
 

--- a/Tests/aweXpect.Reflection.Tests/ThatMethod.IsSealed.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethod.IsSealed.Tests.cs
@@ -83,7 +83,7 @@ public sealed partial class ThatMethod
 					.WithMessage("""
 					             Expected that subject
 					             is not sealed,
-					             but it was sealed Void VirtualMethod()
+					             but it was sealed void ClassWithSealedMembers.VirtualMethod()
 					             """);
 			}
 		}

--- a/Tests/aweXpect.Reflection.Tests/ThatMethods.Have.AttributeTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethods.Have.AttributeTests.cs
@@ -54,7 +54,7 @@ public sealed partial class ThatMethods
 					             Expected that subject
 					             all have ThatMethods.Have.AttributeTests.TestAttribute,
 					             but it contained not matching methods [
-					               Void NoAttributeMethod()
+					               void ThatMethods.Have.AttributeTests.TestClass.NoAttributeMethod()
 					             ]
 					             """);
 			}
@@ -75,8 +75,8 @@ public sealed partial class ThatMethods
 					             Expected that subject
 					             all have ThatMethods.Have.AttributeTests.TestAttribute matching attr => attr.Value == "WrongValue",
 					             but it contained not matching methods [
-					               Void TestMethod1(),
-					               Void TestMethod2()
+					               void ThatMethods.Have.AttributeTests.TestClass.TestMethod1(),
+					               void ThatMethods.Have.AttributeTests.TestClass.TestMethod2()
 					             ]
 					             """);
 			}
@@ -179,7 +179,7 @@ public sealed partial class ThatMethods
 						             Expected that subject
 						             all have ThatMethods.Have.OrHave.AttributeTests.TestAttribute or ThatMethods.Have.OrHave.AttributeTests.BarAttribute,
 						             but it contained not matching methods [
-						               Void NoAttributeMethod()
+						               void ThatMethods.Have.OrHave.AttributeTests.TestClass.NoAttributeMethod()
 						             ]
 						             """);
 				}
@@ -215,7 +215,7 @@ public sealed partial class ThatMethods
 						             Expected that subject
 						             all have ThatMethods.Have.OrHave.AttributeTests.TestAttribute matching attr => attr.Value == "WrongValue" or ThatMethods.Have.OrHave.AttributeTests.BarAttribute matching attr => attr.Name == "wrong",
 						             but it contained not matching methods [
-						               Void TestMethod1()
+						               void ThatMethods.Have.OrHave.AttributeTests.TestClass.TestMethod1()
 						             ]
 						             """);
 				}
@@ -299,7 +299,7 @@ public sealed partial class ThatMethods
 					             Expected that subjects
 					             not all have ThatMethods.Have.NegatedTests.TestAttribute or ThatMethods.Have.NegatedTests.TestAttribute matching x => x.Value == "foo",
 					             but it only contained matching methods [
-					               Void TestMethod1()
+					               void ThatMethods.Have.NegatedTests.TestClass.TestMethod1()
 					             ]
 					             """);
 			}

--- a/Tests/aweXpect.Reflection.Tests/ThatMethods.Return.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethods.Return.Tests.cs
@@ -190,7 +190,7 @@ public sealed partial class ThatMethods
 						             Expected that methods matching m => m.Name == nameof(TestClass.GetString) in type ThatMethods.TestClass
 						             not all return string,
 						             but it only contained matching methods [
-						               System.String GetString()
+						               string ThatMethods.TestClass.GetString()
 						             ]
 						             """)
 						.AsWildcard();
@@ -210,7 +210,7 @@ public sealed partial class ThatMethods
 						             Expected that methods matching m => m.Name == nameof(TestClass.GetDummy) in type ThatMethods.TestClass
 						             not all return ThatMethods.DummyBase,
 						             but it only contained matching methods [
-						               Dummy GetDummy()
+						               ThatMethods.Dummy ThatMethods.TestClass.GetDummy()
 						             ]
 						             """)
 						.AsWildcard();
@@ -245,7 +245,7 @@ public sealed partial class ThatMethods
 						             Expected that methods matching m => m.Name == nameof(TestClass.GetString) in type ThatMethods.TestClass
 						             not all return string,
 						             but it only contained matching methods [
-						               System.String GetString()
+						               string ThatMethods.TestClass.GetString()
 						             ]
 						             """)
 						.AsWildcard();
@@ -265,7 +265,7 @@ public sealed partial class ThatMethods
 						             Expected that methods matching m => m.Name == nameof(TestClass.GetDummy) in type ThatMethods.TestClass
 						             not all return ThatMethods.DummyBase,
 						             but it only contained matching methods [
-						               Dummy GetDummy()
+						               ThatMethods.Dummy ThatMethods.TestClass.GetDummy()
 						             ]
 						             """)
 						.AsWildcard();
@@ -313,8 +313,8 @@ public sealed partial class ThatMethods
 						             Expected that methods matching m => m.Name is nameof(TestClass.GetString) or nameof(TestClass.GetInt) in type ThatMethods.TestClass
 						             not all return string or int,
 						             but it only contained matching methods [
-						               System.String GetString(),
-						               Int32 GetInt()
+						               string ThatMethods.TestClass.GetString(),
+						               int ThatMethods.TestClass.GetInt()
 						             ]
 						             """)
 						.AsWildcard();

--- a/Tests/aweXpect.Reflection.Tests/ThatMethods.ReturnExactly.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethods.ReturnExactly.Tests.cs
@@ -114,7 +114,7 @@ public sealed partial class ThatMethods
 					             Expected that methods matching m => m.Name == nameof(TestClass.GetDummy) in type ThatMethods.TestClass
 					             all return exactly ThatMethods.DummyBase or exactly string,
 					             but it contained not matching methods [
-					               Dummy GetDummy()
+					               ThatMethods.Dummy ThatMethods.TestClass.GetDummy()
 					             ]
 					             """)
 					.AsWildcard();
@@ -177,7 +177,7 @@ public sealed partial class ThatMethods
 					             Expected that methods matching m => m.Name == nameof(TestClass.GetDummy) in type ThatMethods.TestClass
 					             all return exactly ThatMethods.DummyBase or string,
 					             but it contained not matching methods [
-					               Dummy GetDummy()
+					               ThatMethods.Dummy ThatMethods.TestClass.GetDummy()
 					             ]
 					             """)
 					.AsWildcard();
@@ -229,7 +229,7 @@ public sealed partial class ThatMethods
 						             Expected that methods matching m => m.Name == nameof(TestClass.GetString) in type ThatMethods.TestClass
 						             not all return exactly string,
 						             but it only contained matching methods [
-						               System.String GetString()
+						               string ThatMethods.TestClass.GetString()
 						             ]
 						             """)
 						.AsWildcard();


### PR DESCRIPTION
This PR implements method formatting functionality for the aweXpect.Reflection library. It adds a new `MethodFormatter` class that provides improved formatting for `MethodInfo` objects in test error messages, making them more descriptive and readable.

---

- *Implements part of #136*