### PR TITLE
feat: Enhance member filtering with fluent chaining and modifier support

### DIFF
--- a/Source/aweXpect.Reflection/Collections/Filtered.Assemblies.cs
+++ b/Source/aweXpect.Reflection/Collections/Filtered.Assemblies.cs
@@ -22,8 +22,8 @@ public static partial class Filtered
 		ITypeAssemblies.IPrivate
 	{
 		private readonly string _description;
+		private readonly MemberFilterState _memberState = new();
 		private readonly List<Func<Type, bool>> _typeFilters = [];
-		private AccessModifiers? _implicitAccessModifier;
 		private string? _typeFilterDescription;
 
 		/// <summary>
@@ -66,7 +66,7 @@ public static partial class Filtered
 		{
 			get
 			{
-				_implicitAccessModifier = AccessModifiers.Public;
+				_memberState.SetAccess(AccessModifiers.Public);
 				return this;
 			}
 		}
@@ -78,7 +78,7 @@ public static partial class Filtered
 		{
 			get
 			{
-				_implicitAccessModifier = AccessModifiers.Private;
+				_memberState.SetAccess(AccessModifiers.Private);
 				return this;
 			}
 		}
@@ -90,7 +90,7 @@ public static partial class Filtered
 		{
 			get
 			{
-				_implicitAccessModifier = AccessModifiers.Protected;
+				_memberState.SetAccess(AccessModifiers.Protected);
 				return this;
 			}
 		}
@@ -102,7 +102,7 @@ public static partial class Filtered
 		{
 			get
 			{
-				_implicitAccessModifier = AccessModifiers.Internal;
+				_memberState.SetAccess(AccessModifiers.Internal);
 				return this;
 			}
 		}
@@ -124,7 +124,7 @@ public static partial class Filtered
 		{
 			get
 			{
-				_implicitAccessModifier = AccessModifiers.PrivateProtected;
+				_memberState.SetAccess(AccessModifiers.PrivateProtected);
 				return this;
 			}
 		}
@@ -134,7 +134,7 @@ public static partial class Filtered
 		{
 			get
 			{
-				_implicitAccessModifier = AccessModifiers.ProtectedInternal;
+				_memberState.SetAccess(AccessModifiers.ProtectedInternal);
 				return this;
 			}
 		}
@@ -144,12 +144,9 @@ public static partial class Filtered
 		{
 			get
 			{
-				_typeFilterDescription = _typeFilterDescription switch
-				{
-					null => "abstract ",
-					_ => _typeFilterDescription + "abstract ",
-				};
+				_typeFilterDescription = (_typeFilterDescription ?? "") + "abstract ";
 				_typeFilters.Add(type => type.IsReallyAbstract());
+				_memberState.SetAbstract();
 				return this;
 			}
 		}
@@ -159,12 +156,9 @@ public static partial class Filtered
 		{
 			get
 			{
-				_typeFilterDescription = _typeFilterDescription switch
-				{
-					null => "sealed ",
-					_ => _typeFilterDescription + "sealed ",
-				};
+				_typeFilterDescription = (_typeFilterDescription ?? "") + "sealed ";
 				_typeFilters.Add(type => type.IsReallySealed());
+				_memberState.SetSealed();
 				return this;
 			}
 		}
@@ -174,12 +168,9 @@ public static partial class Filtered
 		{
 			get
 			{
-				_typeFilterDescription = _typeFilterDescription switch
-				{
-					null => "static ",
-					_ => _typeFilterDescription + "static ",
-				};
+				_typeFilterDescription = (_typeFilterDescription ?? "") + "static ";
 				_typeFilters.Add(type => type.IsReallyStatic());
+				_memberState.SetStatic();
 				return this;
 			}
 		}
@@ -189,11 +180,7 @@ public static partial class Filtered
 		{
 			get
 			{
-				_typeFilterDescription = _typeFilterDescription switch
-				{
-					null => "generic ",
-					_ => _typeFilterDescription + "generic ",
-				};
+				_typeFilterDescription = (_typeFilterDescription ?? "") + "generic ";
 				_typeFilters.Add(type => type.IsGenericType);
 				return this;
 			}
@@ -204,11 +191,7 @@ public static partial class Filtered
 		{
 			get
 			{
-				_typeFilterDescription = _typeFilterDescription switch
-				{
-					null => "nested ",
-					_ => _typeFilterDescription + "nested ",
-				};
+				_typeFilterDescription = (_typeFilterDescription ?? "") + "nested ";
 				_typeFilters.Add(type => type.IsNested);
 				return this;
 			}
@@ -217,10 +200,11 @@ public static partial class Filtered
 		/// <inheritdoc cref="ILimitedStaticTypeAssemblies.Types(AccessModifiers)" />
 		public Types Types(AccessModifiers accessModifier = AccessModifiers.Any)
 		{
-			if (_implicitAccessModifier is not null)
+			AccessModifiers? implicitAccess = _memberState.AccessModifier;
+			if (implicitAccess is not null)
 			{
-				_typeFilters.Add(type => type.HasAccessModifier(_implicitAccessModifier.Value));
-				_typeFilterDescription = (_typeFilterDescription ?? "") + _implicitAccessModifier.Value.GetString(" ");
+				_typeFilters.Add(type => type.HasAccessModifier(implicitAccess.Value));
+				_typeFilterDescription = (_typeFilterDescription ?? "") + implicitAccess.Value.GetString(" ");
 			}
 
 			if (accessModifier != AccessModifiers.Any)
@@ -244,10 +228,11 @@ public static partial class Filtered
 		public Types Classes(AccessModifiers accessModifier = AccessModifiers.Any)
 		{
 			_typeFilters.Add(type => type.IsReallyClass());
-			if (_implicitAccessModifier is not null)
+			AccessModifiers? implicitAccess = _memberState.AccessModifier;
+			if (implicitAccess is not null)
 			{
-				_typeFilters.Add(type => type.HasAccessModifier(_implicitAccessModifier.Value));
-				_typeFilterDescription = (_typeFilterDescription ?? "") + _implicitAccessModifier.Value.GetString(" ");
+				_typeFilters.Add(type => type.HasAccessModifier(implicitAccess.Value));
+				_typeFilterDescription = (_typeFilterDescription ?? "") + implicitAccess.Value.GetString(" ");
 			}
 
 			if (accessModifier != AccessModifiers.Any)
@@ -266,10 +251,11 @@ public static partial class Filtered
 		public Types Records(AccessModifiers accessModifier = AccessModifiers.Any)
 		{
 			_typeFilters.Add(type => type.IsRecordClass());
-			if (_implicitAccessModifier is not null)
+			AccessModifiers? implicitAccess = _memberState.AccessModifier;
+			if (implicitAccess is not null)
 			{
-				_typeFilters.Add(type => type.HasAccessModifier(_implicitAccessModifier.Value));
-				_typeFilterDescription = (_typeFilterDescription ?? "") + _implicitAccessModifier.Value.GetString(" ");
+				_typeFilters.Add(type => type.HasAccessModifier(implicitAccess.Value));
+				_typeFilterDescription = (_typeFilterDescription ?? "") + implicitAccess.Value.GetString(" ");
 			}
 
 			if (accessModifier != AccessModifiers.Any)
@@ -288,10 +274,11 @@ public static partial class Filtered
 		public Types RecordStructs(AccessModifiers accessModifier = AccessModifiers.Any)
 		{
 			_typeFilters.Add(type => type.IsRecordStruct());
-			if (_implicitAccessModifier is not null)
+			AccessModifiers? implicitAccess = _memberState.AccessModifier;
+			if (implicitAccess is not null)
 			{
-				_typeFilters.Add(type => type.HasAccessModifier(_implicitAccessModifier.Value));
-				_typeFilterDescription = (_typeFilterDescription ?? "") + _implicitAccessModifier.Value.GetString(" ");
+				_typeFilters.Add(type => type.HasAccessModifier(implicitAccess.Value));
+				_typeFilterDescription = (_typeFilterDescription ?? "") + implicitAccess.Value.GetString(" ");
 			}
 
 			if (accessModifier != AccessModifiers.Any)
@@ -310,10 +297,11 @@ public static partial class Filtered
 		public Types Structs(AccessModifiers accessModifier = AccessModifiers.Any)
 		{
 			_typeFilters.Add(type => type.IsReallyStruct());
-			if (_implicitAccessModifier is not null)
+			AccessModifiers? implicitAccess = _memberState.AccessModifier;
+			if (implicitAccess is not null)
 			{
-				_typeFilters.Add(type => type.HasAccessModifier(_implicitAccessModifier.Value));
-				_typeFilterDescription = (_typeFilterDescription ?? "") + _implicitAccessModifier.Value.GetString(" ");
+				_typeFilters.Add(type => type.HasAccessModifier(implicitAccess.Value));
+				_typeFilterDescription = (_typeFilterDescription ?? "") + implicitAccess.Value.GetString(" ");
 			}
 
 			if (accessModifier != AccessModifiers.Any)
@@ -332,10 +320,11 @@ public static partial class Filtered
 		public Types Interfaces(AccessModifiers accessModifier = AccessModifiers.Any)
 		{
 			_typeFilters.Add(type => type.IsInterface);
-			if (_implicitAccessModifier is not null)
+			AccessModifiers? implicitAccess = _memberState.AccessModifier;
+			if (implicitAccess is not null)
 			{
-				_typeFilters.Add(type => type.HasAccessModifier(_implicitAccessModifier.Value));
-				_typeFilterDescription = (_typeFilterDescription ?? "") + _implicitAccessModifier.Value.GetString(" ");
+				_typeFilters.Add(type => type.HasAccessModifier(implicitAccess.Value));
+				_typeFilterDescription = (_typeFilterDescription ?? "") + implicitAccess.Value.GetString(" ");
 			}
 
 			if (accessModifier != AccessModifiers.Any)
@@ -354,10 +343,11 @@ public static partial class Filtered
 		public Types Enums(AccessModifiers accessModifier = AccessModifiers.Any)
 		{
 			_typeFilters.Add(type => type.IsEnum);
-			if (_implicitAccessModifier is not null)
+			AccessModifiers? implicitAccess = _memberState.AccessModifier;
+			if (implicitAccess is not null)
 			{
-				_typeFilters.Add(type => type.HasAccessModifier(_implicitAccessModifier.Value));
-				_typeFilterDescription = (_typeFilterDescription ?? "") + _implicitAccessModifier.Value.GetString(" ");
+				_typeFilters.Add(type => type.HasAccessModifier(implicitAccess.Value));
+				_typeFilterDescription = (_typeFilterDescription ?? "") + implicitAccess.Value.GetString(" ");
 			}
 
 			if (accessModifier != AccessModifiers.Any)
@@ -372,94 +362,44 @@ public static partial class Filtered
 					_typeFilterDescription ?? ""));
 		}
 
-		/// <inheritdoc cref="ITypeAssemblies.Constructors()" />
+		/// <inheritdoc cref="ILimitedStaticTypeAssemblies.Constructors()" />
 		public Constructors Constructors()
 		{
-			if (_implicitAccessModifier is not null)
-			{
-				List<Func<ConstructorInfo, bool>> filters = [];
-				filters.Add(constructor => constructor.HasAccessModifier(_implicitAccessModifier.Value));
-				string filterDescription = _implicitAccessModifier.Value.GetString(" ");
-
-				return new Constructors(new Types(this, ""), "constructors ")
-					.Which(Filter.Prefix<ConstructorInfo>(
-						constructor => filters.All(predicate => predicate.Invoke(constructor)),
-						filterDescription));
-			}
-
-			return new Constructors(new Types(this, ""), "constructors ");
+			Constructors constructors = new(new Types(this, ""), "constructors ");
+			IFilter<ConstructorInfo>? filter = _memberState.BuildConstructorFilter();
+			return filter is null ? constructors : constructors.Which(filter);
 		}
 
-		/// <inheritdoc cref="ITypeAssemblies.Events()" />
+		/// <inheritdoc cref="ILimitedStaticTypeAssemblies.Events()" />
 		public Events Events()
 		{
-			if (_implicitAccessModifier is not null)
-			{
-				List<Func<EventInfo, bool>> filters = [];
-				filters.Add(constructor => constructor.HasAccessModifier(_implicitAccessModifier.Value));
-				string filterDescription = _implicitAccessModifier.Value.GetString(" ");
-
-				return new Events(new Types(this, ""), "events ")
-					.Which(Filter.Prefix<EventInfo>(
-						@event => filters.All(predicate => predicate.Invoke(@event)),
-						filterDescription));
-			}
-
-			return new Events(new Types(this, ""), "events ");
+			Events events = new(new Types(this, ""), "events ");
+			IFilter<EventInfo>? filter = _memberState.BuildEventFilter();
+			return filter is null ? events : events.Which(filter);
 		}
 
-		/// <inheritdoc cref="ITypeAssemblies.Fields()" />
+		/// <inheritdoc cref="ILimitedStaticTypeAssemblies.Fields()" />
 		public Fields Fields()
 		{
-			if (_implicitAccessModifier is not null)
-			{
-				List<Func<FieldInfo, bool>> filters = [];
-				filters.Add(constructor => constructor.HasAccessModifier(_implicitAccessModifier.Value));
-				string filterDescription = _implicitAccessModifier.Value.GetString(" ");
-
-				return new Fields(new Types(this, ""), "fields ")
-					.Which(Filter.Prefix<FieldInfo>(
-						field => filters.All(predicate => predicate.Invoke(field)),
-						filterDescription));
-			}
-
-			return new Fields(new Types(this, ""), "fields ");
+			Fields fields = new(new Types(this, ""), "fields ");
+			IFilter<FieldInfo>? filter = _memberState.BuildFieldFilter();
+			return filter is null ? fields : fields.Which(filter);
 		}
 
-		/// <inheritdoc cref="ITypeAssemblies.Methods()" />
+		/// <inheritdoc cref="ILimitedStaticTypeAssemblies.Methods()" />
 		public Methods Methods()
 		{
-			if (_implicitAccessModifier is not null)
-			{
-				List<Func<MethodInfo, bool>> filters = [];
-				filters.Add(constructor => constructor.HasAccessModifier(_implicitAccessModifier.Value));
-				string filterDescription = _implicitAccessModifier.Value.GetString(" ");
-
-				return new Methods(new Types(this, ""), "methods ")
-					.Which(Filter.Prefix<MethodInfo>(
-						method => filters.All(predicate => predicate.Invoke(method)),
-						filterDescription));
-			}
-
-			return new Methods(new Types(this, ""), "methods ");
+			Methods methods = new(new Types(this, ""), "methods ");
+			IFilter<MethodInfo>? filter = _memberState.BuildMethodFilter();
+			return filter is null ? methods : methods.Which(filter);
 		}
 
-		/// <inheritdoc cref="ITypeAssemblies.Properties()" />
+		/// <inheritdoc cref="ILimitedStaticTypeAssemblies.Properties()" />
 		public Properties Properties()
 		{
-			if (_implicitAccessModifier is not null)
-			{
-				List<Func<PropertyInfo, bool>> filters = [];
-				filters.Add(constructor => constructor.HasAccessModifier(_implicitAccessModifier.Value));
-				string filterDescription = _implicitAccessModifier.Value.GetString(" ");
-
-				return new Properties(new Types(this, ""), "properties ")
-					.Which(Filter.Prefix<PropertyInfo>(
-						property => filters.All(predicate => predicate.Invoke(property)),
-						filterDescription));
-			}
-
-			return new Properties(new Types(this, ""), "properties ");
+			Properties properties = new(new Types(this, ""), "properties ");
+			IFilter<PropertyInfo>? filter = _memberState.BuildPropertyFilter();
+			return filter is null ? properties : properties.Which(filter);
 		}
 
 		/// <summary>

--- a/Source/aweXpect.Reflection/Collections/Filtered.Assemblies.cs
+++ b/Source/aweXpect.Reflection/Collections/Filtered.Assemblies.cs
@@ -147,7 +147,7 @@ public static partial class Filtered
 				_typeFilterDescription = (_typeFilterDescription ?? "") + "abstract ";
 				_typeFilters.Add(type => type.IsReallyAbstract());
 				_memberState.SetAbstract();
-				return this;
+				return new LimitedAbstractSealedAssemblies(this);
 			}
 		}
 
@@ -159,7 +159,7 @@ public static partial class Filtered
 				_typeFilterDescription = (_typeFilterDescription ?? "") + "sealed ";
 				_typeFilters.Add(type => type.IsReallySealed());
 				_memberState.SetSealed();
-				return this;
+				return new LimitedAbstractSealedAssemblies(this);
 			}
 		}
 
@@ -207,6 +207,8 @@ public static partial class Filtered
 				_typeFilterDescription = (_typeFilterDescription ?? "") + implicitAccess.Value.GetString(" ");
 			}
 
+			_memberState.Reset();
+
 			if (accessModifier != AccessModifiers.Any)
 			{
 				_typeFilters.Add(type => type.HasAccessModifier(accessModifier));
@@ -235,6 +237,8 @@ public static partial class Filtered
 				_typeFilterDescription = (_typeFilterDescription ?? "") + implicitAccess.Value.GetString(" ");
 			}
 
+			_memberState.Reset();
+
 			if (accessModifier != AccessModifiers.Any)
 			{
 				_typeFilters.Add(type => type.HasAccessModifier(accessModifier));
@@ -257,6 +261,8 @@ public static partial class Filtered
 				_typeFilters.Add(type => type.HasAccessModifier(implicitAccess.Value));
 				_typeFilterDescription = (_typeFilterDescription ?? "") + implicitAccess.Value.GetString(" ");
 			}
+
+			_memberState.Reset();
 
 			if (accessModifier != AccessModifiers.Any)
 			{
@@ -281,6 +287,8 @@ public static partial class Filtered
 				_typeFilterDescription = (_typeFilterDescription ?? "") + implicitAccess.Value.GetString(" ");
 			}
 
+			_memberState.Reset();
+
 			if (accessModifier != AccessModifiers.Any)
 			{
 				_typeFilters.Add(type => type.HasAccessModifier(accessModifier));
@@ -303,6 +311,8 @@ public static partial class Filtered
 				_typeFilters.Add(type => type.HasAccessModifier(implicitAccess.Value));
 				_typeFilterDescription = (_typeFilterDescription ?? "") + implicitAccess.Value.GetString(" ");
 			}
+
+			_memberState.Reset();
 
 			if (accessModifier != AccessModifiers.Any)
 			{
@@ -327,6 +337,8 @@ public static partial class Filtered
 				_typeFilterDescription = (_typeFilterDescription ?? "") + implicitAccess.Value.GetString(" ");
 			}
 
+			_memberState.Reset();
+
 			if (accessModifier != AccessModifiers.Any)
 			{
 				_typeFilters.Add(type => type.HasAccessModifier(accessModifier));
@@ -350,6 +362,8 @@ public static partial class Filtered
 				_typeFilterDescription = (_typeFilterDescription ?? "") + implicitAccess.Value.GetString(" ");
 			}
 
+			_memberState.Reset();
+
 			if (accessModifier != AccessModifiers.Any)
 			{
 				_typeFilters.Add(type => type.HasAccessModifier(accessModifier));
@@ -367,6 +381,7 @@ public static partial class Filtered
 		{
 			Constructors constructors = new(new Types(this, ""), "constructors ");
 			IFilter<ConstructorInfo>? filter = _memberState.BuildConstructorFilter();
+			_memberState.Reset();
 			return filter is null ? constructors : constructors.Which(filter);
 		}
 
@@ -375,6 +390,7 @@ public static partial class Filtered
 		{
 			Events events = new(new Types(this, ""), "events ");
 			IFilter<EventInfo>? filter = _memberState.BuildEventFilter();
+			_memberState.Reset();
 			return filter is null ? events : events.Which(filter);
 		}
 
@@ -383,6 +399,7 @@ public static partial class Filtered
 		{
 			Fields fields = new(new Types(this, ""), "fields ");
 			IFilter<FieldInfo>? filter = _memberState.BuildFieldFilter();
+			_memberState.Reset();
 			return filter is null ? fields : fields.Which(filter);
 		}
 
@@ -391,6 +408,7 @@ public static partial class Filtered
 		{
 			Methods methods = new(new Types(this, ""), "methods ");
 			IFilter<MethodInfo>? filter = _memberState.BuildMethodFilter();
+			_memberState.Reset();
 			return filter is null ? methods : methods.Which(filter);
 		}
 
@@ -399,6 +417,7 @@ public static partial class Filtered
 		{
 			Properties properties = new(new Types(this, ""), "properties ");
 			IFilter<PropertyInfo>? filter = _memberState.BuildPropertyFilter();
+			_memberState.Reset();
 			return filter is null ? properties : properties.Which(filter);
 		}
 
@@ -517,6 +536,48 @@ public static partial class Filtered
 				_options.AsWildcard();
 				return this;
 			}
+		}
+
+		private sealed class LimitedAbstractSealedAssemblies
+			: ILimitedAbstractSealedTypeAssemblies<ILimitedAbstractSealedTypeAssemblies>
+		{
+			private readonly Assemblies _inner;
+
+			public LimitedAbstractSealedAssemblies(Assemblies inner)
+			{
+				_inner = inner;
+			}
+
+			public ILimitedAbstractSealedTypeAssemblies Generic
+			{
+				get
+				{
+					_ = _inner.Generic;
+					return this;
+				}
+			}
+
+			public ILimitedAbstractSealedTypeAssemblies Nested
+			{
+				get
+				{
+					_ = _inner.Nested;
+					return this;
+				}
+			}
+
+			public Types Types(AccessModifiers accessModifier = AccessModifiers.Any)
+				=> _inner.Types(accessModifier);
+
+			public Types Classes(AccessModifiers accessModifier = AccessModifiers.Any)
+				=> _inner.Classes(accessModifier);
+
+			public Types Records(AccessModifiers accessModifier = AccessModifiers.Any)
+				=> _inner.Records(accessModifier);
+
+			public Events Events() => _inner.Events();
+			public Methods Methods() => _inner.Methods();
+			public Properties Properties() => _inner.Properties();
 		}
 	}
 }

