### PR TITLE
feat: add `OfType`/`OfExactType` assertions for properties and fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,8 +326,8 @@ In addition to [access modifiers](#access-modifiers),
 
 |                                       | Filter                                      | Assert (single)                 | Assert (many)                     |
 |---------------------------------------|---------------------------------------------|---------------------------------|-----------------------------------|
-| of type (or a subtype)                | `.OfType<T>()`                              | -                               | -                                 |
-| of exact type                         | `.OfExactType<T>()`                         | -                               | -                                 |
+| of type (or a subtype)                | `.OfType<T>()`                              | `.IsOfType<T>()`                | `.AreOfType<T>()`                 |
+| of exact type                         | `.OfExactType<T>()`                         | `.IsOfExactType<T>()`           | `.AreOfExactType<T>()`            |
 | static *(properties & fields)*        | `.WhichAreStatic()`                         | `.IsStatic()`                   | `.AreStatic()`                    |
 | abstract / sealed *(properties only)* | `.WhichAreAbstract()` / `.WhichAreSealed()` | `.IsAbstract()` / `.IsSealed()` | `.AreAbstract()` / `.AreSealed()` |
 

--- a/Source/aweXpect.Reflection/Options/TypeFilterOptions.cs
+++ b/Source/aweXpect.Reflection/Options/TypeFilterOptions.cs
@@ -54,6 +54,25 @@ public class TypeFilterOptions
 	}
 
 	/// <summary>
+	///     Appends the registered types as <c>"of type {type}"</c> (or <c>"of exact type {type}"</c> for exact
+	///     matches), joined by <c>" or "</c>.
+	/// </summary>
+	internal void AppendOfTypeDescription(StringBuilder stringBuilder)
+	{
+		int index = 0;
+		foreach ((Type type, bool isDirect) in _types)
+		{
+			if (index++ > 0)
+			{
+				stringBuilder.Append(" or ");
+			}
+
+			stringBuilder.Append(isDirect ? "of exact type " : "of type ");
+			Formatter.Format(stringBuilder, type);
+		}
+	}
+
+	/// <summary>
 	///     Registers a <paramref name="type" />.
 	/// </summary>
 	public void RegisterType(Type type, bool forceDirect) => _types.Add((type, forceDirect));

--- a/Source/aweXpect.Reflection/ThatField.IsOfExactType.cs
+++ b/Source/aweXpect.Reflection/ThatField.IsOfExactType.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Reflection;
+using aweXpect.Core;
+using aweXpect.Reflection.Helpers;
+using aweXpect.Reflection.Options;
+
+namespace aweXpect.Reflection;
+
+public static partial class ThatField
+{
+	/// <summary>
+	///     Verifies that the <see cref="FieldInfo" /> is of exactly type <typeparamref name="TField" />.
+	/// </summary>
+	public static FieldOfTypeResult<FieldInfo?, IThat<FieldInfo?>> IsOfExactType<TField>(
+		this IThat<FieldInfo?> subject)
+		=> IsOfExactType(subject, typeof(TField));
+
+	/// <summary>
+	///     Verifies that the <see cref="FieldInfo" /> is of exactly type <paramref name="fieldType" />.
+	/// </summary>
+	public static FieldOfTypeResult<FieldInfo?, IThat<FieldInfo?>> IsOfExactType(
+		this IThat<FieldInfo?> subject, Type fieldType)
+	{
+		TypeFilterOptions typeFilterOptions = new();
+		typeFilterOptions.RegisterType(fieldType, true);
+		return new FieldOfTypeResult<FieldInfo?, IThat<FieldInfo?>>(
+			subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new IsOfTypeConstraint(it, grammars, typeFilterOptions)),
+			subject,
+			typeFilterOptions);
+	}
+
+	public sealed partial class FieldOfTypeResult<TValue, TResult>
+	{
+		/// <summary>
+		///     Allow an alternative exact type <typeparamref name="TField" />.
+		/// </summary>
+		public FieldOfTypeResult<TValue, TResult> OrOfExactType<TField>()
+			=> OrOfExactType(typeof(TField));
+
+		/// <summary>
+		///     Allow an alternative exact type <paramref name="fieldType" />.
+		/// </summary>
+		public FieldOfTypeResult<TValue, TResult> OrOfExactType(Type fieldType)
+		{
+			typeFilterOptions.RegisterType(fieldType, true);
+			return this;
+		}
+	}
+}

