### PR TITLE
chore: bump aweXpect

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,8 +3,8 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="aweXpect" Version="2.23.0" />
-    <PackageVersion Include="aweXpect.Core" Version="2.21.1" />
+    <PackageVersion Include="aweXpect" Version="2.25.0" />
+    <PackageVersion Include="aweXpect.Core" Version="2.22.2" />
   </ItemGroup>
   <ItemGroup>
     <PackageVersion Include="Nullable" Version="1.3.1" />


### PR DESCRIPTION
This PR updates the aweXpect dependency versions to their latest releases, bumping the main aweXpect package from 2.23.0 to 2.25.0 and aweXpect.Core from 2.21.1 to 2.22.2.