--- a/Source/aweXpect.Reflection/Collections/Filtered.Types.cs
+++ b/Source/aweXpect.Reflection/Collections/Filtered.Types.cs
@@ -265,6 +265,7 @@ public static partial class Filtered
 		{
 			Constructors constructors = new(this, "constructors ");
 			IFilter<ConstructorInfo>? filter = _memberState.BuildConstructorFilter();
+			_memberState.Reset();
 			return filter is null ? constructors : constructors.Which(filter);
 		}
 
@@ -275,6 +276,7 @@ public static partial class Filtered
 		{
 			Events events = new(this, "events ");
 			IFilter<EventInfo>? filter = _memberState.BuildEventFilter();
+			_memberState.Reset();
 			return filter is null ? events : events.Which(filter);
 		}
 
@@ -285,6 +287,7 @@ public static partial class Filtered
 		{
 			Fields fields = new(this, "fields ");
 			IFilter<FieldInfo>? filter = _memberState.BuildFieldFilter();
+			_memberState.Reset();
 			return filter is null ? fields : fields.Which(filter);
 		}
 
@@ -295,6 +298,7 @@ public static partial class Filtered
 		{
 			Methods methods = new(this, "methods ");
 			IFilter<MethodInfo>? filter = _memberState.BuildMethodFilter();
+			_memberState.Reset();
 			return filter is null ? methods : methods.Which(filter);
 		}
 