--- a/Source/aweXpect.Reflection/ThatField.IsOfType.cs
+++ b/Source/aweXpect.Reflection/ThatField.IsOfType.cs
@@ -12,14 +12,14 @@ namespace aweXpect.Reflection;
 public static partial class ThatField
 {
 	/// <summary>
-	///     Verifies that the <see cref="FieldInfo" /> is of type <typeparamref name="TField" />.
+	///     Verifies that the <see cref="FieldInfo" /> is of type <typeparamref name="TField" /> (or a subtype).
 	/// </summary>
 	public static FieldOfTypeResult<FieldInfo?, IThat<FieldInfo?>> IsOfType<TField>(
 		this IThat<FieldInfo?> subject)
 		=> IsOfType(subject, typeof(TField));
 
 	/// <summary>
-	///     Verifies that the <see cref="FieldInfo" /> is of type <paramref name="fieldType" />.
+	///     Verifies that the <see cref="FieldInfo" /> is of type <paramref name="fieldType" /> (or a subtype).
 	/// </summary>
 	public static FieldOfTypeResult<FieldInfo?, IThat<FieldInfo?>> IsOfType(
 		this IThat<FieldInfo?> subject, Type fieldType)
@@ -48,13 +48,13 @@ public static partial class ThatField
 		TypeFilterOptions IOptionsProvider<TypeFilterOptions>.Options => typeFilterOptions;
 
 		/// <summary>
-		///     Allow an alternative type <typeparamref name="TField" />.
+		///     Allow an alternative type <typeparamref name="TField" /> (or a subtype).
 		/// </summary>
 		public FieldOfTypeResult<TValue, TResult> OrOfType<TField>()
 			=> OrOfType(typeof(TField));
 
 		/// <summary>
-		///     Allow an alternative type <paramref name="fieldType" />.
+		///     Allow an alternative type <paramref name="fieldType" /> (or a subtype).
 		/// </summary>
 		public FieldOfTypeResult<TValue, TResult> OrOfType(Type fieldType)
 		{

--- a/Source/aweXpect.Reflection/ThatField.IsOfType.cs
+++ b/Source/aweXpect.Reflection/ThatField.IsOfType.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.Reflection;
+using System.Text;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Reflection.Helpers;
+using aweXpect.Reflection.Options;
+using aweXpect.Results;
+
+namespace aweXpect.Reflection;
+
+public static partial class ThatField
+{
+	/// <summary>
+	///     Verifies that the <see cref="FieldInfo" /> is of type <typeparamref name="TField" />.
+	/// </summary>
+	public static FieldOfTypeResult<FieldInfo?, IThat<FieldInfo?>> IsOfType<TField>(
+		this IThat<FieldInfo?> subject)
+		=> IsOfType(subject, typeof(TField));
+
+	/// <summary>
+	///     Verifies that the <see cref="FieldInfo" /> is of type <paramref name="fieldType" />.
+	/// </summary>
+	public static FieldOfTypeResult<FieldInfo?, IThat<FieldInfo?>> IsOfType(
+		this IThat<FieldInfo?> subject, Type fieldType)
+	{
+		TypeFilterOptions typeFilterOptions = new();
+		typeFilterOptions.RegisterType(fieldType, false);
+		return new FieldOfTypeResult<FieldInfo?, IThat<FieldInfo?>>(
+			subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new IsOfTypeConstraint(it, grammars, typeFilterOptions)),
+			subject,
+			typeFilterOptions);
+	}
+
+	/// <summary>
+	///     Result that allows chaining additional types for a single field.
+	/// </summary>
+	public sealed partial class FieldOfTypeResult<TValue, TResult>(
+		ExpectationBuilder expectationBuilder,
+		TResult subject,
+		TypeFilterOptions typeFilterOptions)
+		: AndOrResult<TValue, TResult>(expectationBuilder, subject),
+			IOptionsProvider<TypeFilterOptions>
+		where TResult : IThat<TValue>
+	{
+		/// <inheritdoc cref="IOptionsProvider{TypeFilterOptions}.Options" />
+		TypeFilterOptions IOptionsProvider<TypeFilterOptions>.Options => typeFilterOptions;
+
+		/// <summary>
+		///     Allow an alternative type <typeparamref name="TField" />.
+		/// </summary>
+		public FieldOfTypeResult<TValue, TResult> OrOfType<TField>()
+			=> OrOfType(typeof(TField));
+
+		/// <summary>
+		///     Allow an alternative type <paramref name="fieldType" />.
+		/// </summary>
+		public FieldOfTypeResult<TValue, TResult> OrOfType(Type fieldType)
+		{
+			typeFilterOptions.RegisterType(fieldType, false);
+			return this;
+		}
+	}
+
+	private sealed class IsOfTypeConstraint(
+		string it,
+		ExpectationGrammars grammars,
+		TypeFilterOptions typeFilterOptions)
+		: ConstraintResult.WithNotNullValue<FieldInfo?>(it, grammars),
+			IValueConstraint<FieldInfo?>
+	{
+		public ConstraintResult IsMetBy(FieldInfo? actual)
+		{
+			Actual = actual;
+			Outcome = typeFilterOptions.Matches(actual?.FieldType)
+				? Outcome.Success
+				: Outcome.Failure;
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(Grammars.HasFlag(ExpectationGrammars.Negated) ? "is not " : "is ");
+			typeFilterOptions.AppendOfTypeDescription(stringBuilder);
+		}
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("it was of type ").Append(Formatter.Format(Actual?.FieldType));
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> AppendNormalExpectation(stringBuilder, indentation);
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("it did");
+	}
+}

--- a/Source/aweXpect.Reflection/ThatFields.AreOfExactType.cs
+++ b/Source/aweXpect.Reflection/ThatFields.AreOfExactType.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using aweXpect.Core;
+using aweXpect.Reflection.Helpers;
+using aweXpect.Reflection.Options;
+
+namespace aweXpect.Reflection;
+
+public static partial class ThatFields
+{
+	/// <summary>
+	///     Verifies that all fields in the filtered collection are of exactly type <typeparamref name="TField" />.
+	/// </summary>
+	public static FieldsOfTypeResult<IEnumerable<FieldInfo?>, IThat<IEnumerable<FieldInfo?>>> AreOfExactType<TField>(
+		this IThat<IEnumerable<FieldInfo?>> subject)
+		=> AreOfExactType(subject, typeof(TField));
+
+	/// <summary>
+	///     Verifies that all fields in the filtered collection are of exactly type <paramref name="fieldType" />.
+	/// </summary>
+	public static FieldsOfTypeResult<IEnumerable<FieldInfo?>, IThat<IEnumerable<FieldInfo?>>> AreOfExactType(
+		this IThat<IEnumerable<FieldInfo?>> subject, Type fieldType)
+	{
+		TypeFilterOptions typeFilterOptions = new();
+		typeFilterOptions.RegisterType(fieldType, true);
+		return new FieldsOfTypeResult<IEnumerable<FieldInfo?>, IThat<IEnumerable<FieldInfo?>>>(
+			subject.Get().ExpectationBuilder.AddConstraint<IEnumerable<FieldInfo?>>((it, grammars)
+				=> new AreOfTypeConstraint(it, grammars | ExpectationGrammars.Plural, typeFilterOptions)),
+			subject,
+			typeFilterOptions);
+	}
+
+#if NET8_0_OR_GREATER
+	/// <summary>
+	///     Verifies that all fields in the filtered collection are of exactly type <typeparamref name="TField" />.
+	/// </summary>
+	public static FieldsOfTypeResult<IAsyncEnumerable<FieldInfo?>, IThat<IAsyncEnumerable<FieldInfo?>>>
+		AreOfExactType<TField>(
+			this IThat<IAsyncEnumerable<FieldInfo?>> subject)
+		=> AreOfExactType(subject, typeof(TField));
+
+	/// <summary>
+	///     Verifies that all fields in the filtered collection are of exactly type <paramref name="fieldType" />.
+	/// </summary>
+	public static FieldsOfTypeResult<IAsyncEnumerable<FieldInfo?>, IThat<IAsyncEnumerable<FieldInfo?>>>
+		AreOfExactType(
+			this IThat<IAsyncEnumerable<FieldInfo?>> subject, Type fieldType)
+	{
+		TypeFilterOptions typeFilterOptions = new();
+		typeFilterOptions.RegisterType(fieldType, true);
+		return new FieldsOfTypeResult<IAsyncEnumerable<FieldInfo?>, IThat<IAsyncEnumerable<FieldInfo?>>>(
+			subject.Get().ExpectationBuilder.AddConstraint<IAsyncEnumerable<FieldInfo?>>((it, grammars)
+				=> new AreOfTypeConstraint(it, grammars | ExpectationGrammars.Plural, typeFilterOptions)),
+			subject,
+			typeFilterOptions);
+	}
+#endif
+
+	public sealed partial class FieldsOfTypeResult<TValue, TResult>
+	{
+		/// <summary>
+		///     Allow an alternative exact type <typeparamref name="TField" />.
+		/// </summary>
+		public FieldsOfTypeResult<TValue, TResult> OrOfExactType<TField>()
+			=> OrOfExactType(typeof(TField));
+
+		/// <summary>
+		///     Allow an alternative exact type <paramref name="fieldType" />.
+		/// </summary>
+		public FieldsOfTypeResult<TValue, TResult> OrOfExactType(Type fieldType)
+		{
+			typeFilterOptions.RegisterType(fieldType, true);
+			return this;
+		}
+	}
+}

--- a/Source/aweXpect.Reflection/ThatFields.AreOfType.cs
+++ b/Source/aweXpect.Reflection/ThatFields.AreOfType.cs
@@ -17,14 +17,14 @@ namespace aweXpect.Reflection;
 public static partial class ThatFields
 {
 	/// <summary>
-	///     Verifies that all fields in the filtered collection are of type <typeparamref name="TField" />.
+	///     Verifies that all fields in the filtered collection are of type <typeparamref name="TField" /> (or a subtype).
 	/// </summary>
 	public static FieldsOfTypeResult<IEnumerable<FieldInfo?>, IThat<IEnumerable<FieldInfo?>>> AreOfType<TField>(
 		this IThat<IEnumerable<FieldInfo?>> subject)
 		=> AreOfType(subject, typeof(TField));
 
 	/// <summary>
-	///     Verifies that all fields in the filtered collection are of type <paramref name="fieldType" />.
+	///     Verifies that all fields in the filtered collection are of type <paramref name="fieldType" /> (or a subtype).
 	/// </summary>
 	public static FieldsOfTypeResult<IEnumerable<FieldInfo?>, IThat<IEnumerable<FieldInfo?>>> AreOfType(
 		this IThat<IEnumerable<FieldInfo?>> subject, Type fieldType)
@@ -40,7 +40,7 @@ public static partial class ThatFields
 
 #if NET8_0_OR_GREATER
 	/// <summary>
-	///     Verifies that all fields in the filtered collection are of type <typeparamref name="TField" />.
+	///     Verifies that all fields in the filtered collection are of type <typeparamref name="TField" /> (or a subtype).
 	/// </summary>
 	public static FieldsOfTypeResult<IAsyncEnumerable<FieldInfo?>, IThat<IAsyncEnumerable<FieldInfo?>>>
 		AreOfType<TField>(
@@ -48,7 +48,7 @@ public static partial class ThatFields
 		=> AreOfType(subject, typeof(TField));
 
 	/// <summary>
-	///     Verifies that all fields in the filtered collection are of type <paramref name="fieldType" />.
+	///     Verifies that all fields in the filtered collection are of type <paramref name="fieldType" /> (or a subtype).
 	/// </summary>
 	public static FieldsOfTypeResult<IAsyncEnumerable<FieldInfo?>, IThat<IAsyncEnumerable<FieldInfo?>>> AreOfType(
 		this IThat<IAsyncEnumerable<FieldInfo?>> subject, Type fieldType)
@@ -78,13 +78,13 @@ public static partial class ThatFields
 		TypeFilterOptions IOptionsProvider<TypeFilterOptions>.Options => typeFilterOptions;
 
 		/// <summary>
-		///     Allow an alternative type <typeparamref name="TField" />.
+		///     Allow an alternative type <typeparamref name="TField" /> (or a subtype).
 		/// </summary>
 		public FieldsOfTypeResult<TValue, TResult> OrOfType<TField>()
 			=> OrOfType(typeof(TField));
 
 		/// <summary>
-		///     Allow an alternative type <paramref name="fieldType" />.
+		///     Allow an alternative type <paramref name="fieldType" /> (or a subtype).
 		/// </summary>
 		public FieldsOfTypeResult<TValue, TResult> OrOfType(Type fieldType)
 		{

--- a/Source/aweXpect.Reflection/ThatFields.AreOfType.cs
+++ b/Source/aweXpect.Reflection/ThatFields.AreOfType.cs
@@ -1,0 +1,139 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Reflection.Helpers;
+using aweXpect.Reflection.Options;
+using aweXpect.Results;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Reflection;
+
+public static partial class ThatFields
+{
+	/// <summary>
+	///     Verifies that all fields in the filtered collection are of type <typeparamref name="TField" />.
+	/// </summary>
+	public static FieldsOfTypeResult<IEnumerable<FieldInfo?>, IThat<IEnumerable<FieldInfo?>>> AreOfType<TField>(
+		this IThat<IEnumerable<FieldInfo?>> subject)
+		=> AreOfType(subject, typeof(TField));
+
+	/// <summary>
+	///     Verifies that all fields in the filtered collection are of type <paramref name="fieldType" />.
+	/// </summary>
+	public static FieldsOfTypeResult<IEnumerable<FieldInfo?>, IThat<IEnumerable<FieldInfo?>>> AreOfType(
+		this IThat<IEnumerable<FieldInfo?>> subject, Type fieldType)
+	{
+		TypeFilterOptions typeFilterOptions = new();
+		typeFilterOptions.RegisterType(fieldType, false);
+		return new FieldsOfTypeResult<IEnumerable<FieldInfo?>, IThat<IEnumerable<FieldInfo?>>>(
+			subject.Get().ExpectationBuilder.AddConstraint<IEnumerable<FieldInfo?>>((it, grammars)
+				=> new AreOfTypeConstraint(it, grammars | ExpectationGrammars.Plural, typeFilterOptions)),
+			subject,
+			typeFilterOptions);
+	}
+
+#if NET8_0_OR_GREATER
+	/// <summary>
+	///     Verifies that all fields in the filtered collection are of type <typeparamref name="TField" />.
+	/// </summary>
+	public static FieldsOfTypeResult<IAsyncEnumerable<FieldInfo?>, IThat<IAsyncEnumerable<FieldInfo?>>>
+		AreOfType<TField>(
+			this IThat<IAsyncEnumerable<FieldInfo?>> subject)
+		=> AreOfType(subject, typeof(TField));
+
+	/// <summary>
+	///     Verifies that all fields in the filtered collection are of type <paramref name="fieldType" />.
+	/// </summary>
+	public static FieldsOfTypeResult<IAsyncEnumerable<FieldInfo?>, IThat<IAsyncEnumerable<FieldInfo?>>> AreOfType(
+		this IThat<IAsyncEnumerable<FieldInfo?>> subject, Type fieldType)
+	{
+		TypeFilterOptions typeFilterOptions = new();
+		typeFilterOptions.RegisterType(fieldType, false);
+		return new FieldsOfTypeResult<IAsyncEnumerable<FieldInfo?>, IThat<IAsyncEnumerable<FieldInfo?>>>(
+			subject.Get().ExpectationBuilder.AddConstraint<IAsyncEnumerable<FieldInfo?>>((it, grammars)
+				=> new AreOfTypeConstraint(it, grammars | ExpectationGrammars.Plural, typeFilterOptions)),
+			subject,
+			typeFilterOptions);
+	}
+#endif
+
+	/// <summary>
+	///     Result that allows chaining additional types for field collections.
+	/// </summary>
+	public sealed partial class FieldsOfTypeResult<TValue, TResult>(
+		ExpectationBuilder expectationBuilder,
+		TResult subject,
+		TypeFilterOptions typeFilterOptions)
+		: AndOrResult<TValue, TResult>(expectationBuilder, subject),
+			IOptionsProvider<TypeFilterOptions>
+		where TResult : IThat<TValue>
+	{
+		/// <inheritdoc cref="IOptionsProvider{TypeFilterOptions}.Options" />
+		TypeFilterOptions IOptionsProvider<TypeFilterOptions>.Options => typeFilterOptions;
+
+		/// <summary>
+		///     Allow an alternative type <typeparamref name="TField" />.
+		/// </summary>
+		public FieldsOfTypeResult<TValue, TResult> OrOfType<TField>()
+			=> OrOfType(typeof(TField));
+
+		/// <summary>
+		///     Allow an alternative type <paramref name="fieldType" />.
+		/// </summary>
+		public FieldsOfTypeResult<TValue, TResult> OrOfType(Type fieldType)
+		{
+			typeFilterOptions.RegisterType(fieldType, false);
+			return this;
+		}
+	}
+
+	private sealed class AreOfTypeConstraint(
+		string it,
+		ExpectationGrammars grammars,
+		TypeFilterOptions typeFilterOptions)
+		: CollectionConstraintResult<FieldInfo?>(grammars),
+			IValueConstraint<IEnumerable<FieldInfo?>>
+#if NET8_0_OR_GREATER
+			, IAsyncConstraint<IAsyncEnumerable<FieldInfo?>>
+#endif
+	{
+#if NET8_0_OR_GREATER
+		public async Task<ConstraintResult> IsMetBy(IAsyncEnumerable<FieldInfo?> actual,
+			CancellationToken cancellationToken)
+			=> await SetAsyncValue(actual, field => typeFilterOptions.Matches(field?.FieldType));
+#endif
+
+		public ConstraintResult IsMetBy(IEnumerable<FieldInfo?> actual)
+			=> SetValue(actual, field => typeFilterOptions.Matches(field?.FieldType));
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("all are ");
+			typeFilterOptions.AppendOfTypeDescription(stringBuilder);
+		}
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(it).Append(" contained not matching fields ");
+			Formatter.Format(stringBuilder, NotMatching, FormattingOptions.Indented(indentation));
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("not all are ");
+			typeFilterOptions.AppendOfTypeDescription(stringBuilder);
+		}
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(it).Append(" only contained matching fields ");
+			Formatter.Format(stringBuilder, Matching, FormattingOptions.Indented(indentation));
+		}
+	}
+}

--- a/Source/aweXpect.Reflection/ThatProperties.AreOfExactType.cs
+++ b/Source/aweXpect.Reflection/ThatProperties.AreOfExactType.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using aweXpect.Core;
+using aweXpect.Reflection.Helpers;
+using aweXpect.Reflection.Options;
+
+namespace aweXpect.Reflection;
+
+public static partial class ThatProperties
+{
+	/// <summary>
+	///     Verifies that all properties in the filtered collection are of exactly type <typeparamref name="TProperty" />.
+	/// </summary>
+	public static PropertiesOfTypeResult<IEnumerable<PropertyInfo?>, IThat<IEnumerable<PropertyInfo?>>>
+		AreOfExactType<TProperty>(
+			this IThat<IEnumerable<PropertyInfo?>> subject)
+		=> AreOfExactType(subject, typeof(TProperty));
+
+	/// <summary>
+	///     Verifies that all properties in the filtered collection are of exactly type <paramref name="propertyType" />.
+	/// </summary>
+	public static PropertiesOfTypeResult<IEnumerable<PropertyInfo?>, IThat<IEnumerable<PropertyInfo?>>> AreOfExactType(
+		this IThat<IEnumerable<PropertyInfo?>> subject, Type propertyType)
+	{
+		TypeFilterOptions typeFilterOptions = new();
+		typeFilterOptions.RegisterType(propertyType, true);
+		return new PropertiesOfTypeResult<IEnumerable<PropertyInfo?>, IThat<IEnumerable<PropertyInfo?>>>(
+			subject.Get().ExpectationBuilder.AddConstraint<IEnumerable<PropertyInfo?>>((it, grammars)
+				=> new AreOfTypeConstraint(it, grammars | ExpectationGrammars.Plural, typeFilterOptions)),
+			subject,
+			typeFilterOptions);
+	}
+
+#if NET8_0_OR_GREATER
+	/// <summary>
+	///     Verifies that all properties in the filtered collection are of exactly type <typeparamref name="TProperty" />.
+	/// </summary>
+	public static PropertiesOfTypeResult<IAsyncEnumerable<PropertyInfo?>, IThat<IAsyncEnumerable<PropertyInfo?>>>
+		AreOfExactType<TProperty>(
+			this IThat<IAsyncEnumerable<PropertyInfo?>> subject)
+		=> AreOfExactType(subject, typeof(TProperty));
+
+	/// <summary>
+	///     Verifies that all properties in the filtered collection are of exactly type <paramref name="propertyType" />.
+	/// </summary>
+	public static PropertiesOfTypeResult<IAsyncEnumerable<PropertyInfo?>, IThat<IAsyncEnumerable<PropertyInfo?>>>
+		AreOfExactType(
+			this IThat<IAsyncEnumerable<PropertyInfo?>> subject, Type propertyType)
+	{
+		TypeFilterOptions typeFilterOptions = new();
+		typeFilterOptions.RegisterType(propertyType, true);
+		return new PropertiesOfTypeResult<IAsyncEnumerable<PropertyInfo?>, IThat<IAsyncEnumerable<PropertyInfo?>>>(
+			subject.Get().ExpectationBuilder.AddConstraint<IAsyncEnumerable<PropertyInfo?>>((it, grammars)
+				=> new AreOfTypeConstraint(it, grammars | ExpectationGrammars.Plural, typeFilterOptions)),
+			subject,
+			typeFilterOptions);
+	}
+#endif
+
+	public sealed partial class PropertiesOfTypeResult<TValue, TResult>
+	{
+		/// <summary>
+		///     Allow an alternative exact type <typeparamref name="TProperty" />.
+		/// </summary>
+		public PropertiesOfTypeResult<TValue, TResult> OrOfExactType<TProperty>()
+			=> OrOfExactType(typeof(TProperty));
+
+		/// <summary>
+		///     Allow an alternative exact type <paramref name="propertyType" />.
+		/// </summary>
+		public PropertiesOfTypeResult<TValue, TResult> OrOfExactType(Type propertyType)
+		{
+			typeFilterOptions.RegisterType(propertyType, true);
+			return this;
+		}
+	}
+}

--- a/Source/aweXpect.Reflection/ThatProperties.AreOfType.cs
+++ b/Source/aweXpect.Reflection/ThatProperties.AreOfType.cs
@@ -1,0 +1,141 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Reflection.Helpers;
+using aweXpect.Reflection.Options;
+using aweXpect.Results;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Reflection;
+
+public static partial class ThatProperties
+{
+	/// <summary>
+	///     Verifies that all properties in the filtered collection are of type <typeparamref name="TProperty" />.
+	/// </summary>
+	public static PropertiesOfTypeResult<IEnumerable<PropertyInfo?>, IThat<IEnumerable<PropertyInfo?>>>
+		AreOfType<TProperty>(
+			this IThat<IEnumerable<PropertyInfo?>> subject)
+		=> AreOfType(subject, typeof(TProperty));
+
+	/// <summary>
+	///     Verifies that all properties in the filtered collection are of type <paramref name="propertyType" />.
+	/// </summary>
+	public static PropertiesOfTypeResult<IEnumerable<PropertyInfo?>, IThat<IEnumerable<PropertyInfo?>>> AreOfType(
+		this IThat<IEnumerable<PropertyInfo?>> subject, Type propertyType)
+	{
+		TypeFilterOptions typeFilterOptions = new();
+		typeFilterOptions.RegisterType(propertyType, false);
+		return new PropertiesOfTypeResult<IEnumerable<PropertyInfo?>, IThat<IEnumerable<PropertyInfo?>>>(
+			subject.Get().ExpectationBuilder.AddConstraint<IEnumerable<PropertyInfo?>>((it, grammars)
+				=> new AreOfTypeConstraint(it, grammars | ExpectationGrammars.Plural, typeFilterOptions)),
+			subject,
+			typeFilterOptions);
+	}
+
+#if NET8_0_OR_GREATER
+	/// <summary>
+	///     Verifies that all properties in the filtered collection are of type <typeparamref name="TProperty" />.
+	/// </summary>
+	public static PropertiesOfTypeResult<IAsyncEnumerable<PropertyInfo?>, IThat<IAsyncEnumerable<PropertyInfo?>>>
+		AreOfType<TProperty>(
+			this IThat<IAsyncEnumerable<PropertyInfo?>> subject)
+		=> AreOfType(subject, typeof(TProperty));
+
+	/// <summary>
+	///     Verifies that all properties in the filtered collection are of type <paramref name="propertyType" />.
+	/// </summary>
+	public static PropertiesOfTypeResult<IAsyncEnumerable<PropertyInfo?>, IThat<IAsyncEnumerable<PropertyInfo?>>>
+		AreOfType(
+			this IThat<IAsyncEnumerable<PropertyInfo?>> subject, Type propertyType)
+	{
+		TypeFilterOptions typeFilterOptions = new();
+		typeFilterOptions.RegisterType(propertyType, false);
+		return new PropertiesOfTypeResult<IAsyncEnumerable<PropertyInfo?>, IThat<IAsyncEnumerable<PropertyInfo?>>>(
+			subject.Get().ExpectationBuilder.AddConstraint<IAsyncEnumerable<PropertyInfo?>>((it, grammars)
+				=> new AreOfTypeConstraint(it, grammars | ExpectationGrammars.Plural, typeFilterOptions)),
+			subject,
+			typeFilterOptions);
+	}
+#endif
+
+	/// <summary>
+	///     Result that allows chaining additional types for property collections.
+	/// </summary>
+	public sealed partial class PropertiesOfTypeResult<TValue, TResult>(
+		ExpectationBuilder expectationBuilder,
+		TResult subject,
+		TypeFilterOptions typeFilterOptions)
+		: AndOrResult<TValue, TResult>(expectationBuilder, subject),
+			IOptionsProvider<TypeFilterOptions>
+		where TResult : IThat<TValue>
+	{
+		/// <inheritdoc cref="IOptionsProvider{TypeFilterOptions}.Options" />
+		TypeFilterOptions IOptionsProvider<TypeFilterOptions>.Options => typeFilterOptions;
+
+		/// <summary>
+		///     Allow an alternative type <typeparamref name="TProperty" />.
+		/// </summary>
+		public PropertiesOfTypeResult<TValue, TResult> OrOfType<TProperty>()
+			=> OrOfType(typeof(TProperty));
+
+		/// <summary>
+		///     Allow an alternative type <paramref name="propertyType" />.
+		/// </summary>
+		public PropertiesOfTypeResult<TValue, TResult> OrOfType(Type propertyType)
+		{
+			typeFilterOptions.RegisterType(propertyType, false);
+			return this;
+		}
+	}
+
+	private sealed class AreOfTypeConstraint(
+		string it,
+		ExpectationGrammars grammars,
+		TypeFilterOptions typeFilterOptions)
+		: CollectionConstraintResult<PropertyInfo?>(grammars),
+			IValueConstraint<IEnumerable<PropertyInfo?>>
+#if NET8_0_OR_GREATER
+			, IAsyncConstraint<IAsyncEnumerable<PropertyInfo?>>
+#endif
+	{
+#if NET8_0_OR_GREATER
+		public async Task<ConstraintResult> IsMetBy(IAsyncEnumerable<PropertyInfo?> actual,
+			CancellationToken cancellationToken)
+			=> await SetAsyncValue(actual, property => typeFilterOptions.Matches(property?.PropertyType));
+#endif
+
+		public ConstraintResult IsMetBy(IEnumerable<PropertyInfo?> actual)
+			=> SetValue(actual, property => typeFilterOptions.Matches(property?.PropertyType));
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("all are ");
+			typeFilterOptions.AppendOfTypeDescription(stringBuilder);
+		}
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(it).Append(" contained not matching properties ");
+			Formatter.Format(stringBuilder, NotMatching, FormattingOptions.Indented(indentation));
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("not all are ");
+			typeFilterOptions.AppendOfTypeDescription(stringBuilder);
+		}
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(it).Append(" only contained matching properties ");
+			Formatter.Format(stringBuilder, Matching, FormattingOptions.Indented(indentation));
+		}
+	}
+}

