### PR TITLE
fix: ignore members of types that fail to load

### DIFF
--- a/Source/aweXpect.Reflection/Helpers/TypeHelpers.cs
+++ b/Source/aweXpect.Reflection/Helpers/TypeHelpers.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
@@ -17,68 +18,128 @@ internal static class TypeHelpers
 	/// </summary>
 	public static ConstructorInfo[] GetDeclaredConstructors(
 		this Type type)
-		=> type
-			.GetConstructors(BindingFlags.DeclaredOnly |
-			                 BindingFlags.NonPublic |
-			                 BindingFlags.Public |
-			                 BindingFlags.Instance |
-			                 BindingFlags.Static);
+	{
+		try
+		{
+			return type
+				.GetConstructors(BindingFlags.DeclaredOnly |
+				                 BindingFlags.NonPublic |
+				                 BindingFlags.Public |
+				                 BindingFlags.Instance |
+				                 BindingFlags.Static);
+		}
+		catch (Exception exception) when (exception
+			is TypeLoadException
+			or FileNotFoundException
+			or FileLoadException)
+		{
+			return [];
+		}
+	}
 
 	/// <summary>
 	///     Searches for events in the <paramref name="type" /> that were directly declared there.
 	/// </summary>
 	public static EventInfo[] GetDeclaredEvents(
 		this Type type)
-		=> type
-			.GetEvents(BindingFlags.DeclaredOnly |
-			           BindingFlags.NonPublic |
-			           BindingFlags.Public |
-			           BindingFlags.Instance);
+	{
+		try
+		{
+			return type
+				.GetEvents(BindingFlags.DeclaredOnly |
+				           BindingFlags.NonPublic |
+				           BindingFlags.Public |
+				           BindingFlags.Instance);
+		}
+		catch (Exception exception) when (exception
+			is TypeLoadException
+			or FileNotFoundException
+			or FileLoadException)
+		{
+			return [];
+		}
+	}
 
 	/// <summary>
 	///     Searches for fields in the <paramref name="type" /> that were directly declared there.
 	/// </summary>
 	public static FieldInfo[] GetDeclaredFields(
 		this Type type)
-		=> type
-			.GetFields(BindingFlags.DeclaredOnly |
-			           BindingFlags.NonPublic |
-			           BindingFlags.Public |
-			           BindingFlags.Instance |
-			           BindingFlags.Static)
-			.Where(m => !m.IsSpecialName)
-			.Where(m => !m.Name.EndsWith("__BackingField"))
-			.ToArray();
+	{
+		try
+		{
+			return type
+				.GetFields(BindingFlags.DeclaredOnly |
+				           BindingFlags.NonPublic |
+				           BindingFlags.Public |
+				           BindingFlags.Instance |
+				           BindingFlags.Static)
+				.Where(m => !m.IsSpecialName)
+				.Where(m => !m.Name.EndsWith("__BackingField"))
+				.ToArray();
+		}
+		catch (Exception exception) when (exception
+			is TypeLoadException
+			or FileNotFoundException
+			or FileLoadException)
+		{
+			return [];
+		}
+	}
 
 	/// <summary>
 	///     Searches for methods in the <paramref name="type" /> that were directly declared there.
 	/// </summary>
 	public static MethodInfo[] GetDeclaredMethods(
 		this Type type)
-		=> type
-			.GetMethods(BindingFlags.DeclaredOnly |
-			            BindingFlags.NonPublic |
-			            BindingFlags.Public |
-			            BindingFlags.Static |
-			            BindingFlags.Instance |
-			            BindingFlags.Static)
-			.Where(m => !m.IsSpecialName)
-			.ToArray();
+	{
+		try
+		{
+			return type
+				.GetMethods(BindingFlags.DeclaredOnly |
+				            BindingFlags.NonPublic |
+				            BindingFlags.Public |
+				            BindingFlags.Static |
+				            BindingFlags.Instance |
+				            BindingFlags.Static)
+				.Where(m => !m.IsSpecialName)
+				.ToArray();
+		}
+		catch (Exception exception) when (exception
+			is TypeLoadException
+			or FileNotFoundException
+			or FileLoadException)
+		{
+			return [];
+		}
+	}
 
 	/// <summary>
 	///     Searches for properties in the <paramref name="type" /> that were directly declared there.
 	/// </summary>
 	public static PropertyInfo[] GetDeclaredProperties(
 		this Type type)