@@ -305,6 +309,7 @@ public static partial class Filtered
 		{
 			Properties properties = new(this, "properties ");
 			IFilter<PropertyInfo>? filter = _memberState.BuildPropertyFilter();
+			_memberState.Reset();
 			return filter is null ? properties : properties.Which(filter);
 		}
 

--- a/Source/aweXpect.Reflection/Collections/Filtered.Types.cs
+++ b/Source/aweXpect.Reflection/Collections/Filtered.Types.cs
@@ -17,8 +17,6 @@ public static partial class Filtered
 	/// </summary>
 	public class Types : Filtered<Type, Types>,
 		IDescribableSubject,
-		IMemberSelectors,
-		IMembers,
 		IMembers.IPrivate,
 		IMembers.IProtected,
 		ILimitedAbstractSealedMembers

--- a/Source/aweXpect.Reflection/Collections/Filtered.Types.cs
+++ b/Source/aweXpect.Reflection/Collections/Filtered.Types.cs
@@ -15,12 +15,19 @@ public static partial class Filtered
 	/// <summary>
 	///     Container for a filterable collection of <see cref="Type" />.
 	/// </summary>
-	public class Types : Filtered<Type, Types>, IDescribableSubject
+	public class Types : Filtered<Type, Types>,
+		IDescribableSubject,
+		IMemberSelectors,
+		IMembers,
+		IMembers.IPrivate,
+		IMembers.IProtected,
+		ILimitedAbstractSealedMembers
 	{
 		private const string DeclaringTypesPrefix = "declaring types of ";
 
 		private readonly Assemblies? _assemblies;
 		private readonly string _description;
+		private readonly MemberFilterState _memberState = new();
 
 		/// <summary>
 		///     Container for a filterable collection of <see cref="Type" />.
@@ -105,6 +112,110 @@ public static partial class Filtered
 			_assemblies = inner._assemblies;
 		}
 
