### PR TITLE
fix: only list declared members in member collections

### DIFF
--- a/Source/aweXpect.Reflection/Collections/Filtered.Constructors.cs
+++ b/Source/aweXpect.Reflection/Collections/Filtered.Constructors.cs
@@ -21,11 +21,7 @@ public static partial class Filtered
 		///     Container for a filterable collection of <see cref="ConstructorInfo" />.
 		/// </summary>
 		internal Constructors(Types types, string description) : base(types.SelectMany(type =>
-			type.GetConstructors(BindingFlags.DeclaredOnly |
-			                     BindingFlags.NonPublic |
-			                     BindingFlags.Public |
-			                     BindingFlags.Instance |
-			                     BindingFlags.Static)))
+			type.GetDeclaredConstructors()))
 		{
 			_types = types;
 			_description = description;

--- a/Source/aweXpect.Reflection/Collections/Filtered.Events.cs
+++ b/Source/aweXpect.Reflection/Collections/Filtered.Events.cs
@@ -24,10 +24,7 @@ public static partial class Filtered
 		///     Container for a filterable collection of <see cref="EventInfo" />.
 		/// </summary>
 		internal Events(Types types, string description) : base(types.SelectMany(type =>
-			type.GetEvents(BindingFlags.DeclaredOnly |
-			               BindingFlags.NonPublic |
-			               BindingFlags.Public |
-			               BindingFlags.Instance)))
+			type.GetDeclaredEvents()))
 		{
 			_types = types;
 			_description = description;

--- a/Source/aweXpect.Reflection/Collections/Filtered.Fields.cs
+++ b/Source/aweXpect.Reflection/Collections/Filtered.Fields.cs
@@ -24,11 +24,7 @@ public static partial class Filtered
 		///     Container for a filterable collection of <see cref="FieldInfo" />.
 		/// </summary>
 		internal Fields(Types types, string description) : base(types.SelectMany(type =>
-			type.GetFields(BindingFlags.DeclaredOnly |
-			               BindingFlags.NonPublic |
-			               BindingFlags.Public |
-			               BindingFlags.Instance |
-			               BindingFlags.Static)))
+			type.GetDeclaredFields()))
 		{
 			_types = types;
 			_description = description;

--- a/Source/aweXpect.Reflection/Collections/Filtered.Methods.cs
+++ b/Source/aweXpect.Reflection/Collections/Filtered.Methods.cs
@@ -24,11 +24,7 @@ public static partial class Filtered
 		///     Container for a filterable collection of <see cref="MethodInfo" />.
 		/// </summary>
 		internal Methods(Types types, string description) : base(types.SelectMany(type =>
-			type.GetMethods(BindingFlags.DeclaredOnly |
-			                BindingFlags.NonPublic |
-			                BindingFlags.Public |
-			                BindingFlags.Instance |
-			                BindingFlags.Static)))
+			type.GetDeclaredMethods()))
 		{
 			_types = types;
 			_description = description;

--- a/Source/aweXpect.Reflection/Collections/Filtered.Properties.cs
+++ b/Source/aweXpect.Reflection/Collections/Filtered.Properties.cs
@@ -24,11 +24,7 @@ public static partial class Filtered
 		///     Container for a filterable collection of <see cref="PropertyInfo" />.
 		/// </summary>
 		internal Properties(Types types, string description) : base(types.SelectMany(type =>
-			type.GetProperties(BindingFlags.DeclaredOnly |
-			                   BindingFlags.NonPublic |
-			                   BindingFlags.Public |
-			                   BindingFlags.Instance |
-			                   BindingFlags.Static)))
+			type.GetDeclaredProperties()))
 		{
 			_types = types;
 			_description = description;

--- a/Source/aweXpect.Reflection/Helpers/TypeHelpers.cs
+++ b/Source/aweXpect.Reflection/Helpers/TypeHelpers.cs
@@ -25,6 +25,17 @@ internal static class TypeHelpers
 			                 BindingFlags.Static);
 
 	/// <summary>
+	///     Searches for events in the <paramref name="type" /> that were directly declared there.
+	/// </summary>
+	public static EventInfo[] GetDeclaredEvents(
+		this Type type)
+		=> type
+			.GetEvents(BindingFlags.DeclaredOnly |
+			           BindingFlags.NonPublic |
+			           BindingFlags.Public |
+			           BindingFlags.Instance);
+
+	/// <summary>
 	///     Searches for fields in the <paramref name="type" /> that were directly declared there.
 	/// </summary>
 	public static FieldInfo[] GetDeclaredFields(

--- a/Tests/aweXpect.Reflection.Tests/InTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/InTests.cs
@@ -102,6 +102,22 @@ public sealed class InTests
 	}
 
 	[Fact]
+	public async Task Fields_ShouldExcludeCompilerGeneratedBackingFields()
+	{
+		Filtered.Fields fields = In.Type<ClassWithMembers>().Fields();
+
+		await That(fields).All().Satisfy(field => !field.Name.EndsWith("__BackingField")).And.IsNotEmpty();
+	}
+
+	[Fact]
+	public async Task Methods_ShouldExcludeCompilerGeneratedAccessors()
+	{
+		Filtered.Methods methods = In.Type<ClassWithMembers>().Methods();
+
+		await That(methods).All().Satisfy(method => !method.IsSpecialName).And.IsNotEmpty();
+	}
+
+	[Fact]
 	public async Task Type_WithGenericParameter_ShouldIncludeSpecifiedType()
 	{
 		Filtered.Types sut = In.Type<InTests>();
@@ -163,6 +179,14 @@ public sealed class InTests
 		await That(sut.GetDescription())
 			.IsEqualTo(
 				$"in types [{nameof(InTests)}, {nameof(InternalClass)}, {nameof(PublicClass)}, {nameof(AccessModifiers)}]");
+	}
+
+	private sealed class ClassWithMembers
+	{
+		public readonly int Field = 1;
+		public int Property { get; set; }
+
+		public int Method() => Field + Property;
 	}
 
 	private sealed class ThrowingAssembly(Type?[] loadableTypes) : Assembly


### PR DESCRIPTION
The member collections built their results with inline reflection calls (e.g. `type.GetMethods(...)`) that returned compiler-generated members: `.Methods()` included property/event accessors and operators, and `.Fields()` included compiler-generated backing fields.

Route all member collections (methods, properties, fields, events, constructors) through the existing `TypeHelpers.GetDeclared*` helpers, which filter out special-name members and backing fields, so the collections only expose the members actually declared in source. A new `GetDeclaredEvents` helper is added to cover events.