### PR TITLE
chore: bump the aweXpect group

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,8 +3,8 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="aweXpect" Version="2.22.0" />
-    <PackageVersion Include="aweXpect.Core" Version="2.21.0" />
+    <PackageVersion Include="aweXpect" Version="2.23.0" />
+    <PackageVersion Include="aweXpect.Core" Version="2.21.1" />
   </ItemGroup>
   <ItemGroup>
     <PackageVersion Include="Nullable" Version="1.3.1" />


### PR DESCRIPTION
This PR updates the aweXpect package dependencies to newer versions as part of routine maintenance.

- Updates aweXpect from version 2.22.0 to 2.23.0
- Updates aweXpect.Core from version 2.21.0 to 2.21.1