### PR TITLE
docs: avoid link in headline

### DIFF
--- a/Docs/pages/00-index.md
+++ b/Docs/pages/00-index.md
@@ -1,7 +1,7 @@
-# [aweXpect.Reflection](https://github.com/aweXpect/aweXpect.Reflection)
+# aweXpect.Reflection
 
 [![Nuget](https://img.shields.io/nuget/v/aweXpect.Reflection)](https://www.nuget.org/packages/aweXpect.Reflection)
 
-Expectations for reflection types.
+[aweXpect.Reflection](https://github.com/aweXpect/aweXpect.Reflection) contains expectations for reflection types.
 
 {README}


### PR DESCRIPTION
This PR removes a link from the main headline and adds it to the descriptive text below. The change improves documentation formatting by keeping the headline clean while maintaining the repository link in a more appropriate location.