### PR TITLE
feat!: match parameter subtypes in WithParameter and add WithExactParameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,8 @@ In.AllLoadedAssemblies().Methods()
 // Filter by parameters
 In.AllLoadedAssemblies().Methods()
     .WithoutParameters()
-    .WithParameter<string>()
+    .WithParameter<string>()          // Parameter of type string or a subtype
+    .WithExactParameter<string>()     // Parameter of exactly type string
     .WithParameter<int>("count")
     .WithParameterCount(2)
 
@@ -185,7 +186,8 @@ In.AllLoadedAssemblies().Public.Events()
 // Constructors
 In.AllLoadedAssemblies().Public.Constructors()
     .WithoutParameters()
-    .WithParameter<string>()
+    .WithParameter<string>()          // Parameter of type string or a subtype
+    .WithExactParameter<string>()     // Parameter of exactly type string
     .WithParameterCount(1)
     .With<JsonConstructorAttribute>()
 ```

--- a/Source/aweXpect.Reflection/Filters/ConstructorFilters.WithExactParameter.cs
+++ b/Source/aweXpect.Reflection/Filters/ConstructorFilters.WithExactParameter.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using aweXpect.Core;
+using aweXpect.Options;
+using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Helpers;
+using aweXpect.Reflection.Options;
+
+namespace aweXpect.Reflection;
+
+public static partial class ConstructorFilters
+{
+	/// <summary>
+	///     Filter for constructors with a parameter of exact type <typeparamref name="T" />.
+	/// </summary>
+	public static ConstructorsWithParameter<T> WithExactParameter<T>(this Filtered.Constructors @this)
+	{
+		Type parameterType = typeof(T);
+		CollectionIndexOptions collectionIndexOptions = new();
+		ParameterFilterOptions parameterFilterOptions = new(p => p.ParameterType.IsOrInheritsFrom(parameterType, true),
+			() => $"of exact type {Formatter.Format(parameterType)}");
+		IAsyncChangeableFilter<ConstructorInfo> filter = Filter.Suffix<ConstructorInfo>(
+			constructorInfo =>
+			{
+				ParameterInfo[] parameters = constructorInfo.GetParameters();
+				return parameters.AnyAsync(async (p, i) =>
+				{
+					bool? isIndexInRange = collectionIndexOptions.Match switch
+					{
+						CollectionIndexOptions.IMatchFromBeginning fromBeginning => fromBeginning.MatchesIndex(i),
+						CollectionIndexOptions.IMatchFromEnd fromEnd => fromEnd.MatchesIndex(i, parameters.Length),
+						_ => false,
+					};
+					return isIndexInRange == true &&
+					       await parameterFilterOptions.Matches(p);
+				});
+			},
+			()
+				=> $"with parameter {parameterFilterOptions.GetDescription()}{collectionIndexOptions.Match.GetDescription()} ");
+		return new ConstructorsWithParameter<T>(@this.Which(filter), collectionIndexOptions, parameterFilterOptions);
+	}
+
+	/// <summary>
+	///     Filter for constructors with a parameter of exact type <typeparamref name="T" /> with the
+	///     <paramref name="expected" /> name.
+	/// </summary>
+	public static ConstructorsWithNamedParameter<T> WithExactParameter<T>(this Filtered.Constructors @this, string expected)
+	{
+		Type parameterType = typeof(T);
+		StringEqualityOptions stringEqualityOptions = new();
+		ParameterFilterOptions parameterFilterOptions = new(p => p.ParameterType.IsOrInheritsFrom(parameterType, true),
+			() => $"of exact type {Formatter.Format(parameterType)}");
+		parameterFilterOptions.AddPredicate(p => stringEqualityOptions.AreConsideredEqual(p.Name, expected),
+			() => $"name {stringEqualityOptions.GetExpectation(expected, ExpectationGrammars.None)}");
+		CollectionIndexOptions collectionIndexOptions = new();
+		IAsyncChangeableFilter<ConstructorInfo> filter = Filter.Suffix<ConstructorInfo>(
+			constructorInfo =>
+			{
+				ParameterInfo[] parameters = constructorInfo.GetParameters();
+				return parameters.AnyAsync(async (p, i) =>
+				{
+					bool? isIndexInRange = collectionIndexOptions.Match switch
+					{
+						CollectionIndexOptions.IMatchFromBeginning fromBeginning => fromBeginning.MatchesIndex(i),
+						CollectionIndexOptions.IMatchFromEnd fromEnd => fromEnd.MatchesIndex(i, parameters.Length),
+						_ => false,
+					};
+					return isIndexInRange == true &&
+					       await parameterFilterOptions.Matches(p);
+				});
+			},
+			()
+				=> $"with parameter {parameterFilterOptions.GetDescription()}{collectionIndexOptions.Match.GetDescription()} ");
+		return new ConstructorsWithNamedParameter<T>(@this.Which(filter), collectionIndexOptions, parameterFilterOptions, stringEqualityOptions);
+	}
+}

--- a/Source/aweXpect.Reflection/Filters/ConstructorFilters.WithParameter.cs
+++ b/Source/aweXpect.Reflection/Filters/ConstructorFilters.WithParameter.cs
@@ -20,7 +20,7 @@ public static partial class ConstructorFilters
 	{
 		Type parameterType = typeof(T);
 		CollectionIndexOptions collectionIndexOptions = new();
-		ParameterFilterOptions parameterFilterOptions = new(p => p.ParameterType == parameterType,
+		ParameterFilterOptions parameterFilterOptions = new(p => p.ParameterType.IsOrInheritsFrom(parameterType),
 			() => $"of type {Formatter.Format(parameterType)}");
 		IAsyncChangeableFilter<ConstructorInfo> filter = Filter.Suffix<ConstructorInfo>(
 			constructorInfo =>
@@ -51,7 +51,7 @@ public static partial class ConstructorFilters
 	{
 		Type parameterType = typeof(T);
 		StringEqualityOptions stringEqualityOptions = new();
-		ParameterFilterOptions parameterFilterOptions = new(p => p.ParameterType == parameterType,
+		ParameterFilterOptions parameterFilterOptions = new(p => p.ParameterType.IsOrInheritsFrom(parameterType),
 			() => $"of type {Formatter.Format(parameterType)}");
 		parameterFilterOptions.AddPredicate(p => stringEqualityOptions.AreConsideredEqual(p.Name, expected),
 			() => $"name {stringEqualityOptions.GetExpectation(expected, ExpectationGrammars.None)}");

--- a/Source/aweXpect.Reflection/Filters/MethodFilters.WithExactParameter.cs
+++ b/Source/aweXpect.Reflection/Filters/MethodFilters.WithExactParameter.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using aweXpect.Core;
+using aweXpect.Options;
+using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Helpers;
+using aweXpect.Reflection.Options;
+
+namespace aweXpect.Reflection;
+
+public static partial class MethodFilters
+{
+	/// <summary>
+	///     Filter for methods with a parameter of exact type <typeparamref name="T" />.
+	/// </summary>
+	public static MethodsWithParameter<T> WithExactParameter<T>(this Filtered.Methods @this)
+	{
+		Type parameterType = typeof(T);
+		CollectionIndexOptions collectionIndexOptions = new();
+		ParameterFilterOptions parameterFilterOptions = new(p => p.ParameterType.IsOrInheritsFrom(parameterType, true),
+			() => $"of exact type {Formatter.Format(parameterType)}");
+		IAsyncChangeableFilter<MethodInfo> filter = Filter.Suffix<MethodInfo>(
+			methodInfo =>
+			{
+				ParameterInfo[] parameters = methodInfo.GetParameters();
+				return parameters.AnyAsync(async (p, i) =>
+				{
+					bool? isIndexInRange = collectionIndexOptions.Match switch
+					{
+						CollectionIndexOptions.IMatchFromBeginning fromBeginning => fromBeginning.MatchesIndex(i),
+						CollectionIndexOptions.IMatchFromEnd fromEnd => fromEnd.MatchesIndex(i, parameters.Length),
+						_ => false,
+					};
+					return isIndexInRange == true &&
+					       await parameterFilterOptions.Matches(p);
+				});
+			},
+			()
+				=> $"with parameter {parameterFilterOptions.GetDescription()}{collectionIndexOptions.Match.GetDescription()} ");
+		return new MethodsWithParameter<T>(@this.Which(filter), collectionIndexOptions, parameterFilterOptions);
+	}
+
+	/// <summary>
+	///     Filter for methods with a parameter of exact type <typeparamref name="T" /> with the <paramref name="expected" />
+	///     name.
+	/// </summary>
+	public static MethodsWithNamedParameter<T> WithExactParameter<T>(this Filtered.Methods @this, string expected)
+	{
+		Type parameterType = typeof(T);
+		StringEqualityOptions stringEqualityOptions = new();
+		ParameterFilterOptions parameterFilterOptions = new(p => p.ParameterType.IsOrInheritsFrom(parameterType, true),
+			() => $"of exact type {Formatter.Format(parameterType)}");
+		parameterFilterOptions.AddPredicate(p => stringEqualityOptions.AreConsideredEqual(p.Name, expected),
+			() => $"name {stringEqualityOptions.GetExpectation(expected, ExpectationGrammars.None)}");
+		CollectionIndexOptions collectionIndexOptions = new();
+		IAsyncChangeableFilter<MethodInfo> filter = Filter.Suffix<MethodInfo>(
+			methodInfo =>
+			{
+				ParameterInfo[] parameters = methodInfo.GetParameters();
+				return parameters.AnyAsync(async (p, i) =>
+				{
+					bool? isIndexInRange = collectionIndexOptions.Match switch
+					{
+						CollectionIndexOptions.IMatchFromBeginning fromBeginning => fromBeginning.MatchesIndex(i),
+						CollectionIndexOptions.IMatchFromEnd fromEnd => fromEnd.MatchesIndex(i, parameters.Length),
+						_ => false,
+					};
+					return isIndexInRange == true &&
+					       await parameterFilterOptions.Matches(p);
+				});
+			},
+			()
+				=> $"with parameter {parameterFilterOptions.GetDescription()}{collectionIndexOptions.Match.GetDescription()} ");
+		return new MethodsWithNamedParameter<T>(@this.Which(filter), collectionIndexOptions, parameterFilterOptions, stringEqualityOptions);
+	}
+}

--- a/Source/aweXpect.Reflection/Filters/MethodFilters.WithParameter.cs
+++ b/Source/aweXpect.Reflection/Filters/MethodFilters.WithParameter.cs
@@ -20,7 +20,7 @@ public static partial class MethodFilters
 	{
 		Type parameterType = typeof(T);
 		CollectionIndexOptions collectionIndexOptions = new();
-		ParameterFilterOptions parameterFilterOptions = new(p => p.ParameterType == parameterType,
+		ParameterFilterOptions parameterFilterOptions = new(p => p.ParameterType.IsOrInheritsFrom(parameterType),
 			() => $"of type {Formatter.Format(parameterType)}");
 		IAsyncChangeableFilter<MethodInfo> filter = Filter.Suffix<MethodInfo>(
 			methodInfo =>
@@ -51,7 +51,7 @@ public static partial class MethodFilters
 	{
 		Type parameterType = typeof(T);
 		StringEqualityOptions stringEqualityOptions = new();
-		ParameterFilterOptions parameterFilterOptions = new(p => p.ParameterType == parameterType,
+		ParameterFilterOptions parameterFilterOptions = new(p => p.ParameterType.IsOrInheritsFrom(parameterType),
 			() => $"of type {Formatter.Format(parameterType)}");
 		parameterFilterOptions.AddPredicate(p => stringEqualityOptions.AreConsideredEqual(p.Name, expected),
 			() => $"name {stringEqualityOptions.GetExpectation(expected, ExpectationGrammars.None)}");

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net10.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net10.0.txt
@@ -31,6 +31,8 @@ namespace aweXpect.Reflection
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.ConstructorFilters.ConstructorsWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Constructors @this, System.Func<TAttribute, bool>? predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
             where TAttribute : System.Attribute { }
+        public static aweXpect.Reflection.ConstructorFilters.ConstructorsWithParameter<T> WithExactParameter<T>(this aweXpect.Reflection.Collections.Filtered.Constructors @this) { }
+        public static aweXpect.Reflection.ConstructorFilters.ConstructorsWithNamedParameter<T> WithExactParameter<T>(this aweXpect.Reflection.Collections.Filtered.Constructors @this, string expected) { }
         public static aweXpect.Reflection.ConstructorFilters.ConstructorsWithNamedParameter<object?> WithParameter(this aweXpect.Reflection.Collections.Filtered.Constructors @this, string expected) { }
         public static aweXpect.Reflection.ConstructorFilters.ConstructorsWithParameter<T> WithParameter<T>(this aweXpect.Reflection.Collections.Filtered.Constructors @this) { }
         public static aweXpect.Reflection.ConstructorFilters.ConstructorsWithNamedParameter<T> WithParameter<T>(this aweXpect.Reflection.Collections.Filtered.Constructors @this, string expected) { }
@@ -197,6 +199,8 @@ namespace aweXpect.Reflection
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.MethodFilters.MethodsWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Methods @this, System.Func<TAttribute, bool>? predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
             where TAttribute : System.Attribute { }
+        public static aweXpect.Reflection.MethodFilters.MethodsWithParameter<T> WithExactParameter<T>(this aweXpect.Reflection.Collections.Filtered.Methods @this) { }
+        public static aweXpect.Reflection.MethodFilters.MethodsWithNamedParameter<T> WithExactParameter<T>(this aweXpect.Reflection.Collections.Filtered.Methods @this, string expected) { }
         public static aweXpect.Reflection.Collections.Filtered.Methods.StringEqualityResultType WithName(this aweXpect.Reflection.Collections.Filtered.Methods @this, string expected) { }
         public static aweXpect.Reflection.MethodFilters.MethodsWithNamedParameter<object?> WithParameter(this aweXpect.Reflection.Collections.Filtered.Methods @this, string expected) { }
         public static aweXpect.Reflection.MethodFilters.MethodsWithParameter<T> WithParameter<T>(this aweXpect.Reflection.Collections.Filtered.Methods @this) { }

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net8.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net8.0.txt
@@ -31,6 +31,8 @@ namespace aweXpect.Reflection
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.ConstructorFilters.ConstructorsWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Constructors @this, System.Func<TAttribute, bool>? predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
             where TAttribute : System.Attribute { }
+        public static aweXpect.Reflection.ConstructorFilters.ConstructorsWithParameter<T> WithExactParameter<T>(this aweXpect.Reflection.Collections.Filtered.Constructors @this) { }
+        public static aweXpect.Reflection.ConstructorFilters.ConstructorsWithNamedParameter<T> WithExactParameter<T>(this aweXpect.Reflection.Collections.Filtered.Constructors @this, string expected) { }
         public static aweXpect.Reflection.ConstructorFilters.ConstructorsWithNamedParameter<object?> WithParameter(this aweXpect.Reflection.Collections.Filtered.Constructors @this, string expected) { }
         public static aweXpect.Reflection.ConstructorFilters.ConstructorsWithParameter<T> WithParameter<T>(this aweXpect.Reflection.Collections.Filtered.Constructors @this) { }
         public static aweXpect.Reflection.ConstructorFilters.ConstructorsWithNamedParameter<T> WithParameter<T>(this aweXpect.Reflection.Collections.Filtered.Constructors @this, string expected) { }
@@ -197,6 +199,8 @@ namespace aweXpect.Reflection
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.MethodFilters.MethodsWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Methods @this, System.Func<TAttribute, bool>? predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
             where TAttribute : System.Attribute { }
+        public static aweXpect.Reflection.MethodFilters.MethodsWithParameter<T> WithExactParameter<T>(this aweXpect.Reflection.Collections.Filtered.Methods @this) { }
+        public static aweXpect.Reflection.MethodFilters.MethodsWithNamedParameter<T> WithExactParameter<T>(this aweXpect.Reflection.Collections.Filtered.Methods @this, string expected) { }
         public static aweXpect.Reflection.Collections.Filtered.Methods.StringEqualityResultType WithName(this aweXpect.Reflection.Collections.Filtered.Methods @this, string expected) { }
         public static aweXpect.Reflection.MethodFilters.MethodsWithNamedParameter<object?> WithParameter(this aweXpect.Reflection.Collections.Filtered.Methods @this, string expected) { }
         public static aweXpect.Reflection.MethodFilters.MethodsWithParameter<T> WithParameter<T>(this aweXpect.Reflection.Collections.Filtered.Methods @this) { }

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_netstandard2.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_netstandard2.0.txt
@@ -31,6 +31,8 @@ namespace aweXpect.Reflection
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.ConstructorFilters.ConstructorsWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Constructors @this, System.Func<TAttribute, bool>? predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
             where TAttribute : System.Attribute { }
+        public static aweXpect.Reflection.ConstructorFilters.ConstructorsWithParameter<T> WithExactParameter<T>(this aweXpect.Reflection.Collections.Filtered.Constructors @this) { }
+        public static aweXpect.Reflection.ConstructorFilters.ConstructorsWithNamedParameter<T> WithExactParameter<T>(this aweXpect.Reflection.Collections.Filtered.Constructors @this, string expected) { }
         public static aweXpect.Reflection.ConstructorFilters.ConstructorsWithNamedParameter<object?> WithParameter(this aweXpect.Reflection.Collections.Filtered.Constructors @this, string expected) { }
         public static aweXpect.Reflection.ConstructorFilters.ConstructorsWithParameter<T> WithParameter<T>(this aweXpect.Reflection.Collections.Filtered.Constructors @this) { }
         public static aweXpect.Reflection.ConstructorFilters.ConstructorsWithNamedParameter<T> WithParameter<T>(this aweXpect.Reflection.Collections.Filtered.Constructors @this, string expected) { }
@@ -197,6 +199,8 @@ namespace aweXpect.Reflection
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.MethodFilters.MethodsWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Methods @this, System.Func<TAttribute, bool>? predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
             where TAttribute : System.Attribute { }
+        public static aweXpect.Reflection.MethodFilters.MethodsWithParameter<T> WithExactParameter<T>(this aweXpect.Reflection.Collections.Filtered.Methods @this) { }
+        public static aweXpect.Reflection.MethodFilters.MethodsWithNamedParameter<T> WithExactParameter<T>(this aweXpect.Reflection.Collections.Filtered.Methods @this, string expected) { }
         public static aweXpect.Reflection.Collections.Filtered.Methods.StringEqualityResultType WithName(this aweXpect.Reflection.Collections.Filtered.Methods @this, string expected) { }
         public static aweXpect.Reflection.MethodFilters.MethodsWithNamedParameter<object?> WithParameter(this aweXpect.Reflection.Collections.Filtered.Methods @this, string expected) { }
         public static aweXpect.Reflection.MethodFilters.MethodsWithParameter<T> WithParameter<T>(this aweXpect.Reflection.Collections.Filtered.Methods @this) { }

--- a/Tests/aweXpect.Reflection.Tests/Filters/ConstructorFilters.WithExactParameter.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/ConstructorFilters.WithExactParameter.Tests.cs
@@ -1,0 +1,73 @@
+using aweXpect.Reflection.Collections;
+
+namespace aweXpect.Reflection.Tests.Filters;
+
+public sealed partial class ConstructorFilters
+{
+	public sealed class WithExactParameter
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task ShouldFilterForConstructorsWithParameterOfExactType()
+			{
+				Filtered.Constructors constructors = In.Type<TestClass>()
+					.Constructors().WithExactParameter<DummyBase>();
+
+				await That(constructors).IsEqualTo([
+					typeof(TestClass).GetConstructor([typeof(DummyBase),])!,
+				]).InAnyOrder();
+				await That(constructors.GetDescription())
+					.IsEqualTo("constructors with parameter of exact type ").AsPrefix();
+			}
+
+			[Fact]
+			public async Task ShouldNotIncludeConstructorsWithParameterOfDerivedType()
+			{
+				Filtered.Constructors exactConstructors = In.Type<TestClass>()
+					.Constructors().WithExactParameter<DummyBase>();
+				Filtered.Constructors assignableConstructors = In.Type<TestClass>()
+					.Constructors().WithParameter<DummyBase>();
+
+				await That(exactConstructors).IsEqualTo([
+					typeof(TestClass).GetConstructor([typeof(DummyBase),])!,
+				]).InAnyOrder();
+				await That(assignableConstructors).IsEqualTo([
+					typeof(TestClass).GetConstructor([typeof(DummyBase),])!,
+					typeof(TestClass).GetConstructor([typeof(Dummy),])!,
+				]).InAnyOrder();
+			}
+
+			[Fact]
+			public async Task WithName_ShouldFilterForConstructorsWithParameterOfExactTypeAndName()
+			{
+				Filtered.Constructors constructors = In.Type<TestClass>()
+					.Constructors().WithExactParameter<DummyBase>("parameter");
+
+				await That(constructors).IsEqualTo([
+					typeof(TestClass).GetConstructor([typeof(DummyBase),])!,
+				]).InAnyOrder();
+				await That(constructors.GetDescription())
+					.IsEqualTo("constructors with parameter of exact type ").AsPrefix();
+			}
+		}
+
+		// ReSharper disable UnusedMember.Local
+		// ReSharper disable UnusedParameter.Local
+		private class TestClass
+		{
+			public TestClass(DummyBase parameter) { }
+			public TestClass(Dummy parameter) { }
+		}
+		// ReSharper restore UnusedParameter.Local
+		// ReSharper restore UnusedMember.Local
+
+		private class DummyBase
+		{
+		}
+
+		private class Dummy : DummyBase
+		{
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/Filters/ConstructorFilters.WithParameter.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/ConstructorFilters.WithParameter.Tests.cs
@@ -36,8 +36,11 @@ public sealed partial class ConstructorFilters
 			[Fact]
 			public async Task WithParameterAtIndex_WhenIndexIsNegative_ShouldThrowArgumentOutOfRangeException()
 			{
-				void Act() => In.Type<TestClassWithConstructorParameters>()
-					.Constructors().WithParameter<int>().AtIndex(-1);
+				void Act()
+				{
+					In.Type<TestClassWithConstructorParameters>()
+						.Constructors().WithParameter<int>().AtIndex(-1);
+				}
 
 				await That(Act).Throws<ArgumentOutOfRangeException>()
 					.WithParamName("index").And
@@ -175,6 +178,20 @@ public sealed partial class ConstructorFilters
 			}
 
 			[Fact]
+			public async Task WithParameterOfType_ShouldIncludeConstructorsWithParameterOfDerivedType()
+			{
+				Filtered.Constructors constructors = In.Type<TestClassWithInheritedConstructorParameters>()
+					.Constructors().WithParameter<BaseParameter>();
+
+				await That(constructors).IsEqualTo([
+					typeof(TestClassWithInheritedConstructorParameters).GetConstructor([typeof(BaseParameter),])!,
+					typeof(TestClassWithInheritedConstructorParameters).GetConstructor([typeof(DerivedParameter),])!,
+				]).InAnyOrder();
+				await That(constructors.GetDescription())
+					.IsEqualTo("constructors with parameter of type ").AsPrefix();
+			}
+
+			[Fact]
 			public async Task WithParameterOfTypeAndName_ShouldFilterForConstructorsWithParameterOfSpecificTypeAndName()
 			{
 				Filtered.Constructors constructors = In.Type<TestClassWithConstructorParameters>()
@@ -217,6 +234,14 @@ public sealed partial class ConstructorFilters
 			}
 		}
 
+		private class BaseParameter
+		{
+		}
+
+		private class DerivedParameter : BaseParameter
+		{
+		}
+
 		// ReSharper disable UnusedMember.Local
 		// ReSharper disable UnusedParameter.Local
 		private class TestClassWithConstructorParameters
@@ -226,6 +251,12 @@ public sealed partial class ConstructorFilters
 			public TestClassWithConstructorParameters(int id, string name) { }
 			public TestClassWithConstructorParameters(int id = 42) { }
 			public TestClassWithConstructorParameters(string id, int value = 100) { }
+		}
+
+		private class TestClassWithInheritedConstructorParameters
+		{
+			public TestClassWithInheritedConstructorParameters(BaseParameter parameter) { }
+			public TestClassWithInheritedConstructorParameters(DerivedParameter parameter) { }
 		}
 		// ReSharper restore UnusedParameter.Local
 		// ReSharper restore UnusedMember.Local

--- a/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WithExactParameter.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WithExactParameter.Tests.cs
@@ -1,0 +1,74 @@
+using aweXpect.Reflection.Collections;
+
+namespace aweXpect.Reflection.Tests.Filters;
+
+public sealed partial class MethodFilters
+{
+	public sealed class WithExactParameter
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task ShouldFilterForMethodsWithParameterOfExactType()
+			{
+				Filtered.Methods methods = In.Type<TestClass>()
+					.Methods().WithExactParameter<DummyBase>();
+
+				await That(methods).IsEqualTo([
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithDummyBase))!,
+				]).InAnyOrder();
+				await That(methods.GetDescription())
+					.IsEqualTo("methods with parameter of exact type ").AsPrefix();
+			}
+
+			[Fact]
+			public async Task ShouldNotIncludeMethodsWithParameterOfDerivedType()
+			{
+				Filtered.Methods exactMethods = In.Type<TestClass>()
+					.Methods().WithExactParameter<DummyBase>();
+				Filtered.Methods assignableMethods = In.Type<TestClass>()
+					.Methods().WithParameter<DummyBase>();
+
+				await That(exactMethods).IsEqualTo([
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithDummyBase))!,
+				]).InAnyOrder();
+				await That(assignableMethods).IsEqualTo([
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithDummyBase))!,
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithDummy))!,
+				]).InAnyOrder();
+			}
+
+			[Fact]
+			public async Task WithName_ShouldFilterForMethodsWithParameterOfExactTypeAndName()
+			{
+				Filtered.Methods methods = In.Type<TestClass>()
+					.Methods().WithExactParameter<DummyBase>("parameter");
+
+				await That(methods).IsEqualTo([
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithDummyBase))!,
+				]).InAnyOrder();
+				await That(methods.GetDescription())
+					.IsEqualTo("methods with parameter of exact type ").AsPrefix();
+			}
+		}
+
+#pragma warning disable CA1822
+		// ReSharper disable UnusedParameter.Local
+		private class TestClass
+		{
+			public void MethodWithDummyBase(DummyBase parameter) { }
+			public void MethodWithDummy(Dummy parameter) { }
+			public void MethodWithString(string parameter) { }
+		}
+		// ReSharper restore UnusedParameter.Local
+#pragma warning restore CA1822
+
+		private class DummyBase
+		{
+		}
+
+		private class Dummy : DummyBase
+		{
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WithParameter.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WithParameter.Tests.cs
@@ -38,8 +38,11 @@ public sealed partial class MethodFilters
 			[Fact]
 			public async Task WithParameterAtIndex_WhenIndexIsNegative_ShouldThrowArgumentOutOfRangeException()
 			{
-				void Act() => In.Type<TestClassWithMethodParameters>()
-					.Methods().WithParameter<int>().AtIndex(-1);
+				void Act()
+				{
+					In.Type<TestClassWithMethodParameters>()
+						.Methods().WithParameter<int>().AtIndex(-1);
+				}
 
 				await That(Act).Throws<ArgumentOutOfRangeException>()
 					.WithParamName("index").And
@@ -197,6 +200,22 @@ public sealed partial class MethodFilters
 			}
 
 			[Fact]
+			public async Task WithParameterOfType_ShouldIncludeMethodsWithParameterOfDerivedType()
+			{
+				Filtered.Methods methods = In.Type<TestClassWithInheritedParameters>()
+					.Methods().WithParameter<BaseParameter>();
+
+				await That(methods).IsEqualTo([
+					typeof(TestClassWithInheritedParameters).GetMethod(
+						nameof(TestClassWithInheritedParameters.MethodWithBaseParameter))!,
+					typeof(TestClassWithInheritedParameters).GetMethod(
+						nameof(TestClassWithInheritedParameters.MethodWithDerivedParameter))!,
+				]).InAnyOrder();
+				await That(methods.GetDescription())
+					.IsEqualTo("methods with parameter of type ").AsPrefix();
+			}
+
+			[Fact]
 			public async Task WithParameterOfTypeAndName_ShouldFilterForMethodsWithParameterOfSpecificTypeAndName()
 			{
 				Filtered.Methods methods = In.Type<TestClassWithMethodParameters>()
@@ -244,6 +263,14 @@ public sealed partial class MethodFilters
 			}
 		}
 
+		private class BaseParameter
+		{
+		}
+
+		private class DerivedParameter : BaseParameter
+		{
+		}
+
 #pragma warning disable CA1822
 		// ReSharper disable UnusedParameter.Local
 		private class TestClassWithMethodParameters
@@ -253,6 +280,12 @@ public sealed partial class MethodFilters
 			public void Method2(int id, string name) { }
 			public void Method3(int id = 42) { }
 			public void Method4(string id, int value = 100) { }
+		}
+
+		private class TestClassWithInheritedParameters
+		{
+			public void MethodWithBaseParameter(BaseParameter parameter) { }
+			public void MethodWithDerivedParameter(DerivedParameter parameter) { }
 		}
 		// ReSharper restore UnusedParameter.Local
 #pragma warning restore CA1822


### PR DESCRIPTION
Make `WithParameter<T>` on methods and constructors match parameters assignable to `T` (including subtypes) instead of requiring an exact type, mirroring `WhichReturn<T>`. Add `WithExactParameter<T>` for the previous exact-match behavior, mirroring `WhichReturnExactly<T>`.

BEHAVIOR CHANGE: `WithParameter<T>()` now matches parameters of subtypes of `T`. Use `WithExactParameter<T>()` to restore exact-type matching.

---

- *Fixes #204*