-		=> type
-			.GetProperties(BindingFlags.DeclaredOnly |
-			               BindingFlags.NonPublic |
-			               BindingFlags.Public |
-			               BindingFlags.Static |
-			               BindingFlags.Instance |
-			               BindingFlags.Static)
-			.Where(m => !m.IsSpecialName)
-			.ToArray();
+	{
+		try
+		{
+			return type
+				.GetProperties(BindingFlags.DeclaredOnly |
+				               BindingFlags.NonPublic |
+				               BindingFlags.Public |
+				               BindingFlags.Static |
+				               BindingFlags.Instance |
+				               BindingFlags.Static)
+				.Where(m => !m.IsSpecialName)
+				.ToArray();
+		}
+		catch (Exception exception) when (exception
+			is TypeLoadException
+			or FileNotFoundException
+			or FileLoadException)
+		{
+			return [];
+		}
+	}
 
 	/// <summary>
 	///     Checks if the <paramref name="type" /> has the specified <paramref name="accessModifiers" />.

--- a/Tests/aweXpect.Reflection.Internal.Tests/Helpers/TypeHelpersTests.cs
+++ b/Tests/aweXpect.Reflection.Internal.Tests/Helpers/TypeHelpersTests.cs
@@ -1,5 +1,5 @@
 ﻿using System.Collections.Generic;
-using System.Linq;
+using System.IO;
 using System.Reflection;
 using aweXpect.Reflection.Helpers;
 
@@ -16,11 +16,41 @@ public sealed class TypeHelpersTests
 		FieldInfo[] allFields = type.GetFields(BindingFlags.DeclaredOnly |
 		                                       BindingFlags.NonPublic |
 		                                       BindingFlags.Public |
-		                                       BindingFlags.Instance).ToArray();
+		                                       BindingFlags.Instance);
 		FieldInfo[] result = type.GetDeclaredFields();
 
 		await That(allFields).HasCount(2);
 		await That(result).HasCount(1);
+	}
+
+	[Theory]
+	[InlineData(typeof(TypeLoadException))]
+	[InlineData(typeof(FileNotFoundException))]
+	[InlineData(typeof(FileLoadException))]
+	public async Task GetDeclaredMembers_WhenReflectionThrowsLoadException_ShouldReturnEmpty(Type exceptionType)
+	{
+		Exception exception = (Exception)Activator.CreateInstance(exceptionType)!;
+		Type type = new ThrowingType(typeof(TestClassWithAttribute), exception);
+
+		await That(type.GetDeclaredConstructors()).IsEmpty();
+		await That(type.GetDeclaredEvents()).IsEmpty();
+		await That(type.GetDeclaredFields()).IsEmpty();
+		await That(type.GetDeclaredMethods()).IsEmpty();
+		await That(type.GetDeclaredProperties()).IsEmpty();
+	}
+
+	[Fact]
+	public async Task GetDeclaredMembers_WhenReflectionThrowsUnrelatedException_ShouldNotCatch()
+	{
+		Type type = new ThrowingType(typeof(TestClassWithAttribute), new InvalidOperationException());
+
+		async Task Act()
+		{
+			await Task.Yield();
+			type.GetDeclaredMethods();
+		}
+
+		await That(Act).Throws<InvalidOperationException>();
 	}
 
 	[Fact]
@@ -190,6 +220,15 @@ public sealed class TypeHelpersTests
 
 	private interface IFooInterface
 	{
+	}
+
+	private sealed class ThrowingType(Type inner, Exception exception) : TypeDelegator(inner)
+	{
+		public override ConstructorInfo[] GetConstructors(BindingFlags bindingAttr) => throw exception;
+		public override EventInfo[] GetEvents(BindingFlags bindingAttr) => throw exception;
+		public override FieldInfo[] GetFields(BindingFlags bindingAttr) => throw exception;
+		public override MethodInfo[] GetMethods(BindingFlags bindingAttr) => throw exception;
+		public override PropertyInfo[] GetProperties(BindingFlags bindingAttr) => throw exception;
 	}
 
 	[Dummy(1)]


### PR DESCRIPTION
Reflecting over the members of a successfully loaded type can throw when a member signature references a type from an assembly that cannot be resolved. Guard each GetDeclared* helper with a try/catch that falls back to an empty array on TypeLoadException, FileNotFoundException or FileLoadException, so a single unloadable member no longer aborts the whole query.

The caught set is scoped to exceptions these member getters can actually raise: ReflectionTypeLoadException (only thrown by Assembly/Module type enumeration) and BadImageFormatException (thrown at assembly load time) are intentionally excluded.