### PR TITLE
feat: add WhichContain<Member> type filters with quantifier support

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,39 @@ In.AllLoadedAssemblies().Types()
     .Which(t => t.Name.StartsWith("Test"))
 ```
 
+#### Member Containment Filters
+
+You can select types based on the members they contain. The lambda receives the members declared on
+each individual type and may use the full member-filter DSL:
+
+```csharp
+// Types that contain at least one method with [Fact] or [Theory]
+In.AllLoadedAssemblies().Types()
+    .WhichContainMethods(methods => methods.With<FactAttribute>().OrWith<TheoryAttribute>())
+
+// The same is available for the other member kinds
+In.AllLoadedAssemblies().Types()
+    .WhichContainProperties(properties => properties.With<RequiredAttribute>())
+    .WhichContainFields(fields => fields.WithName("_").AsPrefix())
+    .WhichContainEvents(events => events.With<ObsoleteAttribute>())
+    .WhichContainConstructors(constructors => constructors.WithoutParameters())
+```
+
+By default a type matches when it contains **at least one** matching member. You can append a
+quantifier (the same quantifiers as in [`aweXpect`](https://awexpect.com)) to require a specific count:
+
+```csharp
+In.AllLoadedAssemblies().Types()
+    .WhichContainConstructors(c => c.WithoutParameters()).Exactly(1)
+    .WhichContainMethods(m => m.With<ObsoleteAttribute>()).Never()
+    .WhichContainProperties(p => p.With<RequiredAttribute>()).AtLeast(2)
+    .WhichContainFields(f => f.WhichArePrivate()).Between(1).And(5)
+```
+
+Each quantifier applies only to the condition it directly follows; all other conditions implicitly
+require the member to occur _at least once_. The available quantifiers are `Exactly`, `AtLeast`,
+`AtMost`, `MoreThan`, `LessThan`, `Between(…).And(…)`, `Never`, `Once` and `Twice`.
+
 #### Method Filters
 
 ```csharp
