### PR TITLE
refactor: extract fluent-builder state out of Filtered.Types/Assemblies

### DIFF
--- a/Source/aweXpect.Reflection/Collections/AssembliesAbstractSealedBuilder.cs
+++ b/Source/aweXpect.Reflection/Collections/AssembliesAbstractSealedBuilder.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using aweXpect.Reflection.Helpers;
+
+namespace aweXpect.Reflection.Collections;
+
+internal sealed class AssembliesAbstractSealedBuilder
+	: ILimitedAbstractSealedTypeAssemblies<ILimitedAbstractSealedTypeAssemblies>
+{
+	private readonly MemberFilterState _memberState;
+	private readonly Filtered.Assemblies _source;
+	private readonly string _typeFilterDescription;
+	private readonly List<Func<Type, bool>> _typeFilters;
+
+	internal AssembliesAbstractSealedBuilder(
+		Filtered.Assemblies source,
+		MemberFilterState memberState,
+		List<Func<Type, bool>> typeFilters,
+		string typeFilterDescription)
+	{
+		_source = source;
+		_memberState = memberState;
+		_typeFilters = typeFilters;
+		_typeFilterDescription = typeFilterDescription;
+	}
+
+	public ILimitedAbstractSealedTypeAssemblies Generic
+		=> AppendTypeFilter(t => t.IsGenericType, "generic ");
+
+	public ILimitedAbstractSealedTypeAssemblies Nested
+		=> AppendTypeFilter(t => t.IsNested, "nested ");
+
+	public Filtered.Types Types(AccessModifiers accessModifier = AccessModifiers.Any)
+		=> BuildTypes(_typeFilters, _typeFilterDescription, accessModifier, "types ");
+
+	public Filtered.Types Classes(AccessModifiers accessModifier = AccessModifiers.Any)
+		=> BuildTypes(AppendFilter(t => t.IsReallyClass()), _typeFilterDescription, accessModifier, "classes ");
+
+	public Filtered.Types Records(AccessModifiers accessModifier = AccessModifiers.Any)
+		=> BuildTypes(AppendFilter(t => t.IsRecordClass()), _typeFilterDescription, accessModifier, "records ");
+
+	// Member selectors below intentionally do NOT apply _typeFilters to the source type set:
+	// `assemblies.Sealed.Methods()` returns sealed methods on ALL types in the assembly, not
+	// methods on sealed types. This matches pre-refactor behavior; tracked as a separate concern.
+	public Filtered.Events Events()
+	{
+		Filtered.Events events = new(new Filtered.Types(_source, ""), "events ");
+		IFilter<EventInfo>? filter = _memberState.BuildEventFilter();
+		return filter is null ? events : events.Which(filter);
+	}
+
+	public Filtered.Methods Methods()
+	{
+		Filtered.Methods methods = new(new Filtered.Types(_source, ""), "methods ");
+		IFilter<MethodInfo>? filter = _memberState.BuildMethodFilter();
+		return filter is null ? methods : methods.Which(filter);
+	}
+
+	public Filtered.Properties Properties()
+	{
+		Filtered.Properties properties = new(new Filtered.Types(_source, ""), "properties ");
+		IFilter<PropertyInfo>? filter = _memberState.BuildPropertyFilter();
+		return filter is null ? properties : properties.Which(filter);
+	}
+
+	private AssembliesAbstractSealedBuilder AppendTypeFilter(Func<Type, bool> predicate, string descriptionAppend)
+		=> new(
+			_source,
+			_memberState,
+			AppendFilter(predicate),
+			_typeFilterDescription + descriptionAppend);
+
+	private List<Func<Type, bool>> AppendFilter(Func<Type, bool> predicate)
+	{
+		List<Func<Type, bool>> newFilters = new(_typeFilters.Count + 1);
+		newFilters.AddRange(_typeFilters);
+		newFilters.Add(predicate);
+		return newFilters;
+	}
+
+	private Filtered.Types BuildTypes(
+		List<Func<Type, bool>> typeFilters,
+		string typeFilterDescription,
+		AccessModifiers accessModifier,
+		string typeDescription)
+	{
+		AccessModifiers? implicitAccess = _memberState.AccessModifier;
+		if (implicitAccess is not null)
+		{
+			List<Func<Type, bool>> withImplicit = new(typeFilters.Count + 1);
+			withImplicit.AddRange(typeFilters);
+			withImplicit.Add(t => t.HasAccessModifier(implicitAccess.Value));
+			typeFilters = withImplicit;
+			typeFilterDescription += implicitAccess.Value.GetString(" ");
+		}
+
+		if (accessModifier != AccessModifiers.Any)
+		{
+			List<Func<Type, bool>> withExplicit = new(typeFilters.Count + 1);
+			withExplicit.AddRange(typeFilters);
+			withExplicit.Add(t => t.HasAccessModifier(accessModifier));
+			typeFilters = withExplicit;
+			typeFilterDescription = accessModifier.GetString(" ") + typeFilterDescription;
+		}
+
+		Filtered.Types result = new(_source, typeDescription);
+		List<Func<Type, bool>> filters = typeFilters;
+		return result.Which(Filter.Prefix<Type>(
+			type => filters.All(predicate => predicate.Invoke(type)),
+			typeFilterDescription));
+	}
+}

