### PR TITLE
chore: Bump aweXpect.Core to 2.29.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="aweXpect" Version="2.31.0" />
-    <PackageVersion Include="aweXpect.Core" Version="2.28.0" />
+    <PackageVersion Include="aweXpect.Core" Version="2.29.0" />
   </ItemGroup>
   <ItemGroup>
     <PackageVersion Include="Nullable" Version="1.3.1" />

--- a/Source/aweXpect.Reflection/Helpers/StringHelpers.cs
+++ b/Source/aweXpect.Reflection/Helpers/StringHelpers.cs
@@ -60,7 +60,11 @@ internal static class StringHelpers
 		sb.Append(lines[0]);
 		foreach (string? line in lines.Skip(1))
 		{
+#if NET8_0_OR_GREATER
+			sb.Append('\n').Append(line.AsSpan(commonWhiteSpace.Length));
+#else
 			sb.Append('\n').Append(line.Substring(commonWhiteSpace.Length));
+#endif
 		}
 
 		if (lines.Length == 2)


### PR DESCRIPTION
fix: prefer AsSpan over Substring in TrimCommonWhiteSpace