+		/// <summary>
+		///     Filters for public members.
+		/// </summary>
+		public IMembers Public
+		{
+			get
+			{
+				_memberState.SetAccess(AccessModifiers.Public);
+				return this;
+			}
+		}
+
+		/// <summary>
+		///     Filters for private members.
+		/// </summary>
+		public IMembers.IPrivate Private
+		{
+			get
+			{
+				_memberState.SetAccess(AccessModifiers.Private);
+				return this;
+			}
+		}
+
+		/// <summary>
+		///     Filters for protected members.
+		/// </summary>
+		public IMembers.IProtected Protected
+		{
+			get
+			{
+				_memberState.SetAccess(AccessModifiers.Protected);
+				return this;
+			}
+		}
+
+		/// <summary>
+		///     Filters for internal members.
+		/// </summary>
+		public IMembers Internal
+		{
+			get
+			{
+				_memberState.SetAccess(AccessModifiers.Internal);
+				return this;
+			}
+		}
+
+		/// <summary>
+		///     Filters for static members.
+		/// </summary>
+		public IMemberSelectors Static
+		{
+			get
+			{
+				_memberState.SetStatic();
+				return this;
+			}
+		}
+
+		/// <summary>
+		///     Filters for abstract members.
+		/// </summary>
+		public ILimitedAbstractSealedMembers Abstract
+		{
+			get
+			{
+				_memberState.SetAbstract();
+				return this;
+			}
+		}
+
+		/// <summary>
+		///     Filters for sealed members.
+		/// </summary>
+		public ILimitedAbstractSealedMembers Sealed
+		{
+			get
+			{
+				_memberState.SetSealed();
+				return this;
+			}
+		}
+
+		/// <inheritdoc cref="IMembers.IPrivate.Protected" />
+		IMembers IMembers.IPrivate.Protected
+		{
+			get
+			{
+				_memberState.SetAccess(AccessModifiers.PrivateProtected);
+				return this;
+			}
+		}
+
+		/// <inheritdoc cref="IMembers.IProtected.Internal" />
+		IMembers IMembers.IProtected.Internal
+		{
+			get
+			{
+				_memberState.SetAccess(AccessModifiers.ProtectedInternal);
+				return this;
+			}
+		}
+
 		/// <inheritdoc />
 		public string GetDescription()
 		{
@@ -150,27 +261,52 @@ public static partial class Filtered
 		/// <summary>
 		///     Get all constructors in the filtered types.
 		/// </summary>
-		public Constructors Constructors() => new(this, "constructors ");
+		public Constructors Constructors()
+		{
+			Constructors constructors = new(this, "constructors ");
+			IFilter<ConstructorInfo>? filter = _memberState.BuildConstructorFilter();
+			return filter is null ? constructors : constructors.Which(filter);
+		}
 
 		/// <summary>
 		///     Get all events in the filtered types.
 		/// </summary>
-		public Events Events() => new(this, "events ");
+		public Events Events()
+		{
+			Events events = new(this, "events ");
+			IFilter<EventInfo>? filter = _memberState.BuildEventFilter();
+			return filter is null ? events : events.Which(filter);
+		}
 
 		/// <summary>
 		///     Get all fields in the filtered types.
 		/// </summary>
-		public Fields Fields() => new(this, "fields ");
+		public Fields Fields()
+		{
+			Fields fields = new(this, "fields ");
+			IFilter<FieldInfo>? filter = _memberState.BuildFieldFilter();
+			return filter is null ? fields : fields.Which(filter);
+		}
 
 		/// <summary>
 		///     Get all methods in the filtered types.
 		/// </summary>
-		public Methods Methods() => new(this, "methods ");
+		public Methods Methods()
+		{
+			Methods methods = new(this, "methods ");
+			IFilter<MethodInfo>? filter = _memberState.BuildMethodFilter();
+			return filter is null ? methods : methods.Which(filter);
+		}
 
 		/// <summary>
 		///     Get all properties in the filtered types.
 		/// </summary>
-		public Properties Properties() => new(this, "properties ");
+		public Properties Properties()
+		{
+			Properties properties = new(this, "properties ");
+			IFilter<PropertyInfo>? filter = _memberState.BuildPropertyFilter();
+			return filter is null ? properties : properties.Which(filter);
+		}
 
 		/// <summary>
 		///     A Container for a filterable collection of <see cref="Type" />,

--- a/Source/aweXpect.Reflection/Collections/ILimitedAbstractSealedTypeAssemblies.cs
+++ b/Source/aweXpect.Reflection/Collections/ILimitedAbstractSealedTypeAssemblies.cs
@@ -1,29 +1,65 @@
 namespace aweXpect.Reflection.Collections;
 
 /// <summary>
-///     A limited interface to allow basic filtering for types in assemblies.
+///     A limited interface for filtering types in assemblies after an <c>Abstract</c> or <c>Sealed</c> modifier.
 /// </summary>
 /// <remarks>
-///     In addition to the methods in <see cref="ILimitedStaticTypeAssemblies" /> it
-///     only supports accessing <see cref="Records" />.
+///     Only exposes member kinds that can be abstract or sealed (<see cref="Methods" />,
+///     <see cref="Properties" />, <see cref="Events" />). <see cref="Filtered.Constructors" /> and
+///     <see cref="Filtered.Fields" /> are intentionally not reachable, because constructors and fields
+///     cannot be abstract or sealed.
 /// </remarks>
-public interface ILimitedAbstractSealedTypeAssemblies : ILimitedStaticTypeAssemblies
+public interface ILimitedAbstractSealedTypeAssemblies
 {
+	/// <summary>
+	///     Get all types in the filtered assemblies.
+	/// </summary>
+	Filtered.Types Types(AccessModifiers accessModifier = AccessModifiers.Any);
+
+	/// <summary>
+	///     Get all classes in the filtered assemblies.
+	/// </summary>
+	Filtered.Types Classes(AccessModifiers accessModifier = AccessModifiers.Any);
+
 	/// <summary>
 	///     Get all records in the filtered assemblies.
 	/// </summary>
 	Filtered.Types Records(AccessModifiers accessModifier = AccessModifiers.Any);
+
+	/// <summary>
+	///     Get all events matching the current filter.
+	/// </summary>
+	Filtered.Events Events();
+
+	/// <summary>
+	///     Get all methods matching the current filter.
+	/// </summary>
+	Filtered.Methods Methods();
+
+	/// <summary>
+	///     Get all properties matching the current filter.
+	/// </summary>
+	Filtered.Properties Properties();
 }
 
 /// <summary>
-///     A limited interface to allow basic filtering for types in assemblies.
+///     A limited interface for filtering types in assemblies after an <c>Abstract</c> or <c>Sealed</c> modifier.
 /// </summary>
 /// <remarks>
-///     In addition to the methods in <see cref="ILimitedStaticTypeAssemblies" /> it also
+///     In addition to the methods in <see cref="ILimitedAbstractSealedTypeAssemblies" /> it also
 ///     supports adding a filter for generic or nested types.
 /// </remarks>
 public interface ILimitedAbstractSealedTypeAssemblies<out TLimitedTypeAssemblies>
-	: ILimitedAbstractSealedTypeAssemblies, ILimitedStaticTypeAssemblies<TLimitedTypeAssemblies>
+	: ILimitedAbstractSealedTypeAssemblies
 	where TLimitedTypeAssemblies : ILimitedAbstractSealedTypeAssemblies
 {
+	/// <summary>
+	///     Filters only for generic types.
+	/// </summary>
+	TLimitedTypeAssemblies Generic { get; }
+
+	/// <summary>
+	///     Filters only for nested types.
+	/// </summary>
+	TLimitedTypeAssemblies Nested { get; }
 }

--- a/Source/aweXpect.Reflection/Collections/ILimitedStaticTypeAssemblies.cs
+++ b/Source/aweXpect.Reflection/Collections/ILimitedStaticTypeAssemblies.cs
@@ -4,7 +4,8 @@ namespace aweXpect.Reflection.Collections;
 ///     A limited interface to allow basic filtering for types in assemblies.
 /// </summary>
 /// <remarks>
-///     It only supports accessing <see cref="Types" /> or <see cref="Classes" />.
+///     It only supports accessing <see cref="Types" /> or <see cref="Classes" />,
+///     and selecting members of the filtered types.
 /// </remarks>
 public interface ILimitedStaticTypeAssemblies
 {
@@ -17,6 +18,31 @@ public interface ILimitedStaticTypeAssemblies
 	///     Get all classes in the filtered assemblies.
 	/// </summary>
 	Filtered.Types Classes(AccessModifiers accessModifier = AccessModifiers.Any);
+
+	/// <summary>
+	///     Get all constructors in the filtered types.
+	/// </summary>
+	Filtered.Constructors Constructors();
+
+	/// <summary>
+	///     Get all events in the filtered types.
+	/// </summary>
+	Filtered.Events Events();
+
+	/// <summary>
+	///     Get all fields in the filtered types.
+	/// </summary>
+	Filtered.Fields Fields();
+
+	/// <summary>
+	///     Get all methods in the filtered types.
+	/// </summary>
+	Filtered.Methods Methods();
+
+	/// <summary>
+	///     Get all properties in the filtered types.
+	/// </summary>
+	Filtered.Properties Properties();
 }
 
 /// <summary>

--- a/Source/aweXpect.Reflection/Collections/IMembers.cs
+++ b/Source/aweXpect.Reflection/Collections/IMembers.cs
@@ -1,0 +1,102 @@
+namespace aweXpect.Reflection.Collections;
+
+/// <summary>
+///     A terminal interface that exposes the five member-kind selectors.
+/// </summary>
+public interface IMemberSelectors
+{
+	/// <summary>
+	///     Get all constructors matching the current member filter.
+	/// </summary>
+	Filtered.Constructors Constructors();
+
+	/// <summary>
+	///     Get all methods matching the current member filter.
+	/// </summary>
+	Filtered.Methods Methods();
+
+	/// <summary>
+	///     Get all properties matching the current member filter.
+	/// </summary>
+	Filtered.Properties Properties();
+
+	/// <summary>
+	///     Get all fields matching the current member filter.
+	/// </summary>
+	Filtered.Fields Fields();
+
+	/// <summary>
+	///     Get all events matching the current member filter.
+	/// </summary>
+	Filtered.Events Events();
+}
+
+/// <summary>
+///     An interface to allow filtering for members of types.
+/// </summary>
+/// <remarks>
+///     Supports chaining a single one of <c>Static</c>/<c>Abstract</c>/<c>Sealed</c> before selecting
+///     the member kind. The three modifiers are mutually exclusive (a static member cannot be abstract
+///     or sealed) and are not repeatable.
+/// </remarks>
+public interface IMembers : IMemberSelectors
+{
+	/// <summary>
+	///     Filters for static members.
+	/// </summary>
+	IMemberSelectors Static { get; }
+
+	/// <summary>
+	///     Filters for abstract members.
+	/// </summary>
+	ILimitedAbstractSealedMembers Abstract { get; }
+
+	/// <summary>
+	///     Filters for sealed members.
+	/// </summary>
+	ILimitedAbstractSealedMembers Sealed { get; }
+
+	/// <summary>
+	///     An interface to allow filtering for members of types after the <c>Private</c> access modifier.
+	/// </summary>
+	public interface IPrivate : IMembers
+	{
+		/// <summary>
+		///     Filters for private protected members.
+		/// </summary>
+		IMembers Protected { get; }
+	}
+
+	/// <summary>
+	///     An interface to allow filtering for members of types after the <c>Protected</c> access modifier.
+	/// </summary>
+	public interface IProtected : IMembers
+	{
+		/// <summary>
+		///     Filters for protected internal members.
+		/// </summary>
+		IMembers Internal { get; }
+	}
+}
+
+/// <summary>
+///     A limited terminal interface for members whose modifiers are compatible with
+///     <c>Abstract</c> or <c>Sealed</c> (methods, properties, events).
+/// </summary>
+public interface ILimitedAbstractSealedMembers
+{
+	/// <summary>
+	///     Get all methods matching the current member filter.
+	/// </summary>
+	Filtered.Methods Methods();
+
+	/// <summary>
+	///     Get all properties matching the current member filter.
+	/// </summary>
+	Filtered.Properties Properties();
+
+	/// <summary>
+	///     Get all events matching the current member filter.
+	/// </summary>
+	Filtered.Events Events();
+}

--- a/Source/aweXpect.Reflection/Collections/ITypeAssemblies.cs
+++ b/Source/aweXpect.Reflection/Collections/ITypeAssemblies.cs
@@ -47,31 +47,6 @@ public interface ITypeAssemblies
 	Filtered.Types Structs(AccessModifiers accessModifier = AccessModifiers.Any);
 
 	/// <summary>
-	///     Get all constructors in the filtered types.
-	/// </summary>
-	Filtered.Constructors Constructors();
-
-	/// <summary>
-	///     Get all events in the filtered types.
-	/// </summary>
-	Filtered.Events Events();
-
-	/// <summary>
-	///     Get all fields in the filtered types.
-	/// </summary>
-	Filtered.Fields Fields();
-
-	/// <summary>
-	///     Get all methods in the filtered types.
-	/// </summary>
-	Filtered.Methods Methods();
-
-	/// <summary>
-	///     Get all properties in the filtered types.
-	/// </summary>
-	Filtered.Properties Properties();
-
-	/// <summary>
 	///     An interface to allow filtering for types in assemblies.
 	/// </summary>
 	/// <remarks>

--- a/Source/aweXpect.Reflection/Collections/ITypeAssemblies.cs
+++ b/Source/aweXpect.Reflection/Collections/ITypeAssemblies.cs
@@ -1,15 +1,15 @@
-﻿namespace aweXpect.Reflection.Collections;
+namespace aweXpect.Reflection.Collections;
 
 /// <summary>
 ///     An interface to allow filtering for types in assemblies.
 /// </summary>
 /// <remarks>
 ///     In addition to the properties and methods in
-///     <see cref="ILimitedAbstractSealedTypeAssemblies{TLimitedTypeAssemblies}" /> it also
-///     supports adding a filter for abstract, sealed or static types as well as accessing interfaces or enums.
+///     <see cref="ILimitedStaticTypeAssemblies{TLimitedTypeAssemblies}" /> it also
+///     supports adding a filter for abstract, sealed or static types as well as accessing interfaces, records or enums.
 /// </remarks>
 public interface ITypeAssemblies
-	: ILimitedAbstractSealedTypeAssemblies<ITypeAssemblies>
+	: ILimitedStaticTypeAssemblies<ITypeAssemblies>
 {
 	/// <summary>
 	///     Filters only for abstract types.
@@ -30,6 +30,11 @@ public interface ITypeAssemblies
 	///     Get all interfaces in the filtered assemblies.
 	/// </summary>
 	Filtered.Types Interfaces(AccessModifiers accessModifier = AccessModifiers.Any);
+
+	/// <summary>
+	///     Get all records in the filtered assemblies.
+	/// </summary>
+	Filtered.Types Records(AccessModifiers accessModifier = AccessModifiers.Any);
 
 	/// <summary>
 	///     Get all enums in the filtered assemblies.

--- a/Source/aweXpect.Reflection/Collections/MemberFilterState.cs
+++ b/Source/aweXpect.Reflection/Collections/MemberFilterState.cs
@@ -13,6 +13,15 @@ internal sealed class MemberFilterState
 
 	public bool HasAnything => AccessModifier is not null || IsStatic || IsAbstract || IsSealed;
 
+	public void Reset()
+	{
+		AccessModifier = null;
+		IsStatic = false;
+		IsAbstract = false;
+		IsSealed = false;
+		_modifierDescription = "";
+	}
+
 	public void SetAccess(AccessModifiers modifier) => AccessModifier = modifier;
 
 	public void SetStatic()

--- a/Source/aweXpect.Reflection/Collections/MemberFilterState.cs
+++ b/Source/aweXpect.Reflection/Collections/MemberFilterState.cs
@@ -1,0 +1,140 @@
+using System.Reflection;
+using aweXpect.Reflection.Helpers;
+
+namespace aweXpect.Reflection.Collections;
+
+internal sealed class MemberFilterState
+{
+	public AccessModifiers? AccessModifier;
+	public bool IsAbstract;
+	public bool IsSealed;
+	public bool IsStatic;
+	private string _modifierDescription = "";
+
+	public bool HasAnything => AccessModifier is not null || IsStatic || IsAbstract || IsSealed;
+
+	public void SetAccess(AccessModifiers modifier) => AccessModifier = modifier;
+
+	public void SetStatic()
+	{
+		if (IsStatic)
+		{
+			return;
+		}
+
+		IsStatic = true;
+		_modifierDescription += "static ";
+	}
+
+	public void SetAbstract()
+	{
+		if (IsAbstract)
+		{
+			return;
+		}
+
+		IsAbstract = true;
+		_modifierDescription += "abstract ";
+	}
+
+	public void SetSealed()
+	{
+		if (IsSealed)
+		{
+			return;
+		}
+
+		IsSealed = true;
+		_modifierDescription += "sealed ";
+	}
+
+	public string BuildDescription()
+		=> (AccessModifier?.GetString(" ") ?? "") + _modifierDescription;
+
+	public IFilter<ConstructorInfo>? BuildConstructorFilter()
+	{
+		AccessModifiers? access = AccessModifier;
+		bool isStatic = IsStatic;
+		if (access is null && !isStatic)
+		{
+			return null;
+		}
+
+		return Filter.Prefix<ConstructorInfo>(
+			c => (access is null || c.HasAccessModifier(access.Value)) &&
+			     (!isStatic || c.IsStatic),
+			BuildDescription());
+	}
+
+	public IFilter<MethodInfo>? BuildMethodFilter()
+	{
+		AccessModifiers? access = AccessModifier;
+		bool isStatic = IsStatic;
+		bool isAbstract = IsAbstract;
+		bool isSealed = IsSealed;
+		if (access is null && !isStatic && !isAbstract && !isSealed)
+		{
+			return null;
+		}
+
+		return Filter.Prefix<MethodInfo>(
+			m => (access is null || m.HasAccessModifier(access.Value)) &&
+			     (!isStatic || m.IsStatic) &&
+			     (!isAbstract || m.IsAbstract) &&
+			     (!isSealed || m.IsReallySealed()),
+			BuildDescription());
+	}
+
+	public IFilter<PropertyInfo>? BuildPropertyFilter()
+	{
+		AccessModifiers? access = AccessModifier;
+		bool isStatic = IsStatic;
+		bool isAbstract = IsAbstract;
+		bool isSealed = IsSealed;
+		if (access is null && !isStatic && !isAbstract && !isSealed)
+		{
+			return null;
+		}
+
+		return Filter.Prefix<PropertyInfo>(
+			p => (access is null || p.HasAccessModifier(access.Value)) &&
+			     (!isStatic || p.IsReallyStatic()) &&
+			     (!isAbstract || p.IsReallyAbstract()) &&
+			     (!isSealed || p.IsReallySealed()),
+			BuildDescription());
+	}
+
+	public IFilter<FieldInfo>? BuildFieldFilter()
+	{
+		AccessModifiers? access = AccessModifier;
+		bool isStatic = IsStatic;
+		if (access is null && !isStatic)
+		{
+			return null;
+		}
+
+		return Filter.Prefix<FieldInfo>(
+			f => (access is null || f.HasAccessModifier(access.Value)) &&
+			     (!isStatic || f.IsStatic),
+			BuildDescription());
+	}
+
+	public IFilter<EventInfo>? BuildEventFilter()
+	{
+		AccessModifiers? access = AccessModifier;
+		bool isStatic = IsStatic;
+		bool isAbstract = IsAbstract;
+		bool isSealed = IsSealed;
+		if (access is null && !isStatic && !isAbstract && !isSealed)
+		{
+			return null;
+		}
+
+		return Filter.Prefix<EventInfo>(
+			e => (access is null || e.HasAccessModifier(access.Value)) &&
+			     (!isStatic || e.AddMethod?.IsStatic == true) &&
+			     (!isAbstract || e.IsReallyAbstract()) &&
+			     (!isSealed || e.IsReallySealed()),
+			BuildDescription());
+	}
+}

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net10.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net10.0.txt
@@ -845,7 +845,7 @@ namespace aweXpect.Reflection.Collections
     }
     public static class Filtered
     {
-        public class Assemblies : aweXpect.Reflection.Collections.Filtered<System.Reflection.Assembly, aweXpect.Reflection.Collections.Filtered.Assemblies>, aweXpect.Core.IDescribableSubject, aweXpect.Reflection.Collections.ILimitedAbstractSealedTypeAssemblies, aweXpect.Reflection.Collections.ILimitedAbstractSealedTypeAssemblies<aweXpect.Reflection.Collections.ITypeAssemblies>, aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies, aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies<aweXpect.Reflection.Collections.ITypeAssemblies>, aweXpect.Reflection.Collections.ITypeAssemblies, aweXpect.Reflection.Collections.ITypeAssemblies.IPrivate, aweXpect.Reflection.Collections.ITypeAssemblies.IProtected
+        public class Assemblies : aweXpect.Reflection.Collections.Filtered<System.Reflection.Assembly, aweXpect.Reflection.Collections.Filtered.Assemblies>, aweXpect.Core.IDescribableSubject, aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies, aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies<aweXpect.Reflection.Collections.ITypeAssemblies>, aweXpect.Reflection.Collections.ITypeAssemblies, aweXpect.Reflection.Collections.ITypeAssemblies.IPrivate, aweXpect.Reflection.Collections.ITypeAssemblies.IProtected
         {
             protected Assemblies(aweXpect.Reflection.Collections.Filtered.Assemblies inner) { }
             public Assemblies(System.Collections.Generic.IEnumerable<System.Reflection.Assembly?> source, string description) { }
@@ -978,10 +978,17 @@ namespace aweXpect.Reflection.Collections
                 public aweXpect.Reflection.Collections.Filtered.Properties.StringEqualityResult Exactly() { }
             }
         }
-        public class Types : aweXpect.Reflection.Collections.Filtered<System.Type, aweXpect.Reflection.Collections.Filtered.Types>, aweXpect.Core.IDescribableSubject
+        public class Types : aweXpect.Reflection.Collections.Filtered<System.Type, aweXpect.Reflection.Collections.Filtered.Types>, aweXpect.Core.IDescribableSubject, aweXpect.Reflection.Collections.ILimitedAbstractSealedMembers, aweXpect.Reflection.Collections.IMemberSelectors, aweXpect.Reflection.Collections.IMembers, aweXpect.Reflection.Collections.IMembers.IPrivate, aweXpect.Reflection.Collections.IMembers.IProtected
         {
             protected Types(aweXpect.Reflection.Collections.Filtered.Types inner) { }
             public Types(System.Collections.Generic.IEnumerable<System.Type?> source, string description) { }
+            public aweXpect.Reflection.Collections.ILimitedAbstractSealedMembers Abstract { get; }
+            public aweXpect.Reflection.Collections.IMembers Internal { get; }
+            public aweXpect.Reflection.Collections.IMembers.IPrivate Private { get; }
+            public aweXpect.Reflection.Collections.IMembers.IProtected Protected { get; }
+            public aweXpect.Reflection.Collections.IMembers Public { get; }
+            public aweXpect.Reflection.Collections.ILimitedAbstractSealedMembers Sealed { get; }
+            public aweXpect.Reflection.Collections.IMemberSelectors Static { get; }
             public aweXpect.Reflection.Collections.Filtered.Assemblies Assemblies() { }
             public aweXpect.Reflection.Collections.Filtered.Constructors Constructors() { }
             public aweXpect.Reflection.Collections.Filtered.Events Events() { }
@@ -1028,15 +1035,35 @@ namespace aweXpect.Reflection.Collections
         System.Threading.Tasks.ValueTask<bool> Applies(TEntity value);
         string Describes(string text);
     }
-    public interface ILimitedAbstractSealedTypeAssemblies : aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies
+    public interface ILimitedAbstractSealedMembers
     {
-        aweXpect.Reflection.Collections.Filtered.Types Records(aweXpect.Reflection.Collections.AccessModifiers accessModifier = 63);
+        aweXpect.Reflection.Collections.Filtered.Events Events();
+        aweXpect.Reflection.Collections.Filtered.Methods Methods();
+        aweXpect.Reflection.Collections.Filtered.Properties Properties();
     }
-    public interface ILimitedAbstractSealedTypeAssemblies<out TLimitedTypeAssemblies> : aweXpect.Reflection.Collections.ILimitedAbstractSealedTypeAssemblies, aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies, aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies<TLimitedTypeAssemblies>
-        where out TLimitedTypeAssemblies : aweXpect.Reflection.Collections.ILimitedAbstractSealedTypeAssemblies { }
+    public interface ILimitedAbstractSealedTypeAssemblies
+    {
+        aweXpect.Reflection.Collections.Filtered.Types Classes(aweXpect.Reflection.Collections.AccessModifiers accessModifier = 63);
+        aweXpect.Reflection.Collections.Filtered.Events Events();
+        aweXpect.Reflection.Collections.Filtered.Methods Methods();
+        aweXpect.Reflection.Collections.Filtered.Properties Properties();
+        aweXpect.Reflection.Collections.Filtered.Types Records(aweXpect.Reflection.Collections.AccessModifiers accessModifier = 63);
+        aweXpect.Reflection.Collections.Filtered.Types Types(aweXpect.Reflection.Collections.AccessModifiers accessModifier = 63);
+    }
+    public interface ILimitedAbstractSealedTypeAssemblies<out TLimitedTypeAssemblies> : aweXpect.Reflection.Collections.ILimitedAbstractSealedTypeAssemblies
+        where out TLimitedTypeAssemblies : aweXpect.Reflection.Collections.ILimitedAbstractSealedTypeAssemblies
+    {
+        TLimitedTypeAssemblies Generic { get; }
+        TLimitedTypeAssemblies Nested { get; }
+    }
     public interface ILimitedStaticTypeAssemblies
     {
         aweXpect.Reflection.Collections.Filtered.Types Classes(aweXpect.Reflection.Collections.AccessModifiers accessModifier = 63);
+        aweXpect.Reflection.Collections.Filtered.Constructors Constructors();
+        aweXpect.Reflection.Collections.Filtered.Events Events();
+        aweXpect.Reflection.Collections.Filtered.Fields Fields();
+        aweXpect.Reflection.Collections.Filtered.Methods Methods();
+        aweXpect.Reflection.Collections.Filtered.Properties Properties();
         aweXpect.Reflection.Collections.Filtered.Types Types(aweXpect.Reflection.Collections.AccessModifiers accessModifier = 63);
     }
     public interface ILimitedStaticTypeAssemblies<out TLimitedTypeAssemblies> : aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies
@@ -1045,25 +1072,43 @@ namespace aweXpect.Reflection.Collections
         TLimitedTypeAssemblies Generic { get; }
         TLimitedTypeAssemblies Nested { get; }
     }