--- a/Source/aweXpect.Reflection/ThatProperties.AreOfType.cs
+++ b/Source/aweXpect.Reflection/ThatProperties.AreOfType.cs
@@ -17,7 +17,7 @@ namespace aweXpect.Reflection;
 public static partial class ThatProperties
 {
 	/// <summary>
-	///     Verifies that all properties in the filtered collection are of type <typeparamref name="TProperty" />.
+	///     Verifies that all properties in the filtered collection are of type <typeparamref name="TProperty" /> (or a subtype).
 	/// </summary>
 	public static PropertiesOfTypeResult<IEnumerable<PropertyInfo?>, IThat<IEnumerable<PropertyInfo?>>>
 		AreOfType<TProperty>(
@@ -25,7 +25,7 @@ public static partial class ThatProperties
 		=> AreOfType(subject, typeof(TProperty));
 
 	/// <summary>
-	///     Verifies that all properties in the filtered collection are of type <paramref name="propertyType" />.
+	///     Verifies that all properties in the filtered collection are of type <paramref name="propertyType" /> (or a subtype).
 	/// </summary>
 	public static PropertiesOfTypeResult<IEnumerable<PropertyInfo?>, IThat<IEnumerable<PropertyInfo?>>> AreOfType(
 		this IThat<IEnumerable<PropertyInfo?>> subject, Type propertyType)
@@ -41,7 +41,7 @@ public static partial class ThatProperties
 
 #if NET8_0_OR_GREATER
 	/// <summary>
-	///     Verifies that all properties in the filtered collection are of type <typeparamref name="TProperty" />.
+	///     Verifies that all properties in the filtered collection are of type <typeparamref name="TProperty" /> (or a subtype).
 	/// </summary>
 	public static PropertiesOfTypeResult<IAsyncEnumerable<PropertyInfo?>, IThat<IAsyncEnumerable<PropertyInfo?>>>
 		AreOfType<TProperty>(
@@ -49,7 +49,7 @@ public static partial class ThatProperties
 		=> AreOfType(subject, typeof(TProperty));
 
 	/// <summary>
-	///     Verifies that all properties in the filtered collection are of type <paramref name="propertyType" />.
+	///     Verifies that all properties in the filtered collection are of type <paramref name="propertyType" /> (or a subtype).
 	/// </summary>
 	public static PropertiesOfTypeResult<IAsyncEnumerable<PropertyInfo?>, IThat<IAsyncEnumerable<PropertyInfo?>>>
 		AreOfType(
@@ -80,13 +80,13 @@ public static partial class ThatProperties
 		TypeFilterOptions IOptionsProvider<TypeFilterOptions>.Options => typeFilterOptions;
 
 		/// <summary>
-		///     Allow an alternative type <typeparamref name="TProperty" />.
+		///     Allow an alternative type <typeparamref name="TProperty" /> (or a subtype).
 		/// </summary>
 		public PropertiesOfTypeResult<TValue, TResult> OrOfType<TProperty>()
 			=> OrOfType(typeof(TProperty));
 
 		/// <summary>
-		///     Allow an alternative type <paramref name="propertyType" />.
+		///     Allow an alternative type <paramref name="propertyType" /> (or a subtype).
 		/// </summary>
 		public PropertiesOfTypeResult<TValue, TResult> OrOfType(Type propertyType)
 		{

--- a/Source/aweXpect.Reflection/ThatProperty.IsOfExactType.cs
+++ b/Source/aweXpect.Reflection/ThatProperty.IsOfExactType.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Reflection;
+using aweXpect.Core;
+using aweXpect.Reflection.Helpers;
+using aweXpect.Reflection.Options;
+
+namespace aweXpect.Reflection;
+
+public static partial class ThatProperty
+{
+	/// <summary>
+	///     Verifies that the <see cref="PropertyInfo" /> is of exactly type <typeparamref name="TProperty" />.
+	/// </summary>
+	public static PropertyOfTypeResult<PropertyInfo?, IThat<PropertyInfo?>> IsOfExactType<TProperty>(
+		this IThat<PropertyInfo?> subject)
+		=> IsOfExactType(subject, typeof(TProperty));
+
+	/// <summary>
+	///     Verifies that the <see cref="PropertyInfo" /> is of exactly type <paramref name="propertyType" />.
+	/// </summary>
+	public static PropertyOfTypeResult<PropertyInfo?, IThat<PropertyInfo?>> IsOfExactType(
+		this IThat<PropertyInfo?> subject, Type propertyType)
+	{
+		TypeFilterOptions typeFilterOptions = new();
+		typeFilterOptions.RegisterType(propertyType, true);
+		return new PropertyOfTypeResult<PropertyInfo?, IThat<PropertyInfo?>>(
+			subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new IsOfTypeConstraint(it, grammars, typeFilterOptions)),
+			subject,
+			typeFilterOptions);
+	}
+
+	public sealed partial class PropertyOfTypeResult<TValue, TResult>
+	{
+		/// <summary>
+		///     Allow an alternative exact type <typeparamref name="TProperty" />.
+		/// </summary>
+		public PropertyOfTypeResult<TValue, TResult> OrOfExactType<TProperty>()
+			=> OrOfExactType(typeof(TProperty));
+
+		/// <summary>
+		///     Allow an alternative exact type <paramref name="propertyType" />.
+		/// </summary>
+		public PropertyOfTypeResult<TValue, TResult> OrOfExactType(Type propertyType)
+		{
+			typeFilterOptions.RegisterType(propertyType, true);
+			return this;
+		}
+	}
+}

--- a/Source/aweXpect.Reflection/ThatProperty.IsOfType.cs
+++ b/Source/aweXpect.Reflection/ThatProperty.IsOfType.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.Reflection;
+using System.Text;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Reflection.Helpers;
+using aweXpect.Reflection.Options;
+using aweXpect.Results;
+
+namespace aweXpect.Reflection;
+
+public static partial class ThatProperty
+{
+	/// <summary>
+	///     Verifies that the <see cref="PropertyInfo" /> is of type <typeparamref name="TProperty" />.
+	/// </summary>
+	public static PropertyOfTypeResult<PropertyInfo?, IThat<PropertyInfo?>> IsOfType<TProperty>(
+		this IThat<PropertyInfo?> subject)
+		=> IsOfType(subject, typeof(TProperty));
+
+	/// <summary>
+	///     Verifies that the <see cref="PropertyInfo" /> is of type <paramref name="propertyType" />.
+	/// </summary>
+	public static PropertyOfTypeResult<PropertyInfo?, IThat<PropertyInfo?>> IsOfType(
+		this IThat<PropertyInfo?> subject, Type propertyType)
+	{
+		TypeFilterOptions typeFilterOptions = new();
+		typeFilterOptions.RegisterType(propertyType, false);
+		return new PropertyOfTypeResult<PropertyInfo?, IThat<PropertyInfo?>>(
+			subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new IsOfTypeConstraint(it, grammars, typeFilterOptions)),
+			subject,
+			typeFilterOptions);
+	}
+
+	/// <summary>
+	///     Result that allows chaining additional types for a single property.
+	/// </summary>
+	public sealed partial class PropertyOfTypeResult<TValue, TResult>(
+		ExpectationBuilder expectationBuilder,
+		TResult subject,
+		TypeFilterOptions typeFilterOptions)
+		: AndOrResult<TValue, TResult>(expectationBuilder, subject),
+			IOptionsProvider<TypeFilterOptions>
+		where TResult : IThat<TValue>
+	{
+		/// <inheritdoc cref="IOptionsProvider{TypeFilterOptions}.Options" />
+		TypeFilterOptions IOptionsProvider<TypeFilterOptions>.Options => typeFilterOptions;
+
+		/// <summary>
+		///     Allow an alternative type <typeparamref name="TProperty" />.
+		/// </summary>
+		public PropertyOfTypeResult<TValue, TResult> OrOfType<TProperty>()
+			=> OrOfType(typeof(TProperty));
+
+		/// <summary>
+		///     Allow an alternative type <paramref name="propertyType" />.
+		/// </summary>
+		public PropertyOfTypeResult<TValue, TResult> OrOfType(Type propertyType)
+		{
+			typeFilterOptions.RegisterType(propertyType, false);
+			return this;
+		}
+	}
+
+	private sealed class IsOfTypeConstraint(
+		string it,
+		ExpectationGrammars grammars,
+		TypeFilterOptions typeFilterOptions)
+		: ConstraintResult.WithNotNullValue<PropertyInfo?>(it, grammars),
+			IValueConstraint<PropertyInfo?>
+	{
+		public ConstraintResult IsMetBy(PropertyInfo? actual)
+		{
+			Actual = actual;
+			Outcome = typeFilterOptions.Matches(actual?.PropertyType)
+				? Outcome.Success
+				: Outcome.Failure;
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(Grammars.HasFlag(ExpectationGrammars.Negated) ? "is not " : "is ");
+			typeFilterOptions.AppendOfTypeDescription(stringBuilder);
+		}
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("it was of type ").Append(Formatter.Format(Actual?.PropertyType));
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> AppendNormalExpectation(stringBuilder, indentation);
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("it did");
+	}
+}

--- a/Source/aweXpect.Reflection/ThatProperty.IsOfType.cs
+++ b/Source/aweXpect.Reflection/ThatProperty.IsOfType.cs
@@ -12,14 +12,14 @@ namespace aweXpect.Reflection;
 public static partial class ThatProperty
 {
 	/// <summary>
-	///     Verifies that the <see cref="PropertyInfo" /> is of type <typeparamref name="TProperty" />.
+	///     Verifies that the <see cref="PropertyInfo" /> is of type <typeparamref name="TProperty" /> (or a subtype).
 	/// </summary>
 	public static PropertyOfTypeResult<PropertyInfo?, IThat<PropertyInfo?>> IsOfType<TProperty>(
 		this IThat<PropertyInfo?> subject)
 		=> IsOfType(subject, typeof(TProperty));
 
 	/// <summary>
-	///     Verifies that the <see cref="PropertyInfo" /> is of type <paramref name="propertyType" />.
+	///     Verifies that the <see cref="PropertyInfo" /> is of type <paramref name="propertyType" /> (or a subtype).
 	/// </summary>
 	public static PropertyOfTypeResult<PropertyInfo?, IThat<PropertyInfo?>> IsOfType(
 		this IThat<PropertyInfo?> subject, Type propertyType)
@@ -48,13 +48,13 @@ public static partial class ThatProperty
 		TypeFilterOptions IOptionsProvider<TypeFilterOptions>.Options => typeFilterOptions;
 
 		/// <summary>
-		///     Allow an alternative type <typeparamref name="TProperty" />.
+		///     Allow an alternative type <typeparamref name="TProperty" /> (or a subtype).
 		/// </summary>
 		public PropertyOfTypeResult<TValue, TResult> OrOfType<TProperty>()
 			=> OrOfType(typeof(TProperty));
 
 		/// <summary>
-		///     Allow an alternative type <paramref name="propertyType" />.
+		///     Allow an alternative type <paramref name="propertyType" /> (or a subtype).
 		/// </summary>
 		public PropertyOfTypeResult<TValue, TResult> OrOfType(Type propertyType)
 		{

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net10.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net10.0.txt
@@ -424,12 +424,33 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Results.HasAttributeResult<System.Reflection.FieldInfo?> Has<TAttribute>(this aweXpect.Core.IThat<System.Reflection.FieldInfo?> subject, System.Func<TAttribute, bool> predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
             where TAttribute : System.Attribute { }
         public static aweXpect.Results.AndOrResult<System.Reflection.FieldInfo?, aweXpect.Core.IThat<System.Reflection.FieldInfo?>> IsNotStatic(this aweXpect.Core.IThat<System.Reflection.FieldInfo?> subject) { }
+        public static aweXpect.Reflection.ThatField.FieldOfTypeResult<System.Reflection.FieldInfo?, aweXpect.Core.IThat<System.Reflection.FieldInfo?>> IsOfExactType(this aweXpect.Core.IThat<System.Reflection.FieldInfo?> subject, System.Type fieldType) { }
+        public static aweXpect.Reflection.ThatField.FieldOfTypeResult<System.Reflection.FieldInfo?, aweXpect.Core.IThat<System.Reflection.FieldInfo?>> IsOfExactType<TField>(this aweXpect.Core.IThat<System.Reflection.FieldInfo?> subject) { }
+        public static aweXpect.Reflection.ThatField.FieldOfTypeResult<System.Reflection.FieldInfo?, aweXpect.Core.IThat<System.Reflection.FieldInfo?>> IsOfType(this aweXpect.Core.IThat<System.Reflection.FieldInfo?> subject, System.Type fieldType) { }
+        public static aweXpect.Reflection.ThatField.FieldOfTypeResult<System.Reflection.FieldInfo?, aweXpect.Core.IThat<System.Reflection.FieldInfo?>> IsOfType<TField>(this aweXpect.Core.IThat<System.Reflection.FieldInfo?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Reflection.FieldInfo?, aweXpect.Core.IThat<System.Reflection.FieldInfo?>> IsStatic(this aweXpect.Core.IThat<System.Reflection.FieldInfo?> subject) { }
+        public sealed class FieldOfTypeResult<TValue, TResult> : aweXpect.Results.AndOrResult<TValue, TResult>, aweXpect.Core.IOptionsProvider<aweXpect.Reflection.Options.TypeFilterOptions>
+            where TResult : aweXpect.Core.IThat<TValue>
+        {
+            public FieldOfTypeResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TResult subject, aweXpect.Reflection.Options.TypeFilterOptions typeFilterOptions) { }
+            public aweXpect.Reflection.ThatField.FieldOfTypeResult<TValue, TResult> OrOfExactType(System.Type fieldType) { }
+            public aweXpect.Reflection.ThatField.FieldOfTypeResult<TValue, TResult> OrOfExactType<TField>() { }
+            public aweXpect.Reflection.ThatField.FieldOfTypeResult<TValue, TResult> OrOfType(System.Type fieldType) { }
+            public aweXpect.Reflection.ThatField.FieldOfTypeResult<TValue, TResult> OrOfType<TField>() { }
+        }
     }
     public static class ThatFields
     {
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.FieldInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.FieldInfo?>>> AreNotStatic(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.FieldInfo?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>>> AreNotStatic(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>> subject) { }
+        public static aweXpect.Reflection.ThatFields.FieldsOfTypeResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.FieldInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.FieldInfo?>>> AreOfExactType(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.FieldInfo?>> subject, System.Type fieldType) { }
+        public static aweXpect.Reflection.ThatFields.FieldsOfTypeResult<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>>> AreOfExactType(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>> subject, System.Type fieldType) { }
+        public static aweXpect.Reflection.ThatFields.FieldsOfTypeResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.FieldInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.FieldInfo?>>> AreOfExactType<TField>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.FieldInfo?>> subject) { }
+        public static aweXpect.Reflection.ThatFields.FieldsOfTypeResult<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>>> AreOfExactType<TField>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>> subject) { }
+        public static aweXpect.Reflection.ThatFields.FieldsOfTypeResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.FieldInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.FieldInfo?>>> AreOfType(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.FieldInfo?>> subject, System.Type fieldType) { }
+        public static aweXpect.Reflection.ThatFields.FieldsOfTypeResult<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>>> AreOfType(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>> subject, System.Type fieldType) { }
+        public static aweXpect.Reflection.ThatFields.FieldsOfTypeResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.FieldInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.FieldInfo?>>> AreOfType<TField>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.FieldInfo?>> subject) { }
+        public static aweXpect.Reflection.ThatFields.FieldsOfTypeResult<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>>> AreOfType<TField>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.FieldInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.FieldInfo?>>> AreStatic(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.FieldInfo?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>>> AreStatic(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>> subject) { }
         public static aweXpect.Reflection.Results.HaveAttributeResult<System.Reflection.FieldInfo?, System.Collections.Generic.IAsyncEnumerable<System.Reflection.FieldInfo?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.FieldInfo?>> subject, bool inherit = true)
@@ -440,6 +461,15 @@ namespace aweXpect.Reflection
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Results.HaveAttributeResult<System.Reflection.FieldInfo?, System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>> subject, System.Func<TAttribute, bool> predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
             where TAttribute : System.Attribute { }
+        public sealed class FieldsOfTypeResult<TValue, TResult> : aweXpect.Results.AndOrResult<TValue, TResult>, aweXpect.Core.IOptionsProvider<aweXpect.Reflection.Options.TypeFilterOptions>
+            where TResult : aweXpect.Core.IThat<TValue>
+        {
+            public FieldsOfTypeResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TResult subject, aweXpect.Reflection.Options.TypeFilterOptions typeFilterOptions) { }
+            public aweXpect.Reflection.ThatFields.FieldsOfTypeResult<TValue, TResult> OrOfExactType(System.Type fieldType) { }
+            public aweXpect.Reflection.ThatFields.FieldsOfTypeResult<TValue, TResult> OrOfExactType<TField>() { }
+            public aweXpect.Reflection.ThatFields.FieldsOfTypeResult<TValue, TResult> OrOfType(System.Type fieldType) { }
+            public aweXpect.Reflection.ThatFields.FieldsOfTypeResult<TValue, TResult> OrOfType<TField>() { }
+        }
     }
     public static class ThatMember
     {
@@ -632,6 +662,14 @@ namespace aweXpect.Reflection
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>>> AreNotSealed(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.PropertyInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.PropertyInfo?>>> AreNotStatic(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.PropertyInfo?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>>> AreNotStatic(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>> subject) { }
+        public static aweXpect.Reflection.ThatProperties.PropertiesOfTypeResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.PropertyInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.PropertyInfo?>>> AreOfExactType(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.PropertyInfo?>> subject, System.Type propertyType) { }
+        public static aweXpect.Reflection.ThatProperties.PropertiesOfTypeResult<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>>> AreOfExactType(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>> subject, System.Type propertyType) { }
+        public static aweXpect.Reflection.ThatProperties.PropertiesOfTypeResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.PropertyInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.PropertyInfo?>>> AreOfExactType<TProperty>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.PropertyInfo?>> subject) { }
+        public static aweXpect.Reflection.ThatProperties.PropertiesOfTypeResult<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>>> AreOfExactType<TProperty>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>> subject) { }
+        public static aweXpect.Reflection.ThatProperties.PropertiesOfTypeResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.PropertyInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.PropertyInfo?>>> AreOfType(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.PropertyInfo?>> subject, System.Type propertyType) { }
+        public static aweXpect.Reflection.ThatProperties.PropertiesOfTypeResult<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>>> AreOfType(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>> subject, System.Type propertyType) { }
+        public static aweXpect.Reflection.ThatProperties.PropertiesOfTypeResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.PropertyInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.PropertyInfo?>>> AreOfType<TProperty>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.PropertyInfo?>> subject) { }
+        public static aweXpect.Reflection.ThatProperties.PropertiesOfTypeResult<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>>> AreOfType<TProperty>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.PropertyInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.PropertyInfo?>>> AreSealed(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.PropertyInfo?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>>> AreSealed(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.PropertyInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.PropertyInfo?>>> AreStatic(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.PropertyInfo?>> subject) { }
@@ -644,6 +682,15 @@ namespace aweXpect.Reflection
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Results.HaveAttributeResult<System.Reflection.PropertyInfo?, System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>> subject, System.Func<TAttribute, bool> predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
             where TAttribute : System.Attribute { }
+        public sealed class PropertiesOfTypeResult<TValue, TResult> : aweXpect.Results.AndOrResult<TValue, TResult>, aweXpect.Core.IOptionsProvider<aweXpect.Reflection.Options.TypeFilterOptions>
+            where TResult : aweXpect.Core.IThat<TValue>
+        {
+            public PropertiesOfTypeResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TResult subject, aweXpect.Reflection.Options.TypeFilterOptions typeFilterOptions) { }
+            public aweXpect.Reflection.ThatProperties.PropertiesOfTypeResult<TValue, TResult> OrOfExactType(System.Type propertyType) { }
+            public aweXpect.Reflection.ThatProperties.PropertiesOfTypeResult<TValue, TResult> OrOfExactType<TProperty>() { }
+            public aweXpect.Reflection.ThatProperties.PropertiesOfTypeResult<TValue, TResult> OrOfType(System.Type propertyType) { }
+            public aweXpect.Reflection.ThatProperties.PropertiesOfTypeResult<TValue, TResult> OrOfType<TProperty>() { }
+        }
     }
     public static class ThatProperty
     {
@@ -655,8 +702,21 @@ namespace aweXpect.Reflection
         public static aweXpect.Results.AndOrResult<System.Reflection.PropertyInfo?, aweXpect.Core.IThat<System.Reflection.PropertyInfo?>> IsNotAbstract(this aweXpect.Core.IThat<System.Reflection.PropertyInfo?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Reflection.PropertyInfo?, aweXpect.Core.IThat<System.Reflection.PropertyInfo?>> IsNotSealed(this aweXpect.Core.IThat<System.Reflection.PropertyInfo?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Reflection.PropertyInfo?, aweXpect.Core.IThat<System.Reflection.PropertyInfo?>> IsNotStatic(this aweXpect.Core.IThat<System.Reflection.PropertyInfo?> subject) { }
+        public static aweXpect.Reflection.ThatProperty.PropertyOfTypeResult<System.Reflection.PropertyInfo?, aweXpect.Core.IThat<System.Reflection.PropertyInfo?>> IsOfExactType(this aweXpect.Core.IThat<System.Reflection.PropertyInfo?> subject, System.Type propertyType) { }
+        public static aweXpect.Reflection.ThatProperty.PropertyOfTypeResult<System.Reflection.PropertyInfo?, aweXpect.Core.IThat<System.Reflection.PropertyInfo?>> IsOfExactType<TProperty>(this aweXpect.Core.IThat<System.Reflection.PropertyInfo?> subject) { }
+        public static aweXpect.Reflection.ThatProperty.PropertyOfTypeResult<System.Reflection.PropertyInfo?, aweXpect.Core.IThat<System.Reflection.PropertyInfo?>> IsOfType(this aweXpect.Core.IThat<System.Reflection.PropertyInfo?> subject, System.Type propertyType) { }
+        public static aweXpect.Reflection.ThatProperty.PropertyOfTypeResult<System.Reflection.PropertyInfo?, aweXpect.Core.IThat<System.Reflection.PropertyInfo?>> IsOfType<TProperty>(this aweXpect.Core.IThat<System.Reflection.PropertyInfo?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Reflection.PropertyInfo?, aweXpect.Core.IThat<System.Reflection.PropertyInfo?>> IsSealed(this aweXpect.Core.IThat<System.Reflection.PropertyInfo?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Reflection.PropertyInfo?, aweXpect.Core.IThat<System.Reflection.PropertyInfo?>> IsStatic(this aweXpect.Core.IThat<System.Reflection.PropertyInfo?> subject) { }
+        public sealed class PropertyOfTypeResult<TValue, TResult> : aweXpect.Results.AndOrResult<TValue, TResult>, aweXpect.Core.IOptionsProvider<aweXpect.Reflection.Options.TypeFilterOptions>
+            where TResult : aweXpect.Core.IThat<TValue>
+        {
+            public PropertyOfTypeResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TResult subject, aweXpect.Reflection.Options.TypeFilterOptions typeFilterOptions) { }
+            public aweXpect.Reflection.ThatProperty.PropertyOfTypeResult<TValue, TResult> OrOfExactType(System.Type propertyType) { }
+            public aweXpect.Reflection.ThatProperty.PropertyOfTypeResult<TValue, TResult> OrOfExactType<TProperty>() { }
+            public aweXpect.Reflection.ThatProperty.PropertyOfTypeResult<TValue, TResult> OrOfType(System.Type propertyType) { }
+            public aweXpect.Reflection.ThatProperty.PropertyOfTypeResult<TValue, TResult> OrOfType<TProperty>() { }
+        }
     }
     public static class ThatType
     {
@@ -1189,7 +1249,7 @@ namespace aweXpect.Reflection.Options
     public class TypeFilterOptions
     {
         public TypeFilterOptions() { }
-        public void AppendDescription(System.Text.StringBuilder stringBuilder, aweXpect.Core.ExpectationGrammars grammar) { }
+        public void AppendDescription(System.Text.StringBuilder stringBuilder, aweXpect.Core.ExpectationGrammars grammar, string singular = "returns ", string plural = "return ", string negatedSingular = "does not return ") { }
         public bool Matches(System.Type? type) { }
         public void RegisterType(System.Type type, bool forceDirect) { }
     }

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net10.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net10.0.txt
@@ -1249,7 +1249,7 @@ namespace aweXpect.Reflection.Options
     public class TypeFilterOptions
     {
         public TypeFilterOptions() { }
-        public void AppendDescription(System.Text.StringBuilder stringBuilder, aweXpect.Core.ExpectationGrammars grammar, string singular = "returns ", string plural = "return ", string negatedSingular = "does not return ") { }
+        public void AppendDescription(System.Text.StringBuilder stringBuilder, aweXpect.Core.ExpectationGrammars grammar) { }
         public bool Matches(System.Type? type) { }
         public void RegisterType(System.Type type, bool forceDirect) { }
     }

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net8.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net8.0.txt
@@ -424,12 +424,33 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Results.HasAttributeResult<System.Reflection.FieldInfo?> Has<TAttribute>(this aweXpect.Core.IThat<System.Reflection.FieldInfo?> subject, System.Func<TAttribute, bool> predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
             where TAttribute : System.Attribute { }
         public static aweXpect.Results.AndOrResult<System.Reflection.FieldInfo?, aweXpect.Core.IThat<System.Reflection.FieldInfo?>> IsNotStatic(this aweXpect.Core.IThat<System.Reflection.FieldInfo?> subject) { }
+        public static aweXpect.Reflection.ThatField.FieldOfTypeResult<System.Reflection.FieldInfo?, aweXpect.Core.IThat<System.Reflection.FieldInfo?>> IsOfExactType(this aweXpect.Core.IThat<System.Reflection.FieldInfo?> subject, System.Type fieldType) { }
+        public static aweXpect.Reflection.ThatField.FieldOfTypeResult<System.Reflection.FieldInfo?, aweXpect.Core.IThat<System.Reflection.FieldInfo?>> IsOfExactType<TField>(this aweXpect.Core.IThat<System.Reflection.FieldInfo?> subject) { }
+        public static aweXpect.Reflection.ThatField.FieldOfTypeResult<System.Reflection.FieldInfo?, aweXpect.Core.IThat<System.Reflection.FieldInfo?>> IsOfType(this aweXpect.Core.IThat<System.Reflection.FieldInfo?> subject, System.Type fieldType) { }
+        public static aweXpect.Reflection.ThatField.FieldOfTypeResult<System.Reflection.FieldInfo?, aweXpect.Core.IThat<System.Reflection.FieldInfo?>> IsOfType<TField>(this aweXpect.Core.IThat<System.Reflection.FieldInfo?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Reflection.FieldInfo?, aweXpect.Core.IThat<System.Reflection.FieldInfo?>> IsStatic(this aweXpect.Core.IThat<System.Reflection.FieldInfo?> subject) { }
+        public sealed class FieldOfTypeResult<TValue, TResult> : aweXpect.Results.AndOrResult<TValue, TResult>, aweXpect.Core.IOptionsProvider<aweXpect.Reflection.Options.TypeFilterOptions>
+            where TResult : aweXpect.Core.IThat<TValue>
+        {
+            public FieldOfTypeResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TResult subject, aweXpect.Reflection.Options.TypeFilterOptions typeFilterOptions) { }
+            public aweXpect.Reflection.ThatField.FieldOfTypeResult<TValue, TResult> OrOfExactType(System.Type fieldType) { }
+            public aweXpect.Reflection.ThatField.FieldOfTypeResult<TValue, TResult> OrOfExactType<TField>() { }
+            public aweXpect.Reflection.ThatField.FieldOfTypeResult<TValue, TResult> OrOfType(System.Type fieldType) { }
+            public aweXpect.Reflection.ThatField.FieldOfTypeResult<TValue, TResult> OrOfType<TField>() { }
+        }
     }
     public static class ThatFields
     {
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.FieldInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.FieldInfo?>>> AreNotStatic(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.FieldInfo?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>>> AreNotStatic(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>> subject) { }
+        public static aweXpect.Reflection.ThatFields.FieldsOfTypeResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.FieldInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.FieldInfo?>>> AreOfExactType(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.FieldInfo?>> subject, System.Type fieldType) { }
+        public static aweXpect.Reflection.ThatFields.FieldsOfTypeResult<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>>> AreOfExactType(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>> subject, System.Type fieldType) { }
+        public static aweXpect.Reflection.ThatFields.FieldsOfTypeResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.FieldInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.FieldInfo?>>> AreOfExactType<TField>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.FieldInfo?>> subject) { }
+        public static aweXpect.Reflection.ThatFields.FieldsOfTypeResult<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>>> AreOfExactType<TField>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>> subject) { }
+        public static aweXpect.Reflection.ThatFields.FieldsOfTypeResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.FieldInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.FieldInfo?>>> AreOfType(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.FieldInfo?>> subject, System.Type fieldType) { }
+        public static aweXpect.Reflection.ThatFields.FieldsOfTypeResult<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>>> AreOfType(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>> subject, System.Type fieldType) { }
+        public static aweXpect.Reflection.ThatFields.FieldsOfTypeResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.FieldInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.FieldInfo?>>> AreOfType<TField>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.FieldInfo?>> subject) { }
+        public static aweXpect.Reflection.ThatFields.FieldsOfTypeResult<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>>> AreOfType<TField>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.FieldInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.FieldInfo?>>> AreStatic(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.FieldInfo?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>>> AreStatic(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>> subject) { }
         public static aweXpect.Reflection.Results.HaveAttributeResult<System.Reflection.FieldInfo?, System.Collections.Generic.IAsyncEnumerable<System.Reflection.FieldInfo?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.FieldInfo?>> subject, bool inherit = true)
@@ -440,6 +461,15 @@ namespace aweXpect.Reflection
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Results.HaveAttributeResult<System.Reflection.FieldInfo?, System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>> subject, System.Func<TAttribute, bool> predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
             where TAttribute : System.Attribute { }
+        public sealed class FieldsOfTypeResult<TValue, TResult> : aweXpect.Results.AndOrResult<TValue, TResult>, aweXpect.Core.IOptionsProvider<aweXpect.Reflection.Options.TypeFilterOptions>
+            where TResult : aweXpect.Core.IThat<TValue>
+        {
+            public FieldsOfTypeResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TResult subject, aweXpect.Reflection.Options.TypeFilterOptions typeFilterOptions) { }
+            public aweXpect.Reflection.ThatFields.FieldsOfTypeResult<TValue, TResult> OrOfExactType(System.Type fieldType) { }
+            public aweXpect.Reflection.ThatFields.FieldsOfTypeResult<TValue, TResult> OrOfExactType<TField>() { }
+            public aweXpect.Reflection.ThatFields.FieldsOfTypeResult<TValue, TResult> OrOfType(System.Type fieldType) { }
+            public aweXpect.Reflection.ThatFields.FieldsOfTypeResult<TValue, TResult> OrOfType<TField>() { }
+        }
     }
     public static class ThatMember
     {
@@ -632,6 +662,14 @@ namespace aweXpect.Reflection
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>>> AreNotSealed(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.PropertyInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.PropertyInfo?>>> AreNotStatic(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.PropertyInfo?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>>> AreNotStatic(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>> subject) { }
+        public static aweXpect.Reflection.ThatProperties.PropertiesOfTypeResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.PropertyInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.PropertyInfo?>>> AreOfExactType(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.PropertyInfo?>> subject, System.Type propertyType) { }
+        public static aweXpect.Reflection.ThatProperties.PropertiesOfTypeResult<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>>> AreOfExactType(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>> subject, System.Type propertyType) { }
+        public static aweXpect.Reflection.ThatProperties.PropertiesOfTypeResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.PropertyInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.PropertyInfo?>>> AreOfExactType<TProperty>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.PropertyInfo?>> subject) { }
+        public static aweXpect.Reflection.ThatProperties.PropertiesOfTypeResult<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>>> AreOfExactType<TProperty>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>> subject) { }
+        public static aweXpect.Reflection.ThatProperties.PropertiesOfTypeResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.PropertyInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.PropertyInfo?>>> AreOfType(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.PropertyInfo?>> subject, System.Type propertyType) { }
+        public static aweXpect.Reflection.ThatProperties.PropertiesOfTypeResult<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>>> AreOfType(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>> subject, System.Type propertyType) { }
+        public static aweXpect.Reflection.ThatProperties.PropertiesOfTypeResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.PropertyInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.PropertyInfo?>>> AreOfType<TProperty>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.PropertyInfo?>> subject) { }
+        public static aweXpect.Reflection.ThatProperties.PropertiesOfTypeResult<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>>> AreOfType<TProperty>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.PropertyInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.PropertyInfo?>>> AreSealed(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.PropertyInfo?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>>> AreSealed(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.PropertyInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.PropertyInfo?>>> AreStatic(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.PropertyInfo?>> subject) { }
@@ -644,6 +682,15 @@ namespace aweXpect.Reflection
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Results.HaveAttributeResult<System.Reflection.PropertyInfo?, System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>> subject, System.Func<TAttribute, bool> predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
             where TAttribute : System.Attribute { }
+        public sealed class PropertiesOfTypeResult<TValue, TResult> : aweXpect.Results.AndOrResult<TValue, TResult>, aweXpect.Core.IOptionsProvider<aweXpect.Reflection.Options.TypeFilterOptions>
+            where TResult : aweXpect.Core.IThat<TValue>
+        {
+            public PropertiesOfTypeResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TResult subject, aweXpect.Reflection.Options.TypeFilterOptions typeFilterOptions) { }
+            public aweXpect.Reflection.ThatProperties.PropertiesOfTypeResult<TValue, TResult> OrOfExactType(System.Type propertyType) { }
+            public aweXpect.Reflection.ThatProperties.PropertiesOfTypeResult<TValue, TResult> OrOfExactType<TProperty>() { }
+            public aweXpect.Reflection.ThatProperties.PropertiesOfTypeResult<TValue, TResult> OrOfType(System.Type propertyType) { }
+            public aweXpect.Reflection.ThatProperties.PropertiesOfTypeResult<TValue, TResult> OrOfType<TProperty>() { }
+        }
     }
     public static class ThatProperty
     {
@@ -655,8 +702,21 @@ namespace aweXpect.Reflection
         public static aweXpect.Results.AndOrResult<System.Reflection.PropertyInfo?, aweXpect.Core.IThat<System.Reflection.PropertyInfo?>> IsNotAbstract(this aweXpect.Core.IThat<System.Reflection.PropertyInfo?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Reflection.PropertyInfo?, aweXpect.Core.IThat<System.Reflection.PropertyInfo?>> IsNotSealed(this aweXpect.Core.IThat<System.Reflection.PropertyInfo?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Reflection.PropertyInfo?, aweXpect.Core.IThat<System.Reflection.PropertyInfo?>> IsNotStatic(this aweXpect.Core.IThat<System.Reflection.PropertyInfo?> subject) { }
+        public static aweXpect.Reflection.ThatProperty.PropertyOfTypeResult<System.Reflection.PropertyInfo?, aweXpect.Core.IThat<System.Reflection.PropertyInfo?>> IsOfExactType(this aweXpect.Core.IThat<System.Reflection.PropertyInfo?> subject, System.Type propertyType) { }
+        public static aweXpect.Reflection.ThatProperty.PropertyOfTypeResult<System.Reflection.PropertyInfo?, aweXpect.Core.IThat<System.Reflection.PropertyInfo?>> IsOfExactType<TProperty>(this aweXpect.Core.IThat<System.Reflection.PropertyInfo?> subject) { }
+        public static aweXpect.Reflection.ThatProperty.PropertyOfTypeResult<System.Reflection.PropertyInfo?, aweXpect.Core.IThat<System.Reflection.PropertyInfo?>> IsOfType(this aweXpect.Core.IThat<System.Reflection.PropertyInfo?> subject, System.Type propertyType) { }
+        public static aweXpect.Reflection.ThatProperty.PropertyOfTypeResult<System.Reflection.PropertyInfo?, aweXpect.Core.IThat<System.Reflection.PropertyInfo?>> IsOfType<TProperty>(this aweXpect.Core.IThat<System.Reflection.PropertyInfo?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Reflection.PropertyInfo?, aweXpect.Core.IThat<System.Reflection.PropertyInfo?>> IsSealed(this aweXpect.Core.IThat<System.Reflection.PropertyInfo?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Reflection.PropertyInfo?, aweXpect.Core.IThat<System.Reflection.PropertyInfo?>> IsStatic(this aweXpect.Core.IThat<System.Reflection.PropertyInfo?> subject) { }
+        public sealed class PropertyOfTypeResult<TValue, TResult> : aweXpect.Results.AndOrResult<TValue, TResult>, aweXpect.Core.IOptionsProvider<aweXpect.Reflection.Options.TypeFilterOptions>
+            where TResult : aweXpect.Core.IThat<TValue>
+        {
+            public PropertyOfTypeResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TResult subject, aweXpect.Reflection.Options.TypeFilterOptions typeFilterOptions) { }
+            public aweXpect.Reflection.ThatProperty.PropertyOfTypeResult<TValue, TResult> OrOfExactType(System.Type propertyType) { }
+            public aweXpect.Reflection.ThatProperty.PropertyOfTypeResult<TValue, TResult> OrOfExactType<TProperty>() { }
+            public aweXpect.Reflection.ThatProperty.PropertyOfTypeResult<TValue, TResult> OrOfType(System.Type propertyType) { }
+            public aweXpect.Reflection.ThatProperty.PropertyOfTypeResult<TValue, TResult> OrOfType<TProperty>() { }
+        }
     }
     public static class ThatType
     {

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_netstandard2.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_netstandard2.0.txt
@@ -1117,7 +1117,7 @@ namespace aweXpect.Reflection.Options
     public class TypeFilterOptions
     {
         public TypeFilterOptions() { }
-        public void AppendDescription(System.Text.StringBuilder stringBuilder, aweXpect.Core.ExpectationGrammars grammar, string singular = "returns ", string plural = "return ", string negatedSingular = "does not return ") { }
+        public void AppendDescription(System.Text.StringBuilder stringBuilder, aweXpect.Core.ExpectationGrammars grammar) { }
         public bool Matches(System.Type? type) { }
         public void RegisterType(System.Type type, bool forceDirect) { }
     }

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_netstandard2.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_netstandard2.0.txt
@@ -399,16 +399,42 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Results.HasAttributeResult<System.Reflection.FieldInfo?> Has<TAttribute>(this aweXpect.Core.IThat<System.Reflection.FieldInfo?> subject, System.Func<TAttribute, bool> predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
             where TAttribute : System.Attribute { }
         public static aweXpect.Results.AndOrResult<System.Reflection.FieldInfo?, aweXpect.Core.IThat<System.Reflection.FieldInfo?>> IsNotStatic(this aweXpect.Core.IThat<System.Reflection.FieldInfo?> subject) { }
+        public static aweXpect.Reflection.ThatField.FieldOfTypeResult<System.Reflection.FieldInfo?, aweXpect.Core.IThat<System.Reflection.FieldInfo?>> IsOfExactType(this aweXpect.Core.IThat<System.Reflection.FieldInfo?> subject, System.Type fieldType) { }
+        public static aweXpect.Reflection.ThatField.FieldOfTypeResult<System.Reflection.FieldInfo?, aweXpect.Core.IThat<System.Reflection.FieldInfo?>> IsOfExactType<TField>(this aweXpect.Core.IThat<System.Reflection.FieldInfo?> subject) { }
+        public static aweXpect.Reflection.ThatField.FieldOfTypeResult<System.Reflection.FieldInfo?, aweXpect.Core.IThat<System.Reflection.FieldInfo?>> IsOfType(this aweXpect.Core.IThat<System.Reflection.FieldInfo?> subject, System.Type fieldType) { }
+        public static aweXpect.Reflection.ThatField.FieldOfTypeResult<System.Reflection.FieldInfo?, aweXpect.Core.IThat<System.Reflection.FieldInfo?>> IsOfType<TField>(this aweXpect.Core.IThat<System.Reflection.FieldInfo?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Reflection.FieldInfo?, aweXpect.Core.IThat<System.Reflection.FieldInfo?>> IsStatic(this aweXpect.Core.IThat<System.Reflection.FieldInfo?> subject) { }
+        public sealed class FieldOfTypeResult<TValue, TResult> : aweXpect.Results.AndOrResult<TValue, TResult>, aweXpect.Core.IOptionsProvider<aweXpect.Reflection.Options.TypeFilterOptions>
+            where TResult : aweXpect.Core.IThat<TValue>
+        {
+            public FieldOfTypeResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TResult subject, aweXpect.Reflection.Options.TypeFilterOptions typeFilterOptions) { }
+            public aweXpect.Reflection.ThatField.FieldOfTypeResult<TValue, TResult> OrOfExactType(System.Type fieldType) { }
+            public aweXpect.Reflection.ThatField.FieldOfTypeResult<TValue, TResult> OrOfExactType<TField>() { }
+            public aweXpect.Reflection.ThatField.FieldOfTypeResult<TValue, TResult> OrOfType(System.Type fieldType) { }
+            public aweXpect.Reflection.ThatField.FieldOfTypeResult<TValue, TResult> OrOfType<TField>() { }
+        }
     }
     public static class ThatFields
     {
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>>> AreNotStatic(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>> subject) { }
+        public static aweXpect.Reflection.ThatFields.FieldsOfTypeResult<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>>> AreOfExactType(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>> subject, System.Type fieldType) { }
+        public static aweXpect.Reflection.ThatFields.FieldsOfTypeResult<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>>> AreOfExactType<TField>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>> subject) { }
+        public static aweXpect.Reflection.ThatFields.FieldsOfTypeResult<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>>> AreOfType(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>> subject, System.Type fieldType) { }
+        public static aweXpect.Reflection.ThatFields.FieldsOfTypeResult<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>>> AreOfType<TField>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>>> AreStatic(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>> subject) { }
         public static aweXpect.Reflection.Results.HaveAttributeResult<System.Reflection.FieldInfo?, System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>> subject, bool inherit = true)
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Results.HaveAttributeResult<System.Reflection.FieldInfo?, System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>> subject, System.Func<TAttribute, bool> predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
             where TAttribute : System.Attribute { }
+        public sealed class FieldsOfTypeResult<TValue, TResult> : aweXpect.Results.AndOrResult<TValue, TResult>, aweXpect.Core.IOptionsProvider<aweXpect.Reflection.Options.TypeFilterOptions>
+            where TResult : aweXpect.Core.IThat<TValue>
+        {
+            public FieldsOfTypeResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TResult subject, aweXpect.Reflection.Options.TypeFilterOptions typeFilterOptions) { }
+            public aweXpect.Reflection.ThatFields.FieldsOfTypeResult<TValue, TResult> OrOfExactType(System.Type fieldType) { }
+            public aweXpect.Reflection.ThatFields.FieldsOfTypeResult<TValue, TResult> OrOfExactType<TField>() { }
+            public aweXpect.Reflection.ThatFields.FieldsOfTypeResult<TValue, TResult> OrOfType(System.Type fieldType) { }
+            public aweXpect.Reflection.ThatFields.FieldsOfTypeResult<TValue, TResult> OrOfType<TField>() { }
+        }
     }
     public static class ThatMember
     {
@@ -546,12 +572,25 @@ namespace aweXpect.Reflection
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>>> AreNotAbstract(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>>> AreNotSealed(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>>> AreNotStatic(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>> subject) { }
+        public static aweXpect.Reflection.ThatProperties.PropertiesOfTypeResult<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>>> AreOfExactType(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>> subject, System.Type propertyType) { }
+        public static aweXpect.Reflection.ThatProperties.PropertiesOfTypeResult<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>>> AreOfExactType<TProperty>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>> subject) { }
+        public static aweXpect.Reflection.ThatProperties.PropertiesOfTypeResult<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>>> AreOfType(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>> subject, System.Type propertyType) { }
+        public static aweXpect.Reflection.ThatProperties.PropertiesOfTypeResult<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>>> AreOfType<TProperty>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>>> AreSealed(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>>> AreStatic(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>> subject) { }
         public static aweXpect.Reflection.Results.HaveAttributeResult<System.Reflection.PropertyInfo?, System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>> subject, bool inherit = true)
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Results.HaveAttributeResult<System.Reflection.PropertyInfo?, System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>> subject, System.Func<TAttribute, bool> predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
             where TAttribute : System.Attribute { }
+        public sealed class PropertiesOfTypeResult<TValue, TResult> : aweXpect.Results.AndOrResult<TValue, TResult>, aweXpect.Core.IOptionsProvider<aweXpect.Reflection.Options.TypeFilterOptions>
+            where TResult : aweXpect.Core.IThat<TValue>
+        {
+            public PropertiesOfTypeResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TResult subject, aweXpect.Reflection.Options.TypeFilterOptions typeFilterOptions) { }
+            public aweXpect.Reflection.ThatProperties.PropertiesOfTypeResult<TValue, TResult> OrOfExactType(System.Type propertyType) { }
+            public aweXpect.Reflection.ThatProperties.PropertiesOfTypeResult<TValue, TResult> OrOfExactType<TProperty>() { }
+            public aweXpect.Reflection.ThatProperties.PropertiesOfTypeResult<TValue, TResult> OrOfType(System.Type propertyType) { }
+            public aweXpect.Reflection.ThatProperties.PropertiesOfTypeResult<TValue, TResult> OrOfType<TProperty>() { }
+        }
     }
     public static class ThatProperty
     {
@@ -563,8 +602,21 @@ namespace aweXpect.Reflection
         public static aweXpect.Results.AndOrResult<System.Reflection.PropertyInfo?, aweXpect.Core.IThat<System.Reflection.PropertyInfo?>> IsNotAbstract(this aweXpect.Core.IThat<System.Reflection.PropertyInfo?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Reflection.PropertyInfo?, aweXpect.Core.IThat<System.Reflection.PropertyInfo?>> IsNotSealed(this aweXpect.Core.IThat<System.Reflection.PropertyInfo?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Reflection.PropertyInfo?, aweXpect.Core.IThat<System.Reflection.PropertyInfo?>> IsNotStatic(this aweXpect.Core.IThat<System.Reflection.PropertyInfo?> subject) { }
+        public static aweXpect.Reflection.ThatProperty.PropertyOfTypeResult<System.Reflection.PropertyInfo?, aweXpect.Core.IThat<System.Reflection.PropertyInfo?>> IsOfExactType(this aweXpect.Core.IThat<System.Reflection.PropertyInfo?> subject, System.Type propertyType) { }
+        public static aweXpect.Reflection.ThatProperty.PropertyOfTypeResult<System.Reflection.PropertyInfo?, aweXpect.Core.IThat<System.Reflection.PropertyInfo?>> IsOfExactType<TProperty>(this aweXpect.Core.IThat<System.Reflection.PropertyInfo?> subject) { }
+        public static aweXpect.Reflection.ThatProperty.PropertyOfTypeResult<System.Reflection.PropertyInfo?, aweXpect.Core.IThat<System.Reflection.PropertyInfo?>> IsOfType(this aweXpect.Core.IThat<System.Reflection.PropertyInfo?> subject, System.Type propertyType) { }
+        public static aweXpect.Reflection.ThatProperty.PropertyOfTypeResult<System.Reflection.PropertyInfo?, aweXpect.Core.IThat<System.Reflection.PropertyInfo?>> IsOfType<TProperty>(this aweXpect.Core.IThat<System.Reflection.PropertyInfo?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Reflection.PropertyInfo?, aweXpect.Core.IThat<System.Reflection.PropertyInfo?>> IsSealed(this aweXpect.Core.IThat<System.Reflection.PropertyInfo?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Reflection.PropertyInfo?, aweXpect.Core.IThat<System.Reflection.PropertyInfo?>> IsStatic(this aweXpect.Core.IThat<System.Reflection.PropertyInfo?> subject) { }
+        public sealed class PropertyOfTypeResult<TValue, TResult> : aweXpect.Results.AndOrResult<TValue, TResult>, aweXpect.Core.IOptionsProvider<aweXpect.Reflection.Options.TypeFilterOptions>
+            where TResult : aweXpect.Core.IThat<TValue>
+        {
+            public PropertyOfTypeResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TResult subject, aweXpect.Reflection.Options.TypeFilterOptions typeFilterOptions) { }
+            public aweXpect.Reflection.ThatProperty.PropertyOfTypeResult<TValue, TResult> OrOfExactType(System.Type propertyType) { }
+            public aweXpect.Reflection.ThatProperty.PropertyOfTypeResult<TValue, TResult> OrOfExactType<TProperty>() { }
+            public aweXpect.Reflection.ThatProperty.PropertyOfTypeResult<TValue, TResult> OrOfType(System.Type propertyType) { }
+            public aweXpect.Reflection.ThatProperty.PropertyOfTypeResult<TValue, TResult> OrOfType<TProperty>() { }
+        }
     }
     public static class ThatType
     {
@@ -1065,7 +1117,7 @@ namespace aweXpect.Reflection.Options
     public class TypeFilterOptions
     {
         public TypeFilterOptions() { }
-        public void AppendDescription(System.Text.StringBuilder stringBuilder, aweXpect.Core.ExpectationGrammars grammar) { }
+        public void AppendDescription(System.Text.StringBuilder stringBuilder, aweXpect.Core.ExpectationGrammars grammar, string singular = "returns ", string plural = "return ", string negatedSingular = "does not return ") { }
         public bool Matches(System.Type? type) { }
         public void RegisterType(System.Type type, bool forceDirect) { }
     }

--- a/Tests/aweXpect.Reflection.Tests/ThatField.IsOfExactType.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatField.IsOfExactType.Tests.cs
@@ -1,0 +1,102 @@
+﻿using System.Reflection;
+using Xunit.Sdk;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatField
+{
+	public sealed class IsOfExactType
+	{
+		public sealed class GenericTests
+		{
+			[Fact]
+			public async Task WhenFieldIsNull_ShouldFail()
+			{
+				FieldInfo? subject = null;
+
+				async Task Act()
+					=> await That(subject).IsOfExactType<int>();
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             is of exact type int,
+					             but it was <null>
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenFieldIsOfExactType_ShouldSucceed()
+			{
+				FieldInfo subject = typeof(TestClass).GetField(nameof(TestClass.DummyBaseField))!;
+
+				async Task Act()
+					=> await That(subject).IsOfExactType<DummyBase>();
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenFieldTypeInheritsFromExpectedType_ShouldFail()
+			{
+				FieldInfo subject = typeof(TestClass).GetField(nameof(TestClass.DummyField))!;
+
+				async Task Act()
+					=> await That(subject).IsOfExactType<DummyBase>();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is of exact type *DummyBase,
+					             but it was of type *Dummy
+					             """).AsWildcard();
+			}
+		}
+
+		public sealed class TypeTests
+		{
+			[Fact]
+			public async Task WhenFieldIsOfExactType_ShouldSucceed()
+			{
+				FieldInfo subject = typeof(TestClass).GetField(nameof(TestClass.DummyBaseField))!;
+
+				async Task Act()
+					=> await That(subject).IsOfExactType(typeof(DummyBase));
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+		public sealed class OrOfExactTypeTests
+		{
+			[Fact]
+			public async Task WithMultipleOrOfExactType_ShouldSupportChaining()
+			{
+				FieldInfo subject = typeof(TestClass).GetField(nameof(TestClass.DummyField))!;
+
+				async Task Act()
+					=> await That(subject).IsOfExactType<DummyBase>().OrOfType(typeof(bool)).OrOfExactType<Dummy>();
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+		private class TestClass
+		{
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor.
+#pragma warning disable CS0649 // Field is never assigned to, and will always have its default value
+			public DummyBase DummyBaseField;
+			public Dummy DummyField;
+#pragma warning restore CS0649
+#pragma warning restore CS8618
+		}
+
+		private class DummyBase
+		{
+		}
+
+		private class Dummy : DummyBase
+		{
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatField.IsOfExactType.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatField.IsOfExactType.Tests.cs
@@ -15,7 +15,9 @@ public sealed partial class ThatField
 				FieldInfo? subject = null;
 
 				async Task Act()
-					=> await That(subject).IsOfExactType<int>();
+				{
+					await That(subject).IsOfExactType<int>();
+				}
 
 				await That(Act).ThrowsException()
 					.WithMessage("""
@@ -31,7 +33,9 @@ public sealed partial class ThatField
 				FieldInfo subject = typeof(TestClass).GetField(nameof(TestClass.DummyBaseField))!;
 
 				async Task Act()
-					=> await That(subject).IsOfExactType<DummyBase>();
+				{
+					await That(subject).IsOfExactType<DummyBase>();
+				}
 
 				await That(Act).DoesNotThrow();
 			}
@@ -42,7 +46,9 @@ public sealed partial class ThatField
 				FieldInfo subject = typeof(TestClass).GetField(nameof(TestClass.DummyField))!;
 
 				async Task Act()
-					=> await That(subject).IsOfExactType<DummyBase>();
+				{
+					await That(subject).IsOfExactType<DummyBase>();
+				}
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
@@ -53,29 +59,35 @@ public sealed partial class ThatField
 			}
 		}
 
-		public sealed class TypeTests
+		public sealed class NegatedTests
 		{
 			[Fact]
-			public async Task WhenFieldIsOfExactType_ShouldSucceed()
+			public async Task WhenFieldIsOfExactType_ShouldFail()
 			{
 				FieldInfo subject = typeof(TestClass).GetField(nameof(TestClass.DummyBaseField))!;
 
 				async Task Act()
-					=> await That(subject).IsOfExactType(typeof(DummyBase));
+				{
+					await That(subject).DoesNotComplyWith(it => it.IsOfExactType<DummyBase>());
+				}
 
-				await That(Act).DoesNotThrow();
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is not of exact type *DummyBase,
+					             but it did
+					             """).AsWildcard();
 			}
-		}
 
-		public sealed class OrOfExactTypeTests
-		{
 			[Fact]
-			public async Task WithMultipleOrOfExactType_ShouldSupportChaining()
+			public async Task WhenFieldTypeInheritsFromExpectedType_ShouldSucceed()
 			{
 				FieldInfo subject = typeof(TestClass).GetField(nameof(TestClass.DummyField))!;
 
 				async Task Act()
-					=> await That(subject).IsOfExactType<DummyBase>().OrOfType(typeof(bool)).OrOfExactType<Dummy>();
+				{
+					await That(subject).DoesNotComplyWith(it => it.IsOfExactType<DummyBase>());
+				}
 
 				await That(Act).DoesNotThrow();
 			}
@@ -98,5 +110,39 @@ public sealed partial class ThatField
 		private class Dummy : DummyBase
 		{
 		}
+
+#pragma warning disable CA2263 // tests intentionally exercise the non-generic Type overload
+		public sealed class TypeTests
+		{
+			[Fact]
+			public async Task WhenFieldIsOfExactType_ShouldSucceed()
+			{
+				FieldInfo subject = typeof(TestClass).GetField(nameof(TestClass.DummyBaseField))!;
+
+				async Task Act()
+				{
+					await That(subject).IsOfExactType(typeof(DummyBase));
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+		public sealed class OrOfExactTypeTests
+		{
+			[Fact]
+			public async Task WithMultipleOrOfExactType_ShouldSupportChaining()
+			{
+				FieldInfo subject = typeof(TestClass).GetField(nameof(TestClass.DummyField))!;
+
+				async Task Act()
+				{
+					await That(subject).IsOfExactType<DummyBase>().OrOfType(typeof(bool)).OrOfExactType<Dummy>();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+#pragma warning restore CA2263
 	}
 }

--- a/Tests/aweXpect.Reflection.Tests/ThatField.IsOfType.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatField.IsOfType.Tests.cs
@@ -64,6 +64,7 @@ public sealed partial class ThatField
 			}
 		}
 
+#pragma warning disable CA2263 // tests intentionally exercise the non-generic Type overload
 		public sealed class TypeTests
 		{
 			[Fact]
@@ -123,6 +124,7 @@ public sealed partial class ThatField
 					             """);
 			}
 		}
+#pragma warning restore CA2263
 
 		public sealed class OrOfExactTypeTests
 		{
@@ -164,8 +166,7 @@ public sealed partial class ThatField
 					             Expected that subject
 					             is not of type int,
 					             but it did
-					             """)
-					.AsWildcard();
+					             """);
 			}
 		}
 

--- a/Tests/aweXpect.Reflection.Tests/ThatField.IsOfType.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatField.IsOfType.Tests.cs
@@ -1,0 +1,190 @@
+﻿using System.Reflection;
+using Xunit.Sdk;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatField
+{
+	public sealed class IsOfType
+	{
+		public sealed class GenericTests
+		{
+			[Fact]
+			public async Task WhenFieldIsNull_ShouldFail()
+			{
+				FieldInfo? subject = null;
+
+				async Task Act()
+					=> await That(subject).IsOfType<int>();
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             is of type int,
+					             but it was <null>
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenFieldIsOfDifferentType_ShouldFail()
+			{
+				FieldInfo subject = typeof(TestClass).GetField(nameof(TestClass.IntField))!;
+
+				async Task Act()
+					=> await That(subject).IsOfType<string>();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is of type string,
+					             but it was of type int
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenFieldIsOfExpectedType_ShouldSucceed()
+			{
+				FieldInfo subject = typeof(TestClass).GetField(nameof(TestClass.IntField))!;
+
+				async Task Act()
+					=> await That(subject).IsOfType<int>();
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenFieldTypeInheritsFromExpectedType_ShouldSucceed()
+			{
+				FieldInfo subject = typeof(TestClass).GetField(nameof(TestClass.DummyField))!;
+
+				async Task Act()
+					=> await That(subject).IsOfType<DummyBase>();
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+		public sealed class TypeTests
+		{
+			[Fact]
+			public async Task WhenFieldIsOfDifferentType_ShouldFail()
+			{
+				FieldInfo subject = typeof(TestClass).GetField(nameof(TestClass.IntField))!;
+
+				async Task Act()
+					=> await That(subject).IsOfType(typeof(string));
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is of type string,
+					             but it was of type int
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenFieldIsOfExpectedType_ShouldSucceed()
+			{
+				FieldInfo subject = typeof(TestClass).GetField(nameof(TestClass.IntField))!;
+
+				async Task Act()
+					=> await That(subject).IsOfType(typeof(int));
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+		public sealed class OrOfTypeTests
+		{
+			[Fact]
+			public async Task WithMultipleOrOfType_ShouldSupportChaining()
+			{
+				FieldInfo subject = typeof(TestClass).GetField(nameof(TestClass.IntField))!;
+
+				async Task Act()
+					=> await That(subject).IsOfType<string>().OrOfType(typeof(bool)).OrOfType<int>();
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenFieldIsNoneOfTheTypes_ShouldFail()
+			{
+				FieldInfo subject = typeof(TestClass).GetField(nameof(TestClass.IntField))!;
+
+				async Task Act()
+					=> await That(subject).IsOfType<string>().OrOfType<bool>();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is of type string or of type bool,
+					             but it was of type int
+					             """);
+			}
+		}
+
+		public sealed class OrOfExactTypeTests
+		{
+			[Fact]
+			public async Task WhenFieldIsOneOfTheTypes_ShouldSucceed()
+			{
+				FieldInfo subject = typeof(TestClass).GetField(nameof(TestClass.IntField))!;
+
+				async Task Act()
+					=> await That(subject).IsOfType<string>().OrOfExactType<int>();
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+		public sealed class NegatedTests
+		{
+			[Fact]
+			public async Task WhenFieldIsOfDifferentType_ShouldSucceed()
+			{
+				FieldInfo subject = typeof(TestClass).GetField(nameof(TestClass.IntField))!;
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.IsOfType<string>());
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenFieldIsOfExpectedType_ShouldFail()
+			{
+				FieldInfo subject = typeof(TestClass).GetField(nameof(TestClass.IntField))!;
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.IsOfType<int>());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is not of type int,
+					             but it did
+					             """)
+					.AsWildcard();
+			}
+		}
+
+		private class TestClass
+		{
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor.
+#pragma warning disable CS0649 // Field is never assigned to, and will always have its default value
+			public int IntField;
+			public Dummy DummyField;
+#pragma warning restore CS0649
+#pragma warning restore CS8618
+		}
+
+		private class DummyBase
+		{
+		}
+
+		private class Dummy : DummyBase
+		{
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatFields.AreOfExactType.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatFields.AreOfExactType.Tests.cs
@@ -1,0 +1,85 @@
+﻿using System.Collections.Generic;
+using System.Reflection;
+using Xunit.Sdk;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatFields
+{
+	public sealed class AreOfExactType
+	{
+		public sealed class GenericTests
+		{
+			[Fact]
+			public async Task ShouldFailWhenFieldsInheritFromType()
+			{
+				IEnumerable<FieldInfo> subject =
+				[
+					typeof(TestClass).GetField(nameof(TestClass.DummyField))!,
+				];
+
+				async Task Act()
+					=> await That(subject).AreOfExactType<DummyBase>();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             all are of exact type *DummyBase,
+					             but it contained not matching fields [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task ShouldSucceedWhenAllFieldsAreOfExactType()
+			{
+				IEnumerable<FieldInfo> subject =
+				[
+					typeof(TestClass).GetField(nameof(TestClass.DummyBaseField))!,
+				];
+
+				async Task Act()
+					=> await That(subject).AreOfExactType<DummyBase>();
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+		public sealed class OrOfExactTypeTests
+		{
+			[Fact]
+			public async Task WhenAllFieldsAreOneOfTheExactTypes_ShouldSucceed()
+			{
+				IEnumerable<FieldInfo> subject =
+				[
+					typeof(TestClass).GetField(nameof(TestClass.DummyBaseField))!,
+					typeof(TestClass).GetField(nameof(TestClass.DummyField))!,
+				];
+
+				async Task Act()
+					=> await That(subject).AreOfExactType<DummyBase>().OrOfExactType<Dummy>();
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+		private class TestClass
+		{
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor.
+#pragma warning disable CS0649 // Field is never assigned to, and will always have its default value
+			public DummyBase DummyBaseField;
+			public Dummy DummyField;
+#pragma warning restore CS0649
+#pragma warning restore CS8618
+		}
+
+		private class DummyBase
+		{
+		}
+
+		private class Dummy : DummyBase
+		{
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatFields.AreOfType.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatFields.AreOfType.Tests.cs
@@ -62,6 +62,7 @@ public sealed partial class ThatFields
 			}
 		}
 
+#pragma warning disable CA2263 // tests intentionally exercise the non-generic Type overload
 		public sealed class TypeTests
 		{
 			[Fact]
@@ -119,6 +120,7 @@ public sealed partial class ThatFields
 					             """).AsWildcard();
 			}
 		}
+#pragma warning restore CA2263
 
 		public sealed class NegatedTests
 		{

--- a/Tests/aweXpect.Reflection.Tests/ThatFields.AreOfType.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatFields.AreOfType.Tests.cs
@@ -1,0 +1,183 @@
+﻿using System.Collections.Generic;
+using System.Reflection;
+using Xunit.Sdk;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatFields
+{
+	public sealed class AreOfType
+	{
+		public sealed class GenericTests
+		{
+			[Fact]
+			public async Task ShouldFailWhenSomeFieldsAreNotOfType()
+			{
+				IEnumerable<FieldInfo> subject =
+				[
+					typeof(TestClass).GetField(nameof(TestClass.IntField))!,
+					typeof(TestClass).GetField(nameof(TestClass.StringField))!,
+				];
+
+				async Task Act()
+					=> await That(subject).AreOfType<int>();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             all are of type int,
+					             but it contained not matching fields [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task ShouldSucceedWhenAllFieldsAreOfType()
+			{
+				IEnumerable<FieldInfo> subject =
+				[
+					typeof(TestClass).GetField(nameof(TestClass.IntField))!,
+					typeof(TestClass).GetField(nameof(TestClass.OtherIntField))!,
+				];
+
+				async Task Act()
+					=> await That(subject).AreOfType<int>();
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task ShouldSucceedWithInheritance()
+			{
+				IEnumerable<FieldInfo> subject =
+				[
+					typeof(TestClass).GetField(nameof(TestClass.DummyField))!,
+				];
+
+				async Task Act()
+					=> await That(subject).AreOfType<DummyBase>();
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+		public sealed class TypeTests
+		{
+			[Fact]
+			public async Task ShouldSucceedWhenAllFieldsAreOfType()
+			{
+				IEnumerable<FieldInfo> subject =
+				[
+					typeof(TestClass).GetField(nameof(TestClass.IntField))!,
+					typeof(TestClass).GetField(nameof(TestClass.OtherIntField))!,
+				];
+
+				async Task Act()
+					=> await That(subject).AreOfType(typeof(int));
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+		public sealed class OrOfTypeTests
+		{
+			[Fact]
+			public async Task WhenAllFieldsAreOneOfTheTypes_ShouldSucceed()
+			{
+				IEnumerable<FieldInfo> subject =
+				[
+					typeof(TestClass).GetField(nameof(TestClass.IntField))!,
+					typeof(TestClass).GetField(nameof(TestClass.StringField))!,
+				];
+
+				async Task Act()
+					=> await That(subject).AreOfType<int>().OrOfType(typeof(string));
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSomeFieldsAreNoneOfTheTypes_ShouldFail()
+			{
+				IEnumerable<FieldInfo> subject =
+				[
+					typeof(TestClass).GetField(nameof(TestClass.IntField))!,
+					typeof(TestClass).GetField(nameof(TestClass.StringField))!,
+				];
+
+				async Task Act()
+					=> await That(subject).AreOfType<bool>().OrOfType<long>();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             all are of type bool or of type long,
+					             but it contained not matching fields [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+		}
+
+		public sealed class NegatedTests
+		{
+			[Fact]
+			public async Task WhenAllFieldsAreOfType_ShouldFail()
+			{
+				IEnumerable<FieldInfo> subject =
+				[
+					typeof(TestClass).GetField(nameof(TestClass.IntField))!,
+					typeof(TestClass).GetField(nameof(TestClass.OtherIntField))!,
+				];
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(they => they.AreOfType<int>());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             not all are of type int,
+					             but it only contained matching fields [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenSomeFieldsAreNotOfType_ShouldSucceed()
+			{
+				IEnumerable<FieldInfo> subject =
+				[
+					typeof(TestClass).GetField(nameof(TestClass.IntField))!,
+					typeof(TestClass).GetField(nameof(TestClass.StringField))!,
+				];
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(they => they.AreOfType<int>());
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+		private class TestClass
+		{
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor.
+#pragma warning disable CS0649 // Field is never assigned to, and will always have its default value
+			public int IntField;
+			public int OtherIntField;
+			public string StringField;
+			public Dummy DummyField;
+#pragma warning restore CS0649
+#pragma warning restore CS8618
+		}
+
+		private class DummyBase
+		{
+		}
+
+		private class Dummy : DummyBase
+		{
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatProperties.AreOfExactType.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatProperties.AreOfExactType.Tests.cs
@@ -1,0 +1,83 @@
+﻿using System.Collections.Generic;
+using System.Reflection;
+using Xunit.Sdk;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatProperties
+{
+	public sealed class AreOfExactType
+	{
+		public sealed class GenericTests
+		{
+			[Fact]
+			public async Task ShouldFailWhenPropertiesInheritFromType()
+			{
+				IEnumerable<PropertyInfo> subject =
+				[
+					typeof(TestClass).GetProperty(nameof(TestClass.DummyProperty))!,
+				];
+
+				async Task Act()
+					=> await That(subject).AreOfExactType<DummyBase>();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             all are of exact type *DummyBase,
+					             but it contained not matching properties [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task ShouldSucceedWhenAllPropertiesAreOfExactType()
+			{
+				IEnumerable<PropertyInfo> subject =
+				[
+					typeof(TestClass).GetProperty(nameof(TestClass.DummyBaseProperty))!,
+				];
+
+				async Task Act()
+					=> await That(subject).AreOfExactType<DummyBase>();
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+		public sealed class OrOfExactTypeTests
+		{
+			[Fact]
+			public async Task WhenAllPropertiesAreOneOfTheExactTypes_ShouldSucceed()
+			{
+				IEnumerable<PropertyInfo> subject =
+				[
+					typeof(TestClass).GetProperty(nameof(TestClass.DummyBaseProperty))!,
+					typeof(TestClass).GetProperty(nameof(TestClass.DummyProperty))!,
+				];
+
+				async Task Act()
+					=> await That(subject).AreOfExactType<DummyBase>().OrOfExactType<Dummy>();
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+		private class TestClass
+		{
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor.
+			public DummyBase DummyBaseProperty { get; set; }
+			public Dummy DummyProperty { get; set; }
+#pragma warning restore CS8618
+		}
+
+		private class DummyBase
+		{
+		}
+
+		private class Dummy : DummyBase
+		{
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatProperties.AreOfType.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatProperties.AreOfType.Tests.cs
@@ -62,6 +62,7 @@ public sealed partial class ThatProperties
 			}
 		}
 
+#pragma warning disable CA2263 // tests intentionally exercise the non-generic Type overload
 		public sealed class TypeTests
 		{
 			[Fact]
@@ -119,6 +120,7 @@ public sealed partial class ThatProperties
 					             """).AsWildcard();
 			}
 		}
+#pragma warning restore CA2263
 
 		public sealed class NegatedTests
 		{

--- a/Tests/aweXpect.Reflection.Tests/ThatProperties.AreOfType.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatProperties.AreOfType.Tests.cs
@@ -1,0 +1,181 @@
+﻿using System.Collections.Generic;
+using System.Reflection;
+using Xunit.Sdk;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatProperties
+{
+	public sealed class AreOfType
+	{
+		public sealed class GenericTests
+		{
+			[Fact]
+			public async Task ShouldFailWhenSomePropertiesAreNotOfType()
+			{
+				IEnumerable<PropertyInfo> subject =
+				[
+					typeof(TestClass).GetProperty(nameof(TestClass.IntProperty))!,
+					typeof(TestClass).GetProperty(nameof(TestClass.StringProperty))!,
+				];
+
+				async Task Act()
+					=> await That(subject).AreOfType<int>();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             all are of type int,
+					             but it contained not matching properties [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task ShouldSucceedWhenAllPropertiesAreOfType()
+			{
+				IEnumerable<PropertyInfo> subject =
+				[
+					typeof(TestClass).GetProperty(nameof(TestClass.IntProperty))!,
+					typeof(TestClass).GetProperty(nameof(TestClass.OtherIntProperty))!,
+				];
+
+				async Task Act()
+					=> await That(subject).AreOfType<int>();
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task ShouldSucceedWithInheritance()
+			{
+				IEnumerable<PropertyInfo> subject =
+				[
+					typeof(TestClass).GetProperty(nameof(TestClass.DummyProperty))!,
+				];
+
+				async Task Act()
+					=> await That(subject).AreOfType<DummyBase>();
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+		public sealed class TypeTests
+		{
+			[Fact]
+			public async Task ShouldSucceedWhenAllPropertiesAreOfType()
+			{
+				IEnumerable<PropertyInfo> subject =
+				[
+					typeof(TestClass).GetProperty(nameof(TestClass.IntProperty))!,
+					typeof(TestClass).GetProperty(nameof(TestClass.OtherIntProperty))!,
+				];
+
+				async Task Act()
+					=> await That(subject).AreOfType(typeof(int));
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+		public sealed class OrOfTypeTests
+		{
+			[Fact]
+			public async Task WhenAllPropertiesAreOneOfTheTypes_ShouldSucceed()
+			{
+				IEnumerable<PropertyInfo> subject =
+				[
+					typeof(TestClass).GetProperty(nameof(TestClass.IntProperty))!,
+					typeof(TestClass).GetProperty(nameof(TestClass.StringProperty))!,
+				];
+
+				async Task Act()
+					=> await That(subject).AreOfType<int>().OrOfType(typeof(string));
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSomePropertiesAreNoneOfTheTypes_ShouldFail()
+			{
+				IEnumerable<PropertyInfo> subject =
+				[
+					typeof(TestClass).GetProperty(nameof(TestClass.IntProperty))!,
+					typeof(TestClass).GetProperty(nameof(TestClass.StringProperty))!,
+				];
+
+				async Task Act()
+					=> await That(subject).AreOfType<bool>().OrOfType<long>();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             all are of type bool or of type long,
+					             but it contained not matching properties [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+		}
+
+		public sealed class NegatedTests
+		{
+			[Fact]
+			public async Task WhenAllPropertiesAreOfType_ShouldFail()
+			{
+				IEnumerable<PropertyInfo> subject =
+				[
+					typeof(TestClass).GetProperty(nameof(TestClass.IntProperty))!,
+					typeof(TestClass).GetProperty(nameof(TestClass.OtherIntProperty))!,
+				];
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(they => they.AreOfType<int>());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             not all are of type int,
+					             but it only contained matching properties [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenSomePropertiesAreNotOfType_ShouldSucceed()
+			{
+				IEnumerable<PropertyInfo> subject =
+				[
+					typeof(TestClass).GetProperty(nameof(TestClass.IntProperty))!,
+					typeof(TestClass).GetProperty(nameof(TestClass.StringProperty))!,
+				];
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(they => they.AreOfType<int>());
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+		private class TestClass
+		{
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor.
+			public int IntProperty { get; set; }
+			public int OtherIntProperty { get; set; }
+			public string StringProperty { get; set; }
+			public Dummy DummyProperty { get; set; }
+#pragma warning restore CS8618
+		}
+
+		private class DummyBase
+		{
+		}
+
+		private class Dummy : DummyBase
+		{
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatProperty.IsOfExactType.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatProperty.IsOfExactType.Tests.cs
@@ -1,0 +1,116 @@
+﻿using System.Reflection;
+using Xunit.Sdk;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatProperty
+{
+	public sealed class IsOfExactType
+	{
+		public sealed class GenericTests
+		{
+			[Fact]
+			public async Task WhenPropertyIsNull_ShouldFail()
+			{
+				PropertyInfo? subject = null;
+
+				async Task Act()
+					=> await That(subject).IsOfExactType<int>();
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             is of exact type int,
+					             but it was <null>
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenPropertyIsOfExactType_ShouldSucceed()
+			{
+				PropertyInfo subject = typeof(TestClass).GetProperty(nameof(TestClass.DummyBaseProperty))!;
+
+				async Task Act()
+					=> await That(subject).IsOfExactType<DummyBase>();
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenPropertyTypeInheritsFromExpectedType_ShouldFail()
+			{
+				PropertyInfo subject = typeof(TestClass).GetProperty(nameof(TestClass.DummyProperty))!;
+
+				async Task Act()
+					=> await That(subject).IsOfExactType<DummyBase>();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is of exact type *DummyBase,
+					             but it was of type *Dummy
+					             """).AsWildcard();
+			}
+		}
+
+		public sealed class TypeTests
+		{
+			[Fact]
+			public async Task WhenPropertyIsOfExactType_ShouldSucceed()
+			{
+				PropertyInfo subject = typeof(TestClass).GetProperty(nameof(TestClass.DummyBaseProperty))!;
+
+				async Task Act()
+					=> await That(subject).IsOfExactType(typeof(DummyBase));
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenPropertyTypeInheritsFromExpectedType_ShouldFail()
+			{
+				PropertyInfo subject = typeof(TestClass).GetProperty(nameof(TestClass.DummyProperty))!;
+
+				async Task Act()
+					=> await That(subject).IsOfExactType(typeof(DummyBase));
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is of exact type *DummyBase,
+					             but it was of type *Dummy
+					             """).AsWildcard();
+			}
+		}
+
+		public sealed class OrOfExactTypeTests
+		{
+			[Fact]
+			public async Task WithMultipleOrOfExactType_ShouldSupportChaining()
+			{
+				PropertyInfo subject = typeof(TestClass).GetProperty(nameof(TestClass.DummyProperty))!;
+
+				async Task Act()
+					=> await That(subject).IsOfExactType<DummyBase>().OrOfType(typeof(bool)).OrOfExactType<Dummy>();
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+		private class TestClass
+		{
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor.
+			public DummyBase DummyBaseProperty { get; set; }
+			public Dummy DummyProperty { get; set; }
+#pragma warning restore CS8618
+		}
+
+		private class DummyBase
+		{
+		}
+
+		private class Dummy : DummyBase
+		{
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatProperty.IsOfExactType.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatProperty.IsOfExactType.Tests.cs
@@ -15,7 +15,9 @@ public sealed partial class ThatProperty
 				PropertyInfo? subject = null;
 
 				async Task Act()
-					=> await That(subject).IsOfExactType<int>();
+				{
+					await That(subject).IsOfExactType<int>();
+				}
 
 				await That(Act).ThrowsException()
 					.WithMessage("""
@@ -31,7 +33,9 @@ public sealed partial class ThatProperty
 				PropertyInfo subject = typeof(TestClass).GetProperty(nameof(TestClass.DummyBaseProperty))!;
 
 				async Task Act()
-					=> await That(subject).IsOfExactType<DummyBase>();
+				{
+					await That(subject).IsOfExactType<DummyBase>();
+				}
 
 				await That(Act).DoesNotThrow();
 			}
@@ -42,7 +46,9 @@ public sealed partial class ThatProperty
 				PropertyInfo subject = typeof(TestClass).GetProperty(nameof(TestClass.DummyProperty))!;
 
 				async Task Act()
-					=> await That(subject).IsOfExactType<DummyBase>();
+				{
+					await That(subject).IsOfExactType<DummyBase>();
+				}
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
@@ -53,45 +59,35 @@ public sealed partial class ThatProperty
 			}
 		}
 
-		public sealed class TypeTests
+		public sealed class NegatedTests
 		{
 			[Fact]
-			public async Task WhenPropertyIsOfExactType_ShouldSucceed()
+			public async Task WhenPropertyIsOfExactType_ShouldFail()
 			{
 				PropertyInfo subject = typeof(TestClass).GetProperty(nameof(TestClass.DummyBaseProperty))!;
 
 				async Task Act()
-					=> await That(subject).IsOfExactType(typeof(DummyBase));
-
-				await That(Act).DoesNotThrow();
-			}
-
-			[Fact]
-			public async Task WhenPropertyTypeInheritsFromExpectedType_ShouldFail()
-			{
-				PropertyInfo subject = typeof(TestClass).GetProperty(nameof(TestClass.DummyProperty))!;
-
-				async Task Act()
-					=> await That(subject).IsOfExactType(typeof(DummyBase));
+				{
+					await That(subject).DoesNotComplyWith(it => it.IsOfExactType<DummyBase>());
+				}
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
 					             Expected that subject
-					             is of exact type *DummyBase,
-					             but it was of type *Dummy
+					             is not of exact type *DummyBase,
+					             but it did
 					             """).AsWildcard();
 			}
-		}
 
-		public sealed class OrOfExactTypeTests
-		{
 			[Fact]
-			public async Task WithMultipleOrOfExactType_ShouldSupportChaining()
+			public async Task WhenPropertyTypeInheritsFromExpectedType_ShouldSucceed()
 			{
 				PropertyInfo subject = typeof(TestClass).GetProperty(nameof(TestClass.DummyProperty))!;
 
 				async Task Act()
-					=> await That(subject).IsOfExactType<DummyBase>().OrOfType(typeof(bool)).OrOfExactType<Dummy>();
+				{
+					await That(subject).DoesNotComplyWith(it => it.IsOfExactType<DummyBase>());
+				}
 
 				await That(Act).DoesNotThrow();
 			}
@@ -112,5 +108,57 @@ public sealed partial class ThatProperty
 		private class Dummy : DummyBase
 		{
 		}
+
+#pragma warning disable CA2263 // tests intentionally exercise the non-generic Type overload
+		public sealed class TypeTests
+		{
+			[Fact]
+			public async Task WhenPropertyIsOfExactType_ShouldSucceed()
+			{
+				PropertyInfo subject = typeof(TestClass).GetProperty(nameof(TestClass.DummyBaseProperty))!;
+
+				async Task Act()
+				{
+					await That(subject).IsOfExactType(typeof(DummyBase));
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenPropertyTypeInheritsFromExpectedType_ShouldFail()
+			{
+				PropertyInfo subject = typeof(TestClass).GetProperty(nameof(TestClass.DummyProperty))!;
+
+				async Task Act()
+				{
+					await That(subject).IsOfExactType(typeof(DummyBase));
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is of exact type *DummyBase,
+					             but it was of type *Dummy
+					             """).AsWildcard();
+			}
+		}
+
+		public sealed class OrOfExactTypeTests
+		{
+			[Fact]
+			public async Task WithMultipleOrOfExactType_ShouldSupportChaining()
+			{
+				PropertyInfo subject = typeof(TestClass).GetProperty(nameof(TestClass.DummyProperty))!;
+
+				async Task Act()
+				{
+					await That(subject).IsOfExactType<DummyBase>().OrOfType(typeof(bool)).OrOfExactType<Dummy>();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+#pragma warning restore CA2263
 	}
 }

--- a/Tests/aweXpect.Reflection.Tests/ThatProperty.IsOfType.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatProperty.IsOfType.Tests.cs
@@ -1,0 +1,204 @@
+﻿using System.Reflection;
+using Xunit.Sdk;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatProperty
+{
+	public sealed class IsOfType
+	{
+		public sealed class GenericTests
+		{
+			[Fact]
+			public async Task WhenPropertyIsNull_ShouldFail()
+			{
+				PropertyInfo? subject = null;
+
+				async Task Act()
+					=> await That(subject).IsOfType<int>();
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             is of type int,
+					             but it was <null>
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenPropertyIsOfDifferentType_ShouldFail()
+			{
+				PropertyInfo subject = typeof(TestClass).GetProperty(nameof(TestClass.IntProperty))!;
+
+				async Task Act()
+					=> await That(subject).IsOfType<string>();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is of type string,
+					             but it was of type int
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenPropertyIsOfExpectedType_ShouldSucceed()
+			{
+				PropertyInfo subject = typeof(TestClass).GetProperty(nameof(TestClass.IntProperty))!;
+
+				async Task Act()
+					=> await That(subject).IsOfType<int>();
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenPropertyTypeInheritsFromExpectedType_ShouldSucceed()
+			{
+				PropertyInfo subject = typeof(TestClass).GetProperty(nameof(TestClass.DummyProperty))!;
+
+				async Task Act()
+					=> await That(subject).IsOfType<DummyBase>();
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+		public sealed class TypeTests
+		{
+			[Fact]
+			public async Task WhenPropertyIsOfDifferentType_ShouldFail()
+			{
+				PropertyInfo subject = typeof(TestClass).GetProperty(nameof(TestClass.IntProperty))!;
+
+				async Task Act()
+					=> await That(subject).IsOfType(typeof(string));
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is of type string,
+					             but it was of type int
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenPropertyIsOfExpectedType_ShouldSucceed()
+			{
+				PropertyInfo subject = typeof(TestClass).GetProperty(nameof(TestClass.IntProperty))!;
+
+				async Task Act()
+					=> await That(subject).IsOfType(typeof(int));
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+		public sealed class OrOfTypeTests
+		{
+			[Fact]
+			public async Task WithMultipleOrOfType_ShouldSupportChaining()
+			{
+				PropertyInfo subject = typeof(TestClass).GetProperty(nameof(TestClass.IntProperty))!;
+
+				async Task Act()
+					=> await That(subject).IsOfType<string>().OrOfType(typeof(bool)).OrOfType<int>();
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenPropertyIsNoneOfTheTypes_ShouldFail()
+			{
+				PropertyInfo subject = typeof(TestClass).GetProperty(nameof(TestClass.IntProperty))!;
+
+				async Task Act()
+					=> await That(subject).IsOfType<string>().OrOfType<bool>();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is of type string or of type bool,
+					             but it was of type int
+					             """);
+			}
+		}
+
+		public sealed class OrOfExactTypeTests
+		{
+			[Fact]
+			public async Task WhenPropertyIsOneOfTheTypes_ShouldSucceed()
+			{
+				PropertyInfo subject = typeof(TestClass).GetProperty(nameof(TestClass.IntProperty))!;
+
+				async Task Act()
+					=> await That(subject).IsOfType<string>().OrOfExactType<int>();
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenPropertyIsNoneOfTheTypes_ShouldFail()
+			{
+				PropertyInfo subject = typeof(TestClass).GetProperty(nameof(TestClass.IntProperty))!;
+
+				async Task Act()
+					=> await That(subject).IsOfType<string>().OrOfExactType<bool>();
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is of type string or of exact type bool,
+					             but it was of type int
+					             """);
+			}
+		}
+
+		public sealed class NegatedTests
+		{
+			[Fact]
+			public async Task WhenPropertyIsOfDifferentType_ShouldSucceed()
+			{
+				PropertyInfo subject = typeof(TestClass).GetProperty(nameof(TestClass.IntProperty))!;
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.IsOfType<string>());
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenPropertyIsOfExpectedType_ShouldFail()
+			{
+				PropertyInfo subject = typeof(TestClass).GetProperty(nameof(TestClass.IntProperty))!;
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it => it.IsOfType<int>());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is not of type int,
+					             but it did
+					             """)
+					.AsWildcard();
+			}
+		}
+
+		private class TestClass
+		{
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor.
+			public int IntProperty { get; set; }
+			public Dummy DummyProperty { get; set; }
+#pragma warning restore CS8618
+		}
+
+		private class DummyBase
+		{
+		}
+
+		private class Dummy : DummyBase
+		{
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatProperty.IsOfType.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatProperty.IsOfType.Tests.cs
@@ -64,6 +64,7 @@ public sealed partial class ThatProperty
 			}
 		}
 
+#pragma warning disable CA2263 // tests intentionally exercise the non-generic Type overload
 		public sealed class TypeTests
 		{
 			[Fact]
@@ -123,6 +124,7 @@ public sealed partial class ThatProperty
 					             """);
 			}
 		}
+#pragma warning restore CA2263
 
 		public sealed class OrOfExactTypeTests
 		{
@@ -180,8 +182,7 @@ public sealed partial class ThatProperty
 					             Expected that subject
 					             is not of type int,
 					             but it did
-					             """)
-					.AsWildcard();
+					             """);
 			}
 		}
 


### PR DESCRIPTION
Add `IsOfType<T>`/`IsOfExactType<T>` (single) and `AreOfType<T>`/`AreOfExactType<T>` (many) assertions for properties and fields, filling the previously empty assert columns in the README. They mirror the existing method return-type assertions, support Or-chaining via `OrOfType`/`OrOfExactType`, and reuse `TypeFilterOptions` for matching. Descriptions read "is of type X" / "is of exact type X".