### PR TITLE
ci: trigger Testably.Site rebuild after main build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -238,18 +238,4 @@ jobs:
                         state: released
                     skip-label: |
                         state: released
-    
-    build-pages:
-        name: Update Pages
-        runs-on: ubuntu-latest
-        needs: [ benchmarks ]
-        steps:
-            -   name: Trigger pages update in aweXpect Repo
-                run: |
-                    curl -L \
-                      -X POST \
-                      -H "Accept: application/vnd.github+json" \
-                      -H "Authorization: Bearer ${{ secrets.REPOSITORY_DISPATCH }}" \
-                      -H "X-GitHub-Api-Version: 2022-11-28" \
-                      https://api.github.com/repos/aweXpect/aweXpect/dispatches \
-                      -d "{\"event_type\": \"extension-documentation-updated-event\"}"
+

--- a/.github/workflows/notify-docs-site.yml
+++ b/.github/workflows/notify-docs-site.yml
@@ -1,0 +1,22 @@
+name: Notify Docs Site
+
+on:
+    workflow_run:
+        workflows: [ "Build" ]
+        types: [ completed ]
+        branches: [ main ]
+    workflow_dispatch:
+
+jobs:
+    dispatch:
+        if: (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
+        name: Trigger Site rebuild
+        runs-on: ubuntu-latest
+        steps:
+            -   name: Dispatch extension-documentation-updated-event to Testably/Testably.Site
+                uses: peter-evans/repository-dispatch@v3
+                with:
+                    token: ${{ secrets.SITE_DISPATCH_TOKEN }}
+                    repository: Testably/Testably.Site
+                    event-type: extension-documentation-updated-event
+                    client-payload: '{"source": "${{ github.repository }}", "sha": "${{ github.event.workflow_run.head_sha || github.sha }}"}'


### PR DESCRIPTION
After moving the repository to the Testably organization, documentation is centralized in Testably/Testably.Site. Adds a notify-docs-site workflow that dispatches an
`extension-documentation-updated-event` to Testably.Site whenever the Build workflow completes successfully on main, and removes the obsolete build-pages job that dispatched to aweXpect/aweXpect.