-    public interface ITypeAssemblies : aweXpect.Reflection.Collections.ILimitedAbstractSealedTypeAssemblies, aweXpect.Reflection.Collections.ILimitedAbstractSealedTypeAssemblies<aweXpect.Reflection.Collections.ITypeAssemblies>, aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies, aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies<aweXpect.Reflection.Collections.ITypeAssemblies>
+    public interface IMemberSelectors
+    {
+        aweXpect.Reflection.Collections.Filtered.Constructors Constructors();
+        aweXpect.Reflection.Collections.Filtered.Events Events();
+        aweXpect.Reflection.Collections.Filtered.Fields Fields();
+        aweXpect.Reflection.Collections.Filtered.Methods Methods();
+        aweXpect.Reflection.Collections.Filtered.Properties Properties();
+    }
+    public interface IMembers : aweXpect.Reflection.Collections.IMemberSelectors
+    {
+        aweXpect.Reflection.Collections.ILimitedAbstractSealedMembers Abstract { get; }
+        aweXpect.Reflection.Collections.ILimitedAbstractSealedMembers Sealed { get; }
+        aweXpect.Reflection.Collections.IMemberSelectors Static { get; }
+        public interface IPrivate : aweXpect.Reflection.Collections.IMemberSelectors, aweXpect.Reflection.Collections.IMembers
+        {
+            aweXpect.Reflection.Collections.IMembers Protected { get; }
+        }
+        public interface IProtected : aweXpect.Reflection.Collections.IMemberSelectors, aweXpect.Reflection.Collections.IMembers
+        {
+            aweXpect.Reflection.Collections.IMembers Internal { get; }
+        }
+    }
+    public interface ITypeAssemblies : aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies, aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies<aweXpect.Reflection.Collections.ITypeAssemblies>
     {
         aweXpect.Reflection.Collections.ILimitedAbstractSealedTypeAssemblies<aweXpect.Reflection.Collections.ILimitedAbstractSealedTypeAssemblies> Abstract { get; }
         aweXpect.Reflection.Collections.ILimitedAbstractSealedTypeAssemblies<aweXpect.Reflection.Collections.ILimitedAbstractSealedTypeAssemblies> Sealed { get; }
         aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies<aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies> Static { get; }
-        aweXpect.Reflection.Collections.Filtered.Constructors Constructors();
         aweXpect.Reflection.Collections.Filtered.Types Enums(aweXpect.Reflection.Collections.AccessModifiers accessModifier = 63);
-        aweXpect.Reflection.Collections.Filtered.Events Events();
-        aweXpect.Reflection.Collections.Filtered.Fields Fields();
         aweXpect.Reflection.Collections.Filtered.Types Interfaces(aweXpect.Reflection.Collections.AccessModifiers accessModifier = 63);
-        aweXpect.Reflection.Collections.Filtered.Methods Methods();
-        aweXpect.Reflection.Collections.Filtered.Properties Properties();
         aweXpect.Reflection.Collections.Filtered.Types RecordStructs(aweXpect.Reflection.Collections.AccessModifiers accessModifier = 63);
+        aweXpect.Reflection.Collections.Filtered.Types Records(aweXpect.Reflection.Collections.AccessModifiers accessModifier = 63);
         aweXpect.Reflection.Collections.Filtered.Types Structs(aweXpect.Reflection.Collections.AccessModifiers accessModifier = 63);
-        public interface IPrivate : aweXpect.Reflection.Collections.ILimitedAbstractSealedTypeAssemblies, aweXpect.Reflection.Collections.ILimitedAbstractSealedTypeAssemblies<aweXpect.Reflection.Collections.ITypeAssemblies>, aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies, aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies<aweXpect.Reflection.Collections.ITypeAssemblies>, aweXpect.Reflection.Collections.ITypeAssemblies
+        public interface IPrivate : aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies, aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies<aweXpect.Reflection.Collections.ITypeAssemblies>, aweXpect.Reflection.Collections.ITypeAssemblies
         {
             aweXpect.Reflection.Collections.ITypeAssemblies Protected { get; }
         }
-        public interface IProtected : aweXpect.Reflection.Collections.ILimitedAbstractSealedTypeAssemblies, aweXpect.Reflection.Collections.ILimitedAbstractSealedTypeAssemblies<aweXpect.Reflection.Collections.ITypeAssemblies>, aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies, aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies<aweXpect.Reflection.Collections.ITypeAssemblies>, aweXpect.Reflection.Collections.ITypeAssemblies
+        public interface IProtected : aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies, aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies<aweXpect.Reflection.Collections.ITypeAssemblies>, aweXpect.Reflection.Collections.ITypeAssemblies
         {
             aweXpect.Reflection.Collections.ITypeAssemblies Internal { get; }
         }

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net8.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net8.0.txt
@@ -845,7 +845,7 @@ namespace aweXpect.Reflection.Collections
     }
     public static class Filtered
     {
-        public class Assemblies : aweXpect.Reflection.Collections.Filtered<System.Reflection.Assembly, aweXpect.Reflection.Collections.Filtered.Assemblies>, aweXpect.Core.IDescribableSubject, aweXpect.Reflection.Collections.ILimitedAbstractSealedTypeAssemblies, aweXpect.Reflection.Collections.ILimitedAbstractSealedTypeAssemblies<aweXpect.Reflection.Collections.ITypeAssemblies>, aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies, aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies<aweXpect.Reflection.Collections.ITypeAssemblies>, aweXpect.Reflection.Collections.ITypeAssemblies, aweXpect.Reflection.Collections.ITypeAssemblies.IPrivate, aweXpect.Reflection.Collections.ITypeAssemblies.IProtected
+        public class Assemblies : aweXpect.Reflection.Collections.Filtered<System.Reflection.Assembly, aweXpect.Reflection.Collections.Filtered.Assemblies>, aweXpect.Core.IDescribableSubject, aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies, aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies<aweXpect.Reflection.Collections.ITypeAssemblies>, aweXpect.Reflection.Collections.ITypeAssemblies, aweXpect.Reflection.Collections.ITypeAssemblies.IPrivate, aweXpect.Reflection.Collections.ITypeAssemblies.IProtected
         {
             protected Assemblies(aweXpect.Reflection.Collections.Filtered.Assemblies inner) { }
             public Assemblies(System.Collections.Generic.IEnumerable<System.Reflection.Assembly?> source, string description) { }
@@ -978,10 +978,17 @@ namespace aweXpect.Reflection.Collections
                 public aweXpect.Reflection.Collections.Filtered.Properties.StringEqualityResult Exactly() { }
             }
         }