--- a/Source/aweXpect.Reflection/Collections/AssembliesTypeBuilder.cs
+++ b/Source/aweXpect.Reflection/Collections/AssembliesTypeBuilder.cs
@@ -1,0 +1,180 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using aweXpect.Reflection.Helpers;
+
+namespace aweXpect.Reflection.Collections;
+
+internal sealed class AssembliesTypeBuilder :
+	ITypeAssemblies.IPrivate,
+	ITypeAssemblies.IProtected
+{
+	private readonly MemberFilterState _memberState;
+	private readonly Filtered.Assemblies _source;
+	private readonly string _typeFilterDescription;
+	private readonly List<Func<Type, bool>> _typeFilters;
+
+	internal AssembliesTypeBuilder(
+		Filtered.Assemblies source,
+		MemberFilterState memberState,
+		List<Func<Type, bool>> typeFilters,
+		string typeFilterDescription)
+	{
+		_source = source;
+		_memberState = memberState;
+		_typeFilters = typeFilters;
+		_typeFilterDescription = typeFilterDescription;
+	}
+
+	public ITypeAssemblies Generic => AppendTypeFilter(t => t.IsGenericType, "generic ");
+
+	public ITypeAssemblies Nested => AppendTypeFilter(t => t.IsNested, "nested ");
+
+	public ILimitedAbstractSealedTypeAssemblies<ILimitedAbstractSealedTypeAssemblies> Abstract
+		=> new AssembliesAbstractSealedBuilder(
+			_source,
+			_memberState.WithAbstract(),
+			AppendFilter(t => t.IsReallyAbstract()),
+			_typeFilterDescription + "abstract ");
+
+	public ILimitedAbstractSealedTypeAssemblies<ILimitedAbstractSealedTypeAssemblies> Sealed
+		=> new AssembliesAbstractSealedBuilder(
+			_source,
+			_memberState.WithSealed(),
+			AppendFilter(t => t.IsReallySealed()),
+			_typeFilterDescription + "sealed ");
+
+	public ILimitedStaticTypeAssemblies<ILimitedStaticTypeAssemblies> Static
+		=> new AssembliesTypeBuilder(
+			_source,
+			_memberState.WithStatic(),
+			AppendFilter(t => t.IsReallyStatic()),
+			_typeFilterDescription + "static ");
+
+	ITypeAssemblies ITypeAssemblies.IPrivate.Protected
+		=> new AssembliesTypeBuilder(
+			_source,
+			_memberState.WithAccess(AccessModifiers.PrivateProtected),
+			_typeFilters,
+			_typeFilterDescription);
+
+	ITypeAssemblies ITypeAssemblies.IProtected.Internal
+		=> new AssembliesTypeBuilder(
+			_source,
+			_memberState.WithAccess(AccessModifiers.ProtectedInternal),
+			_typeFilters,
+			_typeFilterDescription);
+
+	public Filtered.Types Types(AccessModifiers accessModifier = AccessModifiers.Any)
+		=> BuildTypes(_typeFilters, _typeFilterDescription, accessModifier, "types ", includeWhenEmpty: false);
+
+	public Filtered.Types Classes(AccessModifiers accessModifier = AccessModifiers.Any)
+		=> BuildTypes(AppendFilter(t => t.IsReallyClass()), _typeFilterDescription, accessModifier, "classes ");
+
+	public Filtered.Types Records(AccessModifiers accessModifier = AccessModifiers.Any)
+		=> BuildTypes(AppendFilter(t => t.IsRecordClass()), _typeFilterDescription, accessModifier, "records ");
+
+	public Filtered.Types RecordStructs(AccessModifiers accessModifier = AccessModifiers.Any)
+		=> BuildTypes(AppendFilter(t => t.IsRecordStruct()), _typeFilterDescription, accessModifier, "record structs ");
+
+	public Filtered.Types Structs(AccessModifiers accessModifier = AccessModifiers.Any)
+		=> BuildTypes(AppendFilter(t => t.IsReallyStruct()), _typeFilterDescription, accessModifier, "structs ");
+
+	public Filtered.Types Interfaces(AccessModifiers accessModifier = AccessModifiers.Any)
+		=> BuildTypes(AppendFilter(t => t.IsInterface), _typeFilterDescription, accessModifier, "interfaces ");
+
+	public Filtered.Types Enums(AccessModifiers accessModifier = AccessModifiers.Any)
+		=> BuildTypes(AppendFilter(t => t.IsEnum), _typeFilterDescription, accessModifier, "enums ");
+
+	// Member selectors below intentionally do NOT apply _typeFilters to the source type set:
+	// `assemblies.Static.Methods()` returns static methods on ALL types in the assembly, not
+	// methods on static types. This matches pre-refactor behavior; tracked as a separate concern.
+	public Filtered.Constructors Constructors()
+	{
+		Filtered.Constructors constructors = new(new Filtered.Types(_source, ""), "constructors ");
+		IFilter<ConstructorInfo>? filter = _memberState.BuildConstructorFilter();
+		return filter is null ? constructors : constructors.Which(filter);
+	}
+
+	public Filtered.Events Events()
+	{
+		Filtered.Events events = new(new Filtered.Types(_source, ""), "events ");
+		IFilter<EventInfo>? filter = _memberState.BuildEventFilter();
+		return filter is null ? events : events.Which(filter);
+	}
+
+	public Filtered.Fields Fields()
+	{
+		Filtered.Fields fields = new(new Filtered.Types(_source, ""), "fields ");
+		IFilter<FieldInfo>? filter = _memberState.BuildFieldFilter();
+		return filter is null ? fields : fields.Which(filter);
+	}
+
+	public Filtered.Methods Methods()
+	{
+		Filtered.Methods methods = new(new Filtered.Types(_source, ""), "methods ");
+		IFilter<MethodInfo>? filter = _memberState.BuildMethodFilter();
+		return filter is null ? methods : methods.Which(filter);
+	}
+
+	public Filtered.Properties Properties()
+	{
+		Filtered.Properties properties = new(new Filtered.Types(_source, ""), "properties ");
+		IFilter<PropertyInfo>? filter = _memberState.BuildPropertyFilter();
+		return filter is null ? properties : properties.Which(filter);
+	}
+
+	private AssembliesTypeBuilder AppendTypeFilter(Func<Type, bool> predicate, string descriptionAppend)
+		=> new(
+			_source,
+			_memberState,
+			AppendFilter(predicate),
+			_typeFilterDescription + descriptionAppend);
+
+	private List<Func<Type, bool>> AppendFilter(Func<Type, bool> predicate)
+	{
+		List<Func<Type, bool>> newFilters = new(_typeFilters.Count + 1);
+		newFilters.AddRange(_typeFilters);
+		newFilters.Add(predicate);
+		return newFilters;
+	}
+
+	private Filtered.Types BuildTypes(
+		List<Func<Type, bool>> typeFilters,
+		string typeFilterDescription,
+		AccessModifiers accessModifier,
+		string typeDescription,
+		bool includeWhenEmpty = true)
+	{
+		AccessModifiers? implicitAccess = _memberState.AccessModifier;
+		if (implicitAccess is not null)
+		{
+			List<Func<Type, bool>> withImplicit = new(typeFilters.Count + 1);
+			withImplicit.AddRange(typeFilters);
+			withImplicit.Add(t => t.HasAccessModifier(implicitAccess.Value));
+			typeFilters = withImplicit;
+			typeFilterDescription += implicitAccess.Value.GetString(" ");
+		}
+
+		if (accessModifier != AccessModifiers.Any)
+		{
+			List<Func<Type, bool>> withExplicit = new(typeFilters.Count + 1);
+			withExplicit.AddRange(typeFilters);
+			withExplicit.Add(t => t.HasAccessModifier(accessModifier));
+			typeFilters = withExplicit;
+			typeFilterDescription = accessModifier.GetString(" ") + typeFilterDescription;
+		}
+
+		Filtered.Types result = new(_source, typeDescription);
+		if (typeFilters.Count == 0 && !includeWhenEmpty)
+		{
+			return result;
+		}
+
+		List<Func<Type, bool>> filters = typeFilters;
+		return result.Which(Filter.Prefix<Type>(
+			type => filters.All(predicate => predicate.Invoke(type)),
+			typeFilterDescription));
+	}
+}