@@ -245,6 +278,17 @@ await Expect.That(In.AllLoadedAssemblies()
 await Expect.That(In.AssemblyContaining<MyAggregate>()
         .Methods().Which(m => m.GetParameters().Length == 1))
     .HaveName(method => "On" + method.GetParameters()[0].ParameterType.Name);
+
+// Verify all test classes (those containing a [Fact] or [Theory] method) follow naming convention
+await Expect.That(In.AllLoadedAssemblies()
+        .Types().WhichContainMethods(m => m.With<FactAttribute>().OrWith<TheoryAttribute>()))
+    .HaveName("Tests").AsSuffix();
+
+// Verify each serializable type has exactly one parameterless constructor
+await Expect.That(In.AllLoadedAssemblies()
+        .Types().With<SerializableAttribute>()
+        .WhichContainConstructors(c => c.WithoutParameters()).Exactly(1))
+    .AreClasses();
 ```
 
 ## Assemblies

--- a/Source/aweXpect.Reflection/Filters/TypeFilters.WhichContainConstructors.cs
+++ b/Source/aweXpect.Reflection/Filters/TypeFilters.WhichContainConstructors.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Reflection;
+using aweXpect.Core;
+using aweXpect.Reflection.Collections;
+
+namespace aweXpect.Reflection;
+
+public static partial class TypeFilters
+{
+	/// <summary>
+	///     Filters for types that contain constructors matching the <paramref name="filter" />.
+	/// </summary>
+	/// <remarks>
+	///     By default a type passes when it contains at least one matching constructor. Append a quantifier
+	///     (e.g. <see cref="TypesContainingMembers.Exactly(Times)" />) to require a specific count.
+	/// </remarks>
+	public static TypesContainingMembers WhichContainConstructors(this Filtered.Types @this,
+		Func<Filtered.Constructors, Filtered.Constructors> filter)
+		=> Containing<ConstructorInfo, Filtered.Constructors>(@this, types => types.Constructors(), filter);
+}

--- a/Source/aweXpect.Reflection/Filters/TypeFilters.WhichContainEvents.cs
+++ b/Source/aweXpect.Reflection/Filters/TypeFilters.WhichContainEvents.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Reflection;
+using aweXpect.Core;
+using aweXpect.Reflection.Collections;
+
+namespace aweXpect.Reflection;
+
+public static partial class TypeFilters
+{
+	/// <summary>
+	///     Filters for types that contain events matching the <paramref name="filter" />.
+	/// </summary>
+	/// <remarks>
+	///     By default a type passes when it contains at least one matching event. Append a quantifier
+	///     (e.g. <see cref="TypesContainingMembers.Exactly(Times)" />) to require a specific count.
+	/// </remarks>
+	public static TypesContainingMembers WhichContainEvents(this Filtered.Types @this,
+		Func<Filtered.Events, Filtered.Events> filter)
+		=> Containing<EventInfo, Filtered.Events>(@this, types => types.Events(), filter);
+}

--- a/Source/aweXpect.Reflection/Filters/TypeFilters.WhichContainFields.cs
+++ b/Source/aweXpect.Reflection/Filters/TypeFilters.WhichContainFields.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Reflection;
+using aweXpect.Core;
+using aweXpect.Reflection.Collections;
+
+namespace aweXpect.Reflection;
+
+public static partial class TypeFilters
+{
+	/// <summary>
+	///     Filters for types that contain fields matching the <paramref name="filter" />.
+	/// </summary>
+	/// <remarks>
+	///     By default a type passes when it contains at least one matching field. Append a quantifier
+	///     (e.g. <see cref="TypesContainingMembers.Exactly(Times)" />) to require a specific count.
+	/// </remarks>
+	public static TypesContainingMembers WhichContainFields(this Filtered.Types @this,
+		Func<Filtered.Fields, Filtered.Fields> filter)
+		=> Containing<FieldInfo, Filtered.Fields>(@this, types => types.Fields(), filter);
+}

--- a/Source/aweXpect.Reflection/Filters/TypeFilters.WhichContainMethods.cs
+++ b/Source/aweXpect.Reflection/Filters/TypeFilters.WhichContainMethods.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Reflection;
+using aweXpect.Core;
+using aweXpect.Reflection.Collections;
+
+namespace aweXpect.Reflection;
+
+public static partial class TypeFilters
+{
+	/// <summary>
+	///     Filters for types that contain methods matching the <paramref name="filter" />.
+	/// </summary>
+	/// <remarks>
+	///     The <paramref name="filter" /> receives the methods declared on each individual type and may use the
+	///     full method-filter DSL (e.g. <c>methods.With&lt;FactAttribute&gt;().OrWith&lt;TheoryAttribute&gt;()</c>).<br />
+	///     By default a type passes when it contains at least one matching method. Append a quantifier
+	///     (e.g. <see cref="TypesContainingMembers.Exactly(Times)" />) to require a specific count.
+	/// </remarks>
+	public static TypesContainingMembers WhichContainMethods(this Filtered.Types @this,
+		Func<Filtered.Methods, Filtered.Methods> filter)
+		=> Containing<MethodInfo, Filtered.Methods>(@this, types => types.Methods(), filter);
+}

--- a/Source/aweXpect.Reflection/Filters/TypeFilters.WhichContainProperties.cs
+++ b/Source/aweXpect.Reflection/Filters/TypeFilters.WhichContainProperties.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Reflection;
+using aweXpect.Core;
+using aweXpect.Reflection.Collections;
+
+namespace aweXpect.Reflection;
+
+public static partial class TypeFilters
+{
+	/// <summary>
+	///     Filters for types that contain properties matching the <paramref name="filter" />.
+	/// </summary>
+	/// <remarks>
+	///     By default a type passes when it contains at least one matching property. Append a quantifier
+	///     (e.g. <see cref="TypesContainingMembers.Exactly(Times)" />) to require a specific count.
+	/// </remarks>
+	public static TypesContainingMembers WhichContainProperties(this Filtered.Types @this,
+		Func<Filtered.Properties, Filtered.Properties> filter)
+		=> Containing<PropertyInfo, Filtered.Properties>(@this, types => types.Properties(), filter);
+}

--- a/Source/aweXpect.Reflection/Filters/TypeFilters.cs
+++ b/Source/aweXpect.Reflection/Filters/TypeFilters.cs
@@ -1,4 +1,10 @@
-﻿using aweXpect.Reflection.Collections;
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using aweXpect.Core;
+using aweXpect.Options;
+using aweXpect.Reflection.Collections;
+using aweXpect.Results;
 
 namespace aweXpect.Reflection;
 
@@ -7,4 +13,199 @@ namespace aweXpect.Reflection;
 /// </summary>
 public static partial class TypeFilters
 {
+	private static TypesContainingMembers Containing<TMember, TFiltered>(Filtered.Types @this,
+		Func<Filtered.Types, TFiltered> navigate,
+		Func<TFiltered, TFiltered> filter)
+		where TFiltered : Filtered<TMember, TFiltered>, IDescribableSubject
+	{
+		Quantifier quantifier = new();
+		return new TypesContainingMembers(
+			@this.Which(new ContainedMembersFilter<TMember, TFiltered>(navigate, filter, quantifier)),
+			quantifier);
+	}
+
+	/// <summary>
+	///     A filterable collection of <see cref="Type" /> that contain matching members, allowing to specify a quantifier
+	///     for the number of matching members.
+	/// </summary>
+	public class TypesContainingMembers : Filtered.Types
+	{
+		private readonly Quantifier _quantifier;
+
+		internal TypesContainingMembers(Filtered.Types inner, Quantifier quantifier) : base(inner)
+		{
+			_quantifier = quantifier;
+		}
+
+		/// <summary>
+		///     Verifies, that the matching members occur at least…
+		/// </summary>
+		public CountTimesResult<Filtered.Types> AtLeast()
+			=> new(value =>
+			{
+				_quantifier.AtLeast(value);
+				return this;
+			});
+
+		/// <summary>
+		///     Verifies, that the matching members occur at least <paramref name="minimum" /> times.
+		/// </summary>
+		public Filtered.Types AtLeast(Times minimum)
+		{
+			_quantifier.AtLeast(minimum.Value);
+			return this;
+		}
+
+		/// <summary>
+		///     Verifies, that the matching members occur at most…
+		/// </summary>
+		public CountTimesResult<Filtered.Types> AtMost()
+			=> new(value =>
+			{
+				_quantifier.AtMost(value);
+				return this;
+			});
+
+		/// <summary>
+		///     Verifies, that the matching members occur at most <paramref name="maximum" /> times.
+		/// </summary>
+		public Filtered.Types AtMost(Times maximum)
+		{
+			_quantifier.AtMost(maximum.Value);
+			return this;
+		}
+
+		/// <summary>
+		///     Verifies, that the matching members occur between <paramref name="minimum" />…
+		/// </summary>
+		public BetweenResult<Filtered.Types> Between(int minimum)
+			=> new(maximum =>
+			{
+				_quantifier.Between(minimum, maximum);
+				return this;
+			});
+
+		/// <summary>
+		///     Verifies, that the matching members occur exactly <paramref name="expected" /> times.
+		/// </summary>
+		public Filtered.Types Exactly(Times expected)
+		{
+			_quantifier.Exactly(expected.Value);
+			return this;
+		}
+
+		/// <summary>
+		///     Verifies, that the matching members occur less than…
+		/// </summary>
+		public CountTimesResult<Filtered.Types> LessThan()
+			=> new(value =>
+			{
+				_quantifier.LessThan(value);
+				return this;
+			});
+
+		/// <summary>
+		///     Verifies, that the matching members occur less than <paramref name="maximum" /> times.
+		/// </summary>
+		public Filtered.Types LessThan(Times maximum)
+		{
+			_quantifier.LessThan(maximum.Value);
+			return this;
+		}
+
+		/// <summary>
+		///     Verifies, that the matching members occur more than…
+		/// </summary>
+		public CountTimesResult<Filtered.Types> MoreThan()
+			=> new(value =>
+			{
+				_quantifier.MoreThan(value);
+				return this;
+			});
+
+		/// <summary>
+		///     Verifies, that the matching members occur more than <paramref name="minimum" /> times.
+		/// </summary>
+		public Filtered.Types MoreThan(Times minimum)
+		{
+			_quantifier.MoreThan(minimum.Value);
+			return this;
+		}
+
+		/// <summary>
+		///     Verifies, that no member matches the filter.
+		/// </summary>
+		public Filtered.Types Never()
+		{
+			_quantifier.Exactly(0);
+			return this;
+		}
+
+		/// <summary>
+		///     Verifies, that exactly one member matches the filter.
+		/// </summary>
+		public Filtered.Types Once()
+		{
+			_quantifier.Exactly(1);
+			return this;
+		}
+
+		/// <summary>
+		///     Verifies, that exactly two members match the filter.
+		/// </summary>
+		public Filtered.Types Twice()
+		{
+			_quantifier.Exactly(2);
+			return this;
+		}
+	}
+
+	private sealed class ContainedMembersFilter<TMember, TFiltered> : IFilter<Type>
+		where TFiltered : Filtered<TMember, TFiltered>, IDescribableSubject
+	{
+		private readonly Func<TFiltered, TFiltered> _filter;
+		private readonly string _membersDescription;
+		private readonly Func<Filtered.Types, TFiltered> _navigate;
+		private readonly Quantifier _quantifier;
+
+		public ContainedMembersFilter(Func<Filtered.Types, TFiltered> navigate,
+			Func<TFiltered, TFiltered> filter,
+			Quantifier quantifier)
+		{
+			_navigate = navigate;
+			_filter = filter;
+			_quantifier = quantifier;
+
+			// Derive the inner description from an empty probe, e.g. "methods with FactAttribute or with TheoryAttribute ".
+			string inner = _filter(_navigate(new Filtered.Types([], ""))).GetDescription();
+			if (inner.EndsWith("in "))
+			{
+				inner = inner.Substring(0, inner.Length - "in ".Length);
+			}
+
+			_membersDescription = inner;
+		}
+
+#if NET8_0_OR_GREATER
+		public async ValueTask<bool> Applies(Type value)
+		{
+			int count = 0;
+			await foreach (var _ in _filter(_navigate(new Filtered.Types([value,], ""))))
+			{
+				count++;
+			}
+
+			return _quantifier.Check(count, true) ?? false;
+		}
+#else
+		public Task<bool> Applies(Type value)
+		{
+			int count = _filter(_navigate(new Filtered.Types([value,], ""))).Count();
+			return Task.FromResult(_quantifier.Check(count, true) ?? false);
+		}
+#endif
+
+		public string Describes(string text)
+			=> $"{text.TrimEnd()} which contain {_membersDescription}{_quantifier} ";
+	}
 }

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net10.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net10.0.txt
@@ -784,6 +784,11 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreSealed(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreStatic(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreStructs(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
+        public static aweXpect.Reflection.TypeFilters.TypesContainingMembers WhichContainConstructors(this aweXpect.Reflection.Collections.Filtered.Types @this, System.Func<aweXpect.Reflection.Collections.Filtered.Constructors, aweXpect.Reflection.Collections.Filtered.Constructors> filter) { }
+        public static aweXpect.Reflection.TypeFilters.TypesContainingMembers WhichContainEvents(this aweXpect.Reflection.Collections.Filtered.Types @this, System.Func<aweXpect.Reflection.Collections.Filtered.Events, aweXpect.Reflection.Collections.Filtered.Events> filter) { }
+        public static aweXpect.Reflection.TypeFilters.TypesContainingMembers WhichContainFields(this aweXpect.Reflection.Collections.Filtered.Types @this, System.Func<aweXpect.Reflection.Collections.Filtered.Fields, aweXpect.Reflection.Collections.Filtered.Fields> filter) { }
+        public static aweXpect.Reflection.TypeFilters.TypesContainingMembers WhichContainMethods(this aweXpect.Reflection.Collections.Filtered.Types @this, System.Func<aweXpect.Reflection.Collections.Filtered.Methods, aweXpect.Reflection.Collections.Filtered.Methods> filter) { }
+        public static aweXpect.Reflection.TypeFilters.TypesContainingMembers WhichContainProperties(this aweXpect.Reflection.Collections.Filtered.Types @this, System.Func<aweXpect.Reflection.Collections.Filtered.Properties, aweXpect.Reflection.Collections.Filtered.Properties> filter) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichInheritFrom(this aweXpect.Reflection.Collections.Filtered.Types @this, System.Type baseType, bool forceDirect = false) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichInheritFrom<TBaseType>(this aweXpect.Reflection.Collections.Filtered.Types @this, bool forceDirect = false) { }
         public static aweXpect.Reflection.TypeFilters.TypesWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Types @this, bool inherit = true)
@@ -819,6 +824,22 @@ namespace aweXpect.Reflection
                 public aweXpect.Reflection.TypeFilters.GenericTypes.GenericTypesWithNamedArgument IgnoringCase(bool ignoreCase = true) { }
                 public aweXpect.Reflection.TypeFilters.GenericTypes.GenericTypesWithNamedArgument Using(System.Collections.Generic.IEqualityComparer<string> comparer) { }
             }
+        }
+        public class TypesContainingMembers : aweXpect.Reflection.Collections.Filtered.Types
+        {
+            public aweXpect.Results.CountTimesResult<aweXpect.Reflection.Collections.Filtered.Types> AtLeast() { }
+            public aweXpect.Reflection.Collections.Filtered.Types AtLeast(aweXpect.Core.Times minimum) { }
+            public aweXpect.Results.CountTimesResult<aweXpect.Reflection.Collections.Filtered.Types> AtMost() { }
+            public aweXpect.Reflection.Collections.Filtered.Types AtMost(aweXpect.Core.Times maximum) { }
+            public aweXpect.Results.BetweenResult<aweXpect.Reflection.Collections.Filtered.Types> Between(int minimum) { }
+            public aweXpect.Reflection.Collections.Filtered.Types Exactly(aweXpect.Core.Times expected) { }
+            public aweXpect.Results.CountTimesResult<aweXpect.Reflection.Collections.Filtered.Types> LessThan() { }
+            public aweXpect.Reflection.Collections.Filtered.Types LessThan(aweXpect.Core.Times maximum) { }
+            public aweXpect.Results.CountTimesResult<aweXpect.Reflection.Collections.Filtered.Types> MoreThan() { }
+            public aweXpect.Reflection.Collections.Filtered.Types MoreThan(aweXpect.Core.Times minimum) { }
+            public aweXpect.Reflection.Collections.Filtered.Types Never() { }
+            public aweXpect.Reflection.Collections.Filtered.Types Once() { }
+            public aweXpect.Reflection.Collections.Filtered.Types Twice() { }
         }
         public class TypesWith : aweXpect.Reflection.Collections.Filtered.Types
         {

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net8.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net8.0.txt
@@ -784,6 +784,11 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreSealed(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreStatic(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreStructs(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
+        public static aweXpect.Reflection.TypeFilters.TypesContainingMembers WhichContainConstructors(this aweXpect.Reflection.Collections.Filtered.Types @this, System.Func<aweXpect.Reflection.Collections.Filtered.Constructors, aweXpect.Reflection.Collections.Filtered.Constructors> filter) { }
+        public static aweXpect.Reflection.TypeFilters.TypesContainingMembers WhichContainEvents(this aweXpect.Reflection.Collections.Filtered.Types @this, System.Func<aweXpect.Reflection.Collections.Filtered.Events, aweXpect.Reflection.Collections.Filtered.Events> filter) { }
+        public static aweXpect.Reflection.TypeFilters.TypesContainingMembers WhichContainFields(this aweXpect.Reflection.Collections.Filtered.Types @this, System.Func<aweXpect.Reflection.Collections.Filtered.Fields, aweXpect.Reflection.Collections.Filtered.Fields> filter) { }
+        public static aweXpect.Reflection.TypeFilters.TypesContainingMembers WhichContainMethods(this aweXpect.Reflection.Collections.Filtered.Types @this, System.Func<aweXpect.Reflection.Collections.Filtered.Methods, aweXpect.Reflection.Collections.Filtered.Methods> filter) { }
+        public static aweXpect.Reflection.TypeFilters.TypesContainingMembers WhichContainProperties(this aweXpect.Reflection.Collections.Filtered.Types @this, System.Func<aweXpect.Reflection.Collections.Filtered.Properties, aweXpect.Reflection.Collections.Filtered.Properties> filter) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichInheritFrom(this aweXpect.Reflection.Collections.Filtered.Types @this, System.Type baseType, bool forceDirect = false) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichInheritFrom<TBaseType>(this aweXpect.Reflection.Collections.Filtered.Types @this, bool forceDirect = false) { }
         public static aweXpect.Reflection.TypeFilters.TypesWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Types @this, bool inherit = true)
@@ -819,6 +824,22 @@ namespace aweXpect.Reflection
                 public aweXpect.Reflection.TypeFilters.GenericTypes.GenericTypesWithNamedArgument IgnoringCase(bool ignoreCase = true) { }
                 public aweXpect.Reflection.TypeFilters.GenericTypes.GenericTypesWithNamedArgument Using(System.Collections.Generic.IEqualityComparer<string> comparer) { }
             }
+        }
+        public class TypesContainingMembers : aweXpect.Reflection.Collections.Filtered.Types
+        {
+            public aweXpect.Results.CountTimesResult<aweXpect.Reflection.Collections.Filtered.Types> AtLeast() { }
+            public aweXpect.Reflection.Collections.Filtered.Types AtLeast(aweXpect.Core.Times minimum) { }
+            public aweXpect.Results.CountTimesResult<aweXpect.Reflection.Collections.Filtered.Types> AtMost() { }
+            public aweXpect.Reflection.Collections.Filtered.Types AtMost(aweXpect.Core.Times maximum) { }
+            public aweXpect.Results.BetweenResult<aweXpect.Reflection.Collections.Filtered.Types> Between(int minimum) { }
+            public aweXpect.Reflection.Collections.Filtered.Types Exactly(aweXpect.Core.Times expected) { }
+            public aweXpect.Results.CountTimesResult<aweXpect.Reflection.Collections.Filtered.Types> LessThan() { }
+            public aweXpect.Reflection.Collections.Filtered.Types LessThan(aweXpect.Core.Times maximum) { }
+            public aweXpect.Results.CountTimesResult<aweXpect.Reflection.Collections.Filtered.Types> MoreThan() { }
+            public aweXpect.Reflection.Collections.Filtered.Types MoreThan(aweXpect.Core.Times minimum) { }
+            public aweXpect.Reflection.Collections.Filtered.Types Never() { }
+            public aweXpect.Reflection.Collections.Filtered.Types Once() { }
+            public aweXpect.Reflection.Collections.Filtered.Types Twice() { }
         }
         public class TypesWith : aweXpect.Reflection.Collections.Filtered.Types
         {

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_netstandard2.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_netstandard2.0.txt
@@ -665,6 +665,11 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreSealed(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreStatic(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreStructs(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
+        public static aweXpect.Reflection.TypeFilters.TypesContainingMembers WhichContainConstructors(this aweXpect.Reflection.Collections.Filtered.Types @this, System.Func<aweXpect.Reflection.Collections.Filtered.Constructors, aweXpect.Reflection.Collections.Filtered.Constructors> filter) { }
+        public static aweXpect.Reflection.TypeFilters.TypesContainingMembers WhichContainEvents(this aweXpect.Reflection.Collections.Filtered.Types @this, System.Func<aweXpect.Reflection.Collections.Filtered.Events, aweXpect.Reflection.Collections.Filtered.Events> filter) { }
+        public static aweXpect.Reflection.TypeFilters.TypesContainingMembers WhichContainFields(this aweXpect.Reflection.Collections.Filtered.Types @this, System.Func<aweXpect.Reflection.Collections.Filtered.Fields, aweXpect.Reflection.Collections.Filtered.Fields> filter) { }
+        public static aweXpect.Reflection.TypeFilters.TypesContainingMembers WhichContainMethods(this aweXpect.Reflection.Collections.Filtered.Types @this, System.Func<aweXpect.Reflection.Collections.Filtered.Methods, aweXpect.Reflection.Collections.Filtered.Methods> filter) { }
+        public static aweXpect.Reflection.TypeFilters.TypesContainingMembers WhichContainProperties(this aweXpect.Reflection.Collections.Filtered.Types @this, System.Func<aweXpect.Reflection.Collections.Filtered.Properties, aweXpect.Reflection.Collections.Filtered.Properties> filter) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichInheritFrom(this aweXpect.Reflection.Collections.Filtered.Types @this, System.Type baseType, bool forceDirect = false) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichInheritFrom<TBaseType>(this aweXpect.Reflection.Collections.Filtered.Types @this, bool forceDirect = false) { }
         public static aweXpect.Reflection.TypeFilters.TypesWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Types @this, bool inherit = true)
@@ -700,6 +705,22 @@ namespace aweXpect.Reflection
                 public aweXpect.Reflection.TypeFilters.GenericTypes.GenericTypesWithNamedArgument IgnoringCase(bool ignoreCase = true) { }
                 public aweXpect.Reflection.TypeFilters.GenericTypes.GenericTypesWithNamedArgument Using(System.Collections.Generic.IEqualityComparer<string> comparer) { }
             }
+        }
+        public class TypesContainingMembers : aweXpect.Reflection.Collections.Filtered.Types
+        {
+            public aweXpect.Results.CountTimesResult<aweXpect.Reflection.Collections.Filtered.Types> AtLeast() { }
+            public aweXpect.Reflection.Collections.Filtered.Types AtLeast(aweXpect.Core.Times minimum) { }
+            public aweXpect.Results.CountTimesResult<aweXpect.Reflection.Collections.Filtered.Types> AtMost() { }
+            public aweXpect.Reflection.Collections.Filtered.Types AtMost(aweXpect.Core.Times maximum) { }
+            public aweXpect.Results.BetweenResult<aweXpect.Reflection.Collections.Filtered.Types> Between(int minimum) { }
+            public aweXpect.Reflection.Collections.Filtered.Types Exactly(aweXpect.Core.Times expected) { }
+            public aweXpect.Results.CountTimesResult<aweXpect.Reflection.Collections.Filtered.Types> LessThan() { }
+            public aweXpect.Reflection.Collections.Filtered.Types LessThan(aweXpect.Core.Times maximum) { }
+            public aweXpect.Results.CountTimesResult<aweXpect.Reflection.Collections.Filtered.Types> MoreThan() { }
+            public aweXpect.Reflection.Collections.Filtered.Types MoreThan(aweXpect.Core.Times minimum) { }
+            public aweXpect.Reflection.Collections.Filtered.Types Never() { }
+            public aweXpect.Reflection.Collections.Filtered.Types Once() { }
+            public aweXpect.Reflection.Collections.Filtered.Types Twice() { }
         }
         public class TypesWith : aweXpect.Reflection.Collections.Filtered.Types
         {

--- a/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichContainConstructors.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichContainConstructors.Tests.cs
@@ -1,0 +1,50 @@
+using aweXpect.Reflection.Collections;
+
+namespace aweXpect.Reflection.Tests.Filters;
+
+public sealed partial class TypeFilters
+{
+	public sealed class WhichContainConstructors
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task ShouldFilterByMatchingConstructor()
+			{
+				Filtered.Types types = In.Types<ClassWithMarkedConstructor, UntaggedClass>()
+					.WhichContainConstructors(constructors => constructors.With<MarkerAttribute>());
+
+				await That(types).IsEqualTo([typeof(ClassWithMarkedConstructor),]).InAnyOrder();
+			}
+
+			[Fact]
+			public async Task ShouldUseTheInnerFilterDescription()
+			{
+				Filtered.Types types = In.AssemblyContaining<MarkerAttribute>().Types()
+					.WhichContainConstructors(constructors => constructors.With<MarkerAttribute>());
+
+				await That(types.GetDescription())
+					.IsEqualTo(
+						"types which contain constructors with TypeFilters.WhichContainConstructors.MarkerAttribute at least once ")
+					.AsPrefix();
+			}
+		}
+
+		[AttributeUsage(AttributeTargets.Constructor)]
+		private class MarkerAttribute : Attribute
+		{
+		}
+
+		private class ClassWithMarkedConstructor
+		{
+			[Marker]
+			public ClassWithMarkedConstructor()
+			{
+			}
+		}
+
+		private class UntaggedClass
+		{
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichContainEvents.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichContainEvents.Tests.cs
@@ -1,0 +1,52 @@
+using aweXpect.Reflection.Collections;
+
+namespace aweXpect.Reflection.Tests.Filters;
+
+public sealed partial class TypeFilters
+{
+	public sealed class WhichContainEvents
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task ShouldFilterByMatchingEvent()
+			{
+				Filtered.Types types = In.Types<ClassWithMarkedEvent, UntaggedClass>()
+					.WhichContainEvents(events => events.With<MarkerAttribute>());
+
+				await That(types).IsEqualTo([typeof(ClassWithMarkedEvent),]).InAnyOrder();
+			}
+
+			[Fact]
+			public async Task ShouldUseTheInnerFilterDescription()
+			{
+				Filtered.Types types = In.AssemblyContaining<MarkerAttribute>().Types()
+					.WhichContainEvents(events => events.With<MarkerAttribute>());
+
+				await That(types.GetDescription())
+					.IsEqualTo(
+						"types which contain events with TypeFilters.WhichContainEvents.MarkerAttribute at least once ")
+					.AsPrefix();
+			}
+		}
+
+		[AttributeUsage(AttributeTargets.Event)]
+		private class MarkerAttribute : Attribute
+		{
+		}
+
+		private class ClassWithMarkedEvent
+		{
+#pragma warning disable CS0067 // The event is never used
+			[Marker] public event EventHandler? Changed;
+#pragma warning restore CS0067
+		}
+
+		private class UntaggedClass
+		{
+#pragma warning disable CS0067 // The event is never used
+			public event EventHandler? Changed;
+#pragma warning restore CS0067
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichContainFields.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichContainFields.Tests.cs
@@ -1,0 +1,52 @@
+using aweXpect.Reflection.Collections;
+
+namespace aweXpect.Reflection.Tests.Filters;
+
+public sealed partial class TypeFilters
+{
+	public sealed class WhichContainFields
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task ShouldFilterByMatchingField()
+			{
+				Filtered.Types types = In.Types<ClassWithMarkedField, UntaggedClass>()
+					.WhichContainFields(fields => fields.With<MarkerAttribute>());
+
+				await That(types).IsEqualTo([typeof(ClassWithMarkedField),]).InAnyOrder();
+			}
+
+			[Fact]
+			public async Task ShouldUseTheInnerFilterDescription()
+			{
+				Filtered.Types types = In.AssemblyContaining<MarkerAttribute>().Types()
+					.WhichContainFields(fields => fields.With<MarkerAttribute>());
+
+				await That(types.GetDescription())
+					.IsEqualTo(
+						"types which contain fields with TypeFilters.WhichContainFields.MarkerAttribute at least once ")
+					.AsPrefix();
+			}
+		}
+
+		[AttributeUsage(AttributeTargets.Field)]
+		private class MarkerAttribute : Attribute
+		{
+		}
+
+		private class ClassWithMarkedField
+		{
+#pragma warning disable CS0649 // Field is never assigned to, and will always have its default value
+			[Marker] public int? MarkedField;
+#pragma warning restore CS0649
+		}
+
+		private class UntaggedClass
+		{
+#pragma warning disable CS0649 // Field is never assigned to, and will always have its default value
+			public int? PlainField;
+#pragma warning restore CS0649
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichContainMethods.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichContainMethods.Tests.cs
@@ -134,7 +134,7 @@ public sealed partial class TypeFilters
 		private class TaggedClass
 		{
 			[Marker]
-			public void Tagged()
+			public static void Tagged()
 			{
 			}
 		}
@@ -142,19 +142,19 @@ public sealed partial class TypeFilters
 		private class TwiceTaggedClass
 		{
 			[Marker]
-			public void TaggedOne()
+			public static void TaggedOne()
 			{
 			}
 
 			[Marker]
-			public void TaggedTwo()
+			public static void TaggedTwo()
 			{
 			}
 		}
 
 		private class UntaggedClass
 		{
-			public void Untagged()
+			public static void Untagged()
 			{
 			}
 		}
@@ -172,7 +172,7 @@ public sealed partial class TypeFilters
 			}
 
 			[Marker]
-			public void Method()
+			public static void Method()
 			{
 			}
 		}
@@ -185,7 +185,7 @@ public sealed partial class TypeFilters
 			}
 
 			[Marker]
-			public void Method()
+			public static void Method()
 			{
 			}
 		}
@@ -202,7 +202,7 @@ public sealed partial class TypeFilters
 			{
 			}
 
-			public void Method()
+			public static void Method()
 			{
 			}
 		}

--- a/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichContainMethods.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichContainMethods.Tests.cs
@@ -1,0 +1,210 @@
+using aweXpect.Reflection.Collections;
+using Xunit.Sdk;
+
+namespace aweXpect.Reflection.Tests.Filters;
+
+public sealed partial class TypeFilters
+{
+	public sealed class WhichContainMethods
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task AtMost_ShouldFilterForTypesWithAtMostTheCount()
+			{
+				Filtered.Types types = In.Types<TaggedClass, TwiceTaggedClass, UntaggedClass>()
+					.WhichContainMethods(methods => methods.With<MarkerAttribute>()).AtMost(1);
+
+				await That(types).IsEqualTo([typeof(TaggedClass), typeof(UntaggedClass),]).InAnyOrder();
+			}
+
+			[Fact]
+			public async Task Between_ShouldFilterForTypesWithinTheRange()
+			{
+				Filtered.Types types = In.Types<TaggedClass, TwiceTaggedClass, UntaggedClass>()
+					.WhichContainMethods(methods => methods.With<MarkerAttribute>()).Between(1).And(2);
+
+				await That(types).IsEqualTo([typeof(TaggedClass), typeof(TwiceTaggedClass),]).InAnyOrder();
+			}
+
+			[Fact]
+			public async Task ByDefault_ShouldFilterForTypesContainingAtLeastOneMatchingMethod()
+			{
+				Filtered.Types types = In.Types<TaggedClass, TwiceTaggedClass, UntaggedClass>()
+					.WhichContainMethods(methods => methods.With<MarkerAttribute>());
+
+				await That(types).IsEqualTo([typeof(TaggedClass), typeof(TwiceTaggedClass),]).InAnyOrder();
+			}
+
+			[Fact]
+			public async Task ChainedConditions_ShouldApplyTheQuantifierOnlyToTheLastCondition()
+			{
+				// Methods: implicitly "at least once"; Constructors: "exactly twice".
+				Filtered.Types types =
+					In.Types<ClassWith1Method2Constructors, ClassWith1Method1Constructor,
+							ClassWith0Methods2Constructors>()
+						.WhichContainMethods(methods => methods.With<MarkerAttribute>())
+						.WhichContainConstructors(constructors => constructors.With<MarkerAttribute>()).Exactly(2);
+
+				await That(types).IsEqualTo([typeof(ClassWith1Method2Constructors),]).InAnyOrder();
+			}
+
+			[Fact]
+			public async Task ChainedConditions_ShouldDescribeEachConditionWithItsOwnQuantifier()
+			{
+				Filtered.Types types = In.AssemblyContaining<MarkerAttribute>().Types()
+					.WhichContainMethods(methods => methods.With<MarkerAttribute>())
+					.WhichContainConstructors(constructors => constructors.With<MarkerAttribute>()).Exactly(2);
+
+				await That(types.GetDescription())
+					.IsEqualTo(
+						"types which contain methods with TypeFilters.WhichContainMethods.MarkerAttribute at least once which contain constructors with TypeFilters.WhichContainMethods.MarkerAttribute exactly twice ")
+					.AsPrefix();
+			}
+
+			[Fact]
+			public async Task Exactly_ShouldFilterForTypesWithTheExactCount()
+			{
+				Filtered.Types types = In.Types<TaggedClass, TwiceTaggedClass, UntaggedClass>()
+					.WhichContainMethods(methods => methods.With<MarkerAttribute>()).Exactly(2);
+
+				await That(types).IsEqualTo([typeof(TwiceTaggedClass),]).InAnyOrder();
+			}
+
+			[Fact]
+			public async Task Never_ShouldFilterForTypesWithoutAMatchingMethod()
+			{
+				Filtered.Types types = In.Types<TaggedClass, TwiceTaggedClass, UntaggedClass>()
+					.WhichContainMethods(methods => methods.With<MarkerAttribute>()).Never();
+
+				await That(types).IsEqualTo([typeof(UntaggedClass),]).InAnyOrder();
+			}
+
+			[Fact]
+			public async Task Quantifier_ShouldBeReflectedInTheDescription()
+			{
+				Filtered.Types types = In.AssemblyContaining<MarkerAttribute>().Types()
+					.WhichContainMethods(methods => methods.With<MarkerAttribute>()).Exactly(3);
+
+				await That(types.GetDescription())
+					.IsEqualTo(
+						"types which contain methods with TypeFilters.WhichContainMethods.MarkerAttribute exactly 3 times ")
+					.AsPrefix();
+			}
+
+			[Fact]
+			public async Task ShouldReadNaturallyInAFailingExpectation()
+			{
+				async Task Act()
+				{
+					await That(In.Types<TaggedClass, UntaggedClass>()
+							.WhichContainMethods(methods => methods.With<MarkerAttribute>()))
+						.HaveName("Tests").AsSuffix();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage(
+						"Expected that in types * which contain methods with TypeFilters.WhichContainMethods.MarkerAttribute at least once *all have name ending with \"Tests\"*")
+					.AsWildcard();
+			}
+
+			[Fact]
+			public async Task ShouldUseTheInnerFilterDescriptionWithTheDefaultQuantifier()
+			{
+				Filtered.Types types = In.AssemblyContaining<MarkerAttribute>().Types()
+					.WhichContainMethods(methods => methods.With<MarkerAttribute>().OrWith<OtherAttribute>());
+
+				await That(types.GetDescription())
+					.IsEqualTo(
+						"types which contain methods with TypeFilters.WhichContainMethods.MarkerAttribute or with TypeFilters.WhichContainMethods.OtherAttribute at least once ")
+					.AsPrefix();
+			}
+		}
+
+		[AttributeUsage(AttributeTargets.All)]
+		private class MarkerAttribute : Attribute
+		{
+		}
+
+		[AttributeUsage(AttributeTargets.Method)]
+		private class OtherAttribute : Attribute
+		{
+		}
+
+		private class TaggedClass
+		{
+			[Marker]
+			public void Tagged()
+			{
+			}
+		}
+
+		private class TwiceTaggedClass
+		{
+			[Marker]
+			public void TaggedOne()
+			{
+			}
+
+			[Marker]
+			public void TaggedTwo()
+			{
+			}
+		}
+
+		private class UntaggedClass
+		{
+			public void Untagged()
+			{
+			}
+		}
+
+		private class ClassWith1Method2Constructors
+		{
+			[Marker]
+			public ClassWith1Method2Constructors()
+			{
+			}
+
+			[Marker]
+			public ClassWith1Method2Constructors(int value)
+			{
+			}
+
+			[Marker]
+			public void Method()
+			{
+			}
+		}
+
+		private class ClassWith1Method1Constructor
+		{
+			[Marker]
+			public ClassWith1Method1Constructor()
+			{
+			}
+
+			[Marker]
+			public void Method()
+			{
+			}
+		}
+
+		private class ClassWith0Methods2Constructors
+		{
+			[Marker]
+			public ClassWith0Methods2Constructors()
+			{
+			}
+
+			[Marker]
+			public ClassWith0Methods2Constructors(int value)
+			{
+			}
+
+			public void Method()
+			{
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichContainProperties.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichContainProperties.Tests.cs
@@ -1,0 +1,57 @@
+using aweXpect.Reflection.Collections;
+
+namespace aweXpect.Reflection.Tests.Filters;
+
+public sealed partial class TypeFilters
+{
+	public sealed class WhichContainProperties
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task ShouldFilterByMatchingProperty()
+			{
+				Filtered.Types types = In.Types<ClassWithMarkedProperty, UntaggedClass>()
+					.WhichContainProperties(properties => properties.With<MarkerAttribute>());
+
+				await That(types).IsEqualTo([typeof(ClassWithMarkedProperty),]).InAnyOrder();
+			}
+
+			[Fact]
+			public async Task ShouldSupportQuantifiers()
+			{
+				Filtered.Types types = In.Types<ClassWithMarkedProperty, UntaggedClass>()
+					.WhichContainProperties(properties => properties.With<MarkerAttribute>()).Never();
+
+				await That(types).IsEqualTo([typeof(UntaggedClass),]).InAnyOrder();
+			}
+
+			[Fact]
+			public async Task ShouldUseTheInnerFilterDescription()
+			{
+				Filtered.Types types = In.AssemblyContaining<MarkerAttribute>().Types()
+					.WhichContainProperties(properties => properties.With<MarkerAttribute>());
+
+				await That(types.GetDescription())
+					.IsEqualTo(
+						"types which contain properties with TypeFilters.WhichContainProperties.MarkerAttribute at least once ")
+					.AsPrefix();
+			}
+		}
+
+		[AttributeUsage(AttributeTargets.Property)]
+		private class MarkerAttribute : Attribute
+		{
+		}
+
+		private class ClassWithMarkedProperty
+		{
+			[Marker] public int Id { get; set; }
+		}
+
+		private class UntaggedClass
+		{
+			public int Id { get; set; }
+		}
+	}
+}


### PR DESCRIPTION
Add WhichContainMethods, WhichContainProperties, WhichContainFields, WhichContainEvents and WhichContainConstructors extensions on Filtered.Types to select types based on the members they contain. The lambda receives the members declared on each type and may use the full member-filter DSL.

The returned TypesContainingMembers exposes the same quantifier surface as aweXpect (Exactly, AtLeast, AtMost, MoreThan, LessThan, Between(...).And(...), Never, Once, Twice); by default a type matches when it contains at least one matching member. Each quantifier applies only to the condition it directly follows.

Document the new filters in the README and regenerate the public API approval files.