### PR TITLE
refactor!: rename WhichSatisfy extensions to Which and drop base predicate overload

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ In.AllLoadedAssemblies().Types()
 
 // Filter by custom predicates
 In.AllLoadedAssemblies().Types()
-    .WhichSatisfy(t => t.Name.StartsWith("Test"))
+    .Which(t => t.Name.StartsWith("Test"))
 ```
 
 #### Method Filters
@@ -243,7 +243,7 @@ await Expect.That(In.AllLoadedAssemblies()
 
 // Verify each event handler is named after the event it handles (e.g. "OnOrderPlaced")
 await Expect.That(In.AssemblyContaining<MyAggregate>()
-        .Methods().WhichSatisfy(m => m.GetParameters().Length == 1))
+        .Methods().Which(m => m.GetParameters().Length == 1))
     .HaveName(method => "On" + method.GetParameters()[0].ParameterType.Name);
 ```
 

--- a/Source/aweXpect.Reflection/Collections/Filtered.cs
+++ b/Source/aweXpect.Reflection/Collections/Filtered.cs
@@ -1,8 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.CompilerServices;
-using aweXpect.Reflection.Helpers;
 #if NET8_0_OR_GREATER
 using System.Threading;
 using System.Threading.Tasks;
@@ -63,13 +60,4 @@ public abstract class Filtered<T, TFiltered>(IEnumerable<T> source, List<IFilter
 		Filters.Add(filter);
 		return (TFiltered)this;
 	}
-
-	/// <summary>
-	///     Filters the applicable <typeparamref name="T" /> on which the expectations should be applied
-	///     according to the <paramref name="predicate" />.
-	/// </summary>
-	public TFiltered Which(Func<T, bool> predicate,
-		[CallerArgumentExpression("predicate")]
-		string doNotPopulateThisValue = "")
-		=> Which(Filter.Suffix(predicate, $"matching {doNotPopulateThisValue.TrimCommonWhiteSpace()} "));
 }

--- a/Source/aweXpect.Reflection/Filters/AssemblyFilters.Which.cs
+++ b/Source/aweXpect.Reflection/Filters/AssemblyFilters.Which.cs
@@ -11,7 +11,7 @@ public static partial class AssemblyFilters
 	/// <summary>
 	///     Filters for assemblies that satisfy the <paramref name="predicate" />.
 	/// </summary>