--- a/Source/aweXpect.Reflection/Collections/Filtered.Assemblies.cs
+++ b/Source/aweXpect.Reflection/Collections/Filtered.Assemblies.cs
@@ -5,7 +5,6 @@ using System.Reflection;
 using System.Text.RegularExpressions;
 using aweXpect.Core;
 using aweXpect.Options;
-using aweXpect.Reflection.Helpers;
 
 // ReSharper disable MemberHidesStaticFromOuterClass
 
@@ -22,9 +21,6 @@ public static partial class Filtered
 		ITypeAssemblies.IPrivate
 	{
 		private readonly string _description;
-		private readonly MemberFilterState _memberState = new();
-		private readonly List<Func<Type, bool>> _typeFilters = [];
-		private string? _typeFilterDescription;
 
 		/// <summary>
 		///     Container for a filterable collection of <see cref="Assembly" />.
@@ -62,50 +58,49 @@ public static partial class Filtered
 		/// <summary>
 		///     Filters for public types.
 		/// </summary>
-		public ITypeAssemblies Public
-		{
-			get
-			{
-				_memberState.SetAccess(AccessModifiers.Public);
-				return this;
-			}
-		}
+		public ITypeAssemblies Public => NewBuilder(MemberFilterState.Empty.WithAccess(AccessModifiers.Public));
 
 		/// <summary>
 		///     Filters for private types.
 		/// </summary>
-		public ITypeAssemblies.IPrivate Private
-		{
-			get
-			{
-				_memberState.SetAccess(AccessModifiers.Private);
-				return this;
-			}
-		}
+		public ITypeAssemblies.IPrivate Private => NewBuilder(MemberFilterState.Empty.WithAccess(AccessModifiers.Private));
 
 		/// <summary>
 		///     Filters for protected types.
 		/// </summary>
 		public ITypeAssemblies.IProtected Protected
-		{
-			get
-			{
-				_memberState.SetAccess(AccessModifiers.Protected);
-				return this;
-			}
-		}
+			=> NewBuilder(MemberFilterState.Empty.WithAccess(AccessModifiers.Protected));
 
 		/// <summary>
 		///     Filters for internal types.
 		/// </summary>
-		public ITypeAssemblies Internal
-		{
-			get
-			{
-				_memberState.SetAccess(AccessModifiers.Internal);
-				return this;
-			}
-		}
+		public ITypeAssemblies Internal => NewBuilder(MemberFilterState.Empty.WithAccess(AccessModifiers.Internal));
+
+		/// <inheritdoc cref="ITypeAssemblies.Abstract" />
+		public ILimitedAbstractSealedTypeAssemblies<ILimitedAbstractSealedTypeAssemblies> Abstract
+			=> NewBuilder(MemberFilterState.Empty).Abstract;
+
+		/// <inheritdoc cref="ITypeAssemblies.Sealed" />
+		public ILimitedAbstractSealedTypeAssemblies<ILimitedAbstractSealedTypeAssemblies> Sealed
+			=> NewBuilder(MemberFilterState.Empty).Sealed;
+
+		/// <inheritdoc cref="ITypeAssemblies.Static" />
+		public ILimitedStaticTypeAssemblies<ILimitedStaticTypeAssemblies> Static
+			=> NewBuilder(MemberFilterState.Empty).Static;
+
+		/// <inheritdoc cref="ILimitedStaticTypeAssemblies{TLimitedTypeAssemblies}.Generic" />
+		public ITypeAssemblies Generic => NewBuilder(MemberFilterState.Empty).Generic;
+
+		/// <inheritdoc cref="ILimitedStaticTypeAssemblies{TLimitedTypeAssemblies}.Nested" />
+		public ITypeAssemblies Nested => NewBuilder(MemberFilterState.Empty).Nested;
+
+		/// <inheritdoc cref="ITypeAssemblies.IPrivate.Protected" />
+		ITypeAssemblies ITypeAssemblies.IPrivate.Protected
+			=> NewBuilder(MemberFilterState.Empty.WithAccess(AccessModifiers.PrivateProtected));
+
+		/// <inheritdoc cref="ITypeAssemblies.IProtected.Internal" />
+		ITypeAssemblies ITypeAssemblies.IProtected.Internal
+			=> NewBuilder(MemberFilterState.Empty.WithAccess(AccessModifiers.ProtectedInternal));
 
 		/// <inheritdoc />
 		public string GetDescription()
@@ -119,307 +114,51 @@ public static partial class Filtered
 			return description;
 		}
 
