### PR TITLE
docs: move nuget badge in documentation on separate line

### DIFF
--- a/Docs/pages/00-index.md
+++ b/Docs/pages/00-index.md
@@ -1,4 +1,6 @@
-# [aweXpect.Reflection](https://github.com/aweXpect/aweXpect.Reflection) [![Nuget](https://img.shields.io/nuget/v/aweXpect.Reflection)](https://www.nuget.org/packages/aweXpect.Reflection)
+# [aweXpect.Reflection](https://github.com/aweXpect/aweXpect.Reflection)
+
+[![Nuget](https://img.shields.io/nuget/v/aweXpect.Reflection)](https://www.nuget.org/packages/aweXpect.Reflection)
 
 Expectations for reflection types.
 


### PR DESCRIPTION
Move the NuGet badge from the same line as the main heading to a separate line in the documentation index page for better formatting and readability.