### PR TITLE
feat: add support for generic arguments expectations

### DIFF
--- a/Source/aweXpect.Reflection/Filters/MethodFilters.WhichAreGeneric.cs
+++ b/Source/aweXpect.Reflection/Filters/MethodFilters.WhichAreGeneric.cs
@@ -52,15 +52,15 @@ public static partial class MethodFilters
 		/// </summary>
 		public GenericMethodsWithArgument WithArgument<T>()
 		{
-			Type? argumentType = typeof(T);
+			Type argumentType = typeof(T);
 			GenericArgumentFilterOptions genericArgumentFilterOptions = new(
 				p => argumentType == p.BaseType,
 				() => $"of type {Formatter.Format(typeof(T))}");
 			CollectionIndexOptions collectionIndexOptions = new();
-			IChangeableFilter<MethodInfo>? filter = Filter.Suffix<MethodInfo>(
+			IChangeableFilter<MethodInfo> filter = Filter.Suffix<MethodInfo>(
 				method =>
 				{
-					Type[]? arguments = method.GetGenericArguments();
+					Type[] arguments = method.GetGenericArguments();
 					return arguments.Where((p, i) =>
 					{
 						bool? isIndexInRange = collectionIndexOptions.Match switch
@@ -84,7 +84,7 @@ public static partial class MethodFilters
 		/// </summary>
 		public GenericMethodsWithNamedArgument WithArgument<T>(string expected)
 		{
-			Type? argumentType = typeof(T);
+			Type argumentType = typeof(T);
 			StringEqualityOptions stringEqualityOptions = new();
 			GenericArgumentFilterOptions genericArgumentFilterOptions = new(
 				p => argumentType == p.BaseType,
@@ -93,10 +93,10 @@ public static partial class MethodFilters
 				p => stringEqualityOptions.AreConsideredEqual(p.Name, expected),
 				() => $"name {stringEqualityOptions.GetExpectation(expected, ExpectationGrammars.None)}");
 			CollectionIndexOptions collectionIndexOptions = new();
-			IChangeableFilter<MethodInfo>? filter = Filter.Suffix<MethodInfo>(
+			IChangeableFilter<MethodInfo> filter = Filter.Suffix<MethodInfo>(
 				method =>
 				{
-					Type[]? arguments = method.GetGenericArguments();
+					Type[] arguments = method.GetGenericArguments();
 					return arguments.Where((p, i) =>
 					{
 						bool? isIndexInRange = collectionIndexOptions.Match switch
@@ -125,10 +125,10 @@ public static partial class MethodFilters
 				p => stringEqualityOptions.AreConsideredEqual(p.Name, expected),
 				() => $"name {stringEqualityOptions.GetExpectation(expected, ExpectationGrammars.None)}");
 			CollectionIndexOptions collectionIndexOptions = new();
-			IChangeableFilter<MethodInfo>? filter = Filter.Suffix<MethodInfo>(
+			IChangeableFilter<MethodInfo> filter = Filter.Suffix<MethodInfo>(
 				method =>
 				{
-					Type[]? arguments = method.GetGenericArguments();
+					Type[] arguments = method.GetGenericArguments();
 					return arguments.Where((p, i) =>
 					{
 						bool? isIndexInRange = collectionIndexOptions.Match switch
@@ -184,7 +184,7 @@ public static partial class MethodFilters
 		StringEqualityOptions IOptionsProvider<StringEqualityOptions>.Options => options;
 
 		/// <summary>
-		///     Ignores casing when comparing the parameter name,
+		///     Ignores casing when comparing the generic argument name,
 		///     according to the <paramref name="ignoreCase" /> parameter.
 		/// </summary>
 		public GenericMethodsWithNamedArgument IgnoringCase(bool ignoreCase = true)
@@ -194,7 +194,7 @@ public static partial class MethodFilters
 		}
 
 		/// <summary>
-		///     Uses the provided <paramref name="comparer" /> for comparing parameter names.
+		///     Uses the provided <paramref name="comparer" /> for comparing generic argument names.
 		/// </summary>
 		public GenericMethodsWithNamedArgument Using(IEqualityComparer<string> comparer)
 		{
@@ -203,7 +203,7 @@ public static partial class MethodFilters
 		}
 
 		/// <summary>
-		///     Interprets the expected parameter name as a prefix, so that the actual value starts with it.
+		///     Interprets the expected generic argument name as a prefix, so that the actual value starts with it.
 		/// </summary>
 		public GenericMethodsWithNamedArgument AsPrefix()
 		{
@@ -212,7 +212,7 @@ public static partial class MethodFilters
 		}
 
 		/// <summary>
-		///     Interprets the expected parameter name as a <see cref="Regex" /> pattern.
+		///     Interprets the expected generic argument name as a <see cref="Regex" /> pattern.
 		/// </summary>
 		public GenericMethodsWithNamedArgument AsRegex()
 		{
@@ -221,7 +221,7 @@ public static partial class MethodFilters
 		}
 
 		/// <summary>
-		///     Interprets the expected parameter name as a suffix, so that the actual value ends with it.
+		///     Interprets the expected generic argument name as a suffix, so that the actual value ends with it.
 		/// </summary>
 		public GenericMethodsWithNamedArgument AsSuffix()
 		{
@@ -230,7 +230,7 @@ public static partial class MethodFilters
 		}
 
 		/// <summary>
-		///     Interprets the expected parameter name as wildcard pattern.<br />
+		///     Interprets the expected generic argument name as wildcard pattern.<br />
 		///     Supports * to match zero or more characters and ? to match exactly one character.
 		/// </summary>
 		public GenericMethodsWithNamedArgument AsWildcard()

--- a/Source/aweXpect.Reflection/Options/GenericArgumentFilterOptions.cs
+++ b/Source/aweXpect.Reflection/Options/GenericArgumentFilterOptions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using aweXpect.Options;
 
 namespace aweXpect.Reflection.Options;
 
@@ -39,4 +40,87 @@ public class GenericArgumentFilterOptions(Func<Type, bool> predicate, Func<strin
 	/// </summary>
 	public string GetDescription()
 		=> string.Join(" and ", _descriptions.Select(@delegate => @delegate()));
+}
+
+/// <summary>
+///     Options for adding additional <see cref="GenericArgumentFilterOptions" /> to filter the generic arguments.
+/// </summary>
+public class GenericArgumentsFilterOptions
+{
+	private readonly List<Func<string>> _descriptions = [];
+	private readonly Dictionary<GenericArgumentFilterOptions, CollectionIndexOptions> _filters = [];
+	private readonly List<Func<Type[], bool>> _predicates = [];
+
+	/// <summary>
+	///     Adds an additional <paramref name="predicate" /> with the <paramref name="description" />.
+	/// </summary>
+	public void AddPredicate(Func<Type[], bool> predicate, Func<string> description)
+	{
+		_predicates.Add(predicate);
+		_descriptions.Add(description);
+	}
+
+	/// <summary>
+	///     Adds an additional <see cref="GenericArgumentFilterOptions" />.
+	/// </summary>
+	public void AddFilter(GenericArgumentFilterOptions filter, CollectionIndexOptions options)
+		=> _filters.Add(filter, options);
+
+	/// <summary>
+	///     Verifies that the <paramref name="arguments" /> matches all predicates.
+	/// </summary>
+	public bool Matches(Type[] arguments)
+	{
+		if (_predicates.Count == 0 && _filters.Count == 0)
+		{
+			return true;
+		}
+
+		if (_predicates.All(predicate => predicate(arguments)))
+		{
+#if NET8_0_OR_GREATER
+			foreach (var (filter, collectionIndexOptions) in _filters)
+			{
+#else
+			foreach (KeyValuePair<GenericArgumentFilterOptions, CollectionIndexOptions> keyItem in _filters)
+			{
+				GenericArgumentFilterOptions filter = keyItem.Key;
+				CollectionIndexOptions collectionIndexOptions = keyItem.Value;
+#endif
+				if (!arguments.Where((p, i) =>
+				    {
+					    bool? isIndexInRange = collectionIndexOptions.Match switch
+					    {
+						    CollectionIndexOptions.IMatchFromBeginning fromBeginning => fromBeginning.MatchesIndex(i),
+						    CollectionIndexOptions.IMatchFromEnd fromEnd => fromEnd.MatchesIndex(i, arguments.Length),
+						    _ => false,
+					    };
+					    return isIndexInRange == true &&
+					           filter.Matches(p);
+				    }).Any())
+				{
+					return false;
+				}
+			}
+
+			return true;
+		}
+
+		return false;
+	}
+
+	/// <summary>
+	///     Returns the combination of all descriptions joined by <c>" and "</c>.
+	/// </summary>
+	public string GetDescription()
+	{
+		List<string> descriptions = _descriptions.Select(@delegate => @delegate()).ToList();
+		descriptions.AddRange(_filters.Select(x => $"with argument {x.Key.GetDescription()}{x.Value.Match.GetDescription()}"));
+		if (descriptions.Count == 0)
+		{
+			return string.Empty;
+		}
+
+		return $" {string.Join(" and ", descriptions)}";
+	}
 }

--- a/Source/aweXpect.Reflection/Results/GenericArgumentCollectionResult.cs
+++ b/Source/aweXpect.Reflection/Results/GenericArgumentCollectionResult.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using aweXpect.Core;
+using aweXpect.Options;
+using aweXpect.Reflection.Options;
+using aweXpect.Results;
+
+namespace aweXpect.Reflection.Results;
+
+/// <summary>
+///     Additional constraints on a parameter collection with a parameter of a specific type.
+/// </summary>
+public class GenericArgumentCollectionResult<TThat>(
+	ExpectationBuilder expectationBuilder,
+	IThat<TThat> subject,
+	GenericArgumentsFilterOptions genericArgumentsFilterOptions)
+	: AndOrResult<TThat, IThat<TThat>>(expectationBuilder, subject),
+		IOptionsProvider<GenericArgumentsFilterOptions>
+{
+	private readonly ExpectationBuilder _expectationBuilder = expectationBuilder;
+	private readonly IThat<TThat> _subject = subject;
+
+	/// <inheritdoc cref="IOptionsProvider{GenericArgumentsFilterOptions}.Options" />
+	GenericArgumentsFilterOptions IOptionsProvider<GenericArgumentsFilterOptions>.Options
+		=> genericArgumentsFilterOptions;
+
+	/// <summary>
+	///     …with the <paramref name="expected" /> number of generic arguments.
+	/// </summary>
+	public GenericArgumentCollectionResult<TThat> WithArgumentCount(int expected)
+	{
+		genericArgumentsFilterOptions.AddPredicate(arguments => arguments.Length == expected,
+			() => $"with {expected} generic {(expected == 1 ? "argument" : "arguments")}");
+		return this;
+	}
+
+	/// <summary>
+	///     …with a generic argument constrained to type <typeparamref name="T" />.
+	/// </summary>
+	public GenericArgumentCollectionWithArgumentResult<TThat> WithArgument<T>()
+	{
+		Type argumentType = typeof(T);
+		GenericArgumentFilterOptions genericArgumentFilterOptions = new(
+			p => argumentType == p.BaseType,
+			() => $"of type {Formatter.Format(typeof(T))}");
+		CollectionIndexOptions collectionIndexOptions = new();
+		genericArgumentsFilterOptions.AddFilter(genericArgumentFilterOptions, collectionIndexOptions);
+		return new GenericArgumentCollectionWithArgumentResult<TThat>(
+			_expectationBuilder, _subject, genericArgumentsFilterOptions, collectionIndexOptions);
+	}
+
+	/// <summary>
+	///     …with a generic argument constrained to type <typeparamref name="T" /> and the <paramref name="expected" /> name.
+	/// </summary>
+	public GenericArgumentCollectionWithNamedArgumentResult<TThat> WithArgument<T>(string expected)
+	{
+		StringEqualityOptions stringEqualityOptions = new();
+		Type argumentType = typeof(T);
+		GenericArgumentFilterOptions genericArgumentFilterOptions = new(
+			p => argumentType == p.BaseType,
+			() => $"of type {Formatter.Format(typeof(T))}");
+		genericArgumentFilterOptions.AddPredicate(
+			p => stringEqualityOptions.AreConsideredEqual(p.Name, expected),
+			() => $"name {stringEqualityOptions.GetExpectation(expected, ExpectationGrammars.None)}");
+		CollectionIndexOptions collectionIndexOptions = new();
+		genericArgumentsFilterOptions.AddFilter(genericArgumentFilterOptions, collectionIndexOptions);
+		return new GenericArgumentCollectionWithNamedArgumentResult<TThat>(
+			_expectationBuilder, _subject, genericArgumentsFilterOptions, collectionIndexOptions,
+			stringEqualityOptions);
+	}
+
+	/// <summary>
+	///     …with a generic argument with the <paramref name="expected" /> name.
+	/// </summary>
+	public GenericArgumentCollectionWithNamedArgumentResult<TThat> WithArgument(string expected)
+	{
+		StringEqualityOptions stringEqualityOptions = new();
+		GenericArgumentFilterOptions genericArgumentFilterOptions = new(
+			p => stringEqualityOptions.AreConsideredEqual(p.Name, expected),
+			() => $"name {stringEqualityOptions.GetExpectation(expected, ExpectationGrammars.None)}");
+		CollectionIndexOptions collectionIndexOptions = new();
+		genericArgumentsFilterOptions.AddFilter(genericArgumentFilterOptions, collectionIndexOptions);
+		return new GenericArgumentCollectionWithNamedArgumentResult<TThat>(
+			_expectationBuilder, _subject, genericArgumentsFilterOptions, collectionIndexOptions,
+			stringEqualityOptions);
+	}
+}

--- a/Source/aweXpect.Reflection/Results/GenericArgumentCollectionWithArgumentAtIndexResult.cs
+++ b/Source/aweXpect.Reflection/Results/GenericArgumentCollectionWithArgumentAtIndexResult.cs
@@ -1,0 +1,35 @@
+﻿using aweXpect.Core;
+using aweXpect.Options;
+using aweXpect.Reflection.Options;
+
+namespace aweXpect.Reflection.Results;
+
+/// <summary>
+///     Additional constraints on a collection of generic arguments at a given index.
+/// </summary>
+public class GenericArgumentCollectionWithArgumentAtIndexResult<TThat>(
+	ExpectationBuilder expectationBuilder,
+	IThat<TThat> subject,
+	GenericArgumentsFilterOptions genericArgumentsFilterOptions,
+	CollectionIndexOptions collectionIndexOptions)
+	: GenericArgumentCollectionResult<TThat>(expectationBuilder, subject, genericArgumentsFilterOptions),
+		IOptionsProvider<CollectionIndexOptions>
+{
+	private readonly CollectionIndexOptions _collectionIndexOptions = collectionIndexOptions;
+
+	/// <inheritdoc cref="IOptionsProvider{CollectionIndexOptions}.Options" />
+	CollectionIndexOptions IOptionsProvider<CollectionIndexOptions>.Options => _collectionIndexOptions;
+
+	/// <summary>
+	///     …from end.
+	/// </summary>
+	public GenericArgumentCollectionResult<TThat> FromEnd()
+	{
+		if (_collectionIndexOptions.Match is CollectionIndexOptions.IMatchFromBeginning match)
+		{
+			_collectionIndexOptions.SetMatch(match.FromEnd());
+		}
+
+		return this;
+	}
+}

--- a/Source/aweXpect.Reflection/Results/GenericArgumentCollectionWithArgumentResult.cs
+++ b/Source/aweXpect.Reflection/Results/GenericArgumentCollectionWithArgumentResult.cs
@@ -1,0 +1,36 @@
+﻿using aweXpect.Core;
+using aweXpect.Options;
+using aweXpect.Reflection.Helpers;
+using aweXpect.Reflection.Options;
+
+namespace aweXpect.Reflection.Results;
+
+/// <summary>
+///     Additional constraints on a collection of generic arguments with a specific type.
+/// </summary>
+public class GenericArgumentCollectionWithArgumentResult<TThat>(
+	ExpectationBuilder expectationBuilder,
+	IThat<TThat> subject,
+	GenericArgumentsFilterOptions genericArgumentsFilterOptions,
+	CollectionIndexOptions collectionIndexOptions)
+	: GenericArgumentCollectionResult<TThat>(
+			expectationBuilder, subject, genericArgumentsFilterOptions),
+		IOptionsProvider<CollectionIndexOptions>
+{
+	private readonly ExpectationBuilder _expectationBuilder = expectationBuilder;
+	private readonly GenericArgumentsFilterOptions _genericArgumentsFilterOptions = genericArgumentsFilterOptions;
+	private readonly IThat<TThat> _subject = subject;
+
+	/// <inheritdoc cref="IOptionsProvider{CollectionIndexOptions}.Options" />
+	CollectionIndexOptions IOptionsProvider<CollectionIndexOptions>.Options => collectionIndexOptions;
+
+	/// <summary>
+	///     …at the given <paramref name="index" />.
+	/// </summary>
+	public GenericArgumentCollectionWithArgumentAtIndexResult<TThat> AtIndex(int index)
+	{
+		collectionIndexOptions.SetMatch(new AtIndexMatch(index));
+		return new GenericArgumentCollectionWithArgumentAtIndexResult<TThat>(
+			_expectationBuilder, _subject, _genericArgumentsFilterOptions, collectionIndexOptions);
+	}
+}

--- a/Source/aweXpect.Reflection/Results/GenericArgumentCollectionWithNamedArgumentResult.cs
+++ b/Source/aweXpect.Reflection/Results/GenericArgumentCollectionWithNamedArgumentResult.cs
@@ -1,0 +1,80 @@
+﻿using System.Collections.Generic;
+using System.Text.RegularExpressions;
+using aweXpect.Core;
+using aweXpect.Options;
+using aweXpect.Reflection.Options;
+
+namespace aweXpect.Reflection.Results;
+
+/// <summary>
+///     Additional constraints on a collection of generic arguments with a parameter with an expected name.
+/// </summary>
+public class GenericArgumentCollectionWithNamedArgumentResult<TThat>(
+	ExpectationBuilder expectationBuilder,
+	IThat<TThat> subject,
+	GenericArgumentsFilterOptions genericArgumentsFilterOptions,
+	CollectionIndexOptions collectionIndexOptions,
+	StringEqualityOptions options)
+	: GenericArgumentCollectionWithArgumentResult<TThat>(
+			expectationBuilder, subject, genericArgumentsFilterOptions, collectionIndexOptions),
+		IOptionsProvider<StringEqualityOptions>
+{
+	/// <inheritdoc cref="IOptionsProvider{CollectionIndexOptions}.Options" />
+	StringEqualityOptions IOptionsProvider<StringEqualityOptions>.Options => options;
+
+	/// <summary>
+	///     Ignores casing when comparing the generic argument name,
+	///     according to the <paramref name="ignoreCase" /> parameter.
+	/// </summary>
+	public GenericArgumentCollectionWithArgumentResult<TThat> IgnoringCase(bool ignoreCase = true)
+	{
+		options.IgnoringCase(ignoreCase);
+		return this;
+	}
+
+	/// <summary>
+	///     Uses the provided <paramref name="comparer" /> for comparing generic argument names.
+	/// </summary>
+	public GenericArgumentCollectionWithArgumentResult<TThat> Using(IEqualityComparer<string> comparer)
+	{
+		options.UsingComparer(comparer);
+		return this;
+	}
+
+	/// <summary>
+	///     Interprets the expected generic argument name as a prefix, so that the actual value starts with it.
+	/// </summary>
+	public GenericArgumentCollectionWithArgumentResult<TThat> AsPrefix()
+	{
+		options.AsPrefix();
+		return this;
+	}
+
+	/// <summary>
+	///     Interprets the expected generic argument name as a <see cref="Regex" /> pattern.
+	/// </summary>
+	public GenericArgumentCollectionWithArgumentResult<TThat> AsRegex()
+	{
+		options.AsRegex();
+		return this;
+	}
+
+	/// <summary>
+	///     Interprets the expected generic argument name as a suffix, so that the actual value ends with it.
+	/// </summary>
+	public GenericArgumentCollectionWithArgumentResult<TThat> AsSuffix()
+	{
+		options.AsSuffix();
+		return this;
+	}
+
+	/// <summary>
+	///     Interprets the expected generic argument name as wildcard pattern.<br />
+	///     Supports * to match zero or more characters and ? to match exactly one character.
+	/// </summary>
+	public GenericArgumentCollectionWithArgumentResult<TThat> AsWildcard()
+	{
+		options.AsWildcard();
+		return this;
+	}
+}

--- a/Source/aweXpect.Reflection/ThatMethod.IsGeneric.cs
+++ b/Source/aweXpect.Reflection/ThatMethod.IsGeneric.cs
@@ -3,6 +3,8 @@ using System.Text;
 using aweXpect.Core;
 using aweXpect.Core.Constraints;
 using aweXpect.Reflection.Helpers;
+using aweXpect.Reflection.Options;
+using aweXpect.Reflection.Results;
 using aweXpect.Results;
 
 namespace aweXpect.Reflection;
@@ -12,38 +14,64 @@ public static partial class ThatMethod
 	/// <summary>
 	///     Verifies that the <see cref="MethodInfo" /> is generic.
 	/// </summary>
-	public static AndOrResult<MethodInfo?, IThat<MethodInfo?>> IsGeneric(
+	public static GenericArgumentCollectionResult<MethodInfo?> IsGeneric(
 		this IThat<MethodInfo?> subject)
-		=> new(subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new IsGenericConstraint(it, grammars)),
-			subject);
+	{
+		GenericArgumentsFilterOptions genericFilterOptions = new();
+		return new GenericArgumentCollectionResult<MethodInfo?>(subject.Get().ExpectationBuilder
+				.AddConstraint((it, grammars)
+					=> new IsGenericConstraint(it, grammars,
+						genericFilterOptions)),
+			subject,
+			genericFilterOptions);
+	}
 
 	/// <summary>
 	///     Verifies that the <see cref="MethodInfo" /> is not generic.
 	/// </summary>
 	public static AndOrResult<MethodInfo?, IThat<MethodInfo?>> IsNotGeneric(
 		this IThat<MethodInfo?> subject)
-		=> new(subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new IsGenericConstraint(it, grammars).Invert()),
+	{
+		GenericArgumentsFilterOptions genericFilterOptions = new();
+		return new AndOrResult<MethodInfo?, IThat<MethodInfo?>>(subject.Get().ExpectationBuilder
+				.AddConstraint((it, grammars)
+					=> new IsGenericConstraint(it, grammars, genericFilterOptions).Invert()),
 			subject);
+	}
 
-	private sealed class IsGenericConstraint(string it, ExpectationGrammars grammars)
+	private sealed class IsGenericConstraint(
+		string it,
+		ExpectationGrammars grammars,
+		GenericArgumentsFilterOptions options)
 		: ConstraintResult.WithNotNullValue<MethodInfo?>(it, grammars),
 			IValueConstraint<MethodInfo?>
 	{
 		public ConstraintResult IsMetBy(MethodInfo? actual)
 		{
 			Actual = actual;
-			Outcome = actual?.IsGenericMethod == true ? Outcome.Success : Outcome.Failure;
+			Outcome = actual?.IsGenericMethod == true && options.Matches(actual.GetGenericArguments())
+				? Outcome.Success
+				: Outcome.Failure;
 			return this;
 		}
 
 		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
-			=> stringBuilder.Append("is generic");
+		{
+			stringBuilder.Append("is generic");
+			stringBuilder.Append(options.GetDescription());
+		}
 
 		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
 		{
-			stringBuilder.Append(It).Append(" was non-generic ");
+			if (Actual?.IsGenericMethod == true)
+			{
+				stringBuilder.Append(It).Append(" was generic ");
+			}
+			else
+			{
+				stringBuilder.Append(It).Append(" was non-generic ");
+			}
+
 			Formatter.Format(stringBuilder, Actual);
 		}
 

--- a/Source/aweXpect.Reflection/ThatMethods.AreGeneric.cs
+++ b/Source/aweXpect.Reflection/ThatMethods.AreGeneric.cs
@@ -5,6 +5,8 @@ using System.Text;
 using aweXpect.Core;
 using aweXpect.Core.Constraints;
 using aweXpect.Reflection.Helpers;
+using aweXpect.Reflection.Options;
+using aweXpect.Reflection.Results;
 using aweXpect.Results;
 
 // ReSharper disable PossibleMultipleEnumeration
@@ -16,11 +18,16 @@ public static partial class ThatMethods
 	/// <summary>
 	///     Verifies that all items in the filtered collection of <see cref="MethodInfo" /> are generic.
 	/// </summary>
-	public static AndOrResult<IEnumerable<MethodInfo?>, IThat<IEnumerable<MethodInfo?>>> AreGeneric(
+	public static GenericArgumentCollectionResult<IEnumerable<MethodInfo?>> AreGeneric(
 		this IThat<IEnumerable<MethodInfo?>> subject)
-		=> new(subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new AreGenericConstraint(it, grammars)),
-			subject);
+	{
+		GenericArgumentsFilterOptions genericFilterOptions = new();
+		return new GenericArgumentCollectionResult<IEnumerable<MethodInfo?>>(subject.Get().ExpectationBuilder
+				.AddConstraint((it, grammars)
+					=> new AreGenericConstraint(it, grammars, genericFilterOptions)),
+			subject,
+			genericFilterOptions);
+	}
 
 	/// <summary>
 	///     Verifies that all items in the filtered collection of <see cref="MethodInfo" /> are not generic.
@@ -31,24 +38,37 @@ public static partial class ThatMethods
 				=> new AreNotGenericConstraint(it, grammars)),
 			subject);
 
-	private sealed class AreGenericConstraint(string it, ExpectationGrammars grammars)
+	private sealed class AreGenericConstraint(
+		string it,
+		ExpectationGrammars grammars,
+		GenericArgumentsFilterOptions options)
 		: ConstraintResult.WithValue<IEnumerable<MethodInfo?>>(grammars),
 			IValueConstraint<IEnumerable<MethodInfo?>>
 	{
 		public ConstraintResult IsMetBy(IEnumerable<MethodInfo?> actual)
 		{
 			Actual = actual;
-			Outcome = actual.All(method => method?.IsGenericMethod == true) ? Outcome.Success : Outcome.Failure;
+			Outcome = actual
+				.All(method =>
+					method?.IsGenericMethod == true &&
+					options.Matches(method.GetGenericArguments()))
+				? Outcome.Success
+				: Outcome.Failure;
 			return this;
 		}
 
 		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
-			=> stringBuilder.Append("are all generic");
+		{
+			stringBuilder.Append("are all generic");
+			stringBuilder.Append(options.GetDescription());
+		}
 
 		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
 		{
-			stringBuilder.Append(it).Append(" contained non-generic methods ");
-			Formatter.Format(stringBuilder, Actual?.Where(method => method?.IsGenericMethod != true),
+			stringBuilder.Append(it).Append(" contained not matching methods ");
+			Formatter.Format(stringBuilder,
+				Actual?.Where(method
+					=> method?.IsGenericMethod != true || !options.Matches(method.GetGenericArguments())),
 				FormattingOptions.Indented(indentation));
 		}
 
@@ -58,7 +78,9 @@ public static partial class ThatMethods
 		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
 		{
 			stringBuilder.Append(it).Append(" only contained generic methods ");
-			Formatter.Format(stringBuilder, Actual?.Where(method => method?.IsGenericMethod == true),
+			Formatter.Format(stringBuilder,
+				Actual?.Where(method
+					=> method?.IsGenericMethod == true && options.Matches(method.GetGenericArguments())),
 				FormattingOptions.Indented(indentation));
 		}
 	}

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net8.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net8.0.txt
@@ -473,7 +473,7 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Results.ParameterCollectionResult<System.Reflection.MethodInfo?, TParameter> HasParameter<TParameter>(this aweXpect.Core.IThat<System.Reflection.MethodInfo?> subject) { }
         public static aweXpect.Reflection.Results.NamedParameterCollectionResult<System.Reflection.MethodInfo?, TParameter> HasParameter<TParameter>(this aweXpect.Core.IThat<System.Reflection.MethodInfo?> subject, string expected) { }
         public static aweXpect.Results.AndOrResult<System.Reflection.MethodInfo?, aweXpect.Core.IThat<System.Reflection.MethodInfo?>> IsAbstract(this aweXpect.Core.IThat<System.Reflection.MethodInfo?> subject) { }
-        public static aweXpect.Results.AndOrResult<System.Reflection.MethodInfo?, aweXpect.Core.IThat<System.Reflection.MethodInfo?>> IsGeneric(this aweXpect.Core.IThat<System.Reflection.MethodInfo?> subject) { }
+        public static aweXpect.Reflection.Results.GenericArgumentCollectionResult<System.Reflection.MethodInfo?> IsGeneric(this aweXpect.Core.IThat<System.Reflection.MethodInfo?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Reflection.MethodInfo?, aweXpect.Core.IThat<System.Reflection.MethodInfo?>> IsNotAbstract(this aweXpect.Core.IThat<System.Reflection.MethodInfo?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Reflection.MethodInfo?, aweXpect.Core.IThat<System.Reflection.MethodInfo?>> IsNotGeneric(this aweXpect.Core.IThat<System.Reflection.MethodInfo?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Reflection.MethodInfo?, aweXpect.Core.IThat<System.Reflection.MethodInfo?>> IsNotSealed(this aweXpect.Core.IThat<System.Reflection.MethodInfo?> subject) { }
@@ -497,7 +497,7 @@ namespace aweXpect.Reflection
     public static class ThatMethods
     {
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo?>>> AreAbstract(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo?>> subject) { }
-        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo?>>> AreGeneric(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo?>> subject) { }
+        public static aweXpect.Reflection.Results.GenericArgumentCollectionResult<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo?>> AreGeneric(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo?>>> AreNotAbstract(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo?>>> AreNotGeneric(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo?>>> AreNotSealed(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo?>> subject) { }
@@ -958,6 +958,14 @@ namespace aweXpect.Reflection.Options
         public string GetDescription() { }
         public bool Matches(System.Type argument) { }
     }
+    public class GenericArgumentsFilterOptions
+    {
+        public GenericArgumentsFilterOptions() { }
+        public void AddFilter(aweXpect.Reflection.Options.GenericArgumentFilterOptions filter, aweXpect.Options.CollectionIndexOptions options) { }
+        public void AddPredicate(System.Func<System.Type[], bool> predicate, System.Func<string> description) { }
+        public string GetDescription() { }
+        public bool Matches(System.Type[] arguments) { }
+    }
     public class ParameterFilterOptions
     {
         public ParameterFilterOptions(System.Func<System.Reflection.ParameterInfo, bool> predicate, System.Func<string> description) { }
@@ -975,6 +983,34 @@ namespace aweXpect.Reflection.Options
 }
 namespace aweXpect.Reflection.Results
 {
+    public class GenericArgumentCollectionResult<TThat> : aweXpect.Results.AndOrResult<TThat, aweXpect.Core.IThat<TThat>>, aweXpect.Core.IOptionsProvider<aweXpect.Reflection.Options.GenericArgumentsFilterOptions>
+    {
+        public GenericArgumentCollectionResult(aweXpect.Core.ExpectationBuilder expectationBuilder, aweXpect.Core.IThat<TThat> subject, aweXpect.Reflection.Options.GenericArgumentsFilterOptions genericArgumentsFilterOptions) { }
+        public aweXpect.Reflection.Results.GenericArgumentCollectionWithNamedArgumentResult<TThat> WithArgument(string expected) { }
+        public aweXpect.Reflection.Results.GenericArgumentCollectionWithArgumentResult<TThat> WithArgument<T>() { }
+        public aweXpect.Reflection.Results.GenericArgumentCollectionWithNamedArgumentResult<TThat> WithArgument<T>(string expected) { }
+        public aweXpect.Reflection.Results.GenericArgumentCollectionResult<TThat> WithArgumentCount(int expected) { }
+    }
+    public class GenericArgumentCollectionWithArgumentAtIndexResult<TThat> : aweXpect.Reflection.Results.GenericArgumentCollectionResult<TThat>, aweXpect.Core.IOptionsProvider<aweXpect.Options.CollectionIndexOptions>
+    {
+        public GenericArgumentCollectionWithArgumentAtIndexResult(aweXpect.Core.ExpectationBuilder expectationBuilder, aweXpect.Core.IThat<TThat> subject, aweXpect.Reflection.Options.GenericArgumentsFilterOptions genericArgumentsFilterOptions, aweXpect.Options.CollectionIndexOptions collectionIndexOptions) { }
+        public aweXpect.Reflection.Results.GenericArgumentCollectionResult<TThat> FromEnd() { }
+    }
+    public class GenericArgumentCollectionWithArgumentResult<TThat> : aweXpect.Reflection.Results.GenericArgumentCollectionResult<TThat>, aweXpect.Core.IOptionsProvider<aweXpect.Options.CollectionIndexOptions>
+    {
+        public GenericArgumentCollectionWithArgumentResult(aweXpect.Core.ExpectationBuilder expectationBuilder, aweXpect.Core.IThat<TThat> subject, aweXpect.Reflection.Options.GenericArgumentsFilterOptions genericArgumentsFilterOptions, aweXpect.Options.CollectionIndexOptions collectionIndexOptions) { }
+        public aweXpect.Reflection.Results.GenericArgumentCollectionWithArgumentAtIndexResult<TThat> AtIndex(int index) { }
+    }
+    public class GenericArgumentCollectionWithNamedArgumentResult<TThat> : aweXpect.Reflection.Results.GenericArgumentCollectionWithArgumentResult<TThat>, aweXpect.Core.IOptionsProvider<aweXpect.Options.StringEqualityOptions>
+    {
+        public GenericArgumentCollectionWithNamedArgumentResult(aweXpect.Core.ExpectationBuilder expectationBuilder, aweXpect.Core.IThat<TThat> subject, aweXpect.Reflection.Options.GenericArgumentsFilterOptions genericArgumentsFilterOptions, aweXpect.Options.CollectionIndexOptions collectionIndexOptions, aweXpect.Options.StringEqualityOptions options) { }
+        public aweXpect.Reflection.Results.GenericArgumentCollectionWithArgumentResult<TThat> AsPrefix() { }
+        public aweXpect.Reflection.Results.GenericArgumentCollectionWithArgumentResult<TThat> AsRegex() { }
+        public aweXpect.Reflection.Results.GenericArgumentCollectionWithArgumentResult<TThat> AsSuffix() { }
+        public aweXpect.Reflection.Results.GenericArgumentCollectionWithArgumentResult<TThat> AsWildcard() { }
+        public aweXpect.Reflection.Results.GenericArgumentCollectionWithArgumentResult<TThat> IgnoringCase(bool ignoreCase = true) { }
+        public aweXpect.Reflection.Results.GenericArgumentCollectionWithArgumentResult<TThat> Using(System.Collections.Generic.IEqualityComparer<string> comparer) { }
+    }
     public sealed class HasAttributeResult<TMember> : aweXpect.Results.AndOrResult<TMember, aweXpect.Core.IThat<TMember>>, aweXpect.Core.IOptionsProvider<aweXpect.Reflection.Options.AttributeFilterOptions<TMember>>
     {
         public HasAttributeResult(aweXpect.Core.ExpectationBuilder expectationBuilder, aweXpect.Core.IThat<TMember> subject, aweXpect.Reflection.Options.AttributeFilterOptions<TMember> attributeFilterOptions) { }

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_netstandard2.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_netstandard2.0.txt
@@ -473,7 +473,7 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Results.ParameterCollectionResult<System.Reflection.MethodInfo?, TParameter> HasParameter<TParameter>(this aweXpect.Core.IThat<System.Reflection.MethodInfo?> subject) { }
         public static aweXpect.Reflection.Results.NamedParameterCollectionResult<System.Reflection.MethodInfo?, TParameter> HasParameter<TParameter>(this aweXpect.Core.IThat<System.Reflection.MethodInfo?> subject, string expected) { }
         public static aweXpect.Results.AndOrResult<System.Reflection.MethodInfo?, aweXpect.Core.IThat<System.Reflection.MethodInfo?>> IsAbstract(this aweXpect.Core.IThat<System.Reflection.MethodInfo?> subject) { }
-        public static aweXpect.Results.AndOrResult<System.Reflection.MethodInfo?, aweXpect.Core.IThat<System.Reflection.MethodInfo?>> IsGeneric(this aweXpect.Core.IThat<System.Reflection.MethodInfo?> subject) { }
+        public static aweXpect.Reflection.Results.GenericArgumentCollectionResult<System.Reflection.MethodInfo?> IsGeneric(this aweXpect.Core.IThat<System.Reflection.MethodInfo?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Reflection.MethodInfo?, aweXpect.Core.IThat<System.Reflection.MethodInfo?>> IsNotAbstract(this aweXpect.Core.IThat<System.Reflection.MethodInfo?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Reflection.MethodInfo?, aweXpect.Core.IThat<System.Reflection.MethodInfo?>> IsNotGeneric(this aweXpect.Core.IThat<System.Reflection.MethodInfo?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Reflection.MethodInfo?, aweXpect.Core.IThat<System.Reflection.MethodInfo?>> IsNotSealed(this aweXpect.Core.IThat<System.Reflection.MethodInfo?> subject) { }
@@ -497,7 +497,7 @@ namespace aweXpect.Reflection
     public static class ThatMethods
     {
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo?>>> AreAbstract(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo?>> subject) { }
-        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo?>>> AreGeneric(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo?>> subject) { }
+        public static aweXpect.Reflection.Results.GenericArgumentCollectionResult<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo?>> AreGeneric(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo?>>> AreNotAbstract(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo?>>> AreNotGeneric(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo?>>> AreNotSealed(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo?>> subject) { }
@@ -958,6 +958,14 @@ namespace aweXpect.Reflection.Options
         public string GetDescription() { }
         public bool Matches(System.Type argument) { }
     }
+    public class GenericArgumentsFilterOptions
+    {
+        public GenericArgumentsFilterOptions() { }
+        public void AddFilter(aweXpect.Reflection.Options.GenericArgumentFilterOptions filter, aweXpect.Options.CollectionIndexOptions options) { }
+        public void AddPredicate(System.Func<System.Type[], bool> predicate, System.Func<string> description) { }
+        public string GetDescription() { }
+        public bool Matches(System.Type[] arguments) { }
+    }
     public class ParameterFilterOptions
     {
         public ParameterFilterOptions(System.Func<System.Reflection.ParameterInfo, bool> predicate, System.Func<string> description) { }
@@ -975,6 +983,34 @@ namespace aweXpect.Reflection.Options
 }
 namespace aweXpect.Reflection.Results
 {
+    public class GenericArgumentCollectionResult<TThat> : aweXpect.Results.AndOrResult<TThat, aweXpect.Core.IThat<TThat>>, aweXpect.Core.IOptionsProvider<aweXpect.Reflection.Options.GenericArgumentsFilterOptions>
+    {
+        public GenericArgumentCollectionResult(aweXpect.Core.ExpectationBuilder expectationBuilder, aweXpect.Core.IThat<TThat> subject, aweXpect.Reflection.Options.GenericArgumentsFilterOptions genericArgumentsFilterOptions) { }
+        public aweXpect.Reflection.Results.GenericArgumentCollectionWithNamedArgumentResult<TThat> WithArgument(string expected) { }
+        public aweXpect.Reflection.Results.GenericArgumentCollectionWithArgumentResult<TThat> WithArgument<T>() { }
+        public aweXpect.Reflection.Results.GenericArgumentCollectionWithNamedArgumentResult<TThat> WithArgument<T>(string expected) { }
+        public aweXpect.Reflection.Results.GenericArgumentCollectionResult<TThat> WithArgumentCount(int expected) { }
+    }
+    public class GenericArgumentCollectionWithArgumentAtIndexResult<TThat> : aweXpect.Reflection.Results.GenericArgumentCollectionResult<TThat>, aweXpect.Core.IOptionsProvider<aweXpect.Options.CollectionIndexOptions>
+    {
+        public GenericArgumentCollectionWithArgumentAtIndexResult(aweXpect.Core.ExpectationBuilder expectationBuilder, aweXpect.Core.IThat<TThat> subject, aweXpect.Reflection.Options.GenericArgumentsFilterOptions genericArgumentsFilterOptions, aweXpect.Options.CollectionIndexOptions collectionIndexOptions) { }
+        public aweXpect.Reflection.Results.GenericArgumentCollectionResult<TThat> FromEnd() { }
+    }
+    public class GenericArgumentCollectionWithArgumentResult<TThat> : aweXpect.Reflection.Results.GenericArgumentCollectionResult<TThat>, aweXpect.Core.IOptionsProvider<aweXpect.Options.CollectionIndexOptions>
+    {
+        public GenericArgumentCollectionWithArgumentResult(aweXpect.Core.ExpectationBuilder expectationBuilder, aweXpect.Core.IThat<TThat> subject, aweXpect.Reflection.Options.GenericArgumentsFilterOptions genericArgumentsFilterOptions, aweXpect.Options.CollectionIndexOptions collectionIndexOptions) { }
+        public aweXpect.Reflection.Results.GenericArgumentCollectionWithArgumentAtIndexResult<TThat> AtIndex(int index) { }
+    }
+    public class GenericArgumentCollectionWithNamedArgumentResult<TThat> : aweXpect.Reflection.Results.GenericArgumentCollectionWithArgumentResult<TThat>, aweXpect.Core.IOptionsProvider<aweXpect.Options.StringEqualityOptions>
+    {
+        public GenericArgumentCollectionWithNamedArgumentResult(aweXpect.Core.ExpectationBuilder expectationBuilder, aweXpect.Core.IThat<TThat> subject, aweXpect.Reflection.Options.GenericArgumentsFilterOptions genericArgumentsFilterOptions, aweXpect.Options.CollectionIndexOptions collectionIndexOptions, aweXpect.Options.StringEqualityOptions options) { }
+        public aweXpect.Reflection.Results.GenericArgumentCollectionWithArgumentResult<TThat> AsPrefix() { }
+        public aweXpect.Reflection.Results.GenericArgumentCollectionWithArgumentResult<TThat> AsRegex() { }
+        public aweXpect.Reflection.Results.GenericArgumentCollectionWithArgumentResult<TThat> AsSuffix() { }
+        public aweXpect.Reflection.Results.GenericArgumentCollectionWithArgumentResult<TThat> AsWildcard() { }
+        public aweXpect.Reflection.Results.GenericArgumentCollectionWithArgumentResult<TThat> IgnoringCase(bool ignoreCase = true) { }
+        public aweXpect.Reflection.Results.GenericArgumentCollectionWithArgumentResult<TThat> Using(System.Collections.Generic.IEqualityComparer<string> comparer) { }
+    }
     public sealed class HasAttributeResult<TMember> : aweXpect.Results.AndOrResult<TMember, aweXpect.Core.IThat<TMember>>, aweXpect.Core.IOptionsProvider<aweXpect.Reflection.Options.AttributeFilterOptions<TMember>>
     {
         public HasAttributeResult(aweXpect.Core.ExpectationBuilder expectationBuilder, aweXpect.Core.IThat<TMember> subject, aweXpect.Reflection.Options.AttributeFilterOptions<TMember> attributeFilterOptions) { }

--- a/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WhichAreGeneric.WithArgument.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WhichAreGeneric.WithArgument.Tests.cs
@@ -411,11 +411,11 @@ public sealed partial class MethodFilters
 			// ReSharper disable UnusedTypeParameter
 			private class MyTestClass
 			{
-				public static void GenericMethodWithString<TFoo>()
+				public static void GenericWithUnrestrictedParameterMethod<TFoo>()
 				{
 				}
 
-				public static void GenericMethodWithString<T1, T2>()
+				public static void GenericWithRestrictedSecondParameterMethod<T1, T2>()
 					where T2 : ThatMethod.BaseClass
 				{
 				}

--- a/Tests/aweXpect.Reflection.Tests/ThatMethod.IsGeneric.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethod.IsGeneric.Tests.cs
@@ -4,7 +4,7 @@ namespace aweXpect.Reflection.Tests;
 
 public sealed partial class ThatMethod
 {
-	public sealed class IsGeneric
+	public sealed partial class IsGeneric
 	{
 		public sealed class Tests
 		{

--- a/Tests/aweXpect.Reflection.Tests/ThatMethod.IsGeneric.WithArgument.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethod.IsGeneric.WithArgument.Tests.cs
@@ -1,0 +1,491 @@
+using System.Reflection;
+using aweXpect.Reflection.Tests.TestHelpers;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatMethod
+{
+	public sealed partial class IsGeneric
+	{
+		public sealed class WithArgument
+		{
+			public sealed class GenericTests
+			{
+				[Theory]
+				[InlineData(0, false)]
+				[InlineData(1, true)]
+				[InlineData(2, false)]
+				public async Task AtIndex_ForMethodWithMatchingArgument_ShouldSucceedWhenIndexMatches(int index,
+					bool expectSuccess)
+				{
+					MethodInfo? subject = GetMethod("GenericWithRestrictedSecondArgumentMethod");
+
+					async Task Act()
+						=> await That(subject).IsGeneric().WithArgument<BaseClass>().AtIndex(index);
+
+					await That(Act).ThrowsException()
+						.OnlyIf(!expectSuccess)
+						.WithMessage($$"""
+						               Expected that subject
+						               is generic with argument of type ThatMethod.BaseClass at index {{index}},
+						               but it was generic void ThatMethod.ClassWithMethods.GenericWithRestrictedSecondArgumentMethod<TFoo, TBar>()
+						               """);
+				}
+
+				[Theory]
+				[InlineData(0, true)]
+				[InlineData(1, false)]
+				[InlineData(2, false)]
+				public async Task AtIndex_FromEnd_ForMethodWithMatchingArgument_ShouldSucceedWhenIndexMatches(int index,
+					bool expectSuccess)
+				{
+					MethodInfo? subject = GetMethod("GenericWithRestrictedSecondArgumentMethod");
+
+					async Task Act()
+						=> await That(subject).IsGeneric().WithArgument<BaseClass>().AtIndex(index).FromEnd();
+
+					await That(Act).ThrowsException()
+						.OnlyIf(!expectSuccess)
+						.WithMessage($$"""
+						               Expected that subject
+						               is generic with argument of type ThatMethod.BaseClass at index {{index}} from end,
+						               but it was generic void ThatMethod.ClassWithMethods.GenericWithRestrictedSecondArgumentMethod<TFoo, TBar>()
+						               """);
+				}
+
+				[Fact]
+				public async Task ForMethodWithRestrictedMatchingArgument_ShouldSucceed()
+				{
+					MethodInfo? subject = GetMethod("GenericWithRestrictedSecondArgumentMethod");
+
+					async Task Act()
+						=> await That(subject).IsGeneric().WithArgument<BaseClass>();
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task ForMethodWithRestrictedNotMatchingArgument_ShouldFail()
+				{
+					MethodInfo? subject = GetMethod("GenericWithRestrictedSecondArgumentMethod");
+
+					async Task Act()
+						=> await That(subject).IsGeneric().WithArgument<DerivedClass>();
+
+					await That(Act).ThrowsException()
+						.WithMessage("""
+						             Expected that subject
+						             is generic with argument of type ThatMethod.DerivedClass,
+						             but it was generic void ThatMethod.ClassWithMethods.GenericWithRestrictedSecondArgumentMethod<TFoo, TBar>()
+						             """);
+				}
+
+				[Fact]
+				public async Task ForMethodWithUnrestrictedArgument_ShouldFail()
+				{
+					MethodInfo? subject = GetMethod("GenericWithUnrestrictedArgumentMethod");
+
+					async Task Act()
+						=> await That(subject).IsGeneric().WithArgument<BaseClass>();
+
+					await That(Act).ThrowsException()
+						.WithMessage("""
+						             Expected that subject
+						             is generic with argument of type ThatMethod.BaseClass,
+						             but it was generic void ThatMethod.ClassWithMethods.GenericWithUnrestrictedArgumentMethod<TFoo>()
+						             """);
+				}
+			}
+
+			public sealed class GenericNamedTests
+			{
+				[Theory]
+				[InlineData(0, false)]
+				[InlineData(1, true)]
+				[InlineData(2, false)]
+				public async Task AtIndex_ForMethodWithMatchingArgument_ShouldSucceedWhenIndexMatches(int index,
+					bool expectSuccess)
+				{
+					MethodInfo? subject = GetMethod("GenericWithRestrictedSecondArgumentMethod");
+
+					async Task Act()
+						=> await That(subject).IsGeneric().WithArgument<BaseClass>("TBar").AtIndex(index);
+
+					await That(Act).ThrowsException()
+						.OnlyIf(!expectSuccess)
+						.WithMessage($$"""
+						               Expected that subject
+						               is generic with argument of type ThatMethod.BaseClass and name equal to "TBar" at index {{index}},
+						               but it was generic void ThatMethod.ClassWithMethods.GenericWithRestrictedSecondArgumentMethod<TFoo, TBar>()
+						               """);
+				}
+
+				[Theory]
+				[InlineData(0, true)]
+				[InlineData(1, false)]
+				[InlineData(2, false)]
+				public async Task AtIndex_FromEnd_ForMethodWithMatchingArgument_ShouldSucceedWhenIndexMatches(int index,
+					bool expectSuccess)
+				{
+					MethodInfo? subject = GetMethod("GenericWithRestrictedSecondArgumentMethod");
+
+					async Task Act()
+						=> await That(subject).IsGeneric().WithArgument<BaseClass>("TBar").AtIndex(index).FromEnd();
+
+					await That(Act).ThrowsException()
+						.OnlyIf(!expectSuccess)
+						.WithMessage($$"""
+						               Expected that subject
+						               is generic with argument of type ThatMethod.BaseClass and name equal to "TBar" at index {{index}} from end,
+						               but it was generic void ThatMethod.ClassWithMethods.GenericWithRestrictedSecondArgumentMethod<TFoo, TBar>()
+						               """);
+				}
+
+				[Fact]
+				public async Task ForMethodWithRestrictedMatchingArgumentAndName_ShouldSucceed()
+				{
+					MethodInfo? subject = GetMethod("GenericWithRestrictedSecondArgumentMethod");
+
+					async Task Act()
+						=> await That(subject).IsGeneric().WithArgument<BaseClass>("TBar");
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task ForMethodWithRestrictedMatchingArgumentAndNotMatchingName_ShouldFail()
+				{
+					MethodInfo? subject = GetMethod("GenericWithRestrictedSecondArgumentMethod");
+
+					async Task Act()
+						=> await That(subject).IsGeneric().WithArgument<BaseClass>("Tbar");
+
+					await That(Act).ThrowsException()
+						.WithMessage("""
+						             Expected that subject
+						             is generic with argument of type ThatMethod.BaseClass and name equal to "Tbar",
+						             but it was generic void ThatMethod.ClassWithMethods.GenericWithRestrictedSecondArgumentMethod<TFoo, TBar>()
+						             """);
+				}
+
+				[Fact]
+				public async Task ForMethodWithRestrictedNotMatchingArgumentAndMatchingName_ShouldFail()
+				{
+					MethodInfo? subject = GetMethod("GenericWithRestrictedSecondArgumentMethod");
+
+					async Task Act()
+						=> await That(subject).IsGeneric().WithArgument<DerivedClass>("TBar");
+
+					await That(Act).ThrowsException()
+						.WithMessage("""
+						             Expected that subject
+						             is generic with argument of type ThatMethod.DerivedClass and name equal to "TBar",
+						             but it was generic void ThatMethod.ClassWithMethods.GenericWithRestrictedSecondArgumentMethod<TFoo, TBar>()
+						             """);
+				}
+
+				[Fact]
+				public async Task ForMethodWithUnrestrictedArgument_ShouldFail()
+				{
+					MethodInfo? subject = GetMethod("GenericWithUnrestrictedArgumentMethod");
+
+					async Task Act()
+						=> await That(subject).IsGeneric().WithArgument<BaseClass>("TBar");
+
+					await That(Act).ThrowsException()
+						.WithMessage("""
+						             Expected that subject
+						             is generic with argument of type ThatMethod.BaseClass and name equal to "TBar",
+						             but it was generic void ThatMethod.ClassWithMethods.GenericWithUnrestrictedArgumentMethod<TFoo>()
+						             """);
+				}
+
+				[Theory]
+				[InlineData("TBa", true)]
+				[InlineData("Tba", false)]
+				public async Task ShouldSupportAsPrefix(string prefix, bool expectSuccess)
+				{
+					MethodInfo? subject = GetMethod("GenericWithRestrictedSecondArgumentMethod");
+
+					async Task Act()
+						=> await That(subject).IsGeneric().WithArgument<BaseClass>(prefix).AsPrefix();
+
+					await That(Act).ThrowsException()
+						.OnlyIf(!expectSuccess)
+						.WithMessage($$"""
+						               Expected that subject
+						               is generic with argument of type ThatMethod.BaseClass and name starting with "{{prefix}}",
+						               but it was generic void ThatMethod.ClassWithMethods.GenericWithRestrictedSecondArgumentMethod<TFoo, TBar>()
+						               """);
+				}
+
+				[Theory]
+				[InlineData("T[a-zA-Z]*r", true)]
+				[InlineData("T[a-zA-Z]*o", false)]
+				public async Task ShouldSupportAsRegex(string regex, bool expectSuccess)
+				{
+					MethodInfo? subject = GetMethod("GenericWithRestrictedSecondArgumentMethod");
+
+					async Task Act()
+						=> await That(subject).IsGeneric().WithArgument<BaseClass>(regex).AsRegex();
+
+					await That(Act).ThrowsException()
+						.OnlyIf(!expectSuccess)
+						.WithMessage($$"""
+						               Expected that subject
+						               is generic with argument of type ThatMethod.BaseClass and name matching regex "{{regex}}",
+						               but it was generic void ThatMethod.ClassWithMethods.GenericWithRestrictedSecondArgumentMethod<TFoo, TBar>()
+						               """);
+				}
+
+				[Theory]
+				[InlineData("Bar", true)]
+				[InlineData("bar", false)]
+				public async Task ShouldSupportAsSuffix(string suffix, bool expectSuccess)
+				{
+					MethodInfo? subject = GetMethod("GenericWithRestrictedSecondArgumentMethod");
+
+					async Task Act()
+						=> await That(subject).IsGeneric().WithArgument<BaseClass>(suffix).AsSuffix();
+
+					await That(Act).ThrowsException()
+						.OnlyIf(!expectSuccess)
+						.WithMessage($$"""
+						               Expected that subject
+						               is generic with argument of type ThatMethod.BaseClass and name ending with "{{suffix}}",
+						               but it was generic void ThatMethod.ClassWithMethods.GenericWithRestrictedSecondArgumentMethod<TFoo, TBar>()
+						               """);
+				}
+
+				[Theory]
+				[InlineData("T??r", true)]
+				[InlineData("T??o", false)]
+				public async Task ShouldSupportAsWildcard(string wildcard, bool expectSuccess)
+				{
+					MethodInfo? subject = GetMethod("GenericWithRestrictedSecondArgumentMethod");
+
+					async Task Act()
+						=> await That(subject).IsGeneric().WithArgument<BaseClass>(wildcard).AsWildcard();
+
+					await That(Act).ThrowsException()
+						.OnlyIf(!expectSuccess)
+						.WithMessage($$"""
+						               Expected that subject
+						               is generic with argument of type ThatMethod.BaseClass and name matching "{{wildcard}}",
+						               but it was generic void ThatMethod.ClassWithMethods.GenericWithRestrictedSecondArgumentMethod<TFoo, TBar>()
+						               """);
+				}
+
+				[Theory]
+				[InlineData(true, true)]
+				[InlineData(false, false)]
+				public async Task ShouldSupportIgnoringCase(bool ignoreCase, bool expectSuccess)
+				{
+					MethodInfo? subject = GetMethod("GenericWithRestrictedSecondArgumentMethod");
+
+					async Task Act()
+						=> await That(subject).IsGeneric().WithArgument<BaseClass>("TBAR").IgnoringCase(ignoreCase);
+
+					await That(Act).ThrowsException()
+						.OnlyIf(!expectSuccess)
+						.WithMessage("""
+						             Expected that subject
+						             is generic with argument of type ThatMethod.BaseClass and name equal to "TBAR",
+						             but it was generic void ThatMethod.ClassWithMethods.GenericWithRestrictedSecondArgumentMethod<TFoo, TBar>()
+						             """);
+				}
+
+				[Fact]
+				public async Task ShouldSupportUsingCustomComparer()
+				{
+					MethodInfo? subject = GetMethod("GenericWithRestrictedSecondArgumentMethod");
+
+					async Task Act()
+						=> await That(subject).IsGeneric().WithArgument<BaseClass>("TBAr")
+							.Using(new IgnoreCaseForVocalsComparer());
+
+					await That(Act).DoesNotThrow();
+				}
+			}
+
+			public sealed class NamedTests
+			{
+				[Theory]
+				[InlineData(0, false)]
+				[InlineData(1, true)]
+				[InlineData(2, false)]
+				public async Task AtIndex_ForMethodWithMatchingArgumentName_ShouldSucceedWhenIndexMatches(int index,
+					bool expectSuccess)
+				{
+					MethodInfo? subject = GetMethod("GenericWithRestrictedSecondArgumentMethod");
+
+					async Task Act()
+						=> await That(subject).IsGeneric().WithArgument("TBar").AtIndex(index);
+
+					await That(Act).ThrowsException()
+						.OnlyIf(!expectSuccess)
+						.WithMessage($$"""
+						               Expected that subject
+						               is generic with argument name equal to "TBar" at index {{index}},
+						               but it was generic void ThatMethod.ClassWithMethods.GenericWithRestrictedSecondArgumentMethod<TFoo, TBar>()
+						               """);
+				}
+
+				[Theory]
+				[InlineData(0, true)]
+				[InlineData(1, false)]
+				[InlineData(2, false)]
+				public async Task AtIndex_FromEnd_ForMethodWithMatchingArgumentName_ShouldSucceedWhenIndexMatches(int index,
+					bool expectSuccess)
+				{
+					MethodInfo? subject = GetMethod("GenericWithRestrictedSecondArgumentMethod");
+
+					async Task Act()
+						=> await That(subject).IsGeneric().WithArgument("TBar").AtIndex(index).FromEnd();
+
+					await That(Act).ThrowsException()
+						.OnlyIf(!expectSuccess)
+						.WithMessage($$"""
+						               Expected that subject
+						               is generic with argument name equal to "TBar" at index {{index}} from end,
+						               but it was generic void ThatMethod.ClassWithMethods.GenericWithRestrictedSecondArgumentMethod<TFoo, TBar>()
+						               """);
+				}
+
+				[Fact]
+				public async Task ForMethodWithMatchingArgumentName_ShouldSucceed()
+				{
+					MethodInfo? subject = GetMethod("GenericWithRestrictedSecondArgumentMethod");
+
+					async Task Act()
+						=> await That(subject).IsGeneric().WithArgument("TBar");
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task ForMethodWithNotMatchingArgumentName_ShouldFail()
+				{
+					MethodInfo? subject = GetMethod("GenericWithRestrictedSecondArgumentMethod");
+
+					async Task Act()
+						=> await That(subject).IsGeneric().WithArgument("Tbar");
+
+					await That(Act).ThrowsException()
+						.WithMessage("""
+						             Expected that subject
+						             is generic with argument name equal to "Tbar",
+						             but it was generic void ThatMethod.ClassWithMethods.GenericWithRestrictedSecondArgumentMethod<TFoo, TBar>()
+						             """);
+				}
+
+				[Theory]
+				[InlineData("TBa", true)]
+				[InlineData("Tba", false)]
+				public async Task ShouldSupportAsPrefix(string prefix, bool expectSuccess)
+				{
+					MethodInfo? subject = GetMethod("GenericWithRestrictedSecondArgumentMethod");
+
+					async Task Act()
+						=> await That(subject).IsGeneric().WithArgument(prefix).AsPrefix();
+
+					await That(Act).ThrowsException()
+						.OnlyIf(!expectSuccess)
+						.WithMessage($$"""
+						               Expected that subject
+						               is generic with argument name starting with "{{prefix}}",
+						               but it was generic void ThatMethod.ClassWithMethods.GenericWithRestrictedSecondArgumentMethod<TFoo, TBar>()
+						               """);
+				}
+
+				[Theory]
+				[InlineData("T[a-zA-Z]*r", true)]
+				[InlineData("T[a-zA-Z]*s", false)]
+				public async Task ShouldSupportAsRegex(string regex, bool expectSuccess)
+				{
+					MethodInfo? subject = GetMethod("GenericWithRestrictedSecondArgumentMethod");
+
+					async Task Act()
+						=> await That(subject).IsGeneric().WithArgument(regex).AsRegex();
+
+					await That(Act).ThrowsException()
+						.OnlyIf(!expectSuccess)
+						.WithMessage($$"""
+						               Expected that subject
+						               is generic with argument name matching regex "{{regex}}",
+						               but it was generic void ThatMethod.ClassWithMethods.GenericWithRestrictedSecondArgumentMethod<TFoo, TBar>()
+						               """);
+				}
+
+				[Theory]
+				[InlineData("Bar", true)]
+				[InlineData("bar", false)]
+				public async Task ShouldSupportAsSuffix(string suffix, bool expectSuccess)
+				{
+					MethodInfo? subject = GetMethod("GenericWithRestrictedSecondArgumentMethod");
+
+					async Task Act()
+						=> await That(subject).IsGeneric().WithArgument(suffix).AsSuffix();
+
+					await That(Act).ThrowsException()
+						.OnlyIf(!expectSuccess)
+						.WithMessage($$"""
+						               Expected that subject
+						               is generic with argument name ending with "{{suffix}}",
+						               but it was generic void ThatMethod.ClassWithMethods.GenericWithRestrictedSecondArgumentMethod<TFoo, TBar>()
+						               """);
+				}
+
+				[Theory]
+				[InlineData("T??r", true)]
+				[InlineData("T??s", false)]
+				public async Task ShouldSupportAsWildcard(string wildcard, bool expectSuccess)
+				{
+					MethodInfo? subject = GetMethod("GenericWithRestrictedSecondArgumentMethod");
+
+					async Task Act()
+						=> await That(subject).IsGeneric().WithArgument(wildcard).AsWildcard();
+
+					await That(Act).ThrowsException()
+						.OnlyIf(!expectSuccess)
+						.WithMessage($$"""
+						               Expected that subject
+						               is generic with argument name matching "{{wildcard}}",
+						               but it was generic void ThatMethod.ClassWithMethods.GenericWithRestrictedSecondArgumentMethod<TFoo, TBar>()
+						               """);
+				}
+
+				[Theory]
+				[InlineData(true, true)]
+				[InlineData(false, false)]
+				public async Task ShouldSupportIgnoringCase(bool ignoreCase, bool expectSuccess)
+				{
+					MethodInfo? subject = GetMethod("GenericWithRestrictedSecondArgumentMethod");
+
+					async Task Act()
+						=> await That(subject).IsGeneric().WithArgument("TBAR").IgnoringCase(ignoreCase);
+
+					await That(Act).ThrowsException()
+						.OnlyIf(!expectSuccess)
+						.WithMessage("""
+						             Expected that subject
+						             is generic with argument name equal to "TBAR",
+						             but it was generic void ThatMethod.ClassWithMethods.GenericWithRestrictedSecondArgumentMethod<TFoo, TBar>()
+						             """);
+				}
+
+				[Fact]
+				public async Task ShouldSupportUsingCustomComparer()
+				{
+					MethodInfo? subject = GetMethod("GenericWithRestrictedSecondArgumentMethod");
+
+					async Task Act()
+						=> await That(subject).IsGeneric().WithArgument("TBAr")
+							.Using(new IgnoreCaseForVocalsComparer());
+
+					await That(Act).DoesNotThrow();
+				}
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatMethod.IsGeneric.WithArgumentCount.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethod.IsGeneric.WithArgumentCount.Tests.cs
@@ -1,0 +1,72 @@
+using System.Reflection;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatMethod
+{
+	public sealed partial class IsGeneric
+	{
+		public sealed class WithArgumentCount
+		{
+			public sealed class Tests
+			{
+				[Theory]
+				[InlineData(1, true)]
+				[InlineData(2, false)]
+				public async Task ForMethodWithOneGenericParameter_ShouldSucceedWhenArgumentCountMatches(
+					int argumentCount, bool expectSuccess)
+				{
+					MethodInfo? subject = GetMethod("GenericMethod");
+
+					async Task Act()
+						=> await That(subject).IsGeneric().WithArgumentCount(argumentCount);
+
+					await That(Act).ThrowsException()
+						.OnlyIf(!expectSuccess)
+						.WithMessage("""
+						             Expected that subject
+						             is generic with 2 generic arguments,
+						             but it was generic T ThatMethod.ClassWithMethods.GenericMethod<T>(T value)
+						             """);
+				}
+
+				[Theory]
+				[InlineData(1, false)]
+				[InlineData(2, true)]
+				public async Task ForMethodWithTwoGenericParameters_ShouldSucceedWhenArgumentCountMatches(
+					int argumentCount, bool expectSuccess)
+				{
+					MethodInfo? subject = GetMethod("AnotherGenericMethod");
+
+					async Task Act()
+						=> await That(subject).IsGeneric().WithArgumentCount(argumentCount);
+
+					await That(Act).ThrowsException()
+						.OnlyIf(!expectSuccess)
+						.WithMessage("""
+						             Expected that subject
+						             is generic with 1 generic argument,
+						             but it was generic void ThatMethod.ClassWithMethods.AnotherGenericMethod<T, U>(T first, U second)
+						             """);
+				}
+
+
+				[Fact]
+				public async Task WhenMethodIsNotGeneric_ShouldFail()
+				{
+					MethodInfo? subject = GetMethod("NonGenericMethod");
+
+					async Task Act()
+						=> await That(subject).IsGeneric().WithArgumentCount(1);
+
+					await That(Act).ThrowsException()
+						.WithMessage("""
+						             Expected that subject
+						             is generic with 1 generic argument,
+						             but it was non-generic int ThatMethod.ClassWithMethods.NonGenericMethod()
+						             """);
+				}
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatMethod.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethod.cs
@@ -24,6 +24,14 @@ public sealed partial class ThatMethod
 		public T GenericMethod<T>(T value) => value;
 		public void AnotherGenericMethod<T, U>(T first, U second) { }
 		public int NonGenericMethod() => 1;
+		public void GenericWithUnrestrictedArgumentMethod<TFoo>()
+		{
+		}
+
+		public void GenericWithRestrictedSecondArgumentMethod<TFoo, TBar>()
+			where TBar : ThatMethod.BaseClass
+		{
+		}
 	}
 
 	public class ClassWithSingleMethod

--- a/Tests/aweXpect.Reflection.Tests/ThatMethods.AreGeneric.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethods.AreGeneric.Tests.cs
@@ -4,14 +4,14 @@ namespace aweXpect.Reflection.Tests;
 
 public sealed partial class ThatMethods
 {
-	public sealed class AreGeneric
+	public sealed partial class AreGeneric
 	{
 		public sealed class Tests
 		{
 			[Fact]
 			public async Task WhenFilteringOnlyGenericMethods_ShouldSucceed()
 			{
-				Filtered.Methods subject = GetMethods("GenericMethod");
+				Filtered.Methods subject = GetMethods("GenericMethod1");
 
 				async Task Act()
 					=> await That(subject).AreGeneric();
@@ -31,7 +31,7 @@ public sealed partial class ThatMethods
 					.WithMessage("""
 					             Expected that methods matching methodInfo => methodInfo.Name.StartsWith(methodPrefix) in types matching t => t == typeof(ClassWithMethods) in assembly containing type ThatMethods.ClassWithMethods
 					             are all generic,
-					             but it contained non-generic methods [
+					             but it contained not matching methods [
 					               *
 					             ]
 					             """).AsWildcard();
@@ -43,7 +43,7 @@ public sealed partial class ThatMethods
 			[Fact]
 			public async Task WhenFilteringOnlyGenericMethods_ShouldFail()
 			{
-				Filtered.Methods subject = GetMethods("GenericMethod");
+				Filtered.Methods subject = GetMethods("GenericMethod1");
 
 				async Task Act()
 					=> await That(subject).DoesNotComplyWith(they => they.AreGeneric());

--- a/Tests/aweXpect.Reflection.Tests/ThatMethods.AreGeneric.WithArgument.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethods.AreGeneric.WithArgument.Tests.cs
@@ -1,0 +1,539 @@
+using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Tests.TestHelpers;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatMethods
+{
+	public sealed partial class AreGeneric
+	{
+		public sealed class WithArgument
+		{
+			public sealed class GenericTests
+			{
+				[Theory]
+				[InlineData(0, false)]
+				[InlineData(1, true)]
+				[InlineData(2, false)]
+				public async Task AtIndex_ForMethodWithMatchingArgument_ShouldSucceedWhenIndexMatches(int index,
+					bool expectSuccess)
+				{
+					Filtered.Methods subject = GetMethods("GenericWithRestrictedSecondArgumentMethod");
+
+					async Task Act()
+						=> await That(subject).AreGeneric().WithArgument<ThatMethod.BaseClass>().AtIndex(index);
+
+					await That(Act).ThrowsException()
+						.OnlyIf(!expectSuccess)
+						.WithMessage($$"""
+						               Expected that methods matching methodInfo => methodInfo.Name.StartsWith(methodPrefix) in types matching t => t == typeof(ClassWithMethods) in assembly containing type ThatMethods.ClassWithMethods
+						               are all generic with argument of type ThatMethod.BaseClass at index {{index}},
+						               but it contained not matching methods [
+						                 void ThatMethods.ClassWithMethods.GenericWithRestrictedSecondArgumentMethod<TFoo, TBar>()
+						               ]
+						               """);
+				}
+
+				[Theory]
+				[InlineData(0, true)]
+				[InlineData(1, false)]
+				[InlineData(2, false)]
+				public async Task AtIndex_FromEnd_ForMethodWithMatchingArgument_ShouldSucceedWhenIndexMatches(int index,
+					bool expectSuccess)
+				{
+					Filtered.Methods subject = GetMethods("GenericWithRestrictedSecondArgumentMethod");
+
+					async Task Act()
+						=> await That(subject).AreGeneric().WithArgument<ThatMethod.BaseClass>().AtIndex(index)
+							.FromEnd();
+
+					await That(Act).ThrowsException()
+						.OnlyIf(!expectSuccess)
+						.WithMessage($$"""
+						               Expected that methods matching methodInfo => methodInfo.Name.StartsWith(methodPrefix) in types matching t => t == typeof(ClassWithMethods) in assembly containing type ThatMethods.ClassWithMethods
+						               are all generic with argument of type ThatMethod.BaseClass at index {{index}} from end,
+						               but it contained not matching methods [
+						                 void ThatMethods.ClassWithMethods.GenericWithRestrictedSecondArgumentMethod<TFoo, TBar>()
+						               ]
+						               """);
+				}
+
+				[Fact]
+				public async Task ForMethodWithRestrictedMatchingArgument_ShouldSucceed()
+				{
+					Filtered.Methods subject = GetMethods("GenericWithRestrictedSecondArgumentMethod");
+
+					async Task Act()
+						=> await That(subject).AreGeneric().WithArgument<ThatMethod.BaseClass>();
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task ForMethodWithRestrictedNotMatchingArgument_ShouldFail()
+				{
+					Filtered.Methods subject = GetMethods("GenericWithRestrictedSecondArgumentMethod");
+
+					async Task Act()
+						=> await That(subject).AreGeneric().WithArgument<ThatMethod.DerivedClass>();
+
+					await That(Act).ThrowsException()
+						.WithMessage("""
+						             Expected that methods matching methodInfo => methodInfo.Name.StartsWith(methodPrefix) in types matching t => t == typeof(ClassWithMethods) in assembly containing type ThatMethods.ClassWithMethods
+						             are all generic with argument of type ThatMethod.DerivedClass,
+						             but it contained not matching methods [
+						               void ThatMethods.ClassWithMethods.GenericWithRestrictedSecondArgumentMethod<TFoo, TBar>()
+						             ]
+						             """);
+				}
+
+				[Fact]
+				public async Task ForMethodWithUnrestrictedArgument_ShouldFail()
+				{
+					Filtered.Methods subject = GetMethods("GenericWithUnrestrictedArgumentMethod");
+
+					async Task Act()
+						=> await That(subject).AreGeneric().WithArgument<ThatMethod.BaseClass>();
+
+					await That(Act).ThrowsException()
+						.WithMessage("""
+						             Expected that methods matching methodInfo => methodInfo.Name.StartsWith(methodPrefix) in types matching t => t == typeof(ClassWithMethods) in assembly containing type ThatMethods.ClassWithMethods
+						             are all generic with argument of type ThatMethod.BaseClass,
+						             but it contained not matching methods [
+						               void ThatMethods.ClassWithMethods.GenericWithUnrestrictedArgumentMethod<TFoo>()
+						             ]
+						             """);
+				}
+			}
+
+			public sealed class GenericNamedTests
+			{
+				[Theory]
+				[InlineData(0, false)]
+				[InlineData(1, true)]
+				[InlineData(2, false)]
+				public async Task AtIndex_ForMethodWithMatchingArgument_ShouldSucceedWhenIndexMatches(int index,
+					bool expectSuccess)
+				{
+					Filtered.Methods subject = GetMethods("GenericWithRestrictedSecondArgumentMethod");
+
+					async Task Act()
+						=> await That(subject).AreGeneric().WithArgument<ThatMethod.BaseClass>("TBar").AtIndex(index);
+
+					await That(Act).ThrowsException()
+						.OnlyIf(!expectSuccess)
+						.WithMessage($$"""
+						               Expected that methods matching methodInfo => methodInfo.Name.StartsWith(methodPrefix) in types matching t => t == typeof(ClassWithMethods) in assembly containing type ThatMethods.ClassWithMethods
+						               are all generic with argument of type ThatMethod.BaseClass and name equal to "TBar" at index {{index}},
+						               but it contained not matching methods [
+						                 void ThatMethods.ClassWithMethods.GenericWithRestrictedSecondArgumentMethod<TFoo, TBar>()
+						               ]
+						               """);
+				}
+
+				[Theory]
+				[InlineData(0, true)]
+				[InlineData(1, false)]
+				[InlineData(2, false)]
+				public async Task AtIndex_FromEnd_ForMethodWithMatchingArgument_ShouldSucceedWhenIndexMatches(int index,
+					bool expectSuccess)
+				{
+					Filtered.Methods subject = GetMethods("GenericWithRestrictedSecondArgumentMethod");
+
+					async Task Act()
+						=> await That(subject).AreGeneric().WithArgument<ThatMethod.BaseClass>("TBar").AtIndex(index)
+							.FromEnd();
+
+					await That(Act).ThrowsException()
+						.OnlyIf(!expectSuccess)
+						.WithMessage($$"""
+						               Expected that methods matching methodInfo => methodInfo.Name.StartsWith(methodPrefix) in types matching t => t == typeof(ClassWithMethods) in assembly containing type ThatMethods.ClassWithMethods
+						               are all generic with argument of type ThatMethod.BaseClass and name equal to "TBar" at index {{index}} from end,
+						               but it contained not matching methods [
+						                 void ThatMethods.ClassWithMethods.GenericWithRestrictedSecondArgumentMethod<TFoo, TBar>()
+						               ]
+						               """);
+				}
+
+				[Fact]
+				public async Task ForMethodWithRestrictedMatchingArgumentAndName_ShouldSucceed()
+				{
+					Filtered.Methods subject = GetMethods("GenericWithRestrictedSecondArgumentMethod");
+
+					async Task Act()
+						=> await That(subject).AreGeneric().WithArgument<ThatMethod.BaseClass>("TBar");
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task ForMethodWithRestrictedMatchingArgumentAndNotMatchingName_ShouldFail()
+				{
+					Filtered.Methods subject = GetMethods("GenericWithRestrictedSecondArgumentMethod");
+
+					async Task Act()
+						=> await That(subject).AreGeneric().WithArgument<ThatMethod.BaseClass>("Tbar");
+
+					await That(Act).ThrowsException()
+						.WithMessage("""
+						             Expected that methods matching methodInfo => methodInfo.Name.StartsWith(methodPrefix) in types matching t => t == typeof(ClassWithMethods) in assembly containing type ThatMethods.ClassWithMethods
+						             are all generic with argument of type ThatMethod.BaseClass and name equal to "Tbar",
+						             but it contained not matching methods [
+						               void ThatMethods.ClassWithMethods.GenericWithRestrictedSecondArgumentMethod<TFoo, TBar>()
+						             ]
+						             """);
+				}
+
+				[Fact]
+				public async Task ForMethodWithRestrictedNotMatchingArgumentAndMatchingName_ShouldFail()
+				{
+					Filtered.Methods subject = GetMethods("GenericWithRestrictedSecondArgumentMethod");
+
+					async Task Act()
+						=> await That(subject).AreGeneric().WithArgument<ThatMethod.DerivedClass>("TBar");
+
+					await That(Act).ThrowsException()
+						.WithMessage("""
+						             Expected that methods matching methodInfo => methodInfo.Name.StartsWith(methodPrefix) in types matching t => t == typeof(ClassWithMethods) in assembly containing type ThatMethods.ClassWithMethods
+						             are all generic with argument of type ThatMethod.DerivedClass and name equal to "TBar",
+						             but it contained not matching methods [
+						               void ThatMethods.ClassWithMethods.GenericWithRestrictedSecondArgumentMethod<TFoo, TBar>()
+						             ]
+						             """);
+				}
+
+				[Fact]
+				public async Task ForMethodWithUnrestrictedArgument_ShouldFail()
+				{
+					Filtered.Methods subject = GetMethods("GenericWithUnrestrictedArgumentMethod");
+
+					async Task Act()
+						=> await That(subject).AreGeneric().WithArgument<ThatMethod.BaseClass>("TBar");
+
+					await That(Act).ThrowsException()
+						.WithMessage("""
+						             Expected that methods matching methodInfo => methodInfo.Name.StartsWith(methodPrefix) in types matching t => t == typeof(ClassWithMethods) in assembly containing type ThatMethods.ClassWithMethods
+						             are all generic with argument of type ThatMethod.BaseClass and name equal to "TBar",
+						             but it contained not matching methods [
+						               void ThatMethods.ClassWithMethods.GenericWithUnrestrictedArgumentMethod<TFoo>()
+						             ]
+						             """);
+				}
+
+				[Theory]
+				[InlineData("TBa", true)]
+				[InlineData("Tba", false)]
+				public async Task ShouldSupportAsPrefix(string prefix, bool expectSuccess)
+				{
+					Filtered.Methods subject = GetMethods("GenericWithRestrictedSecondArgumentMethod");
+
+					async Task Act()
+						=> await That(subject).AreGeneric().WithArgument<ThatMethod.BaseClass>(prefix).AsPrefix();
+
+					await That(Act).ThrowsException()
+						.OnlyIf(!expectSuccess)
+						.WithMessage($$"""
+						               Expected that methods matching methodInfo => methodInfo.Name.StartsWith(methodPrefix) in types matching t => t == typeof(ClassWithMethods) in assembly containing type ThatMethods.ClassWithMethods
+						               are all generic with argument of type ThatMethod.BaseClass and name starting with "{{prefix}}",
+						               but it contained not matching methods [
+						                 void ThatMethods.ClassWithMethods.GenericWithRestrictedSecondArgumentMethod<TFoo, TBar>()
+						               ]
+						               """);
+				}
+
+				[Theory]
+				[InlineData("T[a-zA-Z]*r", true)]
+				[InlineData("T[a-zA-Z]*o", false)]
+				public async Task ShouldSupportAsRegex(string regex, bool expectSuccess)
+				{
+					Filtered.Methods subject = GetMethods("GenericWithRestrictedSecondArgumentMethod");
+
+					async Task Act()
+						=> await That(subject).AreGeneric().WithArgument<ThatMethod.BaseClass>(regex).AsRegex();
+
+					await That(Act).ThrowsException()
+						.OnlyIf(!expectSuccess)
+						.WithMessage($$"""
+						               Expected that methods matching methodInfo => methodInfo.Name.StartsWith(methodPrefix) in types matching t => t == typeof(ClassWithMethods) in assembly containing type ThatMethods.ClassWithMethods
+						               are all generic with argument of type ThatMethod.BaseClass and name matching regex "{{regex}}",
+						               but it contained not matching methods [
+						                 void ThatMethods.ClassWithMethods.GenericWithRestrictedSecondArgumentMethod<TFoo, TBar>()
+						               ]
+						               """);
+				}
+
+				[Theory]
+				[InlineData("Bar", true)]
+				[InlineData("bar", false)]
+				public async Task ShouldSupportAsSuffix(string suffix, bool expectSuccess)
+				{
+					Filtered.Methods subject = GetMethods("GenericWithRestrictedSecondArgumentMethod");
+
+					async Task Act()
+						=> await That(subject).AreGeneric().WithArgument<ThatMethod.BaseClass>(suffix).AsSuffix();
+
+					await That(Act).ThrowsException()
+						.OnlyIf(!expectSuccess)
+						.WithMessage($$"""
+						               Expected that methods matching methodInfo => methodInfo.Name.StartsWith(methodPrefix) in types matching t => t == typeof(ClassWithMethods) in assembly containing type ThatMethods.ClassWithMethods
+						               are all generic with argument of type ThatMethod.BaseClass and name ending with "{{suffix}}",
+						               but it contained not matching methods [
+						                 void ThatMethods.ClassWithMethods.GenericWithRestrictedSecondArgumentMethod<TFoo, TBar>()
+						               ]
+						               """);
+				}
+
+				[Theory]
+				[InlineData("T??r", true)]
+				[InlineData("T??o", false)]
+				public async Task ShouldSupportAsWildcard(string wildcard, bool expectSuccess)
+				{
+					Filtered.Methods subject = GetMethods("GenericWithRestrictedSecondArgumentMethod");
+
+					async Task Act()
+						=> await That(subject).AreGeneric().WithArgument<ThatMethod.BaseClass>(wildcard).AsWildcard();
+
+					await That(Act).ThrowsException()
+						.OnlyIf(!expectSuccess)
+						.WithMessage($$"""
+						               Expected that methods matching methodInfo => methodInfo.Name.StartsWith(methodPrefix) in types matching t => t == typeof(ClassWithMethods) in assembly containing type ThatMethods.ClassWithMethods
+						               are all generic with argument of type ThatMethod.BaseClass and name matching "{{wildcard}}",
+						               but it contained not matching methods [
+						                 void ThatMethods.ClassWithMethods.GenericWithRestrictedSecondArgumentMethod<TFoo, TBar>()
+						               ]
+						               """);
+				}
+
+				[Theory]
+				[InlineData(true, true)]
+				[InlineData(false, false)]
+				public async Task ShouldSupportIgnoringCase(bool ignoreCase, bool expectSuccess)
+				{
+					Filtered.Methods subject = GetMethods("GenericWithRestrictedSecondArgumentMethod");
+
+					async Task Act()
+						=> await That(subject).AreGeneric().WithArgument<ThatMethod.BaseClass>("TBAR")
+							.IgnoringCase(ignoreCase);
+
+					await That(Act).ThrowsException()
+						.OnlyIf(!expectSuccess)
+						.WithMessage("""
+						             Expected that methods matching methodInfo => methodInfo.Name.StartsWith(methodPrefix) in types matching t => t == typeof(ClassWithMethods) in assembly containing type ThatMethods.ClassWithMethods
+						             are all generic with argument of type ThatMethod.BaseClass and name equal to "TBAR",
+						             but it contained not matching methods [
+						               void ThatMethods.ClassWithMethods.GenericWithRestrictedSecondArgumentMethod<TFoo, TBar>()
+						             ]
+						             """);
+				}
+
+				[Fact]
+				public async Task ShouldSupportUsingCustomComparer()
+				{
+					Filtered.Methods subject = GetMethods("GenericWithRestrictedSecondArgumentMethod");
+
+					async Task Act()
+						=> await That(subject).AreGeneric().WithArgument<ThatMethod.BaseClass>("TBAr")
+							.Using(new IgnoreCaseForVocalsComparer());
+
+					await That(Act).DoesNotThrow();
+				}
+			}
+
+			public sealed class NamedTests
+			{
+				[Theory]
+				[InlineData(0, false)]
+				[InlineData(1, true)]
+				[InlineData(2, false)]
+				public async Task AtIndex_ForMethodWithMatchingArgumentName_ShouldSucceedWhenIndexMatches(int index,
+					bool expectSuccess)
+				{
+					Filtered.Methods subject = GetMethods("GenericWithRestrictedSecondArgumentMethod");
+
+					async Task Act()
+						=> await That(subject).AreGeneric().WithArgument("TBar").AtIndex(index);
+
+					await That(Act).ThrowsException()
+						.OnlyIf(!expectSuccess)
+						.WithMessage($$"""
+						               Expected that methods matching methodInfo => methodInfo.Name.StartsWith(methodPrefix) in types matching t => t == typeof(ClassWithMethods) in assembly containing type ThatMethods.ClassWithMethods
+						               are all generic with argument name equal to "TBar" at index {{index}},
+						               but it contained not matching methods [
+						                 void ThatMethods.ClassWithMethods.GenericWithRestrictedSecondArgumentMethod<TFoo, TBar>()
+						               ]
+						               """);
+				}
+
+				[Theory]
+				[InlineData(0, true)]
+				[InlineData(1, false)]
+				[InlineData(2, false)]
+				public async Task AtIndex_FromEnd_ForMethodWithMatchingArgumentName_ShouldSucceedWhenIndexMatches(
+					int index,
+					bool expectSuccess)
+				{
+					Filtered.Methods subject = GetMethods("GenericWithRestrictedSecondArgumentMethod");
+
+					async Task Act()
+						=> await That(subject).AreGeneric().WithArgument("TBar").AtIndex(index).FromEnd();
+
+					await That(Act).ThrowsException()
+						.OnlyIf(!expectSuccess)
+						.WithMessage($$"""
+						               Expected that methods matching methodInfo => methodInfo.Name.StartsWith(methodPrefix) in types matching t => t == typeof(ClassWithMethods) in assembly containing type ThatMethods.ClassWithMethods
+						               are all generic with argument name equal to "TBar" at index {{index}} from end,
+						               but it contained not matching methods [
+						                 void ThatMethods.ClassWithMethods.GenericWithRestrictedSecondArgumentMethod<TFoo, TBar>()
+						               ]
+						               """);
+				}
+
+				[Fact]
+				public async Task ForMethodWithMatchingArgumentName_ShouldSucceed()
+				{
+					Filtered.Methods subject = GetMethods("GenericWithRestrictedSecondArgumentMethod");
+
+					async Task Act()
+						=> await That(subject).AreGeneric().WithArgument("TBar");
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task ForMethodWithNotMatchingArgumentName_ShouldFail()
+				{
+					Filtered.Methods subject = GetMethods("GenericWithRestrictedSecondArgumentMethod");
+
+					async Task Act()
+						=> await That(subject).AreGeneric().WithArgument("Tbar");
+
+					await That(Act).ThrowsException()
+						.WithMessage("""
+						             Expected that methods matching methodInfo => methodInfo.Name.StartsWith(methodPrefix) in types matching t => t == typeof(ClassWithMethods) in assembly containing type ThatMethods.ClassWithMethods
+						             are all generic with argument name equal to "Tbar",
+						             but it contained not matching methods [
+						               void ThatMethods.ClassWithMethods.GenericWithRestrictedSecondArgumentMethod<TFoo, TBar>()
+						             ]
+						             """);
+				}
+
+				[Theory]
+				[InlineData("TBa", true)]
+				[InlineData("Tba", false)]
+				public async Task ShouldSupportAsPrefix(string prefix, bool expectSuccess)
+				{
+					Filtered.Methods subject = GetMethods("GenericWithRestrictedSecondArgumentMethod");
+
+					async Task Act()
+						=> await That(subject).AreGeneric().WithArgument(prefix).AsPrefix();
+
+					await That(Act).ThrowsException()
+						.OnlyIf(!expectSuccess)
+						.WithMessage($$"""
+						               Expected that methods matching methodInfo => methodInfo.Name.StartsWith(methodPrefix) in types matching t => t == typeof(ClassWithMethods) in assembly containing type ThatMethods.ClassWithMethods
+						               are all generic with argument name starting with "{{prefix}}",
+						               but it contained not matching methods [
+						                 void ThatMethods.ClassWithMethods.GenericWithRestrictedSecondArgumentMethod<TFoo, TBar>()
+						               ]
+						               """);
+				}
+
+				[Theory]
+				[InlineData("T[a-zA-Z]*r", true)]
+				[InlineData("T[a-zA-Z]*s", false)]
+				public async Task ShouldSupportAsRegex(string regex, bool expectSuccess)
+				{
+					Filtered.Methods subject = GetMethods("GenericWithRestrictedSecondArgumentMethod");
+
+					async Task Act()
+						=> await That(subject).AreGeneric().WithArgument(regex).AsRegex();
+
+					await That(Act).ThrowsException()
+						.OnlyIf(!expectSuccess)
+						.WithMessage($$"""
+						               Expected that methods matching methodInfo => methodInfo.Name.StartsWith(methodPrefix) in types matching t => t == typeof(ClassWithMethods) in assembly containing type ThatMethods.ClassWithMethods
+						               are all generic with argument name matching regex "{{regex}}",
+						               but it contained not matching methods [
+						                 void ThatMethods.ClassWithMethods.GenericWithRestrictedSecondArgumentMethod<TFoo, TBar>()
+						               ]
+						               """);
+				}
+
+				[Theory]
+				[InlineData("Bar", true)]
+				[InlineData("bar", false)]
+				public async Task ShouldSupportAsSuffix(string suffix, bool expectSuccess)
+				{
+					Filtered.Methods subject = GetMethods("GenericWithRestrictedSecondArgumentMethod");
+
+					async Task Act()
+						=> await That(subject).AreGeneric().WithArgument(suffix).AsSuffix();
+
+					await That(Act).ThrowsException()
+						.OnlyIf(!expectSuccess)
+						.WithMessage($$"""
+						               Expected that methods matching methodInfo => methodInfo.Name.StartsWith(methodPrefix) in types matching t => t == typeof(ClassWithMethods) in assembly containing type ThatMethods.ClassWithMethods
+						               are all generic with argument name ending with "{{suffix}}",
+						               but it contained not matching methods [
+						                 void ThatMethods.ClassWithMethods.GenericWithRestrictedSecondArgumentMethod<TFoo, TBar>()
+						               ]
+						               """);
+				}
+
+				[Theory]
+				[InlineData("T??r", true)]
+				[InlineData("T??s", false)]
+				public async Task ShouldSupportAsWildcard(string wildcard, bool expectSuccess)
+				{
+					Filtered.Methods subject = GetMethods("GenericWithRestrictedSecondArgumentMethod");
+
+					async Task Act()
+						=> await That(subject).AreGeneric().WithArgument(wildcard).AsWildcard();
+
+					await That(Act).ThrowsException()
+						.OnlyIf(!expectSuccess)
+						.WithMessage($$"""
+						               Expected that methods matching methodInfo => methodInfo.Name.StartsWith(methodPrefix) in types matching t => t == typeof(ClassWithMethods) in assembly containing type ThatMethods.ClassWithMethods
+						               are all generic with argument name matching "{{wildcard}}",
+						               but it contained not matching methods [
+						                 void ThatMethods.ClassWithMethods.GenericWithRestrictedSecondArgumentMethod<TFoo, TBar>()
+						               ]
+						               """);
+				}
+
+				[Theory]
+				[InlineData(true, true)]
+				[InlineData(false, false)]
+				public async Task ShouldSupportIgnoringCase(bool ignoreCase, bool expectSuccess)
+				{
+					Filtered.Methods subject = GetMethods("GenericWithRestrictedSecondArgumentMethod");
+
+					async Task Act()
+						=> await That(subject).AreGeneric().WithArgument("TBAR").IgnoringCase(ignoreCase);
+
+					await That(Act).ThrowsException()
+						.OnlyIf(!expectSuccess)
+						.WithMessage("""
+						             Expected that methods matching methodInfo => methodInfo.Name.StartsWith(methodPrefix) in types matching t => t == typeof(ClassWithMethods) in assembly containing type ThatMethods.ClassWithMethods
+						             are all generic with argument name equal to "TBAR",
+						             but it contained not matching methods [
+						               void ThatMethods.ClassWithMethods.GenericWithRestrictedSecondArgumentMethod<TFoo, TBar>()
+						             ]
+						             """);
+				}
+
+				[Fact]
+				public async Task ShouldSupportUsingCustomComparer()
+				{
+					Filtered.Methods subject = GetMethods("GenericWithRestrictedSecondArgumentMethod");
+
+					async Task Act()
+						=> await That(subject).AreGeneric().WithArgument("TBAr")
+							.Using(new IgnoreCaseForVocalsComparer());
+
+					await That(Act).DoesNotThrow();
+				}
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatMethods.AreGeneric.WithArgumentCount.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethods.AreGeneric.WithArgumentCount.Tests.cs
@@ -1,0 +1,79 @@
+using aweXpect.Reflection.Collections;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatMethods
+{
+	public sealed partial class AreGeneric
+	{
+		public sealed class WithArgumentCount
+		{
+			public sealed class Tests
+			{
+				[Theory]
+				[InlineData(1, true)]
+				[InlineData(2, false)]
+				public async Task ForMethodWithOneGenericParameter_ShouldSucceedWhenArgumentCountMatches(
+					int argumentCount, bool expectSuccess)
+				{
+					Filtered.Methods subject = GetMethods("GenericMethod1");
+
+					async Task Act()
+						=> await That(subject).AreGeneric().WithArgumentCount(argumentCount);
+
+					await That(Act).ThrowsException()
+						.OnlyIf(!expectSuccess)
+						.WithMessage("""
+						             Expected that methods matching methodInfo => methodInfo.Name.StartsWith(methodPrefix) in types matching t => t == typeof(ClassWithMethods) in assembly containing type ThatMethods.ClassWithMethods
+						             are all generic with 2 generic arguments,
+						             but it contained not matching methods [
+						               T ThatMethods.ClassWithMethods.GenericMethod1<T>(T value)
+						             ]
+						             """);
+				}
+
+				[Theory]
+				[InlineData(1, false)]
+				[InlineData(2, true)]
+				public async Task ForMethodWithTwoGenericParameters_ShouldSucceedWhenArgumentCountMatches(
+					int argumentCount, bool expectSuccess)
+				{
+					Filtered.Methods subject = GetMethods("GenericMethod2");
+
+					async Task Act()
+						=> await That(subject).AreGeneric().WithArgumentCount(argumentCount);
+
+					await That(Act).ThrowsException()
+						.OnlyIf(!expectSuccess)
+						.WithMessage("""
+						             Expected that methods matching methodInfo => methodInfo.Name.StartsWith(methodPrefix) in types matching t => t == typeof(ClassWithMethods) in assembly containing type ThatMethods.ClassWithMethods
+						             are all generic with 1 generic argument,
+						             but it contained not matching methods [
+						               U ThatMethods.ClassWithMethods.GenericMethod2<T, U>(T first, U second)
+						             ]
+						             """);
+				}
+
+
+				[Fact]
+				public async Task WhenMethodIsNotGeneric_ShouldFail()
+				{
+					Filtered.Methods subject = GetMethods("NonGenericMethod");
+
+					async Task Act()
+						=> await That(subject).AreGeneric().WithArgumentCount(1);
+
+					await That(Act).ThrowsException()
+						.WithMessage("""
+						             Expected that methods matching methodInfo => methodInfo.Name.StartsWith(methodPrefix) in types matching t => t == typeof(ClassWithMethods) in assembly containing type ThatMethods.ClassWithMethods
+						             are all generic with 1 generic argument,
+						             but it contained not matching methods [
+						               int ThatMethods.ClassWithMethods.NonGenericMethod1(),
+						               int ThatMethods.ClassWithMethods.NonGenericMethod2()
+						             ]
+						             """);
+				}
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatMethods.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethods.cs
@@ -43,6 +43,15 @@ public sealed partial class ThatMethods
 		public U GenericMethod2<T, U>(T first, U second) => second;
 		public int NonGenericMethod1() => 1;
 		public int NonGenericMethod2() => 2;
+
+		public void GenericWithUnrestrictedArgumentMethod<TFoo>()
+		{
+		}
+
+		public void GenericWithRestrictedSecondArgumentMethod<TFoo, TBar>()
+			where TBar : ThatMethod.BaseClass
+		{
+		}
 	}
 
 	// ReSharper disable UnusedMember.Local


### PR DESCRIPTION
This PR adds support for generic arguments expectations to the aweXpect.Reflection library, enabling assertions on the number and characteristics of generic arguments in methods. The implementation allows fluent chaining for filtering methods based on their generic argument count, type constraints, and argument names.

### Key changes:
- Adds `WithArgumentCount()` method to check generic argument count expectations
- Introduces fluent filtering capabilities for generic arguments by type and name
- Implements support for string equality options (case sensitivity, prefix/suffix, regex, wildcard patterns)

---

- *Fixes for methods: #134*