-		/// <inheritdoc cref="ITypeAssemblies.IPrivate.Protected" />
-		ITypeAssemblies ITypeAssemblies.IPrivate.Protected
-		{
-			get
-			{
-				_memberState.SetAccess(AccessModifiers.PrivateProtected);
-				return this;
-			}
-		}
-
-		/// <inheritdoc cref="ITypeAssemblies.IProtected.Internal" />
-		ITypeAssemblies ITypeAssemblies.IProtected.Internal
-		{
-			get
-			{
-				_memberState.SetAccess(AccessModifiers.ProtectedInternal);
-				return this;
-			}
-		}
-
-		/// <inheritdoc cref="ITypeAssemblies.Abstract" />
-		public ILimitedAbstractSealedTypeAssemblies<ILimitedAbstractSealedTypeAssemblies> Abstract
-		{
-			get
-			{
-				_typeFilterDescription = (_typeFilterDescription ?? "") + "abstract ";
-				_typeFilters.Add(type => type.IsReallyAbstract());
-				_memberState.SetAbstract();
-				return new LimitedAbstractSealedAssemblies(this);
-			}
-		}
-
-		/// <inheritdoc cref="ITypeAssemblies.Sealed" />
-		public ILimitedAbstractSealedTypeAssemblies<ILimitedAbstractSealedTypeAssemblies> Sealed
-		{
-			get
-			{
-				_typeFilterDescription = (_typeFilterDescription ?? "") + "sealed ";
-				_typeFilters.Add(type => type.IsReallySealed());
-				_memberState.SetSealed();
-				return new LimitedAbstractSealedAssemblies(this);
-			}
-		}
-
-		/// <inheritdoc cref="ITypeAssemblies.Static" />
-		public ILimitedStaticTypeAssemblies<ILimitedStaticTypeAssemblies> Static
-		{
-			get
-			{
-				_typeFilterDescription = (_typeFilterDescription ?? "") + "static ";
-				_typeFilters.Add(type => type.IsReallyStatic());
-				_memberState.SetStatic();
-				return this;
-			}
-		}
-
-		/// <inheritdoc cref="ILimitedStaticTypeAssemblies{TLimitedTypeAssemblies}.Generic" />
-		public ITypeAssemblies Generic
-		{
-			get
-			{
-				_typeFilterDescription = (_typeFilterDescription ?? "") + "generic ";
-				_typeFilters.Add(type => type.IsGenericType);
-				return this;
-			}
-		}
-
-		/// <inheritdoc cref="ILimitedStaticTypeAssemblies{TLimitedTypeAssemblies}.Nested" />
-		public ITypeAssemblies Nested
-		{
-			get
-			{
-				_typeFilterDescription = (_typeFilterDescription ?? "") + "nested ";
-				_typeFilters.Add(type => type.IsNested);
-				return this;
-			}
-		}
-
 		/// <inheritdoc cref="ILimitedStaticTypeAssemblies.Types(AccessModifiers)" />
 		public Types Types(AccessModifiers accessModifier = AccessModifiers.Any)
-		{
-			AccessModifiers? implicitAccess = _memberState.AccessModifier;
-			if (implicitAccess is not null)
-			{
-				_typeFilters.Add(type => type.HasAccessModifier(implicitAccess.Value));
-				_typeFilterDescription = (_typeFilterDescription ?? "") + implicitAccess.Value.GetString(" ");
-			}
-
-			_memberState.Reset();
-
-			if (accessModifier != AccessModifiers.Any)
-			{
-				_typeFilters.Add(type => type.HasAccessModifier(accessModifier));
-				_typeFilterDescription = accessModifier.GetString(" ") + (_typeFilterDescription ?? "");
-			}
-
-			if (_typeFilters.Any())
-			{
-				return new Types(this, "types ")
-					.Which(Filter.Prefix<Type>(
-						type => _typeFilters.All(predicate => predicate.Invoke(type)),
-						_typeFilterDescription ?? ""));
-			}
-
-			return new Types(this, "types ");
-		}
+			=> NewBuilder(MemberFilterState.Empty).Types(accessModifier);
 
 		/// <inheritdoc cref="ILimitedStaticTypeAssemblies.Classes(AccessModifiers)" />
 		public Types Classes(AccessModifiers accessModifier = AccessModifiers.Any)
-		{
-			_typeFilters.Add(type => type.IsReallyClass());
-			AccessModifiers? implicitAccess = _memberState.AccessModifier;
-			if (implicitAccess is not null)
-			{
-				_typeFilters.Add(type => type.HasAccessModifier(implicitAccess.Value));
-				_typeFilterDescription = (_typeFilterDescription ?? "") + implicitAccess.Value.GetString(" ");
-			}
-
-			_memberState.Reset();
-
-			if (accessModifier != AccessModifiers.Any)
-			{
-				_typeFilters.Add(type => type.HasAccessModifier(accessModifier));
-				_typeFilterDescription = accessModifier.GetString(" ") + (_typeFilterDescription ?? "");
-			}
-
-			return new Types(this, "classes ")
-				.Which(Filter.Prefix<Type>(
-					type => _typeFilters.All(predicate => predicate.Invoke(type)),
-					_typeFilterDescription ?? ""));
-		}
+			=> NewBuilder(MemberFilterState.Empty).Classes(accessModifier);
 
 		/// <inheritdoc cref="ILimitedAbstractSealedTypeAssemblies.Records(AccessModifiers)" />
 		public Types Records(AccessModifiers accessModifier = AccessModifiers.Any)
-		{
-			_typeFilters.Add(type => type.IsRecordClass());
-			AccessModifiers? implicitAccess = _memberState.AccessModifier;
-			if (implicitAccess is not null)
-			{
-				_typeFilters.Add(type => type.HasAccessModifier(implicitAccess.Value));
-				_typeFilterDescription = (_typeFilterDescription ?? "") + implicitAccess.Value.GetString(" ");
-			}
-
-			_memberState.Reset();
-
-			if (accessModifier != AccessModifiers.Any)
-			{
-				_typeFilters.Add(type => type.HasAccessModifier(accessModifier));
-				_typeFilterDescription = accessModifier.GetString(" ") + (_typeFilterDescription ?? "");
-			}
-
-			return new Types(this, "records ")
-				.Which(Filter.Prefix<Type>(
-					type => _typeFilters.All(predicate => predicate.Invoke(type)),
-					_typeFilterDescription ?? ""));
-		}
+			=> NewBuilder(MemberFilterState.Empty).Records(accessModifier);
 
 		/// <inheritdoc cref="ITypeAssemblies.RecordStructs(AccessModifiers)" />
 		public Types RecordStructs(AccessModifiers accessModifier = AccessModifiers.Any)
