### PR TITLE
chore: update Stryker dashboard URLs to Testably organization

### DIFF
--- a/Pipeline/Build.MutationTests.cs
+++ b/Pipeline/Build.MutationTests.cs
@@ -69,7 +69,7 @@ partial class Build
 				                      {
 				                      	"stryker-config": {
 				                      		"project-info": {
-				                      			"name": "github.com/aweXpect/aweXpect.Reflection",
+				                      			"name": "github.com/Testably/aweXpect.Reflection",
 				                      			"module": "{{project.Key.Name}}",
 				                      			"version": "{{branchName}}"
 				                      		},
@@ -125,7 +125,7 @@ partial class Build
 
 			string body = "## :alien: Mutation Results"
 			              + Environment.NewLine
-			              + $"[![Mutation testing badge](https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2FaweXpect%2FaweXpect.Reflection%2Fpull/{prId}/merge)](https://dashboard.stryker-mutator.io/reports/github.com/aweXpect/aweXpect.Reflection/pull/{prId}/merge)"
+			              + $"[![Mutation testing badge](https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2FTestably%2FaweXpect.Reflection%2Fpull/{prId}/merge)](https://dashboard.stryker-mutator.io/reports/github.com/Testably/aweXpect.Reflection/pull/{prId}/merge)"
 			              + Environment.NewLine
 			              + MutationCommentBody;
 			File.WriteAllText(ArtifactsDirectory / "PR_Comment.md", body);
@@ -161,7 +161,7 @@ partial class Build
 				client.DefaultRequestHeaders.Add("X-Api-Key", apiKey);
 				// https://stryker-mutator.io/docs/General/dashboard/#send-a-report-via-curl
 				await client.PutAsync(
-					$"https://dashboard.stryker-mutator.io/api/reports/github.com/aweXpect/aweXpect.Reflection/{branchName}?module={project.Key.Name}",
+					$"https://dashboard.stryker-mutator.io/api/reports/github.com/Testably/aweXpect.Reflection/{branchName}?module={project.Key.Name}",
 					new StringContent(reportComment, new MediaTypeHeaderValue("application/json")));
 			}
 

--- a/Pipeline/Build.MutationTests.cs
+++ b/Pipeline/Build.MutationTests.cs
@@ -176,7 +176,7 @@ partial class Build
 					Credentials tokenAuth = new(GithubToken);
 					gitHubClient.Credentials = tokenAuth;
 					IReadOnlyList<IssueComment> comments =
-						await gitHubClient.Issue.Comment.GetAllForIssue("aweXpect", "aweXpect.Reflection", prId);
+						await gitHubClient.Issue.Comment.GetAllForIssue("Testably", "aweXpect.Reflection", prId);
 					long? commentId = null;
 					Log.Information($"Found {comments.Count} comments");
 					foreach (IssueComment comment in comments)
@@ -191,12 +191,12 @@ partial class Build
 					if (commentId == null)
 					{
 						Log.Information($"Create comment:\n{body}");
-						await gitHubClient.Issue.Comment.Create("aweXpect", "aweXpect.Reflection", prId, body);
+						await gitHubClient.Issue.Comment.Create("Testably", "aweXpect.Reflection", prId, body);
 					}
 					else
 					{
 						Log.Information($"Update comment:\n{body}");
-						await gitHubClient.Issue.Comment.Update("aweXpect", "aweXpect.Reflection", commentId.Value,
+						await gitHubClient.Issue.Comment.Update("Testably", "aweXpect.Reflection", commentId.Value,
 							body);
 					}
 				}

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # aweXpect.Reflection
 
 [![Nuget](https://img.shields.io/nuget/v/aweXpect.Reflection)](https://www.nuget.org/packages/aweXpect.Reflection)
-[![Build](https://github.com/aweXpect/aweXpect.Reflection/actions/workflows/build.yml/badge.svg)](https://github.com/aweXpect/aweXpect.Reflection/actions/workflows/build.yml)
+[![Build](https://github.com/Testably/aweXpect.Reflection/actions/workflows/build.yml/badge.svg)](https://github.com/Testably/aweXpect.Reflection/actions/workflows/build.yml)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=Testably_aweXpect.Reflection&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=Testably_aweXpect.Reflection)
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=Testably_aweXpect.Reflection&metric=coverage)](https://sonarcloud.io/summary/overall?id=Testably_aweXpect.Reflection)
 [![Mutation testing badge](https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2FTestably%2FaweXpect.Reflection%2Fmain)](https://dashboard.stryker-mutator.io/reports/github.com/Testably/aweXpect.Reflection/main)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Build](https://github.com/aweXpect/aweXpect.Reflection/actions/workflows/build.yml/badge.svg)](https://github.com/aweXpect/aweXpect.Reflection/actions/workflows/build.yml)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=aweXpect_aweXpect.Reflection&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=aweXpect_aweXpect.Reflection)
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=aweXpect_aweXpect.Reflection&metric=coverage)](https://sonarcloud.io/summary/overall?id=aweXpect_aweXpect.Reflection)
-[![Mutation testing badge](https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2FaweXpect%2FaweXpect.Reflection%2Fmain)](https://dashboard.stryker-mutator.io/reports/github.com/aweXpect/aweXpect.Reflection/main)
+[![Mutation testing badge](https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2FTestably%2FaweXpect.Reflection%2Fmain)](https://dashboard.stryker-mutator.io/reports/github.com/Testably/aweXpect.Reflection/main)
 
 Expectations for reflection types for [aweXpect](https://github.com/aweXpect/aweXpect).
 


### PR DESCRIPTION
The repository moved to the Testably GitHub organization, so the Stryker mutator dashboard URL is now
https://dashboard.stryker-mutator.io/reports/github.com/Testably/aweXpect.Reflection. Updates the README badge and the mutation-test build pipeline (stryker-config project name, PR comment badge, dashboard PUT URL).