-	public static Filtered.Assemblies WhichSatisfy(this Filtered.Assemblies @this,
+	public static Filtered.Assemblies Which(this Filtered.Assemblies @this,
 		Func<Assembly, bool> predicate,
 		[CallerArgumentExpression("predicate")]
 		string doNotPopulateThisValue = "")

--- a/Source/aweXpect.Reflection/Filters/ConstructorFilters.Which.cs
+++ b/Source/aweXpect.Reflection/Filters/ConstructorFilters.Which.cs
@@ -6,13 +6,13 @@ using aweXpect.Reflection.Helpers;
 
 namespace aweXpect.Reflection;
 
-public static partial class EventFilters
+public static partial class ConstructorFilters
 {
 	/// <summary>
-	///     Filters for events that satisfy the <paramref name="predicate" />.
+	///     Filters for constructors that satisfy the <paramref name="predicate" />.
 	/// </summary>
-	public static Filtered.Events WhichSatisfy(this Filtered.Events @this,
-		Func<EventInfo, bool> predicate,
+	public static Filtered.Constructors Which(this Filtered.Constructors @this,
+		Func<ConstructorInfo, bool> predicate,
 		[CallerArgumentExpression("predicate")]
 		string doNotPopulateThisValue = "")
 		=> @this.Which(Filter.Suffix(predicate, $"matching {doNotPopulateThisValue.TrimCommonWhiteSpace()} "));

--- a/Source/aweXpect.Reflection/Filters/EventFilters.Which.cs
+++ b/Source/aweXpect.Reflection/Filters/EventFilters.Which.cs
@@ -6,13 +6,13 @@ using aweXpect.Reflection.Helpers;
 
 namespace aweXpect.Reflection;
 
-public static partial class PropertyFilters
+public static partial class EventFilters
 {
 	/// <summary>
-	///     Filters for properties that satisfy the <paramref name="predicate" />.
+	///     Filters for events that satisfy the <paramref name="predicate" />.
 	/// </summary>
-	public static Filtered.Properties WhichSatisfy(this Filtered.Properties @this,
-		Func<PropertyInfo, bool> predicate,
+	public static Filtered.Events Which(this Filtered.Events @this,
+		Func<EventInfo, bool> predicate,
 		[CallerArgumentExpression("predicate")]
 		string doNotPopulateThisValue = "")
 		=> @this.Which(Filter.Suffix(predicate, $"matching {doNotPopulateThisValue.TrimCommonWhiteSpace()} "));

--- a/Source/aweXpect.Reflection/Filters/FieldFilters.Which.cs
+++ b/Source/aweXpect.Reflection/Filters/FieldFilters.Which.cs
@@ -6,13 +6,13 @@ using aweXpect.Reflection.Helpers;
 
 namespace aweXpect.Reflection;
 
-public static partial class ConstructorFilters
+public static partial class FieldFilters
 {
 	/// <summary>
-	///     Filters for constructors that satisfy the <paramref name="predicate" />.
+	///     Filters for fields that satisfy the <paramref name="predicate" />.
 	/// </summary>
-	public static Filtered.Constructors WhichSatisfy(this Filtered.Constructors @this,
-		Func<ConstructorInfo, bool> predicate,
+	public static Filtered.Fields Which(this Filtered.Fields @this,
+		Func<FieldInfo, bool> predicate,
 		[CallerArgumentExpression("predicate")]
 		string doNotPopulateThisValue = "")
 		=> @this.Which(Filter.Suffix(predicate, $"matching {doNotPopulateThisValue.TrimCommonWhiteSpace()} "));

--- a/Source/aweXpect.Reflection/Filters/MethodFilters.Which.cs
+++ b/Source/aweXpect.Reflection/Filters/MethodFilters.Which.cs
@@ -11,7 +11,7 @@ public static partial class MethodFilters
 	/// <summary>
 	///     Filters for methods that satisfy the <paramref name="predicate" />.
 	/// </summary>
-	public static Filtered.Methods WhichSatisfy(this Filtered.Methods @this,
+	public static Filtered.Methods Which(this Filtered.Methods @this,
 		Func<MethodInfo, bool> predicate,
 		[CallerArgumentExpression("predicate")]
 		string doNotPopulateThisValue = "")

--- a/Source/aweXpect.Reflection/Filters/PropertyFilters.Which.cs
+++ b/Source/aweXpect.Reflection/Filters/PropertyFilters.Which.cs
@@ -1,17 +1,18 @@
 ﻿using System;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Helpers;
 
 namespace aweXpect.Reflection;
 
-public static partial class TypeFilters
+public static partial class PropertyFilters
 {
 	/// <summary>
-	///     Filters for types that satisfy the <paramref name="predicate" />.
+	///     Filters for properties that satisfy the <paramref name="predicate" />.
 	/// </summary>
-	public static Filtered.Types WhichSatisfy(this Filtered.Types @this,
-		Func<Type, bool> predicate,
+	public static Filtered.Properties Which(this Filtered.Properties @this,
+		Func<PropertyInfo, bool> predicate,
 		[CallerArgumentExpression("predicate")]
 		string doNotPopulateThisValue = "")
 		=> @this.Which(Filter.Suffix(predicate, $"matching {doNotPopulateThisValue.TrimCommonWhiteSpace()} "));

--- a/Source/aweXpect.Reflection/Filters/TypeFilters.Which.cs
+++ b/Source/aweXpect.Reflection/Filters/TypeFilters.Which.cs
@@ -1,18 +1,17 @@
 ﻿using System;
-using System.Reflection;
 using System.Runtime.CompilerServices;
 using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Helpers;
 
 namespace aweXpect.Reflection;
 
-public static partial class FieldFilters
+public static partial class TypeFilters
 {
 	/// <summary>
-	///     Filters for fields that satisfy the <paramref name="predicate" />.
+	///     Filters for types that satisfy the <paramref name="predicate" />.
 	/// </summary>
-	public static Filtered.Fields WhichSatisfy(this Filtered.Fields @this,
-		Func<FieldInfo, bool> predicate,
+	public static Filtered.Types Which(this Filtered.Types @this,
+		Func<Type, bool> predicate,
 		[CallerArgumentExpression("predicate")]
 		string doNotPopulateThisValue = "")
 		=> @this.Which(Filter.Suffix(predicate, $"matching {doNotPopulateThisValue.TrimCommonWhiteSpace()} "));

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net10.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net10.0.txt
@@ -5,11 +5,12 @@ namespace aweXpect.Reflection
 {
     public static class AssemblyFilters
     {
-        public static aweXpect.Reflection.Collections.Filtered.Assemblies WhichSatisfy(this aweXpect.Reflection.Collections.Filtered.Assemblies @this, System.Func<System.Reflection.Assembly, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
+        public static aweXpect.Reflection.Collections.Filtered.Assemblies Which(this aweXpect.Reflection.Collections.Filtered.Assemblies @this, System.Func<System.Reflection.Assembly, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Reflection.Collections.Filtered.Assemblies.StringEqualityResultType WithName(this aweXpect.Reflection.Collections.Filtered.Assemblies @this, string expected) { }
     }
     public static class ConstructorFilters
     {
+        public static aweXpect.Reflection.Collections.Filtered.Constructors Which(this aweXpect.Reflection.Collections.Filtered.Constructors @this, System.Func<System.Reflection.ConstructorInfo, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Reflection.Collections.Filtered.Constructors WhichAre(this aweXpect.Reflection.Collections.Filtered.Constructors @this, aweXpect.Reflection.Collections.AccessModifiers accessModifier) { }
         public static aweXpect.Reflection.Collections.Filtered.Constructors WhichAreInternal(this aweXpect.Reflection.Collections.Filtered.Constructors @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Constructors WhichAreNot(this aweXpect.Reflection.Collections.Filtered.Constructors @this, aweXpect.Reflection.Collections.AccessModifiers accessModifier) { }
@@ -26,7 +27,6 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Collections.Filtered.Constructors WhichAreProtectedInternal(this aweXpect.Reflection.Collections.Filtered.Constructors @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Constructors WhichArePublic(this aweXpect.Reflection.Collections.Filtered.Constructors @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Constructors WhichAreStatic(this aweXpect.Reflection.Collections.Filtered.Constructors @this) { }
-        public static aweXpect.Reflection.Collections.Filtered.Constructors WhichSatisfy(this aweXpect.Reflection.Collections.Filtered.Constructors @this, System.Func<System.Reflection.ConstructorInfo, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Reflection.ConstructorFilters.ConstructorsWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Constructors @this)
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.ConstructorFilters.ConstructorsWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Constructors @this, System.Func<TAttribute, bool>? predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
@@ -73,6 +73,7 @@ namespace aweXpect.Reflection
     }
     public static class EventFilters
     {
+        public static aweXpect.Reflection.Collections.Filtered.Events Which(this aweXpect.Reflection.Collections.Filtered.Events @this, System.Func<System.Reflection.EventInfo, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Reflection.Collections.Filtered.Events WhichAre(this aweXpect.Reflection.Collections.Filtered.Events @this, aweXpect.Reflection.Collections.AccessModifiers accessModifier) { }
         public static aweXpect.Reflection.Collections.Filtered.Events WhichAreAbstract(this aweXpect.Reflection.Collections.Filtered.Events @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Events WhichAreInternal(this aweXpect.Reflection.Collections.Filtered.Events @this) { }
@@ -91,7 +92,6 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Collections.Filtered.Events WhichAreProtectedInternal(this aweXpect.Reflection.Collections.Filtered.Events @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Events WhichArePublic(this aweXpect.Reflection.Collections.Filtered.Events @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Events WhichAreSealed(this aweXpect.Reflection.Collections.Filtered.Events @this) { }
-        public static aweXpect.Reflection.Collections.Filtered.Events WhichSatisfy(this aweXpect.Reflection.Collections.Filtered.Events @this, System.Func<System.Reflection.EventInfo, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Reflection.EventFilters.EventsWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Events @this, bool inherit = true)
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.EventFilters.EventsWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Events @this, System.Func<TAttribute, bool>? predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
@@ -112,6 +112,7 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.FieldFilters.FieldsOfType OfExactType<TField>(this aweXpect.Reflection.Collections.Filtered.Fields @this) { }
         public static aweXpect.Reflection.FieldFilters.FieldsOfType OfType(this aweXpect.Reflection.Collections.Filtered.Fields @this, System.Type fieldType) { }
         public static aweXpect.Reflection.FieldFilters.FieldsOfType OfType<TField>(this aweXpect.Reflection.Collections.Filtered.Fields @this) { }
+        public static aweXpect.Reflection.Collections.Filtered.Fields Which(this aweXpect.Reflection.Collections.Filtered.Fields @this, System.Func<System.Reflection.FieldInfo, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Reflection.Collections.Filtered.Fields WhichAre(this aweXpect.Reflection.Collections.Filtered.Fields @this, aweXpect.Reflection.Collections.AccessModifiers accessModifier) { }
         public static aweXpect.Reflection.Collections.Filtered.Fields WhichAreInternal(this aweXpect.Reflection.Collections.Filtered.Fields @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Fields WhichAreNot(this aweXpect.Reflection.Collections.Filtered.Fields @this, aweXpect.Reflection.Collections.AccessModifiers accessModifier) { }
@@ -128,7 +129,6 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Collections.Filtered.Fields WhichAreProtectedInternal(this aweXpect.Reflection.Collections.Filtered.Fields @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Fields WhichArePublic(this aweXpect.Reflection.Collections.Filtered.Fields @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Fields WhichAreStatic(this aweXpect.Reflection.Collections.Filtered.Fields @this) { }
-        public static aweXpect.Reflection.Collections.Filtered.Fields WhichSatisfy(this aweXpect.Reflection.Collections.Filtered.Fields @this, System.Func<System.Reflection.FieldInfo, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Reflection.FieldFilters.FieldsWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Fields @this)
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.FieldFilters.FieldsWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Fields @this, System.Func<TAttribute, bool>? predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
@@ -168,6 +168,7 @@ namespace aweXpect.Reflection
     }
     public static class MethodFilters
     {
+        public static aweXpect.Reflection.Collections.Filtered.Methods Which(this aweXpect.Reflection.Collections.Filtered.Methods @this, System.Func<System.Reflection.MethodInfo, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Reflection.Collections.Filtered.Methods WhichAre(this aweXpect.Reflection.Collections.Filtered.Methods @this, aweXpect.Reflection.Collections.AccessModifiers accessModifier) { }
         public static aweXpect.Reflection.Collections.Filtered.Methods WhichAreAbstract(this aweXpect.Reflection.Collections.Filtered.Methods @this) { }
         public static aweXpect.Reflection.MethodFilters.GenericMethods WhichAreGeneric(this aweXpect.Reflection.Collections.Filtered.Methods @this) { }
@@ -194,7 +195,6 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.MethodFilters.MethodsWhichReturn WhichReturn<TReturn>(this aweXpect.Reflection.Collections.Filtered.Methods @this) { }
         public static aweXpect.Reflection.MethodFilters.MethodsWhichReturn WhichReturnExactly(this aweXpect.Reflection.Collections.Filtered.Methods @this, System.Type returnType) { }
         public static aweXpect.Reflection.MethodFilters.MethodsWhichReturn WhichReturnExactly<TReturn>(this aweXpect.Reflection.Collections.Filtered.Methods @this) { }
-        public static aweXpect.Reflection.Collections.Filtered.Methods WhichSatisfy(this aweXpect.Reflection.Collections.Filtered.Methods @this, System.Func<System.Reflection.MethodInfo, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Reflection.MethodFilters.MethodsWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Methods @this, bool inherit = true)
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.MethodFilters.MethodsWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Methods @this, System.Func<TAttribute, bool>? predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
@@ -282,6 +282,7 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.PropertyFilters.PropertiesOfType OfExactType<TProperty>(this aweXpect.Reflection.Collections.Filtered.Properties @this) { }
         public static aweXpect.Reflection.PropertyFilters.PropertiesOfType OfType(this aweXpect.Reflection.Collections.Filtered.Properties @this, System.Type propertyType) { }
         public static aweXpect.Reflection.PropertyFilters.PropertiesOfType OfType<TProperty>(this aweXpect.Reflection.Collections.Filtered.Properties @this) { }
+        public static aweXpect.Reflection.Collections.Filtered.Properties Which(this aweXpect.Reflection.Collections.Filtered.Properties @this, System.Func<System.Reflection.PropertyInfo, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Reflection.Collections.Filtered.Properties WhichAre(this aweXpect.Reflection.Collections.Filtered.Properties @this, aweXpect.Reflection.Collections.AccessModifiers accessModifier) { }
         public static aweXpect.Reflection.Collections.Filtered.Properties WhichAreAbstract(this aweXpect.Reflection.Collections.Filtered.Properties @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Properties WhichAreInternal(this aweXpect.Reflection.Collections.Filtered.Properties @this) { }
@@ -302,7 +303,6 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Collections.Filtered.Properties WhichArePublic(this aweXpect.Reflection.Collections.Filtered.Properties @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Properties WhichAreSealed(this aweXpect.Reflection.Collections.Filtered.Properties @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Properties WhichAreStatic(this aweXpect.Reflection.Collections.Filtered.Properties @this) { }
-        public static aweXpect.Reflection.Collections.Filtered.Properties WhichSatisfy(this aweXpect.Reflection.Collections.Filtered.Properties @this, System.Func<System.Reflection.PropertyInfo, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Reflection.PropertyFilters.PropertiesWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Properties @this, bool inherit = true)
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.PropertyFilters.PropertiesWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Properties @this, System.Func<TAttribute, bool>? predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
@@ -747,6 +747,7 @@ namespace aweXpect.Reflection
     }
     public static class TypeFilters
     {
+        public static aweXpect.Reflection.Collections.Filtered.Types Which(this aweXpect.Reflection.Collections.Filtered.Types @this, System.Func<System.Type, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAre(this aweXpect.Reflection.Collections.Filtered.Types @this, aweXpect.Reflection.Collections.AccessModifiers accessModifier) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreAbstract(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreClasses(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
@@ -785,7 +786,6 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreStructs(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichInheritFrom(this aweXpect.Reflection.Collections.Filtered.Types @this, System.Type baseType, bool forceDirect = false) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichInheritFrom<TBaseType>(this aweXpect.Reflection.Collections.Filtered.Types @this, bool forceDirect = false) { }
-        public static aweXpect.Reflection.Collections.Filtered.Types WhichSatisfy(this aweXpect.Reflection.Collections.Filtered.Types @this, System.Func<System.Type, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Reflection.TypeFilters.TypesWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Types @this, bool inherit = true)
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.TypeFilters.TypesWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Types @this, System.Func<TAttribute, bool>? predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
@@ -1014,7 +1014,6 @@ namespace aweXpect.Reflection.Collections
         [System.Runtime.CompilerServices.AsyncIteratorStateMachine(typeof(aweXpect.Reflection.Collections.Filtered<T, TFiltered>.<GetAsyncEnumerator>d__5))]
         public System.Collections.Generic.IAsyncEnumerator<T> GetAsyncEnumerator(System.Threading.CancellationToken cancellationToken = default) { }
         public TFiltered Which(aweXpect.Reflection.Collections.IFilter<T> filter) { }
-        public TFiltered Which(System.Func<T, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
     }
     public interface IAsyncChangeableFilter<TEntity> : aweXpect.Reflection.Collections.IFilter<TEntity>
     {

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net8.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net8.0.txt
@@ -5,11 +5,12 @@ namespace aweXpect.Reflection
 {
     public static class AssemblyFilters
     {
-        public static aweXpect.Reflection.Collections.Filtered.Assemblies WhichSatisfy(this aweXpect.Reflection.Collections.Filtered.Assemblies @this, System.Func<System.Reflection.Assembly, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
+        public static aweXpect.Reflection.Collections.Filtered.Assemblies Which(this aweXpect.Reflection.Collections.Filtered.Assemblies @this, System.Func<System.Reflection.Assembly, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Reflection.Collections.Filtered.Assemblies.StringEqualityResultType WithName(this aweXpect.Reflection.Collections.Filtered.Assemblies @this, string expected) { }
     }
     public static class ConstructorFilters
     {
+        public static aweXpect.Reflection.Collections.Filtered.Constructors Which(this aweXpect.Reflection.Collections.Filtered.Constructors @this, System.Func<System.Reflection.ConstructorInfo, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Reflection.Collections.Filtered.Constructors WhichAre(this aweXpect.Reflection.Collections.Filtered.Constructors @this, aweXpect.Reflection.Collections.AccessModifiers accessModifier) { }
         public static aweXpect.Reflection.Collections.Filtered.Constructors WhichAreInternal(this aweXpect.Reflection.Collections.Filtered.Constructors @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Constructors WhichAreNot(this aweXpect.Reflection.Collections.Filtered.Constructors @this, aweXpect.Reflection.Collections.AccessModifiers accessModifier) { }
@@ -26,7 +27,6 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Collections.Filtered.Constructors WhichAreProtectedInternal(this aweXpect.Reflection.Collections.Filtered.Constructors @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Constructors WhichArePublic(this aweXpect.Reflection.Collections.Filtered.Constructors @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Constructors WhichAreStatic(this aweXpect.Reflection.Collections.Filtered.Constructors @this) { }
-        public static aweXpect.Reflection.Collections.Filtered.Constructors WhichSatisfy(this aweXpect.Reflection.Collections.Filtered.Constructors @this, System.Func<System.Reflection.ConstructorInfo, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Reflection.ConstructorFilters.ConstructorsWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Constructors @this)
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.ConstructorFilters.ConstructorsWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Constructors @this, System.Func<TAttribute, bool>? predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
@@ -73,6 +73,7 @@ namespace aweXpect.Reflection
     }
     public static class EventFilters
     {
+        public static aweXpect.Reflection.Collections.Filtered.Events Which(this aweXpect.Reflection.Collections.Filtered.Events @this, System.Func<System.Reflection.EventInfo, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Reflection.Collections.Filtered.Events WhichAre(this aweXpect.Reflection.Collections.Filtered.Events @this, aweXpect.Reflection.Collections.AccessModifiers accessModifier) { }
         public static aweXpect.Reflection.Collections.Filtered.Events WhichAreAbstract(this aweXpect.Reflection.Collections.Filtered.Events @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Events WhichAreInternal(this aweXpect.Reflection.Collections.Filtered.Events @this) { }
@@ -91,7 +92,6 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Collections.Filtered.Events WhichAreProtectedInternal(this aweXpect.Reflection.Collections.Filtered.Events @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Events WhichArePublic(this aweXpect.Reflection.Collections.Filtered.Events @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Events WhichAreSealed(this aweXpect.Reflection.Collections.Filtered.Events @this) { }
-        public static aweXpect.Reflection.Collections.Filtered.Events WhichSatisfy(this aweXpect.Reflection.Collections.Filtered.Events @this, System.Func<System.Reflection.EventInfo, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Reflection.EventFilters.EventsWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Events @this, bool inherit = true)
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.EventFilters.EventsWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Events @this, System.Func<TAttribute, bool>? predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
@@ -112,6 +112,7 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.FieldFilters.FieldsOfType OfExactType<TField>(this aweXpect.Reflection.Collections.Filtered.Fields @this) { }
         public static aweXpect.Reflection.FieldFilters.FieldsOfType OfType(this aweXpect.Reflection.Collections.Filtered.Fields @this, System.Type fieldType) { }
         public static aweXpect.Reflection.FieldFilters.FieldsOfType OfType<TField>(this aweXpect.Reflection.Collections.Filtered.Fields @this) { }
+        public static aweXpect.Reflection.Collections.Filtered.Fields Which(this aweXpect.Reflection.Collections.Filtered.Fields @this, System.Func<System.Reflection.FieldInfo, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Reflection.Collections.Filtered.Fields WhichAre(this aweXpect.Reflection.Collections.Filtered.Fields @this, aweXpect.Reflection.Collections.AccessModifiers accessModifier) { }
         public static aweXpect.Reflection.Collections.Filtered.Fields WhichAreInternal(this aweXpect.Reflection.Collections.Filtered.Fields @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Fields WhichAreNot(this aweXpect.Reflection.Collections.Filtered.Fields @this, aweXpect.Reflection.Collections.AccessModifiers accessModifier) { }
@@ -128,7 +129,6 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Collections.Filtered.Fields WhichAreProtectedInternal(this aweXpect.Reflection.Collections.Filtered.Fields @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Fields WhichArePublic(this aweXpect.Reflection.Collections.Filtered.Fields @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Fields WhichAreStatic(this aweXpect.Reflection.Collections.Filtered.Fields @this) { }
-        public static aweXpect.Reflection.Collections.Filtered.Fields WhichSatisfy(this aweXpect.Reflection.Collections.Filtered.Fields @this, System.Func<System.Reflection.FieldInfo, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Reflection.FieldFilters.FieldsWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Fields @this)
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.FieldFilters.FieldsWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Fields @this, System.Func<TAttribute, bool>? predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
@@ -168,6 +168,7 @@ namespace aweXpect.Reflection
     }
     public static class MethodFilters
     {
+        public static aweXpect.Reflection.Collections.Filtered.Methods Which(this aweXpect.Reflection.Collections.Filtered.Methods @this, System.Func<System.Reflection.MethodInfo, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Reflection.Collections.Filtered.Methods WhichAre(this aweXpect.Reflection.Collections.Filtered.Methods @this, aweXpect.Reflection.Collections.AccessModifiers accessModifier) { }
         public static aweXpect.Reflection.Collections.Filtered.Methods WhichAreAbstract(this aweXpect.Reflection.Collections.Filtered.Methods @this) { }
         public static aweXpect.Reflection.MethodFilters.GenericMethods WhichAreGeneric(this aweXpect.Reflection.Collections.Filtered.Methods @this) { }
@@ -194,7 +195,6 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.MethodFilters.MethodsWhichReturn WhichReturn<TReturn>(this aweXpect.Reflection.Collections.Filtered.Methods @this) { }
         public static aweXpect.Reflection.MethodFilters.MethodsWhichReturn WhichReturnExactly(this aweXpect.Reflection.Collections.Filtered.Methods @this, System.Type returnType) { }
         public static aweXpect.Reflection.MethodFilters.MethodsWhichReturn WhichReturnExactly<TReturn>(this aweXpect.Reflection.Collections.Filtered.Methods @this) { }
-        public static aweXpect.Reflection.Collections.Filtered.Methods WhichSatisfy(this aweXpect.Reflection.Collections.Filtered.Methods @this, System.Func<System.Reflection.MethodInfo, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Reflection.MethodFilters.MethodsWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Methods @this, bool inherit = true)
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.MethodFilters.MethodsWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Methods @this, System.Func<TAttribute, bool>? predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
@@ -282,6 +282,7 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.PropertyFilters.PropertiesOfType OfExactType<TProperty>(this aweXpect.Reflection.Collections.Filtered.Properties @this) { }
         public static aweXpect.Reflection.PropertyFilters.PropertiesOfType OfType(this aweXpect.Reflection.Collections.Filtered.Properties @this, System.Type propertyType) { }
         public static aweXpect.Reflection.PropertyFilters.PropertiesOfType OfType<TProperty>(this aweXpect.Reflection.Collections.Filtered.Properties @this) { }
+        public static aweXpect.Reflection.Collections.Filtered.Properties Which(this aweXpect.Reflection.Collections.Filtered.Properties @this, System.Func<System.Reflection.PropertyInfo, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Reflection.Collections.Filtered.Properties WhichAre(this aweXpect.Reflection.Collections.Filtered.Properties @this, aweXpect.Reflection.Collections.AccessModifiers accessModifier) { }
         public static aweXpect.Reflection.Collections.Filtered.Properties WhichAreAbstract(this aweXpect.Reflection.Collections.Filtered.Properties @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Properties WhichAreInternal(this aweXpect.Reflection.Collections.Filtered.Properties @this) { }
@@ -302,7 +303,6 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Collections.Filtered.Properties WhichArePublic(this aweXpect.Reflection.Collections.Filtered.Properties @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Properties WhichAreSealed(this aweXpect.Reflection.Collections.Filtered.Properties @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Properties WhichAreStatic(this aweXpect.Reflection.Collections.Filtered.Properties @this) { }
-        public static aweXpect.Reflection.Collections.Filtered.Properties WhichSatisfy(this aweXpect.Reflection.Collections.Filtered.Properties @this, System.Func<System.Reflection.PropertyInfo, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Reflection.PropertyFilters.PropertiesWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Properties @this, bool inherit = true)
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.PropertyFilters.PropertiesWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Properties @this, System.Func<TAttribute, bool>? predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
@@ -747,6 +747,7 @@ namespace aweXpect.Reflection
     }
     public static class TypeFilters
     {
+        public static aweXpect.Reflection.Collections.Filtered.Types Which(this aweXpect.Reflection.Collections.Filtered.Types @this, System.Func<System.Type, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAre(this aweXpect.Reflection.Collections.Filtered.Types @this, aweXpect.Reflection.Collections.AccessModifiers accessModifier) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreAbstract(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreClasses(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
@@ -785,7 +786,6 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreStructs(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichInheritFrom(this aweXpect.Reflection.Collections.Filtered.Types @this, System.Type baseType, bool forceDirect = false) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichInheritFrom<TBaseType>(this aweXpect.Reflection.Collections.Filtered.Types @this, bool forceDirect = false) { }
-        public static aweXpect.Reflection.Collections.Filtered.Types WhichSatisfy(this aweXpect.Reflection.Collections.Filtered.Types @this, System.Func<System.Type, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Reflection.TypeFilters.TypesWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Types @this, bool inherit = true)
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.TypeFilters.TypesWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Types @this, System.Func<TAttribute, bool>? predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
@@ -1014,7 +1014,6 @@ namespace aweXpect.Reflection.Collections
         [System.Runtime.CompilerServices.AsyncIteratorStateMachine(typeof(aweXpect.Reflection.Collections.Filtered<T, TFiltered>.<GetAsyncEnumerator>d__5))]
         public System.Collections.Generic.IAsyncEnumerator<T> GetAsyncEnumerator(System.Threading.CancellationToken cancellationToken = default) { }
         public TFiltered Which(aweXpect.Reflection.Collections.IFilter<T> filter) { }
-        public TFiltered Which(System.Func<T, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
     }
     public interface IAsyncChangeableFilter<TEntity> : aweXpect.Reflection.Collections.IFilter<TEntity>
     {

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_netstandard2.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_netstandard2.0.txt
@@ -5,11 +5,12 @@ namespace aweXpect.Reflection
 {
     public static class AssemblyFilters
     {
-        public static aweXpect.Reflection.Collections.Filtered.Assemblies WhichSatisfy(this aweXpect.Reflection.Collections.Filtered.Assemblies @this, System.Func<System.Reflection.Assembly, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
+        public static aweXpect.Reflection.Collections.Filtered.Assemblies Which(this aweXpect.Reflection.Collections.Filtered.Assemblies @this, System.Func<System.Reflection.Assembly, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Reflection.Collections.Filtered.Assemblies.StringEqualityResultType WithName(this aweXpect.Reflection.Collections.Filtered.Assemblies @this, string expected) { }
     }
     public static class ConstructorFilters
     {
+        public static aweXpect.Reflection.Collections.Filtered.Constructors Which(this aweXpect.Reflection.Collections.Filtered.Constructors @this, System.Func<System.Reflection.ConstructorInfo, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Reflection.Collections.Filtered.Constructors WhichAre(this aweXpect.Reflection.Collections.Filtered.Constructors @this, aweXpect.Reflection.Collections.AccessModifiers accessModifier) { }
         public static aweXpect.Reflection.Collections.Filtered.Constructors WhichAreInternal(this aweXpect.Reflection.Collections.Filtered.Constructors @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Constructors WhichAreNot(this aweXpect.Reflection.Collections.Filtered.Constructors @this, aweXpect.Reflection.Collections.AccessModifiers accessModifier) { }
@@ -26,7 +27,6 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Collections.Filtered.Constructors WhichAreProtectedInternal(this aweXpect.Reflection.Collections.Filtered.Constructors @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Constructors WhichArePublic(this aweXpect.Reflection.Collections.Filtered.Constructors @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Constructors WhichAreStatic(this aweXpect.Reflection.Collections.Filtered.Constructors @this) { }
-        public static aweXpect.Reflection.Collections.Filtered.Constructors WhichSatisfy(this aweXpect.Reflection.Collections.Filtered.Constructors @this, System.Func<System.Reflection.ConstructorInfo, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Reflection.ConstructorFilters.ConstructorsWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Constructors @this)
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.ConstructorFilters.ConstructorsWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Constructors @this, System.Func<TAttribute, bool>? predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
@@ -73,6 +73,7 @@ namespace aweXpect.Reflection
     }
     public static class EventFilters
     {
+        public static aweXpect.Reflection.Collections.Filtered.Events Which(this aweXpect.Reflection.Collections.Filtered.Events @this, System.Func<System.Reflection.EventInfo, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Reflection.Collections.Filtered.Events WhichAre(this aweXpect.Reflection.Collections.Filtered.Events @this, aweXpect.Reflection.Collections.AccessModifiers accessModifier) { }
         public static aweXpect.Reflection.Collections.Filtered.Events WhichAreAbstract(this aweXpect.Reflection.Collections.Filtered.Events @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Events WhichAreInternal(this aweXpect.Reflection.Collections.Filtered.Events @this) { }
@@ -91,7 +92,6 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Collections.Filtered.Events WhichAreProtectedInternal(this aweXpect.Reflection.Collections.Filtered.Events @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Events WhichArePublic(this aweXpect.Reflection.Collections.Filtered.Events @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Events WhichAreSealed(this aweXpect.Reflection.Collections.Filtered.Events @this) { }
-        public static aweXpect.Reflection.Collections.Filtered.Events WhichSatisfy(this aweXpect.Reflection.Collections.Filtered.Events @this, System.Func<System.Reflection.EventInfo, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Reflection.EventFilters.EventsWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Events @this, bool inherit = true)
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.EventFilters.EventsWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Events @this, System.Func<TAttribute, bool>? predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
@@ -112,6 +112,7 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.FieldFilters.FieldsOfType OfExactType<TField>(this aweXpect.Reflection.Collections.Filtered.Fields @this) { }
         public static aweXpect.Reflection.FieldFilters.FieldsOfType OfType(this aweXpect.Reflection.Collections.Filtered.Fields @this, System.Type fieldType) { }
         public static aweXpect.Reflection.FieldFilters.FieldsOfType OfType<TField>(this aweXpect.Reflection.Collections.Filtered.Fields @this) { }
+        public static aweXpect.Reflection.Collections.Filtered.Fields Which(this aweXpect.Reflection.Collections.Filtered.Fields @this, System.Func<System.Reflection.FieldInfo, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Reflection.Collections.Filtered.Fields WhichAre(this aweXpect.Reflection.Collections.Filtered.Fields @this, aweXpect.Reflection.Collections.AccessModifiers accessModifier) { }
         public static aweXpect.Reflection.Collections.Filtered.Fields WhichAreInternal(this aweXpect.Reflection.Collections.Filtered.Fields @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Fields WhichAreNot(this aweXpect.Reflection.Collections.Filtered.Fields @this, aweXpect.Reflection.Collections.AccessModifiers accessModifier) { }
@@ -128,7 +129,6 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Collections.Filtered.Fields WhichAreProtectedInternal(this aweXpect.Reflection.Collections.Filtered.Fields @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Fields WhichArePublic(this aweXpect.Reflection.Collections.Filtered.Fields @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Fields WhichAreStatic(this aweXpect.Reflection.Collections.Filtered.Fields @this) { }
-        public static aweXpect.Reflection.Collections.Filtered.Fields WhichSatisfy(this aweXpect.Reflection.Collections.Filtered.Fields @this, System.Func<System.Reflection.FieldInfo, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Reflection.FieldFilters.FieldsWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Fields @this)
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.FieldFilters.FieldsWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Fields @this, System.Func<TAttribute, bool>? predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
@@ -168,6 +168,7 @@ namespace aweXpect.Reflection
     }
     public static class MethodFilters
     {
+        public static aweXpect.Reflection.Collections.Filtered.Methods Which(this aweXpect.Reflection.Collections.Filtered.Methods @this, System.Func<System.Reflection.MethodInfo, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Reflection.Collections.Filtered.Methods WhichAre(this aweXpect.Reflection.Collections.Filtered.Methods @this, aweXpect.Reflection.Collections.AccessModifiers accessModifier) { }
         public static aweXpect.Reflection.Collections.Filtered.Methods WhichAreAbstract(this aweXpect.Reflection.Collections.Filtered.Methods @this) { }
         public static aweXpect.Reflection.MethodFilters.GenericMethods WhichAreGeneric(this aweXpect.Reflection.Collections.Filtered.Methods @this) { }
@@ -194,7 +195,6 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.MethodFilters.MethodsWhichReturn WhichReturn<TReturn>(this aweXpect.Reflection.Collections.Filtered.Methods @this) { }
         public static aweXpect.Reflection.MethodFilters.MethodsWhichReturn WhichReturnExactly(this aweXpect.Reflection.Collections.Filtered.Methods @this, System.Type returnType) { }
         public static aweXpect.Reflection.MethodFilters.MethodsWhichReturn WhichReturnExactly<TReturn>(this aweXpect.Reflection.Collections.Filtered.Methods @this) { }
-        public static aweXpect.Reflection.Collections.Filtered.Methods WhichSatisfy(this aweXpect.Reflection.Collections.Filtered.Methods @this, System.Func<System.Reflection.MethodInfo, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Reflection.MethodFilters.MethodsWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Methods @this, bool inherit = true)
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.MethodFilters.MethodsWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Methods @this, System.Func<TAttribute, bool>? predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
@@ -282,6 +282,7 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.PropertyFilters.PropertiesOfType OfExactType<TProperty>(this aweXpect.Reflection.Collections.Filtered.Properties @this) { }
         public static aweXpect.Reflection.PropertyFilters.PropertiesOfType OfType(this aweXpect.Reflection.Collections.Filtered.Properties @this, System.Type propertyType) { }
         public static aweXpect.Reflection.PropertyFilters.PropertiesOfType OfType<TProperty>(this aweXpect.Reflection.Collections.Filtered.Properties @this) { }
+        public static aweXpect.Reflection.Collections.Filtered.Properties Which(this aweXpect.Reflection.Collections.Filtered.Properties @this, System.Func<System.Reflection.PropertyInfo, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Reflection.Collections.Filtered.Properties WhichAre(this aweXpect.Reflection.Collections.Filtered.Properties @this, aweXpect.Reflection.Collections.AccessModifiers accessModifier) { }
         public static aweXpect.Reflection.Collections.Filtered.Properties WhichAreAbstract(this aweXpect.Reflection.Collections.Filtered.Properties @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Properties WhichAreInternal(this aweXpect.Reflection.Collections.Filtered.Properties @this) { }
@@ -302,7 +303,6 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Collections.Filtered.Properties WhichArePublic(this aweXpect.Reflection.Collections.Filtered.Properties @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Properties WhichAreSealed(this aweXpect.Reflection.Collections.Filtered.Properties @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Properties WhichAreStatic(this aweXpect.Reflection.Collections.Filtered.Properties @this) { }
-        public static aweXpect.Reflection.Collections.Filtered.Properties WhichSatisfy(this aweXpect.Reflection.Collections.Filtered.Properties @this, System.Func<System.Reflection.PropertyInfo, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Reflection.PropertyFilters.PropertiesWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Properties @this, bool inherit = true)
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.PropertyFilters.PropertiesWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Properties @this, System.Func<TAttribute, bool>? predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
@@ -628,6 +628,7 @@ namespace aweXpect.Reflection
     }
     public static class TypeFilters
     {
+        public static aweXpect.Reflection.Collections.Filtered.Types Which(this aweXpect.Reflection.Collections.Filtered.Types @this, System.Func<System.Type, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAre(this aweXpect.Reflection.Collections.Filtered.Types @this, aweXpect.Reflection.Collections.AccessModifiers accessModifier) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreAbstract(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreClasses(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
@@ -666,7 +667,6 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreStructs(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichInheritFrom(this aweXpect.Reflection.Collections.Filtered.Types @this, System.Type baseType, bool forceDirect = false) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichInheritFrom<TBaseType>(this aweXpect.Reflection.Collections.Filtered.Types @this, bool forceDirect = false) { }
-        public static aweXpect.Reflection.Collections.Filtered.Types WhichSatisfy(this aweXpect.Reflection.Collections.Filtered.Types @this, System.Func<System.Type, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Reflection.TypeFilters.TypesWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Types @this, bool inherit = true)
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.TypeFilters.TypesWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Types @this, System.Func<TAttribute, bool>? predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
@@ -894,7 +894,6 @@ namespace aweXpect.Reflection.Collections
         protected System.Collections.Generic.List<aweXpect.Reflection.Collections.IFilter<T>> Filters { get; }
         public System.Collections.Generic.IEnumerator<T> GetEnumerator() { }
         public TFiltered Which(aweXpect.Reflection.Collections.IFilter<T> filter) { }
-        public TFiltered Which(System.Func<T, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
     }
     public interface IAsyncChangeableFilter<TEntity> : aweXpect.Reflection.Collections.IFilter<TEntity>
     {

--- a/Tests/aweXpect.Reflection.Tests/Filters/AssemblyFilters.Which.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/AssemblyFilters.Which.Tests.cs
@@ -4,7 +4,7 @@ namespace aweXpect.Reflection.Tests.Filters;
 
 public sealed partial class AssemblyFilters
 {
-	public sealed class WhichSatisfy
+	public sealed class Which
 	{
 		public sealed class Tests
 		{
@@ -12,7 +12,7 @@ public sealed partial class AssemblyFilters
 			public async Task ShouldFilterForAssembliesWhichSatisfyThePredicate()
 			{
 				Filtered.Assemblies typeAssemblies = In.AllLoadedAssemblies()
-					.WhichSatisfy(it => it.FullName!.Contains("aweXpect.Reflection.Tests"));
+					.Which(it => it.FullName!.Contains("aweXpect.Reflection.Tests"));
 
 				await That(typeAssemblies).HasSingle().Which.IsEqualTo(typeof(AssemblyFilters).Assembly);
 				await That(typeAssemblies.GetDescription())

--- a/Tests/aweXpect.Reflection.Tests/Filters/ConstructorFilters.Which.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/ConstructorFilters.Which.Tests.cs
@@ -4,7 +4,7 @@ namespace aweXpect.Reflection.Tests.Filters;
 
 public sealed partial class ConstructorFilters
 {
-	public sealed class WhichSatisfy
+	public sealed class Which
 	{
 		public sealed class Tests
 		{
@@ -12,7 +12,7 @@ public sealed partial class ConstructorFilters
 			public async Task ShouldFilterForConstructorsWhichSatisfyThePredicate()
 			{
 				Filtered.Constructors constructors = In.AssemblyContaining<AssemblyFilters>()
-					.Constructors().WhichSatisfy(it
+					.Constructors().Which(it
 						=> it.DeclaringType == typeof(SomeClassToVerifyTheConstructorNameOfIt));
 
 				await That(constructors).HasSingle().Which.IsEqualTo(ExpectedConstructorInfo());

--- a/Tests/aweXpect.Reflection.Tests/Filters/EventFilters.Which.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/EventFilters.Which.Tests.cs
@@ -4,7 +4,7 @@ namespace aweXpect.Reflection.Tests.Filters;
 
 public sealed partial class EventFilters
 {
-	public sealed class WhichSatisfy
+	public sealed class Which
 	{
 		public sealed class Tests
 		{
@@ -12,7 +12,7 @@ public sealed partial class EventFilters
 			public async Task ShouldFilterForEventsWhichSatisfyThePredicate()
 			{
 				Filtered.Events events = In.AssemblyContaining<AssemblyFilters>()
-					.Events().WhichSatisfy(it => it.Name.Equals("SomeEventToVerifyTheNameOfIt"));
+					.Events().Which(it => it.Name.Equals("SomeEventToVerifyTheNameOfIt"));
 
 				await That(events).HasSingle().Which.IsEqualTo(ExpectedEventInfo());
 				await That(events.GetDescription())

--- a/Tests/aweXpect.Reflection.Tests/Filters/FieldFilters.Which.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/FieldFilters.Which.Tests.cs
@@ -4,7 +4,7 @@ namespace aweXpect.Reflection.Tests.Filters;
 
 public sealed partial class FieldFilters
 {
-	public sealed class WhichSatisfy
+	public sealed class Which
 	{
 		public sealed class Tests
 		{
@@ -12,7 +12,7 @@ public sealed partial class FieldFilters
 			public async Task ShouldFilterForFieldsWhichSatisfyThePredicate()
 			{
 				Filtered.Fields fields = In.AssemblyContaining<AssemblyFilters>()
-					.Fields().WhichSatisfy(it => it.Name.Equals("SomeFieldToVerifyTheNameOfIt"));
+					.Fields().Which(it => it.Name.Equals("SomeFieldToVerifyTheNameOfIt"));
 
 				await That(fields).HasSingle().Which.IsEqualTo(ExpectedFieldInfo());
 				await That(fields.GetDescription())

--- a/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.Which.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.Which.Tests.cs
@@ -4,7 +4,7 @@ namespace aweXpect.Reflection.Tests.Filters;
 
 public sealed partial class MethodFilters
 {
-	public sealed class WhichSatisfy
+	public sealed class Which
 	{
 		public sealed class Tests
 		{
@@ -12,7 +12,7 @@ public sealed partial class MethodFilters
 			public async Task ShouldFilterForMethodsWhichSatisfyThePredicate()
 			{
 				Filtered.Methods methods = In.AssemblyContaining<AssemblyFilters>()
-					.Methods().WhichSatisfy(it => it.Name.Equals("SomeMethodToVerifyTheNameOfIt"));
+					.Methods().Which(it => it.Name.Equals("SomeMethodToVerifyTheNameOfIt"));
 
 				await That(methods).HasSingle().Which.IsEqualTo(ExpectedMethodInfo());
 				await That(methods.GetDescription())

--- a/Tests/aweXpect.Reflection.Tests/Filters/PropertyFilters.Which.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/PropertyFilters.Which.Tests.cs
@@ -4,7 +4,7 @@ namespace aweXpect.Reflection.Tests.Filters;
 
 public sealed partial class PropertyFilters
 {
-	public sealed class WhichSatisfy
+	public sealed class Which
 	{
 		public sealed class Tests
 		{
@@ -12,7 +12,7 @@ public sealed partial class PropertyFilters
 			public async Task ShouldFilterForPropertiesWhichSatisfyThePredicate()
 			{
 				Filtered.Properties properties = In.AssemblyContaining<AssemblyFilters>()
-					.Properties().WhichSatisfy(it => it.Name.Equals("SomePropertyToVerifyTheNameOfIt"));
+					.Properties().Which(it => it.Name.Equals("SomePropertyToVerifyTheNameOfIt"));
 
 				await That(properties).HasSingle().Which.IsEqualTo(ExpectedPropertyInfo());
 				await That(properties.GetDescription())

--- a/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.Which.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.Which.Tests.cs
@@ -4,7 +4,7 @@ namespace aweXpect.Reflection.Tests.Filters;
 
 public sealed partial class TypeFilters
 {
-	public sealed class WhichSatisfy
+	public sealed class Which
 	{
 		public sealed class Tests
 		{
@@ -12,7 +12,7 @@ public sealed partial class TypeFilters
 			public async Task ShouldFilterForTypesWhichSatisfyThePredicate()
 			{
 				Filtered.Types types = In.AssemblyContaining<AssemblyFilters>()
-					.Types().WhichSatisfy(it => it.Name.Equals(nameof(SomeClassToVerifyViaAPredicate)));
+					.Types().Which(it => it.Name.Equals(nameof(SomeClassToVerifyViaAPredicate)));
 
 				await That(types).HasSingle().Which.IsEqualTo(typeof(SomeClassToVerifyViaAPredicate));
 				await That(types.GetDescription())

--- a/Tests/aweXpect.Reflection.Tests/InTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/InTests.cs
@@ -22,7 +22,7 @@ public sealed class InTests
 	public async Task AllLoadedAssemblies_WithPredicate_ShouldApplyPredicate()
 	{
 		Filtered.Assemblies sut = In.AllLoadedAssemblies()
-			.WhichSatisfy(assembly => assembly.FullName!.StartsWith("aweXpect."));
+			.Which(assembly => assembly.FullName!.StartsWith("aweXpect."));
 
 		await That(sut).HasCount().Between(2).And(4);
 		await That(sut.GetDescription())

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.AreAbstract.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.AreAbstract.Tests.cs
@@ -31,7 +31,7 @@ public sealed partial class ThatTypes
 			public async Task WhenFilteringOnlyAbstractTypes_ShouldSucceed()
 			{
 				Filtered.Types subject = In.AssemblyContaining<AreAbstract>().Types()
-					.WhichSatisfy(type => type is { IsAbstract: true, IsSealed: false, IsInterface: false, });
+					.Which(type => type is { IsAbstract: true, IsSealed: false, IsInterface: false, });
 
 				async Task Act()
 					=> await That(subject).AreAbstract();
@@ -57,7 +57,7 @@ public sealed partial class ThatTypes
 			public async Task WhenFilteringOnlyAbstractTypes_ShouldFail()
 			{
 				Filtered.Types subject = In.AssemblyContaining<AreAbstract>().Types()
-					.WhichSatisfy(type => type is { IsAbstract: true, IsSealed: false, IsInterface: false, });
+					.Which(type => type is { IsAbstract: true, IsSealed: false, IsInterface: false, });
 
 				async Task Act()
 					=> await That(subject).DoesNotComplyWith(they => they.AreAbstract());

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.AreClasses.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.AreClasses.Tests.cs
@@ -32,7 +32,7 @@ public sealed partial class ThatTypes
 			public async Task WhenFilteringOnlyClasses_ShouldSucceed()
 			{
 				Filtered.Types subject = In.AssemblyContaining<AreClasses>().Types()
-					.WhichSatisfy(type => type.IsClass && !type.IsRecordClass());
+					.Which(type => type.IsClass && !type.IsRecordClass());
 
 				async Task Act()
 					=> await That(subject).AreClasses();
@@ -58,7 +58,7 @@ public sealed partial class ThatTypes
 			public async Task WhenFilteringOnlyClasses_ShouldFail()
 			{
 				Filtered.Types subject = In.AssemblyContaining<AreClasses>().Types()
-					.WhichSatisfy(type => type.IsClass && !type.IsRecordClass());
+					.Which(type => type.IsClass && !type.IsRecordClass());
 
 				async Task Act()
 					=> await That(subject).DoesNotComplyWith(they => they.AreClasses());

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.AreEnums.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.AreEnums.Tests.cs
@@ -31,7 +31,7 @@ public sealed partial class ThatTypes
 			public async Task WhenFilteringOnlyEnums_ShouldSucceed()
 			{
 				Filtered.Types subject = In.AssemblyContaining<AreEnums>().Types()
-					.WhichSatisfy(type => type.IsEnum);
+					.Which(type => type.IsEnum);
 
 				async Task Act()
 					=> await That(subject).AreEnums();
@@ -57,7 +57,7 @@ public sealed partial class ThatTypes
 			public async Task WhenFilteringOnlyEnums_ShouldFail()
 			{
 				Filtered.Types subject = In.AssemblyContaining<AreEnums>().Types()
-					.WhichSatisfy(type => type.IsEnum);
+					.Which(type => type.IsEnum);
 
 				async Task Act()
 					=> await That(subject).DoesNotComplyWith(they => they.AreEnums());

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.AreGeneric.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.AreGeneric.Tests.cs
@@ -31,7 +31,7 @@ public sealed partial class ThatTypes
 			public async Task WhenFilteringOnlyGenericTypes_ShouldSucceed()
 			{
 				Filtered.Types subject = In.AssemblyContaining<AreGeneric>().Types()
-					.WhichSatisfy(type => type.IsGenericType);
+					.Which(type => type.IsGenericType);
 
 				async Task Act()
 					=> await That(subject).AreGeneric();
@@ -57,7 +57,7 @@ public sealed partial class ThatTypes
 			public async Task WhenFilteringOnlyGenericTypes_ShouldFail()
 			{
 				Filtered.Types subject = In.AssemblyContaining<AreGeneric>().Types()
-					.WhichSatisfy(type => type.IsGenericType);
+					.Which(type => type.IsGenericType);
 
 				async Task Act()
 					=> await That(subject).DoesNotComplyWith(they => they.AreGeneric());

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.AreInterfaces.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.AreInterfaces.Tests.cs
@@ -31,7 +31,7 @@ public sealed partial class ThatTypes
 			public async Task WhenFilteringOnlyInterfaces_ShouldSucceed()
 			{
 				Filtered.Types subject = In.AssemblyContaining<AreInterfaces>().Types()
-					.WhichSatisfy(type => type.IsInterface);
+					.Which(type => type.IsInterface);
 
 				async Task Act()
 					=> await That(subject).AreInterfaces();
@@ -57,7 +57,7 @@ public sealed partial class ThatTypes
 			public async Task WhenFilteringOnlyInterfaces_ShouldFail()
 			{
 				Filtered.Types subject = In.AssemblyContaining<AreInterfaces>().Types()
-					.WhichSatisfy(type => type.IsInterface);
+					.Which(type => type.IsInterface);
 
 				async Task Act()
 					=> await That(subject).DoesNotComplyWith(they => they.AreInterfaces());

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.AreNested.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.AreNested.Tests.cs
@@ -31,7 +31,7 @@ public sealed partial class ThatTypes
 			public async Task WhenFilteringOnlyNestedTypes_ShouldSucceed()
 			{
 				Filtered.Types subject = In.AssemblyContaining<AreNested>().Types()
-					.WhichSatisfy(type => type.IsNested);
+					.Which(type => type.IsNested);
 
 				async Task Act()
 					=> await That(subject).AreNested();
@@ -57,7 +57,7 @@ public sealed partial class ThatTypes
 			public async Task WhenFilteringOnlyNestedTypes_ShouldFail()
 			{
 				Filtered.Types subject = In.AssemblyContaining<AreNested>().Types()
-					.WhichSatisfy(type => type.IsNested);
+					.Which(type => type.IsNested);
 
 				async Task Act()
 					=> await That(subject).DoesNotComplyWith(they => they.AreNested());

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.AreNotAbstract.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.AreNotAbstract.Tests.cs
@@ -24,7 +24,7 @@ public sealed partial class ThatTypes
 			public async Task WhenFilteringOnlyAbstractTypes_ShouldFail()
 			{
 				Filtered.Types subject = In.AssemblyContaining<AreNotAbstract>().Types()
-					.WhichSatisfy(type => type is { IsAbstract: true, IsSealed: false, IsInterface: false, });
+					.Which(type => type is { IsAbstract: true, IsSealed: false, IsInterface: false, });
 
 				async Task Act()
 					=> await That(subject).AreNotAbstract();
@@ -64,7 +64,7 @@ public sealed partial class ThatTypes
 			public async Task WhenFilteringOnlyAbstractTypes_ShouldSucceed()
 			{
 				Filtered.Types subject = In.AssemblyContaining<AreNotAbstract>().Types()
-					.WhichSatisfy(type => type is { IsAbstract: true, IsSealed: false, IsInterface: false, });
+					.Which(type => type is { IsAbstract: true, IsSealed: false, IsInterface: false, });
 
 				async Task Act()
 					=> await That(subject).DoesNotComplyWith(they => they.AreNotAbstract());

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.AreNotClasses.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.AreNotClasses.Tests.cs
@@ -25,7 +25,7 @@ public sealed partial class ThatTypes
 			public async Task WhenFilteringOnlyClasses_ShouldFail()
 			{
 				Filtered.Types subject = In.AssemblyContaining<AreNotClasses>().Types()
-					.WhichSatisfy(type => type.IsClass && !type.IsRecordClass());
+					.Which(type => type.IsClass && !type.IsRecordClass());
 
 				async Task Act()
 					=> await That(subject).AreNotClasses();
@@ -65,7 +65,7 @@ public sealed partial class ThatTypes
 			public async Task WhenFilteringOnlyClasses_ShouldSucceed()
 			{
 				Filtered.Types subject = In.AssemblyContaining<AreNotClasses>().Types()
-					.WhichSatisfy(type => type.IsClass && !type.IsRecordClass());
+					.Which(type => type.IsClass && !type.IsRecordClass());
 
 				async Task Act()
 					=> await That(subject).DoesNotComplyWith(they => they.AreNotClasses());

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.AreNotEnums.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.AreNotEnums.Tests.cs
@@ -24,7 +24,7 @@ public sealed partial class ThatTypes
 			public async Task WhenFilteringOnlyEnums_ShouldFail()
 			{
 				Filtered.Types subject = In.AssemblyContaining<AreNotEnums>().Types()
-					.WhichSatisfy(type => type.IsEnum);
+					.Which(type => type.IsEnum);
 
 				async Task Act()
 					=> await That(subject).AreNotEnums();
@@ -64,7 +64,7 @@ public sealed partial class ThatTypes
 			public async Task WhenFilteringOnlyEnums_ShouldSucceed()
 			{
 				Filtered.Types subject = In.AssemblyContaining<AreNotEnums>().Types()
-					.WhichSatisfy(type => type.IsEnum);
+					.Which(type => type.IsEnum);
 
 				async Task Act()
 					=> await That(subject).DoesNotComplyWith(they => they.AreNotEnums());

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.AreNotGeneric.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.AreNotGeneric.Tests.cs
@@ -13,7 +13,7 @@ public sealed partial class ThatTypes
 			public async Task WhenAssembliesContainNonGenericTypes_ShouldSucceed()
 			{
 				Filtered.Types subject = In.AssemblyContaining<AreNotGeneric>().Types()
-					.WhichSatisfy(type => !type.IsGenericType);
+					.Which(type => !type.IsGenericType);
 
 				async Task Act()
 					=> await That(subject).AreNotGeneric();
@@ -25,7 +25,7 @@ public sealed partial class ThatTypes
 			public async Task WhenFilteringOnlyGenericTypes_ShouldFail()
 			{
 				Filtered.Types subject = In.AssemblyContaining<AreNotGeneric>().Types()
-					.WhichSatisfy(type => type.IsGenericType);
+					.Which(type => type.IsGenericType);
 
 				async Task Act()
 					=> await That(subject).AreNotGeneric();
@@ -47,7 +47,7 @@ public sealed partial class ThatTypes
 			public async Task WhenAssembliesContainNonGenericTypes_ShouldFail()
 			{
 				Filtered.Types subject = In.AssemblyContaining<AreNotGeneric>().Types()
-					.WhichSatisfy(type => !type.IsGenericType);
+					.Which(type => !type.IsGenericType);
 
 				async Task Act()
 					=> await That(subject).DoesNotComplyWith(they => they.AreNotGeneric());
@@ -66,7 +66,7 @@ public sealed partial class ThatTypes
 			public async Task WhenFilteringOnlyGenericTypes_ShouldSucceed()
 			{
 				Filtered.Types subject = In.AssemblyContaining<AreNotGeneric>().Types()
-					.WhichSatisfy(type => type.IsGenericType);
+					.Which(type => type.IsGenericType);
 
 				async Task Act()
 					=> await That(subject).DoesNotComplyWith(they => they.AreNotGeneric());

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.AreNotInterfaces.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.AreNotInterfaces.Tests.cs
@@ -24,7 +24,7 @@ public sealed partial class ThatTypes
 			public async Task WhenFilteringOnlyInterfaces_ShouldFail()
 			{
 				Filtered.Types subject = In.AssemblyContaining<AreNotInterfaces>().Types()
-					.WhichSatisfy(type => type.IsInterface);
+					.Which(type => type.IsInterface);
 
 				async Task Act()
 					=> await That(subject).AreNotInterfaces();
@@ -64,7 +64,7 @@ public sealed partial class ThatTypes
 			public async Task WhenFilteringOnlyInterfaces_ShouldSucceed()
 			{
 				Filtered.Types subject = In.AssemblyContaining<AreNotInterfaces>().Types()
-					.WhichSatisfy(type => type.IsInterface);
+					.Which(type => type.IsInterface);
 
 				async Task Act()
 					=> await That(subject).DoesNotComplyWith(they => they.AreNotInterfaces());

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.AreNotNested.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.AreNotNested.Tests.cs
@@ -13,7 +13,7 @@ public sealed partial class ThatTypes
 			public async Task WhenAssembliesContainNonNestedTypes_ShouldSucceed()
 			{
 				Filtered.Types subject = In.AssemblyContaining<AreNotNested>().Types()
-					.WhichSatisfy(type => !type.IsNested);
+					.Which(type => !type.IsNested);
 
 				async Task Act()
 					=> await That(subject).AreNotNested();
@@ -25,7 +25,7 @@ public sealed partial class ThatTypes
 			public async Task WhenFilteringOnlyNestedTypes_ShouldFail()
 			{
 				Filtered.Types subject = In.AssemblyContaining<AreNotNested>().Types()
-					.WhichSatisfy(type => type.IsNested);
+					.Which(type => type.IsNested);
 
 				async Task Act()
 					=> await That(subject).AreNotNested();
@@ -47,7 +47,7 @@ public sealed partial class ThatTypes
 			public async Task WhenAssembliesContainNonNestedTypes_ShouldFail()
 			{
 				Filtered.Types subject = In.AssemblyContaining<AreNotNested>().Types()
-					.WhichSatisfy(type => !type.IsNested);
+					.Which(type => !type.IsNested);
 
 				async Task Act()
 					=> await That(subject).DoesNotComplyWith(they => they.AreNotNested());
@@ -66,7 +66,7 @@ public sealed partial class ThatTypes
 			public async Task WhenFilteringOnlyNestedTypes_ShouldSucceed()
 			{
 				Filtered.Types subject = In.AssemblyContaining<AreNotNested>().Types()
-					.WhichSatisfy(type => type.IsNested);
+					.Which(type => type.IsNested);
 
 				async Task Act()
 					=> await That(subject).DoesNotComplyWith(they => they.AreNotNested());

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.AreNotRecordStructs.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.AreNotRecordStructs.Tests.cs
@@ -25,7 +25,7 @@ public sealed partial class ThatTypes
 			public async Task WhenFilteringOnlyRecordStructs_ShouldFail()
 			{
 				Filtered.Types subject = In.AssemblyContaining<AreNotRecordStructs>().Types()
-					.WhichSatisfy(type => type.IsRecordStruct());
+					.Which(type => type.IsRecordStruct());
 
 				async Task Act()
 					=> await That(subject).AreNotRecordStructs();
@@ -65,7 +65,7 @@ public sealed partial class ThatTypes
 			public async Task WhenFilteringOnlyRecordStructs_ShouldSucceed()
 			{
 				Filtered.Types subject = In.AssemblyContaining<AreNotRecordStructs>().Types()
-					.WhichSatisfy(type => type.IsRecordStruct());
+					.Which(type => type.IsRecordStruct());
 
 				async Task Act()
 					=> await That(subject).DoesNotComplyWith(they => they.AreNotRecordStructs());

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.AreNotRecords.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.AreNotRecords.Tests.cs
@@ -25,7 +25,7 @@ public sealed partial class ThatTypes
 			public async Task WhenFilteringOnlyRecords_ShouldFail()
 			{
 				Filtered.Types subject = In.AssemblyContaining<AreNotRecords>().Types()
-					.WhichSatisfy(type => type.IsRecordClass());
+					.Which(type => type.IsRecordClass());
 
 				async Task Act()
 					=> await That(subject).AreNotRecords();
@@ -65,7 +65,7 @@ public sealed partial class ThatTypes
 			public async Task WhenFilteringOnlyRecords_ShouldSucceed()
 			{
 				Filtered.Types subject = In.AssemblyContaining<AreNotRecords>().Types()
-					.WhichSatisfy(type => type.IsRecordClass());
+					.Which(type => type.IsRecordClass());
 
 				async Task Act()
 					=> await That(subject).DoesNotComplyWith(they => they.AreNotRecords());

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.AreNotSealed.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.AreNotSealed.Tests.cs
@@ -24,7 +24,7 @@ public sealed partial class ThatTypes
 			public async Task WhenFilteringOnlySealedTypes_ShouldFail()
 			{
 				Filtered.Types subject = In.AssemblyContaining<AreNotSealed>().Types()
-					.WhichSatisfy(type => type is { IsAbstract: false, IsSealed: true, IsInterface: false, });
+					.Which(type => type is { IsAbstract: false, IsSealed: true, IsInterface: false, });
 
 				async Task Act()
 					=> await That(subject).AreNotSealed();
@@ -64,7 +64,7 @@ public sealed partial class ThatTypes
 			public async Task WhenFilteringOnlySealedTypes_ShouldSucceed()
 			{
 				Filtered.Types subject = In.AssemblyContaining<AreNotSealed>().Types()
-					.WhichSatisfy(type => type is { IsAbstract: false, IsSealed: true, IsInterface: false, });
+					.Which(type => type is { IsAbstract: false, IsSealed: true, IsInterface: false, });
 
 				async Task Act()
 					=> await That(subject).DoesNotComplyWith(they => they.AreNotSealed());

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.AreNotStatic.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.AreNotStatic.Tests.cs
@@ -23,7 +23,7 @@ public sealed partial class ThatTypes
 			public async Task WhenFilteringOnlyStaticTypes_ShouldFail()
 			{
 				Filtered.Types subject = In.AssemblyContaining<AreNotStatic>().Types()
-					.WhichSatisfy(type => type is { IsAbstract: true, IsSealed: true, IsInterface: false, });
+					.Which(type => type is { IsAbstract: true, IsSealed: true, IsInterface: false, });
 
 				async Task Act()
 					=> await That(subject).AreNotStatic();
@@ -63,7 +63,7 @@ public sealed partial class ThatTypes
 			public async Task WhenFilteringOnlyStaticTypes_ShouldSucceed()
 			{
 				Filtered.Types subject = In.AssemblyContaining<AreNotStatic>().Types()
-					.WhichSatisfy(type => type is { IsAbstract: true, IsSealed: true, IsInterface: false, });
+					.Which(type => type is { IsAbstract: true, IsSealed: true, IsInterface: false, });
 
 				async Task Act()
 					=> await That(subject).DoesNotComplyWith(they => they.AreNotStatic());

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.AreNotStructs.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.AreNotStructs.Tests.cs
@@ -25,7 +25,7 @@ public sealed partial class ThatTypes
 			public async Task WhenFilteringOnlyStructs_ShouldFail()
 			{
 				Filtered.Types subject = In.AssemblyContaining<AreNotStructs>().Types()
-					.WhichSatisfy(type => type.IsValueType && !type.IsRecordStruct() && !type.IsEnum);
+					.Which(type => type.IsValueType && !type.IsRecordStruct() && !type.IsEnum);
 
 				async Task Act()
 					=> await That(subject).AreNotStructs();
@@ -65,7 +65,7 @@ public sealed partial class ThatTypes
 			public async Task WhenFilteringOnlyStructs_ShouldSucceed()
 			{
 				Filtered.Types subject = In.AssemblyContaining<AreNotStructs>().Types()
-					.WhichSatisfy(type => type.IsValueType && !type.IsRecordStruct() && !type.IsEnum);
+					.Which(type => type.IsValueType && !type.IsRecordStruct() && !type.IsEnum);
 
 				async Task Act()
 					=> await That(subject).DoesNotComplyWith(they => they.AreNotStructs());

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.AreRecordStructs.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.AreRecordStructs.Tests.cs
@@ -32,7 +32,7 @@ public sealed partial class ThatTypes
 			public async Task WhenFilteringOnlyRecordStructs_ShouldSucceed()
 			{
 				Filtered.Types subject = In.AssemblyContaining<AreRecordStructs>().Types()
-					.WhichSatisfy(type => type.IsRecordStruct());
+					.Which(type => type.IsRecordStruct());
 
 				async Task Act()
 					=> await That(subject).AreRecordStructs();
@@ -58,7 +58,7 @@ public sealed partial class ThatTypes
 			public async Task WhenFilteringOnlyRecordStructs_ShouldFail()
 			{
 				Filtered.Types subject = In.AssemblyContaining<AreRecordStructs>().Types()
-					.WhichSatisfy(type => type.IsRecordStruct());
+					.Which(type => type.IsRecordStruct());
 
 				async Task Act()
 					=> await That(subject).DoesNotComplyWith(they => they.AreRecordStructs());

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.AreRecords.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.AreRecords.Tests.cs
@@ -32,7 +32,7 @@ public sealed partial class ThatTypes
 			public async Task WhenFilteringOnlyRecords_ShouldSucceed()
 			{
 				Filtered.Types subject = In.AssemblyContaining<AreRecords>().Types()
-					.WhichSatisfy(type => type.IsRecordClass());
+					.Which(type => type.IsRecordClass());
 
 				async Task Act()
 					=> await That(subject).AreRecords();
@@ -58,7 +58,7 @@ public sealed partial class ThatTypes
 			public async Task WhenFilteringOnlyRecords_ShouldFail()
 			{
 				Filtered.Types subject = In.AssemblyContaining<AreRecords>().Types()
-					.WhichSatisfy(type => type.IsRecordClass());
+					.Which(type => type.IsRecordClass());
 
 				async Task Act()
 					=> await That(subject).DoesNotComplyWith(they => they.AreRecords());

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.AreSealed.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.AreSealed.Tests.cs
@@ -31,7 +31,7 @@ public sealed partial class ThatTypes
 			public async Task WhenFilteringOnlySealedTypes_ShouldSucceed()
 			{
 				Filtered.Types subject = In.AssemblyContaining<AreSealed>().Types()
-					.WhichSatisfy(type => type is { IsAbstract: false, IsSealed: true, IsInterface: false, });
+					.Which(type => type is { IsAbstract: false, IsSealed: true, IsInterface: false, });
 
 				async Task Act()
 					=> await That(subject).AreSealed();
@@ -57,7 +57,7 @@ public sealed partial class ThatTypes
 			public async Task WhenFilteringOnlySealedTypes_ShouldFail()
 			{
 				Filtered.Types subject = In.AssemblyContaining<AreSealed>().Types()
-					.WhichSatisfy(type => type is { IsAbstract: false, IsSealed: true, IsInterface: false, });
+					.Which(type => type is { IsAbstract: false, IsSealed: true, IsInterface: false, });
 
 				async Task Act()
 					=> await That(subject).DoesNotComplyWith(they => they.AreSealed());

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.AreStatic.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.AreStatic.Tests.cs
@@ -30,7 +30,7 @@ public sealed partial class ThatTypes
 			public async Task WhenFilteringOnlyStaticTypes_ShouldSucceed()
 			{
 				Filtered.Types subject = In.AssemblyContaining<AreStatic>().Types()
-					.WhichSatisfy(type => type is { IsAbstract: true, IsSealed: true, IsInterface: false, });
+					.Which(type => type is { IsAbstract: true, IsSealed: true, IsInterface: false, });
 
 				async Task Act()
 					=> await That(subject).AreStatic();
@@ -56,7 +56,7 @@ public sealed partial class ThatTypes
 			public async Task WhenFilteringOnlyStaticTypes_ShouldFail()
 			{
 				Filtered.Types subject = In.AssemblyContaining<AreStatic>().Types()
-					.WhichSatisfy(type => type is { IsAbstract: true, IsSealed: true, IsInterface: false, });
+					.Which(type => type is { IsAbstract: true, IsSealed: true, IsInterface: false, });
 
 				async Task Act()
 					=> await That(subject).DoesNotComplyWith(they => they.AreStatic());

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.AreStructs.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.AreStructs.Tests.cs
@@ -32,7 +32,7 @@ public sealed partial class ThatTypes
 			public async Task WhenFilteringOnlyStructs_ShouldSucceed()
 			{
 				Filtered.Types subject = In.AssemblyContaining<AreStructs>().Types()
-					.WhichSatisfy(type => type.IsValueType && !type.IsRecordStruct() && !type.IsEnum);
+					.Which(type => type.IsValueType && !type.IsRecordStruct() && !type.IsEnum);
 
 				async Task Act()
 					=> await That(subject).AreStructs();
@@ -58,7 +58,7 @@ public sealed partial class ThatTypes
 			public async Task WhenFilteringOnlyStructs_ShouldFail()
 			{
 				Filtered.Types subject = In.AssemblyContaining<AreStructs>().Types()
-					.WhichSatisfy(type => type.IsValueType && !type.IsRecordStruct() && !type.IsEnum);
+					.Which(type => type.IsValueType && !type.IsRecordStruct() && !type.IsEnum);
 
 				async Task Act()
 					=> await That(subject).DoesNotComplyWith(they => they.AreStructs());


### PR DESCRIPTION
Collapses the duplicate `Which` / `WhichSatisfy` predicate APIs into a single `Which` name. The seven `*Filters.WhichSatisfy` extensions are renamed to `*Filters.Which`, and the now-redundant base-class `Which(Func<T,bool>)` overload on `Filtered<T, TFiltered>` is removed. `Which(IFilter<T>)` stays as the foundational primitive every extension delegates to.

Migration: replace `.WhichSatisfy(predicate)` with `.Which(predicate)`. Custom-filter callers using `.Which(IFilter<T>)` are unaffected.

The per-collection extensions preserve the per-collection description suffix convention (assemblies are terminal — leading space; types, methods, properties, fields, events, constructors chain — trailing space), which a single base-class predicate overload could not adapt to.