-		{
-			_typeFilters.Add(type => type.IsRecordStruct());
-			AccessModifiers? implicitAccess = _memberState.AccessModifier;
-			if (implicitAccess is not null)
-			{
-				_typeFilters.Add(type => type.HasAccessModifier(implicitAccess.Value));
-				_typeFilterDescription = (_typeFilterDescription ?? "") + implicitAccess.Value.GetString(" ");
-			}
-
-			_memberState.Reset();
-
-			if (accessModifier != AccessModifiers.Any)
-			{
-				_typeFilters.Add(type => type.HasAccessModifier(accessModifier));
-				_typeFilterDescription = accessModifier.GetString(" ") + (_typeFilterDescription ?? "");
-			}
-
-			return new Types(this, "record structs ")
-				.Which(Filter.Prefix<Type>(
-					type => _typeFilters.All(predicate => predicate.Invoke(type)),
-					_typeFilterDescription ?? ""));
-		}
+			=> NewBuilder(MemberFilterState.Empty).RecordStructs(accessModifier);
 
 		/// <inheritdoc cref="ITypeAssemblies.Structs(AccessModifiers)" />
 		public Types Structs(AccessModifiers accessModifier = AccessModifiers.Any)
-		{
-			_typeFilters.Add(type => type.IsReallyStruct());
-			AccessModifiers? implicitAccess = _memberState.AccessModifier;
-			if (implicitAccess is not null)
-			{
-				_typeFilters.Add(type => type.HasAccessModifier(implicitAccess.Value));
-				_typeFilterDescription = (_typeFilterDescription ?? "") + implicitAccess.Value.GetString(" ");
-			}
-
-			_memberState.Reset();
-
-			if (accessModifier != AccessModifiers.Any)
-			{
-				_typeFilters.Add(type => type.HasAccessModifier(accessModifier));
-				_typeFilterDescription = accessModifier.GetString(" ") + (_typeFilterDescription ?? "");
-			}
-
-			return new Types(this, "structs ")
-				.Which(Filter.Prefix<Type>(
-					type => _typeFilters.All(predicate => predicate.Invoke(type)),
-					_typeFilterDescription ?? ""));
-		}
+			=> NewBuilder(MemberFilterState.Empty).Structs(accessModifier);
 
 		/// <inheritdoc cref="ITypeAssemblies.Interfaces(AccessModifiers)" />
 		public Types Interfaces(AccessModifiers accessModifier = AccessModifiers.Any)
-		{
-			_typeFilters.Add(type => type.IsInterface);
-			AccessModifiers? implicitAccess = _memberState.AccessModifier;
-			if (implicitAccess is not null)
-			{
-				_typeFilters.Add(type => type.HasAccessModifier(implicitAccess.Value));
-				_typeFilterDescription = (_typeFilterDescription ?? "") + implicitAccess.Value.GetString(" ");
-			}
-
-			_memberState.Reset();
-
-			if (accessModifier != AccessModifiers.Any)
-			{
-				_typeFilters.Add(type => type.HasAccessModifier(accessModifier));
-				_typeFilterDescription = accessModifier.GetString(" ") + (_typeFilterDescription ?? "");
-			}
-
-			return new Types(this, "interfaces ")
-				.Which(Filter.Prefix<Type>(
-					type => _typeFilters.All(predicate => predicate.Invoke(type)),
-					_typeFilterDescription ?? ""));
-		}
+			=> NewBuilder(MemberFilterState.Empty).Interfaces(accessModifier);
 
 		/// <inheritdoc cref="ITypeAssemblies.Enums(AccessModifiers)" />
 		public Types Enums(AccessModifiers accessModifier = AccessModifiers.Any)
-		{
-			_typeFilters.Add(type => type.IsEnum);
-			AccessModifiers? implicitAccess = _memberState.AccessModifier;
-			if (implicitAccess is not null)
-			{
-				_typeFilters.Add(type => type.HasAccessModifier(implicitAccess.Value));
-				_typeFilterDescription = (_typeFilterDescription ?? "") + implicitAccess.Value.GetString(" ");
-			}
-
-			_memberState.Reset();
-
-			if (accessModifier != AccessModifiers.Any)
-			{
-				_typeFilters.Add(type => type.HasAccessModifier(accessModifier));
-				_typeFilterDescription = accessModifier.GetString(" ") + (_typeFilterDescription ?? "");
-			}
-
-			return new Types(this, "enums ")
-				.Which(Filter.Prefix<Type>(
-					type => _typeFilters.All(predicate => predicate.Invoke(type)),
-					_typeFilterDescription ?? ""));
-		}
+			=> NewBuilder(MemberFilterState.Empty).Enums(accessModifier);
 
 		/// <inheritdoc cref="ILimitedStaticTypeAssemblies.Constructors()" />
-		public Constructors Constructors()
-		{
-			Constructors constructors = new(new Types(this, ""), "constructors ");
-			IFilter<ConstructorInfo>? filter = _memberState.BuildConstructorFilter();
-			_memberState.Reset();
-			return filter is null ? constructors : constructors.Which(filter);
-		}
+		public Constructors Constructors() => NewBuilder(MemberFilterState.Empty).Constructors();
 
 		/// <inheritdoc cref="ILimitedStaticTypeAssemblies.Events()" />
-		public Events Events()
-		{
-			Events events = new(new Types(this, ""), "events ");
-			IFilter<EventInfo>? filter = _memberState.BuildEventFilter();
-			_memberState.Reset();
-			return filter is null ? events : events.Which(filter);
-		}
+		public Events Events() => NewBuilder(MemberFilterState.Empty).Events();
 
 		/// <inheritdoc cref="ILimitedStaticTypeAssemblies.Fields()" />