-        public class Types : aweXpect.Reflection.Collections.Filtered<System.Type, aweXpect.Reflection.Collections.Filtered.Types>, aweXpect.Core.IDescribableSubject
+        public class Types : aweXpect.Reflection.Collections.Filtered<System.Type, aweXpect.Reflection.Collections.Filtered.Types>, aweXpect.Core.IDescribableSubject, aweXpect.Reflection.Collections.ILimitedAbstractSealedMembers, aweXpect.Reflection.Collections.IMemberSelectors, aweXpect.Reflection.Collections.IMembers, aweXpect.Reflection.Collections.IMembers.IPrivate, aweXpect.Reflection.Collections.IMembers.IProtected
         {
             protected Types(aweXpect.Reflection.Collections.Filtered.Types inner) { }
             public Types(System.Collections.Generic.IEnumerable<System.Type?> source, string description) { }
+            public aweXpect.Reflection.Collections.ILimitedAbstractSealedMembers Abstract { get; }
+            public aweXpect.Reflection.Collections.IMembers Internal { get; }
+            public aweXpect.Reflection.Collections.IMembers.IPrivate Private { get; }
+            public aweXpect.Reflection.Collections.IMembers.IProtected Protected { get; }
+            public aweXpect.Reflection.Collections.IMembers Public { get; }
+            public aweXpect.Reflection.Collections.ILimitedAbstractSealedMembers Sealed { get; }
+            public aweXpect.Reflection.Collections.IMemberSelectors Static { get; }
             public aweXpect.Reflection.Collections.Filtered.Assemblies Assemblies() { }
             public aweXpect.Reflection.Collections.Filtered.Constructors Constructors() { }
             public aweXpect.Reflection.Collections.Filtered.Events Events() { }
@@ -1028,15 +1035,35 @@ namespace aweXpect.Reflection.Collections
         System.Threading.Tasks.ValueTask<bool> Applies(TEntity value);
         string Describes(string text);
     }
-    public interface ILimitedAbstractSealedTypeAssemblies : aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies
+    public interface ILimitedAbstractSealedMembers
     {
-        aweXpect.Reflection.Collections.Filtered.Types Records(aweXpect.Reflection.Collections.AccessModifiers accessModifier = 63);
+        aweXpect.Reflection.Collections.Filtered.Events Events();
+        aweXpect.Reflection.Collections.Filtered.Methods Methods();
+        aweXpect.Reflection.Collections.Filtered.Properties Properties();
     }
-    public interface ILimitedAbstractSealedTypeAssemblies<out TLimitedTypeAssemblies> : aweXpect.Reflection.Collections.ILimitedAbstractSealedTypeAssemblies, aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies, aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies<TLimitedTypeAssemblies>
-        where out TLimitedTypeAssemblies : aweXpect.Reflection.Collections.ILimitedAbstractSealedTypeAssemblies { }
+    public interface ILimitedAbstractSealedTypeAssemblies
+    {
+        aweXpect.Reflection.Collections.Filtered.Types Classes(aweXpect.Reflection.Collections.AccessModifiers accessModifier = 63);
+        aweXpect.Reflection.Collections.Filtered.Events Events();
+        aweXpect.Reflection.Collections.Filtered.Methods Methods();
+        aweXpect.Reflection.Collections.Filtered.Properties Properties();
+        aweXpect.Reflection.Collections.Filtered.Types Records(aweXpect.Reflection.Collections.AccessModifiers accessModifier = 63);
+        aweXpect.Reflection.Collections.Filtered.Types Types(aweXpect.Reflection.Collections.AccessModifiers accessModifier = 63);
+    }
+    public interface ILimitedAbstractSealedTypeAssemblies<out TLimitedTypeAssemblies> : aweXpect.Reflection.Collections.ILimitedAbstractSealedTypeAssemblies
+        where out TLimitedTypeAssemblies : aweXpect.Reflection.Collections.ILimitedAbstractSealedTypeAssemblies
+    {
+        TLimitedTypeAssemblies Generic { get; }
+        TLimitedTypeAssemblies Nested { get; }
+    }
     public interface ILimitedStaticTypeAssemblies
     {
         aweXpect.Reflection.Collections.Filtered.Types Classes(aweXpect.Reflection.Collections.AccessModifiers accessModifier = 63);
+        aweXpect.Reflection.Collections.Filtered.Constructors Constructors();
+        aweXpect.Reflection.Collections.Filtered.Events Events();
+        aweXpect.Reflection.Collections.Filtered.Fields Fields();
+        aweXpect.Reflection.Collections.Filtered.Methods Methods();
+        aweXpect.Reflection.Collections.Filtered.Properties Properties();
         aweXpect.Reflection.Collections.Filtered.Types Types(aweXpect.Reflection.Collections.AccessModifiers accessModifier = 63);
     }
     public interface ILimitedStaticTypeAssemblies<out TLimitedTypeAssemblies> : aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies
@@ -1045,25 +1072,43 @@ namespace aweXpect.Reflection.Collections
         TLimitedTypeAssemblies Generic { get; }
         TLimitedTypeAssemblies Nested { get; }
     }
-    public interface ITypeAssemblies : aweXpect.Reflection.Collections.ILimitedAbstractSealedTypeAssemblies, aweXpect.Reflection.Collections.ILimitedAbstractSealedTypeAssemblies<aweXpect.Reflection.Collections.ITypeAssemblies>, aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies, aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies<aweXpect.Reflection.Collections.ITypeAssemblies>
+    public interface IMemberSelectors
+    {
+        aweXpect.Reflection.Collections.Filtered.Constructors Constructors();
+        aweXpect.Reflection.Collections.Filtered.Events Events();
+        aweXpect.Reflection.Collections.Filtered.Fields Fields();
+        aweXpect.Reflection.Collections.Filtered.Methods Methods();
+        aweXpect.Reflection.Collections.Filtered.Properties Properties();
+    }
+    public interface IMembers : aweXpect.Reflection.Collections.IMemberSelectors
+    {
+        aweXpect.Reflection.Collections.ILimitedAbstractSealedMembers Abstract { get; }
+        aweXpect.Reflection.Collections.ILimitedAbstractSealedMembers Sealed { get; }
+        aweXpect.Reflection.Collections.IMemberSelectors Static { get; }
+        public interface IPrivate : aweXpect.Reflection.Collections.IMemberSelectors, aweXpect.Reflection.Collections.IMembers
+        {
+            aweXpect.Reflection.Collections.IMembers Protected { get; }
+        }
+        public interface IProtected : aweXpect.Reflection.Collections.IMemberSelectors, aweXpect.Reflection.Collections.IMembers
+        {
+            aweXpect.Reflection.Collections.IMembers Internal { get; }
+        }
+    }
+    public interface ITypeAssemblies : aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies, aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies<aweXpect.Reflection.Collections.ITypeAssemblies>
     {
         aweXpect.Reflection.Collections.ILimitedAbstractSealedTypeAssemblies<aweXpect.Reflection.Collections.ILimitedAbstractSealedTypeAssemblies> Abstract { get; }
         aweXpect.Reflection.Collections.ILimitedAbstractSealedTypeAssemblies<aweXpect.Reflection.Collections.ILimitedAbstractSealedTypeAssemblies> Sealed { get; }
         aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies<aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies> Static { get; }
-        aweXpect.Reflection.Collections.Filtered.Constructors Constructors();
         aweXpect.Reflection.Collections.Filtered.Types Enums(aweXpect.Reflection.Collections.AccessModifiers accessModifier = 63);
-        aweXpect.Reflection.Collections.Filtered.Events Events();
-        aweXpect.Reflection.Collections.Filtered.Fields Fields();
         aweXpect.Reflection.Collections.Filtered.Types Interfaces(aweXpect.Reflection.Collections.AccessModifiers accessModifier = 63);
-        aweXpect.Reflection.Collections.Filtered.Methods Methods();
-        aweXpect.Reflection.Collections.Filtered.Properties Properties();
         aweXpect.Reflection.Collections.Filtered.Types RecordStructs(aweXpect.Reflection.Collections.AccessModifiers accessModifier = 63);
+        aweXpect.Reflection.Collections.Filtered.Types Records(aweXpect.Reflection.Collections.AccessModifiers accessModifier = 63);
         aweXpect.Reflection.Collections.Filtered.Types Structs(aweXpect.Reflection.Collections.AccessModifiers accessModifier = 63);
-        public interface IPrivate : aweXpect.Reflection.Collections.ILimitedAbstractSealedTypeAssemblies, aweXpect.Reflection.Collections.ILimitedAbstractSealedTypeAssemblies<aweXpect.Reflection.Collections.ITypeAssemblies>, aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies, aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies<aweXpect.Reflection.Collections.ITypeAssemblies>, aweXpect.Reflection.Collections.ITypeAssemblies
+        public interface IPrivate : aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies, aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies<aweXpect.Reflection.Collections.ITypeAssemblies>, aweXpect.Reflection.Collections.ITypeAssemblies
         {
             aweXpect.Reflection.Collections.ITypeAssemblies Protected { get; }
         }
-        public interface IProtected : aweXpect.Reflection.Collections.ILimitedAbstractSealedTypeAssemblies, aweXpect.Reflection.Collections.ILimitedAbstractSealedTypeAssemblies<aweXpect.Reflection.Collections.ITypeAssemblies>, aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies, aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies<aweXpect.Reflection.Collections.ITypeAssemblies>, aweXpect.Reflection.Collections.ITypeAssemblies
+        public interface IProtected : aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies, aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies<aweXpect.Reflection.Collections.ITypeAssemblies>, aweXpect.Reflection.Collections.ITypeAssemblies
         {
             aweXpect.Reflection.Collections.ITypeAssemblies Internal { get; }
         }

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_netstandard2.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_netstandard2.0.txt
@@ -726,7 +726,7 @@ namespace aweXpect.Reflection.Collections
     }
     public static class Filtered
     {
-        public class Assemblies : aweXpect.Reflection.Collections.Filtered<System.Reflection.Assembly, aweXpect.Reflection.Collections.Filtered.Assemblies>, aweXpect.Core.IDescribableSubject, aweXpect.Reflection.Collections.ILimitedAbstractSealedTypeAssemblies, aweXpect.Reflection.Collections.ILimitedAbstractSealedTypeAssemblies<aweXpect.Reflection.Collections.ITypeAssemblies>, aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies, aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies<aweXpect.Reflection.Collections.ITypeAssemblies>, aweXpect.Reflection.Collections.ITypeAssemblies, aweXpect.Reflection.Collections.ITypeAssemblies.IPrivate, aweXpect.Reflection.Collections.ITypeAssemblies.IProtected
+        public class Assemblies : aweXpect.Reflection.Collections.Filtered<System.Reflection.Assembly, aweXpect.Reflection.Collections.Filtered.Assemblies>, aweXpect.Core.IDescribableSubject, aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies, aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies<aweXpect.Reflection.Collections.ITypeAssemblies>, aweXpect.Reflection.Collections.ITypeAssemblies, aweXpect.Reflection.Collections.ITypeAssemblies.IPrivate, aweXpect.Reflection.Collections.ITypeAssemblies.IProtected
         {
             protected Assemblies(aweXpect.Reflection.Collections.Filtered.Assemblies inner) { }
             public Assemblies(System.Collections.Generic.IEnumerable<System.Reflection.Assembly?> source, string description) { }
@@ -859,10 +859,17 @@ namespace aweXpect.Reflection.Collections
                 public aweXpect.Reflection.Collections.Filtered.Properties.StringEqualityResult Exactly() { }
             }
         }
