### PR TITLE
feat: add dependency filters for assemblies

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,8 +386,8 @@ on them directly:
 |-----------------------------|---------------------------------|---------------------------|----------------------------|
 | by name                     | `.WithName("x")`                | `.HasName("x")`           | `.HaveName("x")`           |
 | has attribute               | `.With<TAttribute>()`           | `.Has<TAttribute>()`      | `.Have<TAttribute>()`      |
-| depends on assembly         | -                               | `.HasADependencyOn("x")`  | `.HaveADependencyOn("x")`  |
-| does not depend on assembly | -                               | `.HasNoDependencyOn("x")` | `.HaveNoDependencyOn("x")` |
+| depends on assembly         | `.WhichHaveADependencyOn("x")`  | `.HasADependencyOn("x")`  | `.HaveADependencyOn("x")`  |
+| does not depend on assembly | `.WhichHaveNoDependencyOn("x")` | `.HasNoDependencyOn("x")` | `.HaveNoDependencyOn("x")` |
 | custom predicate            | `.Which(a => …)`                | -                         | -                          |
 
 ```csharp

--- a/Source/aweXpect.Reflection/Filters/AssemblyFilters.WhichHaveADependencyOn.cs
+++ b/Source/aweXpect.Reflection/Filters/AssemblyFilters.WhichHaveADependencyOn.cs
@@ -1,0 +1,24 @@
+using System.Linq;
+using System.Reflection;
+using aweXpect.Core;
+using aweXpect.Options;
+using aweXpect.Reflection.Collections;
+
+namespace aweXpect.Reflection;
+
+public static partial class AssemblyFilters
+{
+	/// <summary>
+	///     Filter for assemblies which have a dependency on the <paramref name="expected" /> assembly.
+	/// </summary>
+	public static Filtered.Assemblies.StringEqualityResultType WhichHaveADependencyOn(
+		this Filtered.Assemblies @this, string expected)
+	{
+		StringEqualityOptions options = new();
+		return new Filtered.Assemblies.StringEqualityResultType(@this.Which(Filter.Suffix<Assembly>(
+				assembly => assembly.GetReferencedAssemblies()
+					.AnyAsync(dependency => options.AreConsideredEqual(dependency.Name, expected)),
+				() => $" which have a dependency on assembly {options.GetExpectation(expected, ExpectationGrammars.None)}")),
+			options);
+	}
+}

--- a/Source/aweXpect.Reflection/Filters/AssemblyFilters.WhichHaveNoDependencyOn.cs
+++ b/Source/aweXpect.Reflection/Filters/AssemblyFilters.WhichHaveNoDependencyOn.cs
@@ -1,0 +1,24 @@
+using System.Linq;
+using System.Reflection;
+using aweXpect.Core;
+using aweXpect.Options;
+using aweXpect.Reflection.Collections;
+
+namespace aweXpect.Reflection;
+
+public static partial class AssemblyFilters
+{
+	/// <summary>
+	///     Filter for assemblies which have no dependency on the <paramref name="unexpected" /> assembly.
+	/// </summary>
+	public static Filtered.Assemblies.StringEqualityResultType WhichHaveNoDependencyOn(
+		this Filtered.Assemblies @this, string unexpected)
+	{
+		StringEqualityOptions options = new();
+		return new Filtered.Assemblies.StringEqualityResultType(@this.Which(Filter.Suffix<Assembly>(
+				async assembly => !await assembly.GetReferencedAssemblies()
+					.AnyAsync(dependency => options.AreConsideredEqual(dependency.Name, unexpected)),
+				() => $" which have no dependency on assembly {options.GetExpectation(unexpected, ExpectationGrammars.None)}")),
+			options);
+	}
+}

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net10.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net10.0.txt
@@ -6,6 +6,8 @@ namespace aweXpect.Reflection
     public static class AssemblyFilters
     {
         public static aweXpect.Reflection.Collections.Filtered.Assemblies Which(this aweXpect.Reflection.Collections.Filtered.Assemblies @this, System.Func<System.Reflection.Assembly, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
+        public static aweXpect.Reflection.Collections.Filtered.Assemblies.StringEqualityResultType WhichHaveADependencyOn(this aweXpect.Reflection.Collections.Filtered.Assemblies @this, string expected) { }
+        public static aweXpect.Reflection.Collections.Filtered.Assemblies.StringEqualityResultType WhichHaveNoDependencyOn(this aweXpect.Reflection.Collections.Filtered.Assemblies @this, string unexpected) { }
         public static aweXpect.Reflection.AssemblyFilters.AssembliesWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Assemblies @this, bool inherit = true)
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.AssemblyFilters.AssembliesWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Assemblies @this, System.Func<TAttribute, bool>? predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net8.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net8.0.txt
@@ -6,6 +6,8 @@ namespace aweXpect.Reflection
     public static class AssemblyFilters
     {
         public static aweXpect.Reflection.Collections.Filtered.Assemblies Which(this aweXpect.Reflection.Collections.Filtered.Assemblies @this, System.Func<System.Reflection.Assembly, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
+        public static aweXpect.Reflection.Collections.Filtered.Assemblies.StringEqualityResultType WhichHaveADependencyOn(this aweXpect.Reflection.Collections.Filtered.Assemblies @this, string expected) { }
+        public static aweXpect.Reflection.Collections.Filtered.Assemblies.StringEqualityResultType WhichHaveNoDependencyOn(this aweXpect.Reflection.Collections.Filtered.Assemblies @this, string unexpected) { }
         public static aweXpect.Reflection.AssemblyFilters.AssembliesWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Assemblies @this, bool inherit = true)
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.AssemblyFilters.AssembliesWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Assemblies @this, System.Func<TAttribute, bool>? predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_netstandard2.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_netstandard2.0.txt
@@ -6,6 +6,8 @@ namespace aweXpect.Reflection
     public static class AssemblyFilters
     {
         public static aweXpect.Reflection.Collections.Filtered.Assemblies Which(this aweXpect.Reflection.Collections.Filtered.Assemblies @this, System.Func<System.Reflection.Assembly, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
+        public static aweXpect.Reflection.Collections.Filtered.Assemblies.StringEqualityResultType WhichHaveADependencyOn(this aweXpect.Reflection.Collections.Filtered.Assemblies @this, string expected) { }
+        public static aweXpect.Reflection.Collections.Filtered.Assemblies.StringEqualityResultType WhichHaveNoDependencyOn(this aweXpect.Reflection.Collections.Filtered.Assemblies @this, string unexpected) { }
         public static aweXpect.Reflection.AssemblyFilters.AssembliesWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Assemblies @this, bool inherit = true)
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.AssemblyFilters.AssembliesWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Assemblies @this, System.Func<TAttribute, bool>? predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")

--- a/Tests/aweXpect.Reflection.Tests/Filters/AssemblyFilters.WhichHaveADependencyOn.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/AssemblyFilters.WhichHaveADependencyOn.Tests.cs
@@ -1,0 +1,70 @@
+using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Tests.TestHelpers.Types;
+
+namespace aweXpect.Reflection.Tests.Filters;
+
+public sealed partial class AssemblyFilters
+{
+	public sealed class WhichHaveADependencyOn
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task ShouldFilterForAssembliesWithDependency()
+			{
+				Filtered.Assemblies assemblies = In.AssemblyContaining<PublicAbstractClass>()
+					.WhichHaveADependencyOn("aweXpect.Core");
+
+				await That(assemblies).HasSingle().Which.IsEqualTo(typeof(AssemblyFilters).Assembly);
+				await That(assemblies.GetDescription())
+					.IsEqualTo(
+						"in assembly containing type PublicAbstractClass which have a dependency on assembly equal to \"aweXpect.Core\"");
+			}
+
+			[Fact]
+			public async Task WhenAssemblyHasNoSuchDependency_ShouldBeFilteredOut()
+			{
+				Filtered.Assemblies assemblies = In.AssemblyContaining<PublicAbstractClass>()
+					.WhichHaveADependencyOn("NonExistentAssembly");
+
+				await That(assemblies).IsEmpty();
+			}
+
+			[Fact]
+			public async Task ShouldSupportAsPrefix()
+			{
+				Filtered.Assemblies assemblies = In.AssemblyContaining<PublicAbstractClass>()
+					.WhichHaveADependencyOn("aweXpect.C").AsPrefix();
+
+				await That(assemblies).HasSingle().Which.IsEqualTo(typeof(AssemblyFilters).Assembly);
+				await That(assemblies.GetDescription())
+					.IsEqualTo(
+						"in assembly containing type PublicAbstractClass which have a dependency on assembly starting with \"aweXpect.C\"");
+			}
+
+			[Fact]
+			public async Task ShouldSupportAsWildcard()
+			{
+				Filtered.Assemblies assemblies = In.AssemblyContaining<PublicAbstractClass>()
+					.WhichHaveADependencyOn("aweXpect.*").AsWildcard();
+
+				await That(assemblies).HasSingle().Which.IsEqualTo(typeof(AssemblyFilters).Assembly);
+				await That(assemblies.GetDescription())
+					.IsEqualTo(
+						"in assembly containing type PublicAbstractClass which have a dependency on assembly matching \"aweXpect.*\"");
+			}
+
+			[Fact]
+			public async Task ShouldSupportIgnoringCase()
+			{
+				Filtered.Assemblies assemblies = In.AssemblyContaining<PublicAbstractClass>()
+					.WhichHaveADependencyOn("awexpect.core").IgnoringCase();
+
+				await That(assemblies).HasSingle().Which.IsEqualTo(typeof(AssemblyFilters).Assembly);
+				await That(assemblies.GetDescription())
+					.IsEqualTo(
+						"in assembly containing type PublicAbstractClass which have a dependency on assembly equal to \"awexpect.core\" ignoring case");
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/Filters/AssemblyFilters.WhichHaveNoDependencyOn.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/AssemblyFilters.WhichHaveNoDependencyOn.Tests.cs
@@ -1,0 +1,55 @@
+using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Tests.TestHelpers.Types;
+
+namespace aweXpect.Reflection.Tests.Filters;
+
+public sealed partial class AssemblyFilters
+{
+	public sealed class WhichHaveNoDependencyOn
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task ShouldFilterForAssembliesWithoutDependency()
+			{
+				Filtered.Assemblies assemblies = In.AssemblyContaining<PublicAbstractClass>()
+					.WhichHaveNoDependencyOn("NonExistentAssembly");
+
+				await That(assemblies).HasSingle().Which.IsEqualTo(typeof(AssemblyFilters).Assembly);
+				await That(assemblies.GetDescription())
+					.IsEqualTo(
+						"in assembly containing type PublicAbstractClass which have no dependency on assembly equal to \"NonExistentAssembly\"");
+			}
+
+			[Fact]
+			public async Task WhenAssemblyHasTheDependency_ShouldBeFilteredOut()
+			{
+				Filtered.Assemblies assemblies = In.AssemblyContaining<PublicAbstractClass>()
+					.WhichHaveNoDependencyOn("aweXpect.Core");
+
+				await That(assemblies).IsEmpty();
+			}
+
+			[Fact]
+			public async Task ShouldSupportAsWildcard()
+			{
+				Filtered.Assemblies assemblies = In.AssemblyContaining<PublicAbstractClass>()
+					.WhichHaveNoDependencyOn("aweXpect.*").AsWildcard();
+
+				await That(assemblies).IsEmpty();
+			}
+
+			[Fact]
+			public async Task ShouldSupportIgnoringCase()
+			{
+				Filtered.Assemblies assemblies = In.AssemblyContaining<PublicAbstractClass>()
+					.WhichHaveNoDependencyOn("NONEXISTENT").IgnoringCase();
+
+				await That(assemblies).HasSingle().Which.IsEqualTo(typeof(AssemblyFilters).Assembly);
+				await That(assemblies.GetDescription())
+					.IsEqualTo(
+						"in assembly containing type PublicAbstractClass which have no dependency on assembly equal to \"NONEXISTENT\" ignoring case");
+			}
+		}
+	}
+}


### PR DESCRIPTION
Adds `WhichHaveADependencyOn`/`WhichHaveNoDependencyOn` collection-level filters as the counterpart to the existing `HasADependencyOn`/`HasNoDependencyOn` assertions. Both return a string-equality result, so the comparison can be refined with `AsPrefix`/`AsWildcard`/`AsRegex`/`IgnoringCase` and friends.