-		public Fields Fields()
-		{
-			Fields fields = new(new Types(this, ""), "fields ");
-			IFilter<FieldInfo>? filter = _memberState.BuildFieldFilter();
-			_memberState.Reset();
-			return filter is null ? fields : fields.Which(filter);
-		}
+		public Fields Fields() => NewBuilder(MemberFilterState.Empty).Fields();
 
 		/// <inheritdoc cref="ILimitedStaticTypeAssemblies.Methods()" />
-		public Methods Methods()
-		{
-			Methods methods = new(new Types(this, ""), "methods ");
-			IFilter<MethodInfo>? filter = _memberState.BuildMethodFilter();
-			_memberState.Reset();
-			return filter is null ? methods : methods.Which(filter);
-		}
+		public Methods Methods() => NewBuilder(MemberFilterState.Empty).Methods();
 
 		/// <inheritdoc cref="ILimitedStaticTypeAssemblies.Properties()" />
-		public Properties Properties()
-		{
-			Properties properties = new(new Types(this, ""), "properties ");
-			IFilter<PropertyInfo>? filter = _memberState.BuildPropertyFilter();
-			_memberState.Reset();
-			return filter is null ? properties : properties.Which(filter);
-		}
+		public Properties Properties() => NewBuilder(MemberFilterState.Empty).Properties();
+
+		private AssembliesTypeBuilder NewBuilder(MemberFilterState memberState)
+			=> new(this, memberState, new List<Func<Type, bool>>(), "");
 
 		/// <summary>
 		///     A Container for a filterable collection of <see cref="Assembly" />,
@@ -536,48 +275,6 @@ public static partial class Filtered
 				_options.AsWildcard();
 				return this;
 			}
-		}
-
-		private sealed class LimitedAbstractSealedAssemblies
-			: ILimitedAbstractSealedTypeAssemblies<ILimitedAbstractSealedTypeAssemblies>
-		{
-			private readonly Assemblies _inner;
-
-			public LimitedAbstractSealedAssemblies(Assemblies inner)
-			{
-				_inner = inner;
-			}
-
-			public ILimitedAbstractSealedTypeAssemblies Generic
-			{
-				get
-				{
-					_ = _inner.Generic;
-					return this;
-				}
-			}
-
-			public ILimitedAbstractSealedTypeAssemblies Nested
-			{
-				get
-				{
-					_ = _inner.Nested;
-					return this;
-				}
-			}
-
-			public Types Types(AccessModifiers accessModifier = AccessModifiers.Any)
-				=> _inner.Types(accessModifier);
-
-			public Types Classes(AccessModifiers accessModifier = AccessModifiers.Any)
-				=> _inner.Classes(accessModifier);
-
-			public Types Records(AccessModifiers accessModifier = AccessModifiers.Any)
-				=> _inner.Records(accessModifier);
-
-			public Events Events() => _inner.Events();
-			public Methods Methods() => _inner.Methods();
-			public Properties Properties() => _inner.Properties();
 		}
 	}
 }

--- a/Source/aweXpect.Reflection/Collections/Filtered.Types.cs
+++ b/Source/aweXpect.Reflection/Collections/Filtered.Types.cs
@@ -25,7 +25,6 @@ public static partial class Filtered
 
 		private readonly Assemblies? _assemblies;
 		private readonly string _description;
-		private readonly MemberFilterState _memberState = new();
 
 		/// <summary>
 		///     Container for a filterable collection of <see cref="Type" />.
@@ -113,106 +112,50 @@ public static partial class Filtered
 		/// <summary>
 		///     Filters for public members.
 		/// </summary>
-		public IMembers Public
-		{
-			get
-			{
-				_memberState.SetAccess(AccessModifiers.Public);
-				return this;
-			}
-		}
+		public IMembers Public => new TypesMemberBuilder(this, MemberFilterState.Empty.WithAccess(AccessModifiers.Public));
 
 		/// <summary>
 		///     Filters for private members.
 		/// </summary>
 		public IMembers.IPrivate Private
-		{
-			get
-			{
-				_memberState.SetAccess(AccessModifiers.Private);
-				return this;
-			}
-		}
+			=> new TypesMemberBuilder(this, MemberFilterState.Empty.WithAccess(AccessModifiers.Private));
 
 		/// <summary>
 		///     Filters for protected members.
 		/// </summary>
 		public IMembers.IProtected Protected
-		{
-			get
-			{
-				_memberState.SetAccess(AccessModifiers.Protected);
-				return this;
-			}
-		}
+			=> new TypesMemberBuilder(this, MemberFilterState.Empty.WithAccess(AccessModifiers.Protected));
 
 		/// <summary>
 		///     Filters for internal members.
 		/// </summary>
 		public IMembers Internal
-		{
-			get
-			{
-				_memberState.SetAccess(AccessModifiers.Internal);
-				return this;
-			}
-		}
+			=> new TypesMemberBuilder(this, MemberFilterState.Empty.WithAccess(AccessModifiers.Internal));
 
 		/// <summary>
 		///     Filters for static members.
 		/// </summary>
-		public IMemberSelectors Static
-		{
-			get
-			{
-				_memberState.SetStatic();
-				return this;
-			}
-		}
+		public IMemberSelectors Static => new TypesMemberBuilder(this, MemberFilterState.Empty.WithStatic());
 
 		/// <summary>
 		///     Filters for abstract members.
 		/// </summary>
 		public ILimitedAbstractSealedMembers Abstract
-		{
-			get
-			{
-				_memberState.SetAbstract();
-				return this;
-			}
-		}
+			=> new TypesMemberBuilder(this, MemberFilterState.Empty.WithAbstract());
 
 		/// <summary>
 		///     Filters for sealed members.
 		/// </summary>
 		public ILimitedAbstractSealedMembers Sealed
-		{
-			get
-			{
-				_memberState.SetSealed();
-				return this;
-			}
-		}
+			=> new TypesMemberBuilder(this, MemberFilterState.Empty.WithSealed());
 
 		/// <inheritdoc cref="IMembers.IPrivate.Protected" />
 		IMembers IMembers.IPrivate.Protected
-		{
-			get
-			{
-				_memberState.SetAccess(AccessModifiers.PrivateProtected);
-				return this;
-			}
-		}
+			=> new TypesMemberBuilder(this, MemberFilterState.Empty.WithAccess(AccessModifiers.PrivateProtected));
 
 		/// <inheritdoc cref="IMembers.IProtected.Internal" />
 		IMembers IMembers.IProtected.Internal
-		{
-			get
-			{
-				_memberState.SetAccess(AccessModifiers.ProtectedInternal);
-				return this;
-			}
-		}
+			=> new TypesMemberBuilder(this, MemberFilterState.Empty.WithAccess(AccessModifiers.ProtectedInternal));
 
 		/// <inheritdoc />
 		public string GetDescription()
@@ -259,57 +202,27 @@ public static partial class Filtered
 		/// <summary>
 		///     Get all constructors in the filtered types.
 		/// </summary>
-		public Constructors Constructors()
-		{
-			Constructors constructors = new(this, "constructors ");
-			IFilter<ConstructorInfo>? filter = _memberState.BuildConstructorFilter();
-			_memberState.Reset();
-			return filter is null ? constructors : constructors.Which(filter);
-		}
+		public Constructors Constructors() => new TypesMemberBuilder(this, MemberFilterState.Empty).Constructors();
 
 		/// <summary>
 		///     Get all events in the filtered types.
 		/// </summary>
-		public Events Events()
-		{
-			Events events = new(this, "events ");
-			IFilter<EventInfo>? filter = _memberState.BuildEventFilter();
-			_memberState.Reset();
-			return filter is null ? events : events.Which(filter);
-		}
+		public Events Events() => new TypesMemberBuilder(this, MemberFilterState.Empty).Events();
 
 		/// <summary>
 		///     Get all fields in the filtered types.
 		/// </summary>
-		public Fields Fields()
-		{
-			Fields fields = new(this, "fields ");
-			IFilter<FieldInfo>? filter = _memberState.BuildFieldFilter();
-			_memberState.Reset();
-			return filter is null ? fields : fields.Which(filter);
-		}
+		public Fields Fields() => new TypesMemberBuilder(this, MemberFilterState.Empty).Fields();
 
 		/// <summary>
 		///     Get all methods in the filtered types.
 		/// </summary>
-		public Methods Methods()
-		{
-			Methods methods = new(this, "methods ");
-			IFilter<MethodInfo>? filter = _memberState.BuildMethodFilter();
-			_memberState.Reset();
-			return filter is null ? methods : methods.Which(filter);
-		}
+		public Methods Methods() => new TypesMemberBuilder(this, MemberFilterState.Empty).Methods();
 
 		/// <summary>
 		///     Get all properties in the filtered types.
 		/// </summary>
-		public Properties Properties()
-		{
-			Properties properties = new(this, "properties ");
-			IFilter<PropertyInfo>? filter = _memberState.BuildPropertyFilter();
-			_memberState.Reset();
-			return filter is null ? properties : properties.Which(filter);
-		}
+		public Properties Properties() => new TypesMemberBuilder(this, MemberFilterState.Empty).Properties();
 
 		/// <summary>
 		///     A Container for a filterable collection of <see cref="Type" />,