-        public class Types : aweXpect.Reflection.Collections.Filtered<System.Type, aweXpect.Reflection.Collections.Filtered.Types>, aweXpect.Core.IDescribableSubject
+        public class Types : aweXpect.Reflection.Collections.Filtered<System.Type, aweXpect.Reflection.Collections.Filtered.Types>, aweXpect.Core.IDescribableSubject, aweXpect.Reflection.Collections.ILimitedAbstractSealedMembers, aweXpect.Reflection.Collections.IMemberSelectors, aweXpect.Reflection.Collections.IMembers, aweXpect.Reflection.Collections.IMembers.IPrivate, aweXpect.Reflection.Collections.IMembers.IProtected
         {
             protected Types(aweXpect.Reflection.Collections.Filtered.Types inner) { }
             public Types(System.Collections.Generic.IEnumerable<System.Type?> source, string description) { }
+            public aweXpect.Reflection.Collections.ILimitedAbstractSealedMembers Abstract { get; }
+            public aweXpect.Reflection.Collections.IMembers Internal { get; }
+            public aweXpect.Reflection.Collections.IMembers.IPrivate Private { get; }
+            public aweXpect.Reflection.Collections.IMembers.IProtected Protected { get; }
+            public aweXpect.Reflection.Collections.IMembers Public { get; }
+            public aweXpect.Reflection.Collections.ILimitedAbstractSealedMembers Sealed { get; }
+            public aweXpect.Reflection.Collections.IMemberSelectors Static { get; }
             public aweXpect.Reflection.Collections.Filtered.Assemblies Assemblies() { }
             public aweXpect.Reflection.Collections.Filtered.Constructors Constructors() { }
             public aweXpect.Reflection.Collections.Filtered.Events Events() { }
@@ -908,15 +915,35 @@ namespace aweXpect.Reflection.Collections
         System.Threading.Tasks.Task<bool> Applies(TEntity value);
         string Describes(string text);
     }
-    public interface ILimitedAbstractSealedTypeAssemblies : aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies
+    public interface ILimitedAbstractSealedMembers
     {
-        aweXpect.Reflection.Collections.Filtered.Types Records(aweXpect.Reflection.Collections.AccessModifiers accessModifier = 63);
+        aweXpect.Reflection.Collections.Filtered.Events Events();
+        aweXpect.Reflection.Collections.Filtered.Methods Methods();
+        aweXpect.Reflection.Collections.Filtered.Properties Properties();
     }
-    public interface ILimitedAbstractSealedTypeAssemblies<out TLimitedTypeAssemblies> : aweXpect.Reflection.Collections.ILimitedAbstractSealedTypeAssemblies, aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies, aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies<TLimitedTypeAssemblies>
-        where out TLimitedTypeAssemblies : aweXpect.Reflection.Collections.ILimitedAbstractSealedTypeAssemblies { }
+    public interface ILimitedAbstractSealedTypeAssemblies
+    {
+        aweXpect.Reflection.Collections.Filtered.Types Classes(aweXpect.Reflection.Collections.AccessModifiers accessModifier = 63);
+        aweXpect.Reflection.Collections.Filtered.Events Events();
+        aweXpect.Reflection.Collections.Filtered.Methods Methods();
+        aweXpect.Reflection.Collections.Filtered.Properties Properties();
+        aweXpect.Reflection.Collections.Filtered.Types Records(aweXpect.Reflection.Collections.AccessModifiers accessModifier = 63);
+        aweXpect.Reflection.Collections.Filtered.Types Types(aweXpect.Reflection.Collections.AccessModifiers accessModifier = 63);
+    }
+    public interface ILimitedAbstractSealedTypeAssemblies<out TLimitedTypeAssemblies> : aweXpect.Reflection.Collections.ILimitedAbstractSealedTypeAssemblies
+        where out TLimitedTypeAssemblies : aweXpect.Reflection.Collections.ILimitedAbstractSealedTypeAssemblies
+    {
+        TLimitedTypeAssemblies Generic { get; }
+        TLimitedTypeAssemblies Nested { get; }
+    }
     public interface ILimitedStaticTypeAssemblies
     {
         aweXpect.Reflection.Collections.Filtered.Types Classes(aweXpect.Reflection.Collections.AccessModifiers accessModifier = 63);
+        aweXpect.Reflection.Collections.Filtered.Constructors Constructors();
+        aweXpect.Reflection.Collections.Filtered.Events Events();
+        aweXpect.Reflection.Collections.Filtered.Fields Fields();
+        aweXpect.Reflection.Collections.Filtered.Methods Methods();
+        aweXpect.Reflection.Collections.Filtered.Properties Properties();
         aweXpect.Reflection.Collections.Filtered.Types Types(aweXpect.Reflection.Collections.AccessModifiers accessModifier = 63);
     }
     public interface ILimitedStaticTypeAssemblies<out TLimitedTypeAssemblies> : aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies
@@ -925,25 +952,43 @@ namespace aweXpect.Reflection.Collections
         TLimitedTypeAssemblies Generic { get; }
         TLimitedTypeAssemblies Nested { get; }
     }
-    public interface ITypeAssemblies : aweXpect.Reflection.Collections.ILimitedAbstractSealedTypeAssemblies, aweXpect.Reflection.Collections.ILimitedAbstractSealedTypeAssemblies<aweXpect.Reflection.Collections.ITypeAssemblies>, aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies, aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies<aweXpect.Reflection.Collections.ITypeAssemblies>
+    public interface IMemberSelectors
+    {
+        aweXpect.Reflection.Collections.Filtered.Constructors Constructors();
+        aweXpect.Reflection.Collections.Filtered.Events Events();
+        aweXpect.Reflection.Collections.Filtered.Fields Fields();
+        aweXpect.Reflection.Collections.Filtered.Methods Methods();
+        aweXpect.Reflection.Collections.Filtered.Properties Properties();
+    }
+    public interface IMembers : aweXpect.Reflection.Collections.IMemberSelectors
+    {
+        aweXpect.Reflection.Collections.ILimitedAbstractSealedMembers Abstract { get; }
+        aweXpect.Reflection.Collections.ILimitedAbstractSealedMembers Sealed { get; }
+        aweXpect.Reflection.Collections.IMemberSelectors Static { get; }
+        public interface IPrivate : aweXpect.Reflection.Collections.IMemberSelectors, aweXpect.Reflection.Collections.IMembers
+        {
+            aweXpect.Reflection.Collections.IMembers Protected { get; }
+        }
+        public interface IProtected : aweXpect.Reflection.Collections.IMemberSelectors, aweXpect.Reflection.Collections.IMembers
+        {
+            aweXpect.Reflection.Collections.IMembers Internal { get; }
+        }
+    }
+    public interface ITypeAssemblies : aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies, aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies<aweXpect.Reflection.Collections.ITypeAssemblies>
     {
         aweXpect.Reflection.Collections.ILimitedAbstractSealedTypeAssemblies<aweXpect.Reflection.Collections.ILimitedAbstractSealedTypeAssemblies> Abstract { get; }
         aweXpect.Reflection.Collections.ILimitedAbstractSealedTypeAssemblies<aweXpect.Reflection.Collections.ILimitedAbstractSealedTypeAssemblies> Sealed { get; }
         aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies<aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies> Static { get; }
-        aweXpect.Reflection.Collections.Filtered.Constructors Constructors();
         aweXpect.Reflection.Collections.Filtered.Types Enums(aweXpect.Reflection.Collections.AccessModifiers accessModifier = 63);
-        aweXpect.Reflection.Collections.Filtered.Events Events();
-        aweXpect.Reflection.Collections.Filtered.Fields Fields();
         aweXpect.Reflection.Collections.Filtered.Types Interfaces(aweXpect.Reflection.Collections.AccessModifiers accessModifier = 63);
-        aweXpect.Reflection.Collections.Filtered.Methods Methods();
-        aweXpect.Reflection.Collections.Filtered.Properties Properties();
         aweXpect.Reflection.Collections.Filtered.Types RecordStructs(aweXpect.Reflection.Collections.AccessModifiers accessModifier = 63);
+        aweXpect.Reflection.Collections.Filtered.Types Records(aweXpect.Reflection.Collections.AccessModifiers accessModifier = 63);
         aweXpect.Reflection.Collections.Filtered.Types Structs(aweXpect.Reflection.Collections.AccessModifiers accessModifier = 63);
-        public interface IPrivate : aweXpect.Reflection.Collections.ILimitedAbstractSealedTypeAssemblies, aweXpect.Reflection.Collections.ILimitedAbstractSealedTypeAssemblies<aweXpect.Reflection.Collections.ITypeAssemblies>, aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies, aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies<aweXpect.Reflection.Collections.ITypeAssemblies>, aweXpect.Reflection.Collections.ITypeAssemblies
+        public interface IPrivate : aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies, aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies<aweXpect.Reflection.Collections.ITypeAssemblies>, aweXpect.Reflection.Collections.ITypeAssemblies
         {
             aweXpect.Reflection.Collections.ITypeAssemblies Protected { get; }
         }
-        public interface IProtected : aweXpect.Reflection.Collections.ILimitedAbstractSealedTypeAssemblies, aweXpect.Reflection.Collections.ILimitedAbstractSealedTypeAssemblies<aweXpect.Reflection.Collections.ITypeAssemblies>, aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies, aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies<aweXpect.Reflection.Collections.ITypeAssemblies>, aweXpect.Reflection.Collections.ITypeAssemblies
+        public interface IProtected : aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies, aweXpect.Reflection.Collections.ILimitedStaticTypeAssemblies<aweXpect.Reflection.Collections.ITypeAssemblies>, aweXpect.Reflection.Collections.ITypeAssemblies
         {
             aweXpect.Reflection.Collections.ITypeAssemblies Internal { get; }
         }

--- a/Tests/aweXpect.Reflection.Tests/Filters/AssemblyFilters.MemberAccess.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/AssemblyFilters.MemberAccess.Tests.cs
@@ -78,6 +78,22 @@ public sealed partial class AssemblyFilters
 				await That(methods.GetDescription())
 					.IsEqualTo("public static methods in assembly").AsPrefix();
 			}
+
+			[Fact]
+			public async Task ShouldResetModifierStateAfterSelector()
+			{
+				Filtered.Assemblies assemblies = In.AssemblyContaining<AssemblyFilters>();
+
+				Filtered.Methods publicMethods = assemblies.Public.Methods();
+				Filtered.Methods anyMethods = assemblies.Methods();
+
+				await That(publicMethods).All().Satisfy(m => m.IsPublic).And.IsNotEmpty();
+				await That(anyMethods).Any().Satisfy(m => !m.IsPublic);
+				await That(publicMethods.GetDescription())
+					.IsEqualTo("public methods in assembly").AsPrefix();
+				await That(anyMethods.GetDescription())
+					.IsEqualTo("methods in assembly").AsPrefix();
+			}
 		}
 	}
 }

