### PR TITLE
fix: ignore types that fail to load when querying assemblies

### DIFF
--- a/Source/aweXpect.Reflection/Collections/Filtered.Types.cs
+++ b/Source/aweXpect.Reflection/Collections/Filtered.Types.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Text.RegularExpressions;
 using aweXpect.Core;
 using aweXpect.Options;
@@ -34,7 +35,7 @@ public static partial class Filtered
 		///     Container for a filterable collection of <see cref="Type" />.
 		/// </summary>
 		internal Types(Assemblies assemblies, string description) : base(
-			assemblies.SelectMany(assembly => assembly.GetTypes()))
+			assemblies.SelectMany(GetLoadableTypes))
 		{
 			_assemblies = assemblies;
 			_description = description;
@@ -119,6 +120,26 @@ public static partial class Filtered
 			}
 
 			return description;
+		}
+
+		/// <summary>
+		///     Gets the types of the <paramref name="assembly" />, ignoring those that fail to load.
+		/// </summary>
+		/// <remarks>
+		///     <see cref="Assembly.GetTypes()" /> throws a <see cref="ReflectionTypeLoadException" /> when any type cannot be
+		///     loaded (e.g. an unresolvable dependency). The exception still exposes the types that loaded successfully via
+		///     <see cref="ReflectionTypeLoadException.Types" />, so we fall back to those instead of failing the whole query.
+		/// </remarks>
+		private static IEnumerable<Type> GetLoadableTypes(Assembly assembly)
+		{
+			try
+			{
+				return assembly.GetTypes();
+			}
+			catch (ReflectionTypeLoadException exception)
+			{
+				return exception.Types.Where(type => type is not null)!;
+			}
 		}
 
 		/// <summary>

--- a/Tests/aweXpect.Reflection.Tests/InTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/InTests.cs
@@ -122,6 +122,17 @@ public sealed class InTests
 	}
 
 	[Fact]
+	public async Task Types_WhenGetTypesThrowsReflectionTypeLoadException_ShouldUseTypesThatLoaded()
+	{
+		Type?[] loadableTypes = [typeof(PublicClass), null, typeof(InternalClass),];
+		Assembly assembly = new ThrowingAssembly(loadableTypes);
+
+		Filtered.Types sut = In.Assemblies(assembly).Types();
+
+		await That(sut).IsEqualTo([typeof(PublicClass), typeof(InternalClass),]).InAnyOrder();
+	}
+
+	[Fact]
 	public async Task Types_WithThreeGenericParameters_ShouldIncludeSpecifiedTypes()
 	{
 		Filtered.Types sut = In.Types<InTests, InternalClass, PublicClass>();
@@ -152,5 +163,13 @@ public sealed class InTests
 		await That(sut.GetDescription())
 			.IsEqualTo(
 				$"in types [{nameof(InTests)}, {nameof(InternalClass)}, {nameof(PublicClass)}, {nameof(AccessModifiers)}]");
+	}
+
+	private sealed class ThrowingAssembly(Type?[] loadableTypes) : Assembly
+	{
+		public override string FullName => nameof(ThrowingAssembly);
+
+		public override Type[] GetTypes()
+			=> throw new ReflectionTypeLoadException(loadableTypes, null);
 	}
 }


### PR DESCRIPTION
`Assembly.GetTypes()` throws a `ReflectionTypeLoadException` when any type in the assembly cannot be loaded (e.g. an unresolvable dependency), which aborted the entire query for chains like `In.AllLoadedAssemblies().Types()`.

Catch the exception and fall back to the successfully loaded types exposed via `ReflectionTypeLoadException.Types`.