--- a/Source/aweXpect.Reflection/Collections/MemberFilterState.cs
+++ b/Source/aweXpect.Reflection/Collections/MemberFilterState.cs
@@ -5,60 +5,53 @@ namespace aweXpect.Reflection.Collections;
 
 internal sealed class MemberFilterState
 {
-	public AccessModifiers? AccessModifier;
-	public bool IsAbstract;
-	public bool IsSealed;
-	public bool IsStatic;
-	private string _modifierDescription = "";
+	public static readonly MemberFilterState Empty = new(null, false, false, false);
 
-	public bool HasAnything => AccessModifier is not null || IsStatic || IsAbstract || IsSealed;
-
-	public void Reset()
+	private MemberFilterState(AccessModifiers? accessModifier, bool isStatic, bool isAbstract, bool isSealed)
 	{
-		AccessModifier = null;
-		IsStatic = false;
-		IsAbstract = false;
-		IsSealed = false;
-		_modifierDescription = "";
+		AccessModifier = accessModifier;
+		IsStatic = isStatic;
+		IsAbstract = isAbstract;
+		IsSealed = isSealed;
 	}
 
-	public void SetAccess(AccessModifiers modifier) => AccessModifier = modifier;
+	public AccessModifiers? AccessModifier { get; }
+	public bool IsAbstract { get; }
+	public bool IsSealed { get; }
+	public bool IsStatic { get; }
 
-	public void SetStatic()
-	{
-		if (IsStatic)
-		{
-			return;
-		}
+	public MemberFilterState WithAccess(AccessModifiers modifier)
+		=> new(modifier, IsStatic, IsAbstract, IsSealed);
 
-		IsStatic = true;
-		_modifierDescription += "static ";
-	}
+	public MemberFilterState WithStatic()
+		=> IsStatic ? this : new MemberFilterState(AccessModifier, true, IsAbstract, IsSealed);
 
-	public void SetAbstract()
-	{
-		if (IsAbstract)
-		{
-			return;
-		}
+	public MemberFilterState WithAbstract()
+		=> IsAbstract ? this : new MemberFilterState(AccessModifier, IsStatic, true, IsSealed);
 
-		IsAbstract = true;
-		_modifierDescription += "abstract ";
-	}
-
-	public void SetSealed()
-	{
-		if (IsSealed)
-		{
-			return;
-		}
-
-		IsSealed = true;
-		_modifierDescription += "sealed ";
-	}
+	public MemberFilterState WithSealed()
+		=> IsSealed ? this : new MemberFilterState(AccessModifier, IsStatic, IsAbstract, true);
 
 	public string BuildDescription()
-		=> (AccessModifier?.GetString(" ") ?? "") + _modifierDescription;
+	{
+		string description = AccessModifier?.GetString(" ") ?? "";
+		if (IsStatic)
+		{
+			description += "static ";
+		}
+
+		if (IsAbstract)
+		{
+			description += "abstract ";
+		}
+
+		if (IsSealed)
+		{
+			description += "sealed ";
+		}
+
+		return description;
+	}
 
 	public IFilter<ConstructorInfo>? BuildConstructorFilter()
 	{

--- a/Source/aweXpect.Reflection/Collections/TypesMemberBuilder.cs
+++ b/Source/aweXpect.Reflection/Collections/TypesMemberBuilder.cs
@@ -1,0 +1,65 @@
+using System.Reflection;
+
+namespace aweXpect.Reflection.Collections;
+
+internal sealed class TypesMemberBuilder :
+	IMembers.IPrivate,
+	IMembers.IProtected,
+	ILimitedAbstractSealedMembers
+{
+	private readonly Filtered.Types _source;
+	private readonly MemberFilterState _state;
+
+	internal TypesMemberBuilder(Filtered.Types source, MemberFilterState state)
+	{
+		_source = source;
+		_state = state;
+	}
+
+	public IMemberSelectors Static => new TypesMemberBuilder(_source, _state.WithStatic());
+
+	public ILimitedAbstractSealedMembers Abstract => new TypesMemberBuilder(_source, _state.WithAbstract());
+
+	public ILimitedAbstractSealedMembers Sealed => new TypesMemberBuilder(_source, _state.WithSealed());
+
+	IMembers IMembers.IPrivate.Protected
+		=> new TypesMemberBuilder(_source, _state.WithAccess(AccessModifiers.PrivateProtected));
+
+	IMembers IMembers.IProtected.Internal
+		=> new TypesMemberBuilder(_source, _state.WithAccess(AccessModifiers.ProtectedInternal));
+
+	public Filtered.Constructors Constructors()
+	{
+		Filtered.Constructors constructors = new(_source, "constructors ");
+		IFilter<ConstructorInfo>? filter = _state.BuildConstructorFilter();
+		return filter is null ? constructors : constructors.Which(filter);
+	}
+
+	public Filtered.Events Events()
+	{
+		Filtered.Events events = new(_source, "events ");
+		IFilter<EventInfo>? filter = _state.BuildEventFilter();
+		return filter is null ? events : events.Which(filter);
+	}
+
+	public Filtered.Fields Fields()
+	{
+		Filtered.Fields fields = new(_source, "fields ");
+		IFilter<FieldInfo>? filter = _state.BuildFieldFilter();
+		return filter is null ? fields : fields.Which(filter);
+	}
+
+	public Filtered.Methods Methods()
+	{
+		Filtered.Methods methods = new(_source, "methods ");
+		IFilter<MethodInfo>? filter = _state.BuildMethodFilter();
+		return filter is null ? methods : methods.Which(filter);
+	}
+
+	public Filtered.Properties Properties()
+	{
+		Filtered.Properties properties = new(_source, "properties ");
+		IFilter<PropertyInfo>? filter = _state.BuildPropertyFilter();
+		return filter is null ? properties : properties.Which(filter);
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/Filters/AssemblyFilters.MemberAccess.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/AssemblyFilters.MemberAccess.Tests.cs
@@ -94,6 +94,33 @@ public sealed partial class AssemblyFilters
 				await That(anyMethods.GetDescription())
 					.IsEqualTo("methods in assembly").AsPrefix();
 			}
+
+			[Fact]
+			public async Task ShouldNotLeakTypeFiltersAcrossSelectorCalls()
+			{
+				Filtered.Assemblies assemblies = In.AssemblyContaining<AssemblyFilters>();
+
+				_ = assemblies.Sealed.Classes();
+				Filtered.Types interfaces = assemblies.Interfaces();
+
+				await That(interfaces).IsNotEmpty();
+				await That(interfaces).All().Satisfy(t => t.IsInterface);
+				await That(interfaces.GetDescription())
+					.IsEqualTo("interfaces in assembly").AsPrefix();
+			}
+
+			[Fact]
+			public async Task ShouldNotRetroactivelyMutatePredicateOfReturnedTypes()
+			{
+				Filtered.Assemblies assemblies = In.AssemblyContaining<AssemblyFilters>();
+				Filtered.Types sealedClasses = assemblies.Sealed.Classes();
+
+				_ = assemblies.Generic.Nested.Interfaces();
+
+				await That(sealedClasses).IsNotEmpty();
+				await That(sealedClasses).All().Satisfy(t => t is
+					{ IsClass: true, IsSealed: true, IsInterface: false, });
+			}
 		}
 	}
 }


### PR DESCRIPTION
Move accumulated modifier state (Public/Private/Protected/Internal/Static/Abstract/Sealed/Generic/Nested) off the source containers and into per-chain snapshot builders, fixing a latent correctness bug where `Filtered.Assemblies` mutated `_typeFilters` in place and returned `Filtered.Types` whose predicate closure captured that list by reference.

Before this change, `assemblies.Sealed.Classes()` followed by `assemblies.Interfaces()` returned interfaces filtered through the leftover `Sealed + Class` predicates, and a later modifier call could retroactively mutate the predicate of an already-returned `Types`.

After:
- `MemberFilterState` is immutable; `WithAccess/WithStatic/WithAbstract/WithSealed` produce new snapshots, `Reset()` is gone.
- New internal builders `TypesMemberBuilder`, `AssembliesTypeBuilder`, `AssembliesAbstractSealedBuilder` hold the in-progress chain state.
- `Filtered.Types` and `Filtered.Assemblies` no longer carry the mutable `_memberState`/`_typeFilters`/`_typeFilterDescription` fields; every modifier/selector entry-point delegates to a fresh builder.
- Old `LimitedAbstractSealedAssemblies` wrapper is removed.

Public API is unchanged (builders are internal sealed); API approval snapshots untouched. Two regression tests lock in the leak fix (`ShouldNotLeakTypeFiltersAcrossSelectorCalls`, `ShouldNotRetroactivelyMutatePredicateOfReturnedTypes`).