--- a/Tests/aweXpect.Reflection.Tests/Filters/AssemblyFilters.MemberAccess.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/AssemblyFilters.MemberAccess.Tests.cs
@@ -1,0 +1,83 @@
+using aweXpect.Reflection.Collections;
+
+namespace aweXpect.Reflection.Tests.Filters;
+
+public sealed partial class AssemblyFilters
+{
+	public sealed class MemberAccess
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task ShouldStillSupportPublicBeforeInterfaces()
+			{
+				Filtered.Types types = In.AssemblyContaining<AssemblyFilters>().Public.Interfaces();
+
+				await That(types).All().Satisfy(t => t.IsInterface && t.IsPublic).And.IsNotEmpty();
+				await That(types.GetDescription())
+					.IsEqualTo("public interfaces in assembly").AsPrefix();
+			}
+
+			[Fact]
+			public async Task ShouldStillSupportPublicBeforeMethods()
+			{
+				Filtered.Methods methods = In.AssemblyContaining<AssemblyFilters>().Public.Methods();
+
+				await That(methods).All().Satisfy(m => m.IsPublic).And.IsNotEmpty();
+				await That(methods.GetDescription())
+					.IsEqualTo("public methods in assembly").AsPrefix();
+			}
+
+			[Fact]
+			public async Task ShouldSupportStaticBeforeMethods()
+			{
+				Filtered.Methods methods = In.AssemblyContaining<AssemblyFilters>().Static.Methods();
+
+				await That(methods).All().Satisfy(m => m.IsStatic).And.IsNotEmpty();
+				await That(methods.GetDescription())
+					.IsEqualTo("static methods in assembly").AsPrefix();
+			}
+
+			[Fact]
+			public async Task ShouldSupportStaticBeforeConstructors()
+			{
+				Filtered.Constructors constructors = In.AssemblyContaining<AssemblyFilters>().Static.Constructors();
+
+				await That(constructors).All().Satisfy(c => c.IsStatic).And.IsNotEmpty();
+				await That(constructors.GetDescription())
+					.IsEqualTo("static constructors in assembly").AsPrefix();
+			}
+
+			[Fact]
+			public async Task ShouldSupportAbstractBeforeMethods()
+			{
+				Filtered.Methods methods = In.AssemblyContaining<AssemblyFilters>().Abstract.Methods();
+
+				await That(methods).All().Satisfy(m => m.IsAbstract).And.IsNotEmpty();
+				await That(methods.GetDescription())
+					.IsEqualTo("abstract methods in assembly").AsPrefix();
+			}
+
+			[Fact]
+			public async Task ShouldSupportSealedBeforeMethods()
+			{
+				Filtered.Methods methods = In.AssemblyContaining<AssemblyFilters>().Sealed.Methods();
+
+				await That(methods).All().Satisfy(m => m is { IsVirtual: true, IsFinal: true })
+					.And.IsNotEmpty();
+				await That(methods.GetDescription())
+					.IsEqualTo("sealed methods in assembly").AsPrefix();
+			}
+
+			[Fact]
+			public async Task ShouldCombinePublicAndStaticBeforeMethods()
+			{
+				Filtered.Methods methods = In.AssemblyContaining<AssemblyFilters>().Public.Static.Methods();
+
+				await That(methods).All().Satisfy(m => m.IsStatic && m.IsPublic).And.IsNotEmpty();
+				await That(methods.GetDescription())
+					.IsEqualTo("public static methods in assembly").AsPrefix();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.MemberAccess.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.MemberAccess.Tests.cs
@@ -1,0 +1,134 @@
+using aweXpect.Reflection.Collections;
+
+namespace aweXpect.Reflection.Tests.Filters;
+
+public sealed partial class TypeFilters
+{
+	public sealed class MemberAccess
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task ShouldChainPublicBeforeMethods()
+			{
+				Filtered.Methods methods = In.AssemblyContaining<AssemblyFilters>()
+					.Classes().Public.Methods();
+
+				await That(methods).All().Satisfy(m => m.IsPublic).And.IsNotEmpty();
+				await That(methods.GetDescription())
+					.IsEqualTo("public methods in classes in assembly").AsPrefix();
+			}
+
+			[Fact]
+			public async Task ShouldChainPrivateProtectedBeforeFields()
+			{
+				Filtered.Fields fields = In.AssemblyContaining<AssemblyFilters>()
+					.Classes().Private.Protected.Fields();
+
+				await That(fields).All().Satisfy(f => f.IsFamilyAndAssembly);
+				await That(fields.GetDescription())
+					.IsEqualTo("private protected fields in classes in assembly").AsPrefix();
+			}
+
+			[Fact]
+			public async Task ShouldChainProtectedInternalBeforeMethods()
+			{
+				Filtered.Methods methods = In.AssemblyContaining<AssemblyFilters>()
+					.Classes().Protected.Internal.Methods();
+
+				await That(methods).All().Satisfy(m => m.IsFamilyOrAssembly);
+				await That(methods.GetDescription())
+					.IsEqualTo("protected internal methods in classes in assembly").AsPrefix();
+			}
+
+			[Fact]
+			public async Task ShouldChainStaticBeforeConstructors()
+			{
+				Filtered.Constructors constructors = In.AssemblyContaining<AssemblyFilters>()
+					.Classes().Static.Constructors();
+
+				await That(constructors).All().Satisfy(c => c.IsStatic).And.IsNotEmpty();
+				await That(constructors.GetDescription())
+					.IsEqualTo("static constructors in classes in assembly").AsPrefix();
+			}
+
+			[Fact]
+			public async Task ShouldChainStaticBeforeMethods()
+			{
+				Filtered.Methods methods = In.AssemblyContaining<AssemblyFilters>()
+					.Classes().Static.Methods();
+
+				await That(methods).All().Satisfy(m => m.IsStatic).And.IsNotEmpty();
+				await That(methods.GetDescription())
+					.IsEqualTo("static methods in classes in assembly").AsPrefix();
+			}
+
+			[Fact]
+			public async Task ShouldChainAbstractBeforeMethods()
+			{
+				Filtered.Methods methods = In.Type<AbstractMemberClass>().Abstract.Methods();
+
+				await That(methods).All().Satisfy(m => m.IsAbstract).And.IsNotEmpty();
+				await That(methods.GetDescription())
+					.IsEqualTo("abstract methods in type").AsPrefix();
+			}
+
+			[Fact]
+			public async Task ShouldChainAbstractBeforeProperties()
+			{
+				Filtered.Properties properties = In.Type<AbstractMemberClass>().Abstract.Properties();
+
+				await That(properties).All()
+					.Satisfy(p => p.GetMethod?.IsAbstract == true || p.SetMethod?.IsAbstract == true)
+					.And.IsNotEmpty();
+				await That(properties.GetDescription())
+					.IsEqualTo("abstract properties in type").AsPrefix();
+			}
+
+			[Fact]
+			public async Task ShouldChainSealedBeforeMethods()
+			{
+				Filtered.Methods methods = In.Type<SealedMemberClass>().Sealed.Methods();
+
+				await That(methods).All().Satisfy(m => m is { IsVirtual: true, IsFinal: true })
+					.And.IsNotEmpty();
+				await That(methods.GetDescription())
+					.IsEqualTo("sealed methods in type").AsPrefix();
+			}
+
+			[Fact]
+			public async Task ShouldCombinePublicAndStatic()
+			{
+				Filtered.Methods methods = In.AssemblyContaining<AssemblyFilters>()
+					.Classes().Public.Static.Methods();
+
+				await That(methods).All().Satisfy(m => m.IsStatic && m.IsPublic).And.IsNotEmpty();
+				await That(methods.GetDescription())
+					.IsEqualTo("public static methods in classes in assembly").AsPrefix();
+			}
+
+			private abstract class AbstractMemberClass
+			{
+				public abstract int AbstractProperty { get; }
+				public abstract void AbstractMethod();
+
+#pragma warning disable CA1822
+				// ReSharper disable once UnusedMember.Local
+				public void ConcreteMethod() { }
+#pragma warning restore CA1822
+			}
+
+			private class ConcreteForSealed
+			{
+				// ReSharper disable once UnusedMember.Global
+				public virtual void VirtualMethod() { }
+			}
+
+			private sealed class SealedMemberClass : ConcreteForSealed
+			{
+				public sealed override string ToString() => "Sealed";
+				public sealed override void VirtualMethod() { }
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.MemberAccess.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.MemberAccess.Tests.cs
@@ -107,6 +107,22 @@ public sealed partial class TypeFilters
 					.IsEqualTo("public static methods in classes in assembly").AsPrefix();
 			}
 
+			[Fact]
+			public async Task ShouldResetModifierStateAfterSelector()
+			{
+				Filtered.Types types = In.AssemblyContaining<AssemblyFilters>().Classes();
+
+				Filtered.Methods publicMethods = types.Public.Methods();
+				Filtered.Methods anyMethods = types.Methods();
+
+				await That(publicMethods).All().Satisfy(m => m.IsPublic).And.IsNotEmpty();
+				await That(anyMethods).Any().Satisfy(m => !m.IsPublic);
+				await That(publicMethods.GetDescription())
+					.IsEqualTo("public methods in classes in assembly").AsPrefix();
+				await That(anyMethods.GetDescription())
+					.IsEqualTo("methods in classes in assembly").AsPrefix();
+			}
+
 			private abstract class AbstractMemberClass
 			{
 				public abstract int AbstractProperty { get; }


### PR DESCRIPTION
Adds a fluent chain for `Public`/`Private`/`Protected`/`Internal`/`Static`/`Abstract`/`Sealed` modifiers **before** member-kind selectors, on both `Filtered.Types` and `Filtered.Assemblies`. Examples:

```csharp
In.AllLoadedAssemblies().Classes().Public.Methods();
In.AllLoadedAssemblies().Classes().Private.Protected.Fields();
In.AssemblyContaining<X>().Static.Methods();
In.AssemblyContaining<X>().Abstract.Methods();
In.Type<T>().Public.Static.Methods();
```

The chain is type-safe: `.Abstract` and `.Sealed` return a narrower interface, so combinations that don't exist in C# (abstract constructors, sealed fields, abstract+sealed, etc.) don't compile.

## What's new

- **`IMembers`, `IMemberSelectors`, `ILimitedAbstractSealedMembers`** — interfaces that drive the new chain on `Filtered.Types`.
- **`MemberFilterState`** — shared helper that accumulates the access/static/abstract/sealed modifiers and produces the per-member-kind predicate. Used by both `Filtered.Types` and `Filtered.Assemblies`, collapsing the previous per-selector duplication on the assemblies side.
- **`ILimitedAbstractSealedTypeAssemblies` reshaped** — no longer inherits from `ILimitedStaticTypeAssemblies`. It now exposes only the abstract/sealed-compatible surface (`Types`/`Classes`/`Records` + `Methods`/`Properties`/`Events`). `Records()` moves directly onto `ITypeAssemblies` (consumers using `ITypeAssemblies.Records()` are unaffected). `Filtered.Assemblies.Abstract` / `.Sealed` return a small private
wrapper limiting the chain to that surface.
- **Per-selector state reset** — `MemberFilterState.Reset()` is invoked after every selector consumes the modifiers. Reusing a `Filtered.Types` or `Filtered.Assemblies` after `.Public.Methods()` no longer carries the `Public` filter into a later `.Methods()` call.

## Compile-time guarantees

These chains used to compile but produced wrong/empty results — now they don't compile:

```csharp
// constructors and fields can't be abstract or sealed
In.AllLoadedAssemblies().Abstract.Constructors();   // ❌  compile error
In.AllLoadedAssemblies().Sealed.Fields();           // ❌  compile error

// abstract + sealed is mutually exclusive (already enforced on Types side, now also Assemblies)
In.Type<T>().Abstract.Sealed.Methods();             // ❌  compile error
```

## API surface

`ITypeAssemblies` keeps all the member selectors it had before (`Constructors`, `Fields`, `Methods`, `Properties`, `Events`) — they just come from `ILimitedStaticTypeAssemblies` instead of being declared directly. **Direct callers of `ITypeAssemblies` are not affected.**

The narrow break is for code that holds an `ILimitedAbstractSealedTypeAssemblies<>` (the return type of `.Abstract`/`.Sealed`) and calls `Constructors()` or `Fields()` on it. That call no longer compiles, by design.

API approval snapshots regenerated for `net8.0`, `net10.0`, and `netstandard2.0`.