### PR TITLE
feat: add `Contains`/`Contain` assertions for type members

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ In.AllLoadedAssemblies().Public.Abstract.Classes()
 #### Types containing specific members
 
 You can select types based on the members they declare. The lambda receives the members declared on each
-individual type and may use the full member-filter DSL:
+individual type and may use the full member-filter API:
 
 ```csharp
 // Types that contain at least one method with [Fact] or [Theory]
@@ -260,6 +260,32 @@ In.AllLoadedAssemblies().Types()
 Each quantifier applies only to the condition it directly follows; all other conditions implicitly require
 the member to occur _at least once_. The available quantifiers are `Exactly`, `AtLeast`, `AtMost`,
 `MoreThan`, `LessThan`, `Between(…).And(…)`, `Never`, `Once` and `Twice`.
+
+The same five member kinds are available as **assertions** on a single `Type` (`Contains…`) and on a
+collection of types (`Contain…`), using the same member-filter lambdas and the same quantifiers (default:
+_at least one_ matching member):
+
+| Member kind  | Filter                         | Assert (single)            | Assert (many)             |
+|--------------|--------------------------------|----------------------------|---------------------------|
+| methods      | `.WhichContainMethods(…)`      | `.ContainsMethods(…)`      | `.ContainMethods(…)`      |
+| properties   | `.WhichContainProperties(…)`   | `.ContainsProperties(…)`   | `.ContainProperties(…)`   |
+| fields       | `.WhichContainFields(…)`       | `.ContainsFields(…)`       | `.ContainFields(…)`       |
+| events       | `.WhichContainEvents(…)`       | `.ContainsEvents(…)`       | `.ContainEvents(…)`       |
+| constructors | `.WhichContainConstructors(…)` | `.ContainsConstructors(…)` | `.ContainConstructors(…)` |
+
+```csharp
+// A single type contains at least one [Fact] or [Theory] method
+await Expect.That(typeof(MyTests))
+    .ContainsMethods(methods => methods.With<FactAttribute>().OrWith<TheoryAttribute>());
+
+// …with exactly two parameterless constructors
+await Expect.That(typeof(MyService))
+    .ContainsConstructors(constructors => constructors.WithoutParameters()).Exactly(2.Times());
+
+// Every type in a collection contains a matching property
+await Expect.That(types)
+    .ContainProperties(properties => properties.With<RequiredAttribute>()).AtLeast(1.Times());
+```
 
 #### Generic type arguments
 

--- a/Source/aweXpect.Reflection/Filters/IContainedMembersFilter.cs
+++ b/Source/aweXpect.Reflection/Filters/IContainedMembersFilter.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Threading.Tasks;
+using aweXpect.Reflection.Collections;
+
+namespace aweXpect.Reflection;
+
+/// <summary>
+///     A <see cref="IFilter{Type}" /> that counts the members of a single <see cref="Type" /> matching an inner
+///     member-filter, so that the same counting and description logic can be shared between the
+///     <see cref="Filtered.Types" /> filters and the corresponding assertions.
+/// </summary>
+internal interface IContainedMembersFilter : IFilter<Type>
+{
+	/// <summary>
+	///     The description of the matched members (e.g. <c>methods with FactAttribute </c>).
+	/// </summary>
+	string MembersDescription { get; }
+
+	/// <summary>
+	///     Counts the members of the <paramref name="value" /> that match the inner member-filter.
+	/// </summary>
+#if NET8_0_OR_GREATER
+	ValueTask<int> CountMatchingMembers(Type value);
+#else
+	Task<int> CountMatchingMembers(Type value);
+#endif
+}

--- a/Source/aweXpect.Reflection/Filters/TypeFilters.cs
+++ b/Source/aweXpect.Reflection/Filters/TypeFilters.cs
@@ -25,6 +25,18 @@ public static partial class TypeFilters
 	}
 
 	/// <summary>
+	///     Creates the shared <see cref="IContainedMembersFilter" /> that counts the members of a single
+	///     <see cref="Type" /> matching the <paramref name="filter" />, reusing the same counting and description logic
+	///     as the <see cref="Filtered.Types" /> filters.
+	/// </summary>
+	internal static IContainedMembersFilter ContainedMembers<TMember, TFiltered>(
+		Func<Filtered.Types, TFiltered> navigate,
+		Func<TFiltered, TFiltered> filter,
+		Quantifier quantifier)
+		where TFiltered : Filtered<TMember, TFiltered>, IDescribableSubject
+		=> new ContainedMembersFilter<TMember, TFiltered>(navigate, filter, quantifier);
+
+	/// <summary>
 	///     A filterable collection of <see cref="Type" /> that contain matching members, allowing to specify a quantifier
 	///     for the number of matching members.
 	/// </summary>
@@ -160,11 +172,10 @@ public static partial class TypeFilters
 		}
 	}
 
-	private sealed class ContainedMembersFilter<TMember, TFiltered> : IFilter<Type>
+	private sealed class ContainedMembersFilter<TMember, TFiltered> : IContainedMembersFilter
 		where TFiltered : Filtered<TMember, TFiltered>, IDescribableSubject
 	{
 		private readonly Func<TFiltered, TFiltered> _filter;
-		private readonly string _membersDescription;
 		private readonly Func<Filtered.Types, TFiltered> _navigate;
 		private readonly Quantifier _quantifier;
 
@@ -183,11 +194,15 @@ public static partial class TypeFilters
 				inner = inner.Substring(0, inner.Length - "in ".Length);
 			}
 
-			_membersDescription = inner;
+			MembersDescription = inner;
 		}
 
+		/// <inheritdoc cref="IContainedMembersFilter.MembersDescription" />
+		public string MembersDescription { get; }
+
 #if NET8_0_OR_GREATER
-		public async ValueTask<bool> Applies(Type value)
+		/// <inheritdoc cref="IContainedMembersFilter.CountMatchingMembers(Type)" />
+		public async ValueTask<int> CountMatchingMembers(Type value)
 		{
 			int count = 0;
 			await foreach (var _ in _filter(_navigate(new Filtered.Types([value,], ""))))
@@ -195,17 +210,21 @@ public static partial class TypeFilters
 				count++;
 			}
 
-			return _quantifier.Check(count, true) ?? false;
+			return count;
 		}
+
+		public async ValueTask<bool> Applies(Type value)
+			=> _quantifier.Check(await CountMatchingMembers(value), true) ?? false;
 #else
-		public Task<bool> Applies(Type value)
-		{
-			int count = _filter(_navigate(new Filtered.Types([value,], ""))).Count();
-			return Task.FromResult(_quantifier.Check(count, true) ?? false);
-		}
+		/// <inheritdoc cref="IContainedMembersFilter.CountMatchingMembers(Type)" />
+		public Task<int> CountMatchingMembers(Type value)
+			=> Task.FromResult(_filter(_navigate(new Filtered.Types([value,], ""))).Count());
+
+		public async Task<bool> Applies(Type value)
+			=> _quantifier.Check(await CountMatchingMembers(value), true) ?? false;
 #endif
 
 		public string Describes(string text)
-			=> $"{text.TrimEnd()} which contain {_membersDescription}{_quantifier} ";
+			=> $"{text.TrimEnd()} which contain {MembersDescription}{_quantifier} ";
 	}
 }

--- a/Source/aweXpect.Reflection/Results/TypeContainingMembersResult.cs
+++ b/Source/aweXpect.Reflection/Results/TypeContainingMembersResult.cs
@@ -1,0 +1,138 @@
+﻿using aweXpect.Core;
+using aweXpect.Options;
+using aweXpect.Results;
+
+namespace aweXpect.Reflection.Results;
+
+/// <summary>
+///     The result of an assertion that a <see cref="System.Type" /> (or a collection of types) contains matching
+///     members, allowing to specify a quantifier for the number of matching members.
+/// </summary>
+public class TypeContainingMembersResult<TThat>(
+	ExpectationBuilder expectationBuilder,
+	IThat<TThat> subject,
+	Quantifier quantifier)
+	: AndOrResult<TThat, IThat<TThat>>(expectationBuilder, subject)
+{
+	/// <summary>
+	///     Verifies, that the matching members occur at least…
+	/// </summary>
+	public CountTimesResult<TypeContainingMembersResult<TThat>> AtLeast()
+		=> new(value =>
+		{
+			quantifier.AtLeast(value);
+			return this;
+		});
+
+	/// <summary>
+	///     Verifies, that the matching members occur at least <paramref name="minimum" /> times.
+	/// </summary>
+	public TypeContainingMembersResult<TThat> AtLeast(Times minimum)
+	{
+		quantifier.AtLeast(minimum.Value);
+		return this;
+	}
+
+	/// <summary>
+	///     Verifies, that the matching members occur at most…
+	/// </summary>
+	public CountTimesResult<TypeContainingMembersResult<TThat>> AtMost()
+		=> new(value =>
+		{
+			quantifier.AtMost(value);
+			return this;
+		});
+
+	/// <summary>
+	///     Verifies, that the matching members occur at most <paramref name="maximum" /> times.
+	/// </summary>
+	public TypeContainingMembersResult<TThat> AtMost(Times maximum)
+	{
+		quantifier.AtMost(maximum.Value);
+		return this;
+	}
+
+	/// <summary>
+	///     Verifies, that the matching members occur between <paramref name="minimum" />…
+	/// </summary>
+	public BetweenResult<TypeContainingMembersResult<TThat>> Between(int minimum)
+		=> new(maximum =>
+		{
+			quantifier.Between(minimum, maximum);
+			return this;
+		});
+
+	/// <summary>
+	///     Verifies, that the matching members occur exactly <paramref name="expected" /> times.
+	/// </summary>
+	public TypeContainingMembersResult<TThat> Exactly(Times expected)
+	{
+		quantifier.Exactly(expected.Value);
+		return this;
+	}
+
+	/// <summary>
+	///     Verifies, that the matching members occur less than…
+	/// </summary>
+	public CountTimesResult<TypeContainingMembersResult<TThat>> LessThan()
+		=> new(value =>
+		{
+			quantifier.LessThan(value);
+			return this;
+		});
+
+	/// <summary>
+	///     Verifies, that the matching members occur less than <paramref name="maximum" /> times.
+	/// </summary>
+	public TypeContainingMembersResult<TThat> LessThan(Times maximum)
+	{
+		quantifier.LessThan(maximum.Value);
+		return this;
+	}
+
+	/// <summary>
+	///     Verifies, that the matching members occur more than…
+	/// </summary>
+	public CountTimesResult<TypeContainingMembersResult<TThat>> MoreThan()
+		=> new(value =>
+		{
+			quantifier.MoreThan(value);
+			return this;
+		});
+
+	/// <summary>
+	///     Verifies, that the matching members occur more than <paramref name="minimum" /> times.
+	/// </summary>
+	public TypeContainingMembersResult<TThat> MoreThan(Times minimum)
+	{
+		quantifier.MoreThan(minimum.Value);
+		return this;
+	}
+
+	/// <summary>
+	///     Verifies, that no member matches the filter.
+	/// </summary>
+	public TypeContainingMembersResult<TThat> Never()
+	{
+		quantifier.Exactly(0);
+		return this;
+	}
+
+	/// <summary>
+	///     Verifies, that exactly one member matches the filter.
+	/// </summary>
+	public TypeContainingMembersResult<TThat> Once()
+	{
+		quantifier.Exactly(1);
+		return this;
+	}
+
+	/// <summary>
+	///     Verifies, that exactly two members match the filter.
+	/// </summary>
+	public TypeContainingMembersResult<TThat> Twice()
+	{
+		quantifier.Exactly(2);
+		return this;
+	}
+}

--- a/Source/aweXpect.Reflection/ThatType.ContainsConstructors.cs
+++ b/Source/aweXpect.Reflection/ThatType.ContainsConstructors.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Reflection;
 using aweXpect.Core;
-using aweXpect.Options;
 using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Results;
 

--- a/Source/aweXpect.Reflection/ThatType.ContainsConstructors.cs
+++ b/Source/aweXpect.Reflection/ThatType.ContainsConstructors.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Reflection;
+using aweXpect.Core;
+using aweXpect.Options;
+using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Results;
+
+namespace aweXpect.Reflection;
+
+public static partial class ThatType
+{
+	/// <summary>
+	///     Verifies that the <see cref="Type" /> contains constructors matching the <paramref name="filter" />.
+	/// </summary>
+	/// <remarks>
+	///     By default the assertion succeeds when the type contains at least one matching constructor. Append a quantifier
+	///     (e.g. <see cref="TypeContainingMembersResult{TThat}.Exactly(Times)" />) to require a specific count.
+	/// </remarks>
+	public static TypeContainingMembersResult<Type?> ContainsConstructors(
+		this IThat<Type?> subject,
+		Func<Filtered.Constructors, Filtered.Constructors> filter)
+		=> Contains<ConstructorInfo, Filtered.Constructors>(subject, types => types.Constructors(), filter);
+}

--- a/Source/aweXpect.Reflection/ThatType.ContainsEvents.cs
+++ b/Source/aweXpect.Reflection/ThatType.ContainsEvents.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Reflection;
 using aweXpect.Core;
-using aweXpect.Options;
 using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Results;
 

--- a/Source/aweXpect.Reflection/ThatType.ContainsEvents.cs
+++ b/Source/aweXpect.Reflection/ThatType.ContainsEvents.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Reflection;
+using aweXpect.Core;
+using aweXpect.Options;
+using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Results;
+
+namespace aweXpect.Reflection;
+
+public static partial class ThatType
+{
+	/// <summary>
+	///     Verifies that the <see cref="Type" /> contains events matching the <paramref name="filter" />.
+	/// </summary>
+	/// <remarks>
+	///     By default the assertion succeeds when the type contains at least one matching event. Append a quantifier
+	///     (e.g. <see cref="TypeContainingMembersResult{TThat}.Exactly(Times)" />) to require a specific count.
+	/// </remarks>
+	public static TypeContainingMembersResult<Type?> ContainsEvents(
+		this IThat<Type?> subject,
+		Func<Filtered.Events, Filtered.Events> filter)
+		=> Contains<EventInfo, Filtered.Events>(subject, types => types.Events(), filter);
+}

--- a/Source/aweXpect.Reflection/ThatType.ContainsFields.cs
+++ b/Source/aweXpect.Reflection/ThatType.ContainsFields.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Reflection;
+using aweXpect.Core;
+using aweXpect.Options;
+using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Results;
+
+namespace aweXpect.Reflection;
+
+public static partial class ThatType
+{
+	/// <summary>
+	///     Verifies that the <see cref="Type" /> contains fields matching the <paramref name="filter" />.
+	/// </summary>
+	/// <remarks>
+	///     By default the assertion succeeds when the type contains at least one matching field. Append a quantifier
+	///     (e.g. <see cref="TypeContainingMembersResult{TThat}.Exactly(Times)" />) to require a specific count.
+	/// </remarks>
+	public static TypeContainingMembersResult<Type?> ContainsFields(
+		this IThat<Type?> subject,
+		Func<Filtered.Fields, Filtered.Fields> filter)
+		=> Contains<FieldInfo, Filtered.Fields>(subject, types => types.Fields(), filter);
+}

--- a/Source/aweXpect.Reflection/ThatType.ContainsFields.cs
+++ b/Source/aweXpect.Reflection/ThatType.ContainsFields.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Reflection;
 using aweXpect.Core;
-using aweXpect.Options;
 using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Results;
 

--- a/Source/aweXpect.Reflection/ThatType.ContainsMethods.cs
+++ b/Source/aweXpect.Reflection/ThatType.ContainsMethods.cs
@@ -70,10 +70,7 @@ public static partial class ThatType
 			return this;
 		}
 
-		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
-		{
-			stringBuilder.Append("contains ").Append(memberFilter.MembersDescription).Append(quantifier);
-		}
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null) => stringBuilder.Append("contains ").Append(memberFilter.MembersDescription).Append(quantifier);
 
 		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
 		{
@@ -82,10 +79,7 @@ public static partial class ThatType
 			Formatter.Format(stringBuilder, Actual);
 		}
 
-		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
-		{
-			stringBuilder.Append("does not contain ").Append(memberFilter.MembersDescription).Append(quantifier);
-		}
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null) => stringBuilder.Append("does not contain ").Append(memberFilter.MembersDescription).Append(quantifier);
 
 		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
 		{

--- a/Source/aweXpect.Reflection/ThatType.ContainsMethods.cs
+++ b/Source/aweXpect.Reflection/ThatType.ContainsMethods.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.Reflection;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Options;
+using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Helpers;
+using aweXpect.Reflection.Results;
+
+namespace aweXpect.Reflection;
+
+public static partial class ThatType
+{
+	/// <summary>
+	///     Verifies that the <see cref="Type" /> contains methods matching the <paramref name="filter" />.
+	/// </summary>
+	/// <remarks>
+	///     The <paramref name="filter" /> receives the methods declared on the type and may use the full method-filter
+	///     DSL (e.g. <c>methods.With&lt;FactAttribute&gt;().OrWith&lt;TheoryAttribute&gt;()</c>).<br />
+	///     By default the assertion succeeds when the type contains at least one matching method. Append a quantifier
+	///     (e.g. <see cref="TypeContainingMembersResult{TThat}.Exactly(Times)" />) to require a specific count.
+	/// </remarks>
+	public static TypeContainingMembersResult<Type?> ContainsMethods(
+		this IThat<Type?> subject,
+		Func<Filtered.Methods, Filtered.Methods> filter)
+		=> Contains<MethodInfo, Filtered.Methods>(subject, types => types.Methods(), filter);
+
+	private static TypeContainingMembersResult<Type?> Contains<TMember, TFiltered>(
+		IThat<Type?> subject,
+		Func<Filtered.Types, TFiltered> navigate,
+		Func<TFiltered, TFiltered> filter)
+		where TFiltered : Filtered<TMember, TFiltered>, IDescribableSubject
+	{
+		Quantifier quantifier = new();
+		IContainedMembersFilter memberFilter =
+			TypeFilters.ContainedMembers<TMember, TFiltered>(navigate, filter, quantifier);
+		return new TypeContainingMembersResult<Type?>(
+			subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new ContainsMembersConstraint(it, grammars, memberFilter, quantifier)),
+			subject,
+			quantifier);
+	}
+
+	private sealed class ContainsMembersConstraint(
+		string it,
+		ExpectationGrammars grammars,
+		IContainedMembersFilter memberFilter,
+		Quantifier quantifier)
+		: ConstraintResult.WithNotNullValue<Type?>(it, grammars),
+			IAsyncConstraint<Type?>
+	{
+		private int _count;
+
+		public async Task<ConstraintResult> IsMetBy(Type? actual, CancellationToken cancellationToken)
+		{
+			Actual = actual;
+			if (actual is null)
+			{
+				Outcome = Outcome.Failure;
+				return this;
+			}
+
+			_count = await memberFilter.CountMatchingMembers(actual);
+			Outcome = quantifier.Check(_count, true) ?? false
+				? Outcome.Success
+				: Outcome.Failure;
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("contains ").Append(memberFilter.MembersDescription).Append(quantifier);
+		}
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(It).Append(" contained ").Append(_count)
+				.Append(_count == 1 ? " matching member in " : " matching members in ");
+			Formatter.Format(stringBuilder, Actual);
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("does not contain ").Append(memberFilter.MembersDescription).Append(quantifier);
+		}
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(It).Append(" contained ").Append(_count)
+				.Append(_count == 1 ? " matching member in " : " matching members in ");
+			Formatter.Format(stringBuilder, Actual);
+		}
+	}
+}

--- a/Source/aweXpect.Reflection/ThatType.ContainsMethods.cs
+++ b/Source/aweXpect.Reflection/ThatType.ContainsMethods.cs
@@ -82,10 +82,6 @@ public static partial class ThatType
 		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null) => stringBuilder.Append("does not contain ").Append(memberFilter.MembersDescription).Append(quantifier);
 
 		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
-		{
-			stringBuilder.Append(It).Append(" contained ").Append(_count)
-				.Append(_count == 1 ? " matching member in " : " matching members in ");
-			Formatter.Format(stringBuilder, Actual);
-		}
+			=> AppendNormalResult(stringBuilder, indentation);
 	}
 }

--- a/Source/aweXpect.Reflection/ThatType.ContainsProperties.cs
+++ b/Source/aweXpect.Reflection/ThatType.ContainsProperties.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Reflection;
+using aweXpect.Core;
+using aweXpect.Options;
+using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Results;
+
+namespace aweXpect.Reflection;
+
+public static partial class ThatType
+{
+	/// <summary>
+	///     Verifies that the <see cref="Type" /> contains properties matching the <paramref name="filter" />.
+	/// </summary>
+	/// <remarks>
+	///     By default the assertion succeeds when the type contains at least one matching property. Append a quantifier
+	///     (e.g. <see cref="TypeContainingMembersResult{TThat}.Exactly(Times)" />) to require a specific count.
+	/// </remarks>
+	public static TypeContainingMembersResult<Type?> ContainsProperties(
+		this IThat<Type?> subject,
+		Func<Filtered.Properties, Filtered.Properties> filter)
+		=> Contains<PropertyInfo, Filtered.Properties>(subject, types => types.Properties(), filter);
+}

--- a/Source/aweXpect.Reflection/ThatType.ContainsProperties.cs
+++ b/Source/aweXpect.Reflection/ThatType.ContainsProperties.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Reflection;
 using aweXpect.Core;
-using aweXpect.Options;
 using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Results;
 

--- a/Source/aweXpect.Reflection/ThatTypes.ContainConstructors.cs
+++ b/Source/aweXpect.Reflection/ThatTypes.ContainConstructors.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using aweXpect.Core;
+using aweXpect.Options;
+using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Results;
+
+namespace aweXpect.Reflection;
+
+public static partial class ThatTypes
+{
+	/// <summary>
+	///     Verifies that all items in the filtered collection of <see cref="Type" /> contain constructors matching the
+	///     <paramref name="filter" />.
+	/// </summary>
+	/// <remarks>
+	///     By default each type must contain at least one matching constructor. Append a quantifier
+	///     (e.g. <see cref="TypeContainingMembersResult{TThat}.Exactly(Times)" />) to require a specific count.
+	/// </remarks>
+	public static TypeContainingMembersResult<IEnumerable<Type?>> ContainConstructors(
+		this IThat<IEnumerable<Type?>> subject,
+		Func<Filtered.Constructors, Filtered.Constructors> filter)
+		=> Contain<ConstructorInfo, Filtered.Constructors>(subject, types => types.Constructors(), filter);
+
+#if NET8_0_OR_GREATER
+	/// <summary>
+	///     Verifies that all items in the filtered collection of <see cref="Type" /> contain constructors matching the
+	///     <paramref name="filter" />.
+	/// </summary>
+	/// <remarks>
+	///     By default each type must contain at least one matching constructor. Append a quantifier
+	///     (e.g. <see cref="TypeContainingMembersResult{TThat}.Exactly(Times)" />) to require a specific count.
+	/// </remarks>
+	public static TypeContainingMembersResult<IAsyncEnumerable<Type?>> ContainConstructors(
+		this IThat<IAsyncEnumerable<Type?>> subject,
+		Func<Filtered.Constructors, Filtered.Constructors> filter)
+		=> Contain<ConstructorInfo, Filtered.Constructors>(subject, types => types.Constructors(), filter);
+#endif
+}

--- a/Source/aweXpect.Reflection/ThatTypes.ContainConstructors.cs
+++ b/Source/aweXpect.Reflection/ThatTypes.ContainConstructors.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Reflection;
 using aweXpect.Core;
-using aweXpect.Options;
 using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Results;
 

--- a/Source/aweXpect.Reflection/ThatTypes.ContainEvents.cs
+++ b/Source/aweXpect.Reflection/ThatTypes.ContainEvents.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Reflection;
 using aweXpect.Core;
-using aweXpect.Options;
 using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Results;
 

--- a/Source/aweXpect.Reflection/ThatTypes.ContainEvents.cs
+++ b/Source/aweXpect.Reflection/ThatTypes.ContainEvents.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using aweXpect.Core;
+using aweXpect.Options;
+using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Results;
+
+namespace aweXpect.Reflection;
+
+public static partial class ThatTypes
+{
+	/// <summary>
+	///     Verifies that all items in the filtered collection of <see cref="Type" /> contain events matching the
+	///     <paramref name="filter" />.
+	/// </summary>
+	/// <remarks>
+	///     By default each type must contain at least one matching event. Append a quantifier
+	///     (e.g. <see cref="TypeContainingMembersResult{TThat}.Exactly(Times)" />) to require a specific count.
+	/// </remarks>
+	public static TypeContainingMembersResult<IEnumerable<Type?>> ContainEvents(
+		this IThat<IEnumerable<Type?>> subject,
+		Func<Filtered.Events, Filtered.Events> filter)
+		=> Contain<EventInfo, Filtered.Events>(subject, types => types.Events(), filter);
+
+#if NET8_0_OR_GREATER
+	/// <summary>
+	///     Verifies that all items in the filtered collection of <see cref="Type" /> contain events matching the
+	///     <paramref name="filter" />.
+	/// </summary>
+	/// <remarks>
+	///     By default each type must contain at least one matching event. Append a quantifier
+	///     (e.g. <see cref="TypeContainingMembersResult{TThat}.Exactly(Times)" />) to require a specific count.
+	/// </remarks>
+	public static TypeContainingMembersResult<IAsyncEnumerable<Type?>> ContainEvents(
+		this IThat<IAsyncEnumerable<Type?>> subject,
+		Func<Filtered.Events, Filtered.Events> filter)
+		=> Contain<EventInfo, Filtered.Events>(subject, types => types.Events(), filter);
+#endif
+}

--- a/Source/aweXpect.Reflection/ThatTypes.ContainFields.cs
+++ b/Source/aweXpect.Reflection/ThatTypes.ContainFields.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using aweXpect.Core;
+using aweXpect.Options;
+using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Results;
+
+namespace aweXpect.Reflection;
+
+public static partial class ThatTypes
+{
+	/// <summary>
+	///     Verifies that all items in the filtered collection of <see cref="Type" /> contain fields matching the
+	///     <paramref name="filter" />.
+	/// </summary>
+	/// <remarks>
+	///     By default each type must contain at least one matching field. Append a quantifier
+	///     (e.g. <see cref="TypeContainingMembersResult{TThat}.Exactly(Times)" />) to require a specific count.
+	/// </remarks>
+	public static TypeContainingMembersResult<IEnumerable<Type?>> ContainFields(
+		this IThat<IEnumerable<Type?>> subject,
+		Func<Filtered.Fields, Filtered.Fields> filter)
+		=> Contain<FieldInfo, Filtered.Fields>(subject, types => types.Fields(), filter);
+
+#if NET8_0_OR_GREATER
+	/// <summary>
+	///     Verifies that all items in the filtered collection of <see cref="Type" /> contain fields matching the
+	///     <paramref name="filter" />.
+	/// </summary>
+	/// <remarks>
+	///     By default each type must contain at least one matching field. Append a quantifier
+	///     (e.g. <see cref="TypeContainingMembersResult{TThat}.Exactly(Times)" />) to require a specific count.
+	/// </remarks>
+	public static TypeContainingMembersResult<IAsyncEnumerable<Type?>> ContainFields(
+		this IThat<IAsyncEnumerable<Type?>> subject,
+		Func<Filtered.Fields, Filtered.Fields> filter)
+		=> Contain<FieldInfo, Filtered.Fields>(subject, types => types.Fields(), filter);
+#endif
+}

--- a/Source/aweXpect.Reflection/ThatTypes.ContainFields.cs
+++ b/Source/aweXpect.Reflection/ThatTypes.ContainFields.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Reflection;
 using aweXpect.Core;
-using aweXpect.Options;
 using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Results;
 

--- a/Source/aweXpect.Reflection/ThatTypes.ContainMethods.cs
+++ b/Source/aweXpect.Reflection/ThatTypes.ContainMethods.cs
@@ -94,17 +94,19 @@ public static partial class ThatTypes
 		public async Task<ConstraintResult> IsMetBy(IAsyncEnumerable<Type?> actual,
 			CancellationToken cancellationToken)
 			=> await SetAsyncValue(actual, Matches);
+#endif
 
+		public async Task<ConstraintResult> IsMetBy(IEnumerable<Type?> actual,
+			CancellationToken cancellationToken)
+			=> await SetValue(actual, Matches);
+
+#if NET8_0_OR_GREATER
 		private ValueTask<bool> Matches(Type? type)
 			=> type is null ? new ValueTask<bool>(false) : memberFilter.Applies(type);
 #else
 		private Task<bool> Matches(Type? type)
 			=> type is null ? Task.FromResult(false) : memberFilter.Applies(type);
 #endif
-
-		public async Task<ConstraintResult> IsMetBy(IEnumerable<Type?> actual,
-			CancellationToken cancellationToken)
-			=> await SetValue(actual, Matches);
 
 		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null) => stringBuilder.Append("all contain ").Append(memberFilter.MembersDescription).Append(quantifier);
 

--- a/Source/aweXpect.Reflection/ThatTypes.ContainMethods.cs
+++ b/Source/aweXpect.Reflection/ThatTypes.ContainMethods.cs
@@ -106,10 +106,7 @@ public static partial class ThatTypes
 			CancellationToken cancellationToken)
 			=> await SetValue(actual, Matches);
 
-		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
-		{
-			stringBuilder.Append("all contain ").Append(memberFilter.MembersDescription).Append(quantifier);
-		}
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null) => stringBuilder.Append("all contain ").Append(memberFilter.MembersDescription).Append(quantifier);
 
 		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
 		{
@@ -117,10 +114,7 @@ public static partial class ThatTypes
 			Formatter.Format(stringBuilder, NotMatching, FormattingOptions.Indented(indentation));
 		}
 
-		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
-		{
-			stringBuilder.Append("do not all contain ").Append(memberFilter.MembersDescription).Append(quantifier);
-		}
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null) => stringBuilder.Append("do not all contain ").Append(memberFilter.MembersDescription).Append(quantifier);
 
 		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
 		{

--- a/Source/aweXpect.Reflection/ThatTypes.ContainMethods.cs
+++ b/Source/aweXpect.Reflection/ThatTypes.ContainMethods.cs
@@ -1,0 +1,131 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Options;
+using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Helpers;
+using aweXpect.Reflection.Results;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Reflection;
+
+public static partial class ThatTypes
+{
+	/// <summary>
+	///     Verifies that all items in the filtered collection of <see cref="Type" /> contain methods matching the
+	///     <paramref name="filter" />.
+	/// </summary>
+	/// <remarks>
+	///     By default each type must contain at least one matching method. Append a quantifier
+	///     (e.g. <see cref="TypeContainingMembersResult{TThat}.Exactly(Times)" />) to require a specific count.
+	/// </remarks>
+	public static TypeContainingMembersResult<IEnumerable<Type?>> ContainMethods(
+		this IThat<IEnumerable<Type?>> subject,
+		Func<Filtered.Methods, Filtered.Methods> filter)
+		=> Contain<MethodInfo, Filtered.Methods>(subject, types => types.Methods(), filter);
+
+#if NET8_0_OR_GREATER
+	/// <summary>
+	///     Verifies that all items in the filtered collection of <see cref="Type" /> contain methods matching the
+	///     <paramref name="filter" />.
+	/// </summary>
+	/// <remarks>
+	///     By default each type must contain at least one matching method. Append a quantifier
+	///     (e.g. <see cref="TypeContainingMembersResult{TThat}.Exactly(Times)" />) to require a specific count.
+	/// </remarks>
+	public static TypeContainingMembersResult<IAsyncEnumerable<Type?>> ContainMethods(
+		this IThat<IAsyncEnumerable<Type?>> subject,
+		Func<Filtered.Methods, Filtered.Methods> filter)
+		=> Contain<MethodInfo, Filtered.Methods>(subject, types => types.Methods(), filter);
+#endif
+
+	private static TypeContainingMembersResult<IEnumerable<Type?>> Contain<TMember, TFiltered>(
+		IThat<IEnumerable<Type?>> subject,
+		Func<Filtered.Types, TFiltered> navigate,
+		Func<TFiltered, TFiltered> filter)
+		where TFiltered : Filtered<TMember, TFiltered>, IDescribableSubject
+	{
+		Quantifier quantifier = new();
+		IContainedMembersFilter memberFilter =
+			TypeFilters.ContainedMembers<TMember, TFiltered>(navigate, filter, quantifier);
+		return new TypeContainingMembersResult<IEnumerable<Type?>>(
+			subject.Get().ExpectationBuilder.AddConstraint<IEnumerable<Type?>>((it, grammars)
+				=> new ContainMembersConstraint(it, grammars, memberFilter, quantifier)),
+			subject,
+			quantifier);
+	}
+
+#if NET8_0_OR_GREATER
+	private static TypeContainingMembersResult<IAsyncEnumerable<Type?>> Contain<TMember, TFiltered>(
+		IThat<IAsyncEnumerable<Type?>> subject,
+		Func<Filtered.Types, TFiltered> navigate,
+		Func<TFiltered, TFiltered> filter)
+		where TFiltered : Filtered<TMember, TFiltered>, IDescribableSubject
+	{
+		Quantifier quantifier = new();
+		IContainedMembersFilter memberFilter =
+			TypeFilters.ContainedMembers<TMember, TFiltered>(navigate, filter, quantifier);
+		return new TypeContainingMembersResult<IAsyncEnumerable<Type?>>(
+			subject.Get().ExpectationBuilder.AddConstraint<IAsyncEnumerable<Type?>>((it, grammars)
+				=> new ContainMembersConstraint(it, grammars, memberFilter, quantifier)),
+			subject,
+			quantifier);
+	}
+#endif
+
+	private sealed class ContainMembersConstraint(
+		string it,
+		ExpectationGrammars grammars,
+		IContainedMembersFilter memberFilter,
+		Quantifier quantifier)
+		: CollectionConstraintResult<Type?>(grammars),
+			IAsyncConstraint<IEnumerable<Type?>>
+#if NET8_0_OR_GREATER
+			, IAsyncConstraint<IAsyncEnumerable<Type?>>
+#endif
+	{
+#if NET8_0_OR_GREATER
+		public async Task<ConstraintResult> IsMetBy(IAsyncEnumerable<Type?> actual,
+			CancellationToken cancellationToken)
+			=> await SetAsyncValue(actual, Matches);
+
+		private ValueTask<bool> Matches(Type? type)
+			=> type is null ? new ValueTask<bool>(false) : memberFilter.Applies(type);
+#else
+		private Task<bool> Matches(Type? type)
+			=> type is null ? Task.FromResult(false) : memberFilter.Applies(type);
+#endif
+
+		public async Task<ConstraintResult> IsMetBy(IEnumerable<Type?> actual,
+			CancellationToken cancellationToken)
+			=> await SetValue(actual, Matches);
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("all contain ").Append(memberFilter.MembersDescription).Append(quantifier);
+		}
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(it).Append(" contained not matching types ");
+			Formatter.Format(stringBuilder, NotMatching, FormattingOptions.Indented(indentation));
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("do not all contain ").Append(memberFilter.MembersDescription).Append(quantifier);
+		}
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(it).Append(" only contained matching types ");
+			Formatter.Format(stringBuilder, Matching, FormattingOptions.Indented(indentation));
+		}
+	}
+}

--- a/Source/aweXpect.Reflection/ThatTypes.ContainProperties.cs
+++ b/Source/aweXpect.Reflection/ThatTypes.ContainProperties.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Reflection;
 using aweXpect.Core;
-using aweXpect.Options;
 using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Results;
 

--- a/Source/aweXpect.Reflection/ThatTypes.ContainProperties.cs
+++ b/Source/aweXpect.Reflection/ThatTypes.ContainProperties.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using aweXpect.Core;
+using aweXpect.Options;
+using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Results;
+
+namespace aweXpect.Reflection;
+
+public static partial class ThatTypes
+{
+	/// <summary>
+	///     Verifies that all items in the filtered collection of <see cref="Type" /> contain properties matching the
+	///     <paramref name="filter" />.
+	/// </summary>
+	/// <remarks>
+	///     By default each type must contain at least one matching property. Append a quantifier
+	///     (e.g. <see cref="TypeContainingMembersResult{TThat}.Exactly(Times)" />) to require a specific count.
+	/// </remarks>
+	public static TypeContainingMembersResult<IEnumerable<Type?>> ContainProperties(
+		this IThat<IEnumerable<Type?>> subject,
+		Func<Filtered.Properties, Filtered.Properties> filter)
+		=> Contain<PropertyInfo, Filtered.Properties>(subject, types => types.Properties(), filter);
+
+#if NET8_0_OR_GREATER
+	/// <summary>
+	///     Verifies that all items in the filtered collection of <see cref="Type" /> contain properties matching the
+	///     <paramref name="filter" />.
+	/// </summary>
+	/// <remarks>
+	///     By default each type must contain at least one matching property. Append a quantifier
+	///     (e.g. <see cref="TypeContainingMembersResult{TThat}.Exactly(Times)" />) to require a specific count.
+	/// </remarks>
+	public static TypeContainingMembersResult<IAsyncEnumerable<Type?>> ContainProperties(
+		this IThat<IAsyncEnumerable<Type?>> subject,
+		Func<Filtered.Properties, Filtered.Properties> filter)
+		=> Contain<PropertyInfo, Filtered.Properties>(subject, types => types.Properties(), filter);
+#endif
+}

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net10.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net10.0.txt
@@ -746,6 +746,11 @@ namespace aweXpect.Reflection
     }
     public static class ThatType
     {
+        public static aweXpect.Reflection.Results.TypeContainingMembersResult<System.Type?> ContainsConstructors(this aweXpect.Core.IThat<System.Type?> subject, System.Func<aweXpect.Reflection.Collections.Filtered.Constructors, aweXpect.Reflection.Collections.Filtered.Constructors> filter) { }
+        public static aweXpect.Reflection.Results.TypeContainingMembersResult<System.Type?> ContainsEvents(this aweXpect.Core.IThat<System.Type?> subject, System.Func<aweXpect.Reflection.Collections.Filtered.Events, aweXpect.Reflection.Collections.Filtered.Events> filter) { }
+        public static aweXpect.Reflection.Results.TypeContainingMembersResult<System.Type?> ContainsFields(this aweXpect.Core.IThat<System.Type?> subject, System.Func<aweXpect.Reflection.Collections.Filtered.Fields, aweXpect.Reflection.Collections.Filtered.Fields> filter) { }
+        public static aweXpect.Reflection.Results.TypeContainingMembersResult<System.Type?> ContainsMethods(this aweXpect.Core.IThat<System.Type?> subject, System.Func<aweXpect.Reflection.Collections.Filtered.Methods, aweXpect.Reflection.Collections.Filtered.Methods> filter) { }
+        public static aweXpect.Reflection.Results.TypeContainingMembersResult<System.Type?> ContainsProperties(this aweXpect.Core.IThat<System.Type?> subject, System.Func<aweXpect.Reflection.Collections.Filtered.Properties, aweXpect.Reflection.Collections.Filtered.Properties> filter) { }
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> DoesNotInheritFrom(this aweXpect.Core.IThat<System.Type?> subject, System.Type baseType, bool forceDirect = false) { }
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> DoesNotInheritFrom<TBaseType>(this aweXpect.Core.IThat<System.Type?> subject, bool forceDirect = false) { }
         public static aweXpect.Reflection.Results.HasAttributeResult<System.Type?> Has<TAttribute>(this aweXpect.Core.IThat<System.Type?> subject, bool inherit = true)
@@ -824,6 +829,16 @@ namespace aweXpect.Reflection
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreStatic(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>>> AreStructs(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreStructs(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
+        public static aweXpect.Reflection.Results.TypeContainingMembersResult<System.Collections.Generic.IAsyncEnumerable<System.Type?>> ContainConstructors(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>> subject, System.Func<aweXpect.Reflection.Collections.Filtered.Constructors, aweXpect.Reflection.Collections.Filtered.Constructors> filter) { }
+        public static aweXpect.Reflection.Results.TypeContainingMembersResult<System.Collections.Generic.IEnumerable<System.Type?>> ContainConstructors(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject, System.Func<aweXpect.Reflection.Collections.Filtered.Constructors, aweXpect.Reflection.Collections.Filtered.Constructors> filter) { }
+        public static aweXpect.Reflection.Results.TypeContainingMembersResult<System.Collections.Generic.IAsyncEnumerable<System.Type?>> ContainEvents(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>> subject, System.Func<aweXpect.Reflection.Collections.Filtered.Events, aweXpect.Reflection.Collections.Filtered.Events> filter) { }
+        public static aweXpect.Reflection.Results.TypeContainingMembersResult<System.Collections.Generic.IEnumerable<System.Type?>> ContainEvents(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject, System.Func<aweXpect.Reflection.Collections.Filtered.Events, aweXpect.Reflection.Collections.Filtered.Events> filter) { }
+        public static aweXpect.Reflection.Results.TypeContainingMembersResult<System.Collections.Generic.IAsyncEnumerable<System.Type?>> ContainFields(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>> subject, System.Func<aweXpect.Reflection.Collections.Filtered.Fields, aweXpect.Reflection.Collections.Filtered.Fields> filter) { }
+        public static aweXpect.Reflection.Results.TypeContainingMembersResult<System.Collections.Generic.IEnumerable<System.Type?>> ContainFields(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject, System.Func<aweXpect.Reflection.Collections.Filtered.Fields, aweXpect.Reflection.Collections.Filtered.Fields> filter) { }
+        public static aweXpect.Reflection.Results.TypeContainingMembersResult<System.Collections.Generic.IAsyncEnumerable<System.Type?>> ContainMethods(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>> subject, System.Func<aweXpect.Reflection.Collections.Filtered.Methods, aweXpect.Reflection.Collections.Filtered.Methods> filter) { }
+        public static aweXpect.Reflection.Results.TypeContainingMembersResult<System.Collections.Generic.IEnumerable<System.Type?>> ContainMethods(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject, System.Func<aweXpect.Reflection.Collections.Filtered.Methods, aweXpect.Reflection.Collections.Filtered.Methods> filter) { }
+        public static aweXpect.Reflection.Results.TypeContainingMembersResult<System.Collections.Generic.IAsyncEnumerable<System.Type?>> ContainProperties(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>> subject, System.Func<aweXpect.Reflection.Collections.Filtered.Properties, aweXpect.Reflection.Collections.Filtered.Properties> filter) { }
+        public static aweXpect.Reflection.Results.TypeContainingMembersResult<System.Collections.Generic.IEnumerable<System.Type?>> ContainProperties(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject, System.Func<aweXpect.Reflection.Collections.Filtered.Properties, aweXpect.Reflection.Collections.Filtered.Properties> filter) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>>> DoNotInheritFrom(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>> subject, System.Type baseType, bool forceDirect = false) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> DoNotInheritFrom(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject, System.Type baseType, bool forceDirect = false) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>>> DoNotInheritFrom<TBaseType>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>> subject, bool forceDirect = false) { }
@@ -1349,5 +1364,22 @@ namespace aweXpect.Reflection.Results
         public aweXpect.Reflection.Results.ParameterCollectionResult<TThat, TParameter> WithDefaultValue<TValue>(TValue expected)
             where TValue : TParameter { }
         public aweXpect.Reflection.Results.ParameterCollectionResult<TThat, TParameter> WithoutDefaultValue() { }
+    }
+    public class TypeContainingMembersResult<TThat> : aweXpect.Results.AndOrResult<TThat, aweXpect.Core.IThat<TThat>>
+    {
+        public TypeContainingMembersResult(aweXpect.Core.ExpectationBuilder expectationBuilder, aweXpect.Core.IThat<TThat> subject, aweXpect.Options.Quantifier quantifier) { }
+        public aweXpect.Results.CountTimesResult<aweXpect.Reflection.Results.TypeContainingMembersResult<TThat>> AtLeast() { }
+        public aweXpect.Reflection.Results.TypeContainingMembersResult<TThat> AtLeast(aweXpect.Core.Times minimum) { }
+        public aweXpect.Results.CountTimesResult<aweXpect.Reflection.Results.TypeContainingMembersResult<TThat>> AtMost() { }
+        public aweXpect.Reflection.Results.TypeContainingMembersResult<TThat> AtMost(aweXpect.Core.Times maximum) { }
+        public aweXpect.Results.BetweenResult<aweXpect.Reflection.Results.TypeContainingMembersResult<TThat>> Between(int minimum) { }
+        public aweXpect.Reflection.Results.TypeContainingMembersResult<TThat> Exactly(aweXpect.Core.Times expected) { }
+        public aweXpect.Results.CountTimesResult<aweXpect.Reflection.Results.TypeContainingMembersResult<TThat>> LessThan() { }
+        public aweXpect.Reflection.Results.TypeContainingMembersResult<TThat> LessThan(aweXpect.Core.Times maximum) { }
+        public aweXpect.Results.CountTimesResult<aweXpect.Reflection.Results.TypeContainingMembersResult<TThat>> MoreThan() { }
+        public aweXpect.Reflection.Results.TypeContainingMembersResult<TThat> MoreThan(aweXpect.Core.Times minimum) { }
+        public aweXpect.Reflection.Results.TypeContainingMembersResult<TThat> Never() { }
+        public aweXpect.Reflection.Results.TypeContainingMembersResult<TThat> Once() { }
+        public aweXpect.Reflection.Results.TypeContainingMembersResult<TThat> Twice() { }
     }
 }

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net8.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net8.0.txt
@@ -746,6 +746,11 @@ namespace aweXpect.Reflection
     }
     public static class ThatType
     {
+        public static aweXpect.Reflection.Results.TypeContainingMembersResult<System.Type?> ContainsConstructors(this aweXpect.Core.IThat<System.Type?> subject, System.Func<aweXpect.Reflection.Collections.Filtered.Constructors, aweXpect.Reflection.Collections.Filtered.Constructors> filter) { }
+        public static aweXpect.Reflection.Results.TypeContainingMembersResult<System.Type?> ContainsEvents(this aweXpect.Core.IThat<System.Type?> subject, System.Func<aweXpect.Reflection.Collections.Filtered.Events, aweXpect.Reflection.Collections.Filtered.Events> filter) { }
+        public static aweXpect.Reflection.Results.TypeContainingMembersResult<System.Type?> ContainsFields(this aweXpect.Core.IThat<System.Type?> subject, System.Func<aweXpect.Reflection.Collections.Filtered.Fields, aweXpect.Reflection.Collections.Filtered.Fields> filter) { }
+        public static aweXpect.Reflection.Results.TypeContainingMembersResult<System.Type?> ContainsMethods(this aweXpect.Core.IThat<System.Type?> subject, System.Func<aweXpect.Reflection.Collections.Filtered.Methods, aweXpect.Reflection.Collections.Filtered.Methods> filter) { }
+        public static aweXpect.Reflection.Results.TypeContainingMembersResult<System.Type?> ContainsProperties(this aweXpect.Core.IThat<System.Type?> subject, System.Func<aweXpect.Reflection.Collections.Filtered.Properties, aweXpect.Reflection.Collections.Filtered.Properties> filter) { }
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> DoesNotInheritFrom(this aweXpect.Core.IThat<System.Type?> subject, System.Type baseType, bool forceDirect = false) { }
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> DoesNotInheritFrom<TBaseType>(this aweXpect.Core.IThat<System.Type?> subject, bool forceDirect = false) { }
         public static aweXpect.Reflection.Results.HasAttributeResult<System.Type?> Has<TAttribute>(this aweXpect.Core.IThat<System.Type?> subject, bool inherit = true)
@@ -824,6 +829,16 @@ namespace aweXpect.Reflection
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreStatic(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>>> AreStructs(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreStructs(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
+        public static aweXpect.Reflection.Results.TypeContainingMembersResult<System.Collections.Generic.IAsyncEnumerable<System.Type?>> ContainConstructors(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>> subject, System.Func<aweXpect.Reflection.Collections.Filtered.Constructors, aweXpect.Reflection.Collections.Filtered.Constructors> filter) { }
+        public static aweXpect.Reflection.Results.TypeContainingMembersResult<System.Collections.Generic.IEnumerable<System.Type?>> ContainConstructors(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject, System.Func<aweXpect.Reflection.Collections.Filtered.Constructors, aweXpect.Reflection.Collections.Filtered.Constructors> filter) { }
+        public static aweXpect.Reflection.Results.TypeContainingMembersResult<System.Collections.Generic.IAsyncEnumerable<System.Type?>> ContainEvents(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>> subject, System.Func<aweXpect.Reflection.Collections.Filtered.Events, aweXpect.Reflection.Collections.Filtered.Events> filter) { }
+        public static aweXpect.Reflection.Results.TypeContainingMembersResult<System.Collections.Generic.IEnumerable<System.Type?>> ContainEvents(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject, System.Func<aweXpect.Reflection.Collections.Filtered.Events, aweXpect.Reflection.Collections.Filtered.Events> filter) { }
+        public static aweXpect.Reflection.Results.TypeContainingMembersResult<System.Collections.Generic.IAsyncEnumerable<System.Type?>> ContainFields(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>> subject, System.Func<aweXpect.Reflection.Collections.Filtered.Fields, aweXpect.Reflection.Collections.Filtered.Fields> filter) { }
+        public static aweXpect.Reflection.Results.TypeContainingMembersResult<System.Collections.Generic.IEnumerable<System.Type?>> ContainFields(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject, System.Func<aweXpect.Reflection.Collections.Filtered.Fields, aweXpect.Reflection.Collections.Filtered.Fields> filter) { }
+        public static aweXpect.Reflection.Results.TypeContainingMembersResult<System.Collections.Generic.IAsyncEnumerable<System.Type?>> ContainMethods(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>> subject, System.Func<aweXpect.Reflection.Collections.Filtered.Methods, aweXpect.Reflection.Collections.Filtered.Methods> filter) { }
+        public static aweXpect.Reflection.Results.TypeContainingMembersResult<System.Collections.Generic.IEnumerable<System.Type?>> ContainMethods(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject, System.Func<aweXpect.Reflection.Collections.Filtered.Methods, aweXpect.Reflection.Collections.Filtered.Methods> filter) { }
+        public static aweXpect.Reflection.Results.TypeContainingMembersResult<System.Collections.Generic.IAsyncEnumerable<System.Type?>> ContainProperties(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>> subject, System.Func<aweXpect.Reflection.Collections.Filtered.Properties, aweXpect.Reflection.Collections.Filtered.Properties> filter) { }
+        public static aweXpect.Reflection.Results.TypeContainingMembersResult<System.Collections.Generic.IEnumerable<System.Type?>> ContainProperties(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject, System.Func<aweXpect.Reflection.Collections.Filtered.Properties, aweXpect.Reflection.Collections.Filtered.Properties> filter) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>>> DoNotInheritFrom(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>> subject, System.Type baseType, bool forceDirect = false) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> DoNotInheritFrom(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject, System.Type baseType, bool forceDirect = false) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>>> DoNotInheritFrom<TBaseType>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>> subject, bool forceDirect = false) { }
@@ -1349,5 +1364,22 @@ namespace aweXpect.Reflection.Results
         public aweXpect.Reflection.Results.ParameterCollectionResult<TThat, TParameter> WithDefaultValue<TValue>(TValue expected)
             where TValue : TParameter { }
         public aweXpect.Reflection.Results.ParameterCollectionResult<TThat, TParameter> WithoutDefaultValue() { }
+    }
+    public class TypeContainingMembersResult<TThat> : aweXpect.Results.AndOrResult<TThat, aweXpect.Core.IThat<TThat>>
+    {
+        public TypeContainingMembersResult(aweXpect.Core.ExpectationBuilder expectationBuilder, aweXpect.Core.IThat<TThat> subject, aweXpect.Options.Quantifier quantifier) { }
+        public aweXpect.Results.CountTimesResult<aweXpect.Reflection.Results.TypeContainingMembersResult<TThat>> AtLeast() { }
+        public aweXpect.Reflection.Results.TypeContainingMembersResult<TThat> AtLeast(aweXpect.Core.Times minimum) { }
+        public aweXpect.Results.CountTimesResult<aweXpect.Reflection.Results.TypeContainingMembersResult<TThat>> AtMost() { }
+        public aweXpect.Reflection.Results.TypeContainingMembersResult<TThat> AtMost(aweXpect.Core.Times maximum) { }
+        public aweXpect.Results.BetweenResult<aweXpect.Reflection.Results.TypeContainingMembersResult<TThat>> Between(int minimum) { }
+        public aweXpect.Reflection.Results.TypeContainingMembersResult<TThat> Exactly(aweXpect.Core.Times expected) { }
+        public aweXpect.Results.CountTimesResult<aweXpect.Reflection.Results.TypeContainingMembersResult<TThat>> LessThan() { }
+        public aweXpect.Reflection.Results.TypeContainingMembersResult<TThat> LessThan(aweXpect.Core.Times maximum) { }
+        public aweXpect.Results.CountTimesResult<aweXpect.Reflection.Results.TypeContainingMembersResult<TThat>> MoreThan() { }
+        public aweXpect.Reflection.Results.TypeContainingMembersResult<TThat> MoreThan(aweXpect.Core.Times minimum) { }
+        public aweXpect.Reflection.Results.TypeContainingMembersResult<TThat> Never() { }
+        public aweXpect.Reflection.Results.TypeContainingMembersResult<TThat> Once() { }
+        public aweXpect.Reflection.Results.TypeContainingMembersResult<TThat> Twice() { }
     }
 }

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_netstandard2.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_netstandard2.0.txt
@@ -642,6 +642,11 @@ namespace aweXpect.Reflection
     }
     public static class ThatType
     {
+        public static aweXpect.Reflection.Results.TypeContainingMembersResult<System.Type?> ContainsConstructors(this aweXpect.Core.IThat<System.Type?> subject, System.Func<aweXpect.Reflection.Collections.Filtered.Constructors, aweXpect.Reflection.Collections.Filtered.Constructors> filter) { }
+        public static aweXpect.Reflection.Results.TypeContainingMembersResult<System.Type?> ContainsEvents(this aweXpect.Core.IThat<System.Type?> subject, System.Func<aweXpect.Reflection.Collections.Filtered.Events, aweXpect.Reflection.Collections.Filtered.Events> filter) { }
+        public static aweXpect.Reflection.Results.TypeContainingMembersResult<System.Type?> ContainsFields(this aweXpect.Core.IThat<System.Type?> subject, System.Func<aweXpect.Reflection.Collections.Filtered.Fields, aweXpect.Reflection.Collections.Filtered.Fields> filter) { }
+        public static aweXpect.Reflection.Results.TypeContainingMembersResult<System.Type?> ContainsMethods(this aweXpect.Core.IThat<System.Type?> subject, System.Func<aweXpect.Reflection.Collections.Filtered.Methods, aweXpect.Reflection.Collections.Filtered.Methods> filter) { }
+        public static aweXpect.Reflection.Results.TypeContainingMembersResult<System.Type?> ContainsProperties(this aweXpect.Core.IThat<System.Type?> subject, System.Func<aweXpect.Reflection.Collections.Filtered.Properties, aweXpect.Reflection.Collections.Filtered.Properties> filter) { }
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> DoesNotInheritFrom(this aweXpect.Core.IThat<System.Type?> subject, System.Type baseType, bool forceDirect = false) { }
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> DoesNotInheritFrom<TBaseType>(this aweXpect.Core.IThat<System.Type?> subject, bool forceDirect = false) { }
         public static aweXpect.Reflection.Results.HasAttributeResult<System.Type?> Has<TAttribute>(this aweXpect.Core.IThat<System.Type?> subject, bool inherit = true)
@@ -698,6 +703,11 @@ namespace aweXpect.Reflection
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreSealed(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreStatic(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreStructs(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
+        public static aweXpect.Reflection.Results.TypeContainingMembersResult<System.Collections.Generic.IEnumerable<System.Type?>> ContainConstructors(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject, System.Func<aweXpect.Reflection.Collections.Filtered.Constructors, aweXpect.Reflection.Collections.Filtered.Constructors> filter) { }
+        public static aweXpect.Reflection.Results.TypeContainingMembersResult<System.Collections.Generic.IEnumerable<System.Type?>> ContainEvents(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject, System.Func<aweXpect.Reflection.Collections.Filtered.Events, aweXpect.Reflection.Collections.Filtered.Events> filter) { }
+        public static aweXpect.Reflection.Results.TypeContainingMembersResult<System.Collections.Generic.IEnumerable<System.Type?>> ContainFields(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject, System.Func<aweXpect.Reflection.Collections.Filtered.Fields, aweXpect.Reflection.Collections.Filtered.Fields> filter) { }
+        public static aweXpect.Reflection.Results.TypeContainingMembersResult<System.Collections.Generic.IEnumerable<System.Type?>> ContainMethods(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject, System.Func<aweXpect.Reflection.Collections.Filtered.Methods, aweXpect.Reflection.Collections.Filtered.Methods> filter) { }
+        public static aweXpect.Reflection.Results.TypeContainingMembersResult<System.Collections.Generic.IEnumerable<System.Type?>> ContainProperties(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject, System.Func<aweXpect.Reflection.Collections.Filtered.Properties, aweXpect.Reflection.Collections.Filtered.Properties> filter) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> DoNotInheritFrom(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject, System.Type baseType, bool forceDirect = false) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> DoNotInheritFrom<TBaseType>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject, bool forceDirect = false) { }
         public static aweXpect.Reflection.Results.HaveAttributeResult<System.Type?, System.Collections.Generic.IEnumerable<System.Type?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject, bool inherit = true)
@@ -1213,5 +1223,22 @@ namespace aweXpect.Reflection.Results
         public aweXpect.Reflection.Results.ParameterCollectionResult<TThat, TParameter> WithDefaultValue<TValue>(TValue expected)
             where TValue : TParameter { }
         public aweXpect.Reflection.Results.ParameterCollectionResult<TThat, TParameter> WithoutDefaultValue() { }
+    }
+    public class TypeContainingMembersResult<TThat> : aweXpect.Results.AndOrResult<TThat, aweXpect.Core.IThat<TThat>>
+    {
+        public TypeContainingMembersResult(aweXpect.Core.ExpectationBuilder expectationBuilder, aweXpect.Core.IThat<TThat> subject, aweXpect.Options.Quantifier quantifier) { }
+        public aweXpect.Results.CountTimesResult<aweXpect.Reflection.Results.TypeContainingMembersResult<TThat>> AtLeast() { }
+        public aweXpect.Reflection.Results.TypeContainingMembersResult<TThat> AtLeast(aweXpect.Core.Times minimum) { }
+        public aweXpect.Results.CountTimesResult<aweXpect.Reflection.Results.TypeContainingMembersResult<TThat>> AtMost() { }
+        public aweXpect.Reflection.Results.TypeContainingMembersResult<TThat> AtMost(aweXpect.Core.Times maximum) { }
+        public aweXpect.Results.BetweenResult<aweXpect.Reflection.Results.TypeContainingMembersResult<TThat>> Between(int minimum) { }
+        public aweXpect.Reflection.Results.TypeContainingMembersResult<TThat> Exactly(aweXpect.Core.Times expected) { }
+        public aweXpect.Results.CountTimesResult<aweXpect.Reflection.Results.TypeContainingMembersResult<TThat>> LessThan() { }
+        public aweXpect.Reflection.Results.TypeContainingMembersResult<TThat> LessThan(aweXpect.Core.Times maximum) { }
+        public aweXpect.Results.CountTimesResult<aweXpect.Reflection.Results.TypeContainingMembersResult<TThat>> MoreThan() { }
+        public aweXpect.Reflection.Results.TypeContainingMembersResult<TThat> MoreThan(aweXpect.Core.Times minimum) { }
+        public aweXpect.Reflection.Results.TypeContainingMembersResult<TThat> Never() { }
+        public aweXpect.Reflection.Results.TypeContainingMembersResult<TThat> Once() { }
+        public aweXpect.Reflection.Results.TypeContainingMembersResult<TThat> Twice() { }
     }
 }

--- a/Tests/aweXpect.Reflection.Tests/ThatType.ContainsConstructors.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatType.ContainsConstructors.Tests.cs
@@ -1,0 +1,104 @@
+﻿using Xunit.Sdk;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatType
+{
+	public sealed class ContainsConstructors
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenTypeContainsMatchingConstructor_ShouldSucceed()
+			{
+				Type subject = typeof(ClassWithMarkedConstructor);
+
+				async Task Act()
+					=> await That(subject).ContainsConstructors(constructors => constructors.With<MarkerAttribute>());
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenTypeContainsNoMatchingConstructor_ShouldFail()
+			{
+				Type subject = typeof(ClassWithoutMarkedConstructor);
+
+				async Task Act()
+					=> await That(subject).ContainsConstructors(constructors => constructors.With<MarkerAttribute>());
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             contains constructors with ThatType.ContainsConstructors.MarkerAttribute at least once,
+					             but it contained 0 matching members in ThatType.ContainsConstructors.ClassWithoutMarkedConstructor
+					             """);
+			}
+
+			[Fact]
+			public async Task Exactly_WhenCountMatches_ShouldSucceed()
+			{
+				Type subject = typeof(ClassWithTwoMarkedConstructors);
+
+				async Task Act()
+					=> await That(subject).ContainsConstructors(constructors => constructors.With<MarkerAttribute>())
+						.Exactly(2);
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+		public sealed class NegatedTests
+		{
+			[Fact]
+			public async Task WhenTypeContainsMatchingConstructor_ShouldFail()
+			{
+				Type subject = typeof(ClassWithMarkedConstructor);
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it
+						=> it.ContainsConstructors(constructors => constructors.With<MarkerAttribute>()));
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             does not contain constructors with ThatType.ContainsConstructors.MarkerAttribute at least once,
+					             but it contained 1 matching member in ThatType.ContainsConstructors.ClassWithMarkedConstructor
+					             """);
+			}
+		}
+
+		[AttributeUsage(AttributeTargets.Constructor)]
+		private class MarkerAttribute : Attribute
+		{
+		}
+
+		private class ClassWithMarkedConstructor
+		{
+			[Marker]
+			public ClassWithMarkedConstructor()
+			{
+			}
+		}
+
+		private class ClassWithTwoMarkedConstructors
+		{
+			[Marker]
+			public ClassWithTwoMarkedConstructors()
+			{
+			}
+
+			[Marker]
+			public ClassWithTwoMarkedConstructors(int value)
+			{
+			}
+		}
+
+		private class ClassWithoutMarkedConstructor
+		{
+			public ClassWithoutMarkedConstructor()
+			{
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatType.ContainsConstructors.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatType.ContainsConstructors.Tests.cs
@@ -9,12 +9,28 @@ public sealed partial class ThatType
 		public sealed class Tests
 		{
 			[Fact]
+			public async Task Exactly_WhenCountMatches_ShouldSucceed()
+			{
+				Type subject = typeof(ClassWithTwoMarkedConstructors);
+
+				async Task Act()
+				{
+					await That(subject).ContainsConstructors(constructors => constructors.With<MarkerAttribute>())
+						.Exactly(2);
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
 			public async Task WhenTypeContainsMatchingConstructor_ShouldSucceed()
 			{
 				Type subject = typeof(ClassWithMarkedConstructor);
 
 				async Task Act()
-					=> await That(subject).ContainsConstructors(constructors => constructors.With<MarkerAttribute>());
+				{
+					await That(subject).ContainsConstructors(constructors => constructors.With<MarkerAttribute>());
+				}
 
 				await That(Act).DoesNotThrow();
 			}
@@ -25,7 +41,9 @@ public sealed partial class ThatType
 				Type subject = typeof(ClassWithoutMarkedConstructor);
 
 				async Task Act()
-					=> await That(subject).ContainsConstructors(constructors => constructors.With<MarkerAttribute>());
+				{
+					await That(subject).ContainsConstructors(constructors => constructors.With<MarkerAttribute>());
+				}
 
 				await That(Act).ThrowsException()
 					.WithMessage("""
@@ -33,18 +51,6 @@ public sealed partial class ThatType
 					             contains constructors with ThatType.ContainsConstructors.MarkerAttribute at least once,
 					             but it contained 0 matching members in ThatType.ContainsConstructors.ClassWithoutMarkedConstructor
 					             """);
-			}
-
-			[Fact]
-			public async Task Exactly_WhenCountMatches_ShouldSucceed()
-			{
-				Type subject = typeof(ClassWithTwoMarkedConstructors);
-
-				async Task Act()
-					=> await That(subject).ContainsConstructors(constructors => constructors.With<MarkerAttribute>())
-						.Exactly(2);
-
-				await That(Act).DoesNotThrow();
 			}
 		}
 
@@ -56,8 +62,10 @@ public sealed partial class ThatType
 				Type subject = typeof(ClassWithMarkedConstructor);
 
 				async Task Act()
-					=> await That(subject).DoesNotComplyWith(it
+				{
+					await That(subject).DoesNotComplyWith(it
 						=> it.ContainsConstructors(constructors => constructors.With<MarkerAttribute>()));
+				}
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
@@ -96,9 +104,6 @@ public sealed partial class ThatType
 
 		private class ClassWithoutMarkedConstructor
 		{
-			public ClassWithoutMarkedConstructor()
-			{
-			}
 		}
 	}
 }

--- a/Tests/aweXpect.Reflection.Tests/ThatType.ContainsEvents.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatType.ContainsEvents.Tests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Xunit.Sdk;
+﻿using Xunit.Sdk;
 
 namespace aweXpect.Reflection.Tests;
 
@@ -10,12 +9,27 @@ public sealed partial class ThatType
 		public sealed class Tests
 		{
 			[Fact]
+			public async Task Never_WhenTypeContainsNoMatchingEvent_ShouldSucceed()
+			{
+				Type subject = typeof(ClassWithoutMarkedEvent);
+
+				async Task Act()
+				{
+					await That(subject).ContainsEvents(events => events.With<MarkerAttribute>()).Never();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
 			public async Task WhenTypeContainsMatchingEvent_ShouldSucceed()
 			{
 				Type subject = typeof(ClassWithMarkedEvent);
 
 				async Task Act()
-					=> await That(subject).ContainsEvents(events => events.With<MarkerAttribute>());
+				{
+					await That(subject).ContainsEvents(events => events.With<MarkerAttribute>());
+				}
 
 				await That(Act).DoesNotThrow();
 			}
@@ -26,7 +40,9 @@ public sealed partial class ThatType
 				Type subject = typeof(ClassWithoutMarkedEvent);
 
 				async Task Act()
-					=> await That(subject).ContainsEvents(events => events.With<MarkerAttribute>());
+				{
+					await That(subject).ContainsEvents(events => events.With<MarkerAttribute>());
+				}
 
 				await That(Act).ThrowsException()
 					.WithMessage("""
@@ -34,17 +50,6 @@ public sealed partial class ThatType
 					             contains events with ThatType.ContainsEvents.MarkerAttribute at least once,
 					             but it contained 0 matching members in ThatType.ContainsEvents.ClassWithoutMarkedEvent
 					             """);
-			}
-
-			[Fact]
-			public async Task Never_WhenTypeContainsNoMatchingEvent_ShouldSucceed()
-			{
-				Type subject = typeof(ClassWithoutMarkedEvent);
-
-				async Task Act()
-					=> await That(subject).ContainsEvents(events => events.With<MarkerAttribute>()).Never();
-
-				await That(Act).DoesNotThrow();
 			}
 		}
 
@@ -56,8 +61,10 @@ public sealed partial class ThatType
 				Type subject = typeof(ClassWithMarkedEvent);
 
 				async Task Act()
-					=> await That(subject).DoesNotComplyWith(it
+				{
+					await That(subject).DoesNotComplyWith(it
 						=> it.ContainsEvents(events => events.With<MarkerAttribute>()));
+				}
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""

--- a/Tests/aweXpect.Reflection.Tests/ThatType.ContainsEvents.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatType.ContainsEvents.Tests.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using Xunit.Sdk;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatType
+{
+	public sealed class ContainsEvents
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenTypeContainsMatchingEvent_ShouldSucceed()
+			{
+				Type subject = typeof(ClassWithMarkedEvent);
+
+				async Task Act()
+					=> await That(subject).ContainsEvents(events => events.With<MarkerAttribute>());
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenTypeContainsNoMatchingEvent_ShouldFail()
+			{
+				Type subject = typeof(ClassWithoutMarkedEvent);
+
+				async Task Act()
+					=> await That(subject).ContainsEvents(events => events.With<MarkerAttribute>());
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             contains events with ThatType.ContainsEvents.MarkerAttribute at least once,
+					             but it contained 0 matching members in ThatType.ContainsEvents.ClassWithoutMarkedEvent
+					             """);
+			}
+
+			[Fact]
+			public async Task Never_WhenTypeContainsNoMatchingEvent_ShouldSucceed()
+			{
+				Type subject = typeof(ClassWithoutMarkedEvent);
+
+				async Task Act()
+					=> await That(subject).ContainsEvents(events => events.With<MarkerAttribute>()).Never();
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+		public sealed class NegatedTests
+		{
+			[Fact]
+			public async Task WhenTypeContainsMatchingEvent_ShouldFail()
+			{
+				Type subject = typeof(ClassWithMarkedEvent);
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it
+						=> it.ContainsEvents(events => events.With<MarkerAttribute>()));
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             does not contain events with ThatType.ContainsEvents.MarkerAttribute at least once,
+					             but it contained 1 matching member in ThatType.ContainsEvents.ClassWithMarkedEvent
+					             """);
+			}
+		}
+
+		[AttributeUsage(AttributeTargets.Event)]
+		private class MarkerAttribute : Attribute
+		{
+		}
+
+		private class ClassWithMarkedEvent
+		{
+			[Marker] public event EventHandler? Something;
+
+			protected virtual void OnSomething() => Something?.Invoke(this, EventArgs.Empty);
+		}
+
+		private class ClassWithoutMarkedEvent
+		{
+			public event EventHandler? Something;
+
+			protected virtual void OnSomething() => Something?.Invoke(this, EventArgs.Empty);
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatType.ContainsFields.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatType.ContainsFields.Tests.cs
@@ -82,12 +82,16 @@ public sealed partial class ThatType
 
 		private class ClassWithMarkedField
 		{
+#pragma warning disable CS0649 // Field is never assigned to, and will always have its default value
 			[Marker] public int Value;
+#pragma warning restore CS0649
 		}
 
 		private class ClassWithoutMarkedField
 		{
+#pragma warning disable CS0649 // Field is never assigned to, and will always have its default value
 			public int Value;
+#pragma warning restore CS0649
 		}
 	}
 }

--- a/Tests/aweXpect.Reflection.Tests/ThatType.ContainsFields.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatType.ContainsFields.Tests.cs
@@ -1,0 +1,85 @@
+﻿using Xunit.Sdk;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatType
+{
+	public sealed class ContainsFields
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenTypeContainsMatchingField_ShouldSucceed()
+			{
+				Type subject = typeof(ClassWithMarkedField);
+
+				async Task Act()
+					=> await That(subject).ContainsFields(fields => fields.With<MarkerAttribute>());
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenTypeContainsNoMatchingField_ShouldFail()
+			{
+				Type subject = typeof(ClassWithoutMarkedField);
+
+				async Task Act()
+					=> await That(subject).ContainsFields(fields => fields.With<MarkerAttribute>());
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             contains fields with ThatType.ContainsFields.MarkerAttribute at least once,
+					             but it contained 0 matching members in ThatType.ContainsFields.ClassWithoutMarkedField
+					             """);
+			}
+
+			[Fact]
+			public async Task Never_WhenTypeContainsNoMatchingField_ShouldSucceed()
+			{
+				Type subject = typeof(ClassWithoutMarkedField);
+
+				async Task Act()
+					=> await That(subject).ContainsFields(fields => fields.With<MarkerAttribute>()).Never();
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+		public sealed class NegatedTests
+		{
+			[Fact]
+			public async Task WhenTypeContainsMatchingField_ShouldFail()
+			{
+				Type subject = typeof(ClassWithMarkedField);
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it
+						=> it.ContainsFields(fields => fields.With<MarkerAttribute>()));
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             does not contain fields with ThatType.ContainsFields.MarkerAttribute at least once,
+					             but it contained 1 matching member in ThatType.ContainsFields.ClassWithMarkedField
+					             """);
+			}
+		}
+
+		[AttributeUsage(AttributeTargets.Field)]
+		private class MarkerAttribute : Attribute
+		{
+		}
+
+		private class ClassWithMarkedField
+		{
+			[Marker] public int Value;
+		}
+
+		private class ClassWithoutMarkedField
+		{
+			public int Value;
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatType.ContainsFields.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatType.ContainsFields.Tests.cs
@@ -9,12 +9,27 @@ public sealed partial class ThatType
 		public sealed class Tests
 		{
 			[Fact]
+			public async Task Never_WhenTypeContainsNoMatchingField_ShouldSucceed()
+			{
+				Type subject = typeof(ClassWithoutMarkedField);
+
+				async Task Act()
+				{
+					await That(subject).ContainsFields(fields => fields.With<MarkerAttribute>()).Never();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
 			public async Task WhenTypeContainsMatchingField_ShouldSucceed()
 			{
 				Type subject = typeof(ClassWithMarkedField);
 
 				async Task Act()
-					=> await That(subject).ContainsFields(fields => fields.With<MarkerAttribute>());
+				{
+					await That(subject).ContainsFields(fields => fields.With<MarkerAttribute>());
+				}
 
 				await That(Act).DoesNotThrow();
 			}
@@ -25,7 +40,9 @@ public sealed partial class ThatType
 				Type subject = typeof(ClassWithoutMarkedField);
 
 				async Task Act()
-					=> await That(subject).ContainsFields(fields => fields.With<MarkerAttribute>());
+				{
+					await That(subject).ContainsFields(fields => fields.With<MarkerAttribute>());
+				}
 
 				await That(Act).ThrowsException()
 					.WithMessage("""
@@ -33,17 +50,6 @@ public sealed partial class ThatType
 					             contains fields with ThatType.ContainsFields.MarkerAttribute at least once,
 					             but it contained 0 matching members in ThatType.ContainsFields.ClassWithoutMarkedField
 					             """);
-			}
-
-			[Fact]
-			public async Task Never_WhenTypeContainsNoMatchingField_ShouldSucceed()
-			{
-				Type subject = typeof(ClassWithoutMarkedField);
-
-				async Task Act()
-					=> await That(subject).ContainsFields(fields => fields.With<MarkerAttribute>()).Never();
-
-				await That(Act).DoesNotThrow();
 			}
 		}
 
@@ -55,8 +61,10 @@ public sealed partial class ThatType
 				Type subject = typeof(ClassWithMarkedField);
 
 				async Task Act()
-					=> await That(subject).DoesNotComplyWith(it
+				{
+					await That(subject).DoesNotComplyWith(it
 						=> it.ContainsFields(fields => fields.With<MarkerAttribute>()));
+				}
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""

--- a/Tests/aweXpect.Reflection.Tests/ThatType.ContainsMethods.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatType.ContainsMethods.Tests.cs
@@ -9,12 +9,58 @@ public sealed partial class ThatType
 		public sealed class Tests
 		{
 			[Fact]
+			public async Task Exactly_WhenCountDiffers_ShouldFail()
+			{
+				Type subject = typeof(ClassWithMarkedMethod);
+
+				async Task Act()
+				{
+					await That(subject).ContainsMethods(methods => methods.With<MarkerAttribute>()).Exactly(2);
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             contains methods with ThatType.ContainsMethods.MarkerAttribute exactly twice,
+					             but it contained 1 matching member in ThatType.ContainsMethods.ClassWithMarkedMethod
+					             """);
+			}
+
+			[Fact]
+			public async Task Exactly_WhenCountMatches_ShouldSucceed()
+			{
+				Type subject = typeof(ClassWithTwoMarkedMethods);
+
+				async Task Act()
+				{
+					await That(subject).ContainsMethods(methods => methods.With<MarkerAttribute>()).Exactly(2);
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task Never_WhenTypeContainsNoMatchingMethod_ShouldSucceed()
+			{
+				Type subject = typeof(ClassWithoutMarkedMethod);
+
+				async Task Act()
+				{
+					await That(subject).ContainsMethods(methods => methods.With<MarkerAttribute>()).Never();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
 			public async Task WhenTypeContainsMatchingMethod_ShouldSucceed()
 			{
 				Type subject = typeof(ClassWithMarkedMethod);
 
 				async Task Act()
-					=> await That(subject).ContainsMethods(methods => methods.With<MarkerAttribute>());
+				{
+					await That(subject).ContainsMethods(methods => methods.With<MarkerAttribute>());
+				}
 
 				await That(Act).DoesNotThrow();
 			}
@@ -25,7 +71,9 @@ public sealed partial class ThatType
 				Type subject = typeof(ClassWithoutMarkedMethod);
 
 				async Task Act()
-					=> await That(subject).ContainsMethods(methods => methods.With<MarkerAttribute>());
+				{
+					await That(subject).ContainsMethods(methods => methods.With<MarkerAttribute>());
+				}
 
 				await That(Act).ThrowsException()
 					.WithMessage("""
@@ -41,7 +89,9 @@ public sealed partial class ThatType
 				Type? subject = null;
 
 				async Task Act()
-					=> await That(subject).ContainsMethods(methods => methods.With<MarkerAttribute>());
+				{
+					await That(subject).ContainsMethods(methods => methods.With<MarkerAttribute>());
+				}
 
 				await That(Act).ThrowsException()
 					.WithMessage("""
@@ -49,44 +99,6 @@ public sealed partial class ThatType
 					             contains methods with ThatType.ContainsMethods.MarkerAttribute at least once,
 					             but it was <null>
 					             """);
-			}
-
-			[Fact]
-			public async Task Exactly_WhenCountMatches_ShouldSucceed()
-			{
-				Type subject = typeof(ClassWithTwoMarkedMethods);
-
-				async Task Act()
-					=> await That(subject).ContainsMethods(methods => methods.With<MarkerAttribute>()).Exactly(2);
-
-				await That(Act).DoesNotThrow();
-			}
-
-			[Fact]
-			public async Task Exactly_WhenCountDiffers_ShouldFail()
-			{
-				Type subject = typeof(ClassWithMarkedMethod);
-
-				async Task Act()
-					=> await That(subject).ContainsMethods(methods => methods.With<MarkerAttribute>()).Exactly(2);
-
-				await That(Act).ThrowsException()
-					.WithMessage("""
-					             Expected that subject
-					             contains methods with ThatType.ContainsMethods.MarkerAttribute exactly twice,
-					             but it contained 1 matching member in ThatType.ContainsMethods.ClassWithMarkedMethod
-					             """);
-			}
-
-			[Fact]
-			public async Task Never_WhenTypeContainsNoMatchingMethod_ShouldSucceed()
-			{
-				Type subject = typeof(ClassWithoutMarkedMethod);
-
-				async Task Act()
-					=> await That(subject).ContainsMethods(methods => methods.With<MarkerAttribute>()).Never();
-
-				await That(Act).DoesNotThrow();
 			}
 		}
 
@@ -98,8 +110,10 @@ public sealed partial class ThatType
 				Type subject = typeof(ClassWithMarkedMethod);
 
 				async Task Act()
-					=> await That(subject).DoesNotComplyWith(it
+				{
+					await That(subject).DoesNotComplyWith(it
 						=> it.ContainsMethods(methods => methods.With<MarkerAttribute>()));
+				}
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
@@ -115,8 +129,10 @@ public sealed partial class ThatType
 				Type subject = typeof(ClassWithoutMarkedMethod);
 
 				async Task Act()
-					=> await That(subject).DoesNotComplyWith(it
+				{
+					await That(subject).DoesNotComplyWith(it
 						=> it.ContainsMethods(methods => methods.With<MarkerAttribute>()));
+				}
 
 				await That(Act).DoesNotThrow();
 			}

--- a/Tests/aweXpect.Reflection.Tests/ThatType.ContainsMethods.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatType.ContainsMethods.Tests.cs
@@ -1,0 +1,158 @@
+﻿using Xunit.Sdk;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatType
+{
+	public sealed class ContainsMethods
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenTypeContainsMatchingMethod_ShouldSucceed()
+			{
+				Type subject = typeof(ClassWithMarkedMethod);
+
+				async Task Act()
+					=> await That(subject).ContainsMethods(methods => methods.With<MarkerAttribute>());
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenTypeContainsNoMatchingMethod_ShouldFail()
+			{
+				Type subject = typeof(ClassWithoutMarkedMethod);
+
+				async Task Act()
+					=> await That(subject).ContainsMethods(methods => methods.With<MarkerAttribute>());
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             contains methods with ThatType.ContainsMethods.MarkerAttribute at least once,
+					             but it contained 0 matching members in ThatType.ContainsMethods.ClassWithoutMarkedMethod
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenTypeIsNull_ShouldFail()
+			{
+				Type? subject = null;
+
+				async Task Act()
+					=> await That(subject).ContainsMethods(methods => methods.With<MarkerAttribute>());
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             contains methods with ThatType.ContainsMethods.MarkerAttribute at least once,
+					             but it was <null>
+					             """);
+			}
+
+			[Fact]
+			public async Task Exactly_WhenCountMatches_ShouldSucceed()
+			{
+				Type subject = typeof(ClassWithTwoMarkedMethods);
+
+				async Task Act()
+					=> await That(subject).ContainsMethods(methods => methods.With<MarkerAttribute>()).Exactly(2);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task Exactly_WhenCountDiffers_ShouldFail()
+			{
+				Type subject = typeof(ClassWithMarkedMethod);
+
+				async Task Act()
+					=> await That(subject).ContainsMethods(methods => methods.With<MarkerAttribute>()).Exactly(2);
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             contains methods with ThatType.ContainsMethods.MarkerAttribute exactly twice,
+					             but it contained 1 matching member in ThatType.ContainsMethods.ClassWithMarkedMethod
+					             """);
+			}
+
+			[Fact]
+			public async Task Never_WhenTypeContainsNoMatchingMethod_ShouldSucceed()
+			{
+				Type subject = typeof(ClassWithoutMarkedMethod);
+
+				async Task Act()
+					=> await That(subject).ContainsMethods(methods => methods.With<MarkerAttribute>()).Never();
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+		public sealed class NegatedTests
+		{
+			[Fact]
+			public async Task WhenTypeContainsMatchingMethod_ShouldFail()
+			{
+				Type subject = typeof(ClassWithMarkedMethod);
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it
+						=> it.ContainsMethods(methods => methods.With<MarkerAttribute>()));
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             does not contain methods with ThatType.ContainsMethods.MarkerAttribute at least once,
+					             but it contained 1 matching member in ThatType.ContainsMethods.ClassWithMarkedMethod
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenTypeContainsNoMatchingMethod_ShouldSucceed()
+			{
+				Type subject = typeof(ClassWithoutMarkedMethod);
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it
+						=> it.ContainsMethods(methods => methods.With<MarkerAttribute>()));
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+		[AttributeUsage(AttributeTargets.Method)]
+		private class MarkerAttribute : Attribute
+		{
+		}
+
+		private class ClassWithMarkedMethod
+		{
+			[Marker]
+			public static void Tagged()
+			{
+			}
+		}
+
+		private class ClassWithTwoMarkedMethods
+		{
+			[Marker]
+			public static void TaggedOne()
+			{
+			}
+
+			[Marker]
+			public static void TaggedTwo()
+			{
+			}
+		}
+
+		private class ClassWithoutMarkedMethod
+		{
+			public static void Untagged()
+			{
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatType.ContainsProperties.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatType.ContainsProperties.Tests.cs
@@ -1,0 +1,93 @@
+﻿using Xunit.Sdk;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatType
+{
+	public sealed class ContainsProperties
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenTypeContainsMatchingProperty_ShouldSucceed()
+			{
+				Type subject = typeof(ClassWithMarkedProperty);
+
+				async Task Act()
+					=> await That(subject).ContainsProperties(properties => properties.With<MarkerAttribute>());
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenTypeContainsNoMatchingProperty_ShouldFail()
+			{
+				Type subject = typeof(ClassWithoutMarkedProperty);
+
+				async Task Act()
+					=> await That(subject).ContainsProperties(properties => properties.With<MarkerAttribute>());
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             contains properties with ThatType.ContainsProperties.MarkerAttribute at least once,
+					             but it contained 0 matching members in ThatType.ContainsProperties.ClassWithoutMarkedProperty
+					             """);
+			}
+
+			[Fact]
+			public async Task Exactly_WhenCountMatches_ShouldSucceed()
+			{
+				Type subject = typeof(ClassWithTwoMarkedProperties);
+
+				async Task Act()
+					=> await That(subject).ContainsProperties(properties => properties.With<MarkerAttribute>())
+						.Exactly(2);
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+		public sealed class NegatedTests
+		{
+			[Fact]
+			public async Task WhenTypeContainsMatchingProperty_ShouldFail()
+			{
+				Type subject = typeof(ClassWithMarkedProperty);
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(it
+						=> it.ContainsProperties(properties => properties.With<MarkerAttribute>()));
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             does not contain properties with ThatType.ContainsProperties.MarkerAttribute at least once,
+					             but it contained 1 matching member in ThatType.ContainsProperties.ClassWithMarkedProperty
+					             """);
+			}
+		}
+
+		[AttributeUsage(AttributeTargets.Property)]
+		private class MarkerAttribute : Attribute
+		{
+		}
+
+		private class ClassWithMarkedProperty
+		{
+			[Marker] public int Id { get; set; }
+		}
+
+		private class ClassWithTwoMarkedProperties
+		{
+			[Marker] public int Id { get; set; }
+
+			[Marker] public string Name { get; set; } = "";
+		}
+
+		private class ClassWithoutMarkedProperty
+		{
+			public int Id { get; set; }
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatType.ContainsProperties.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatType.ContainsProperties.Tests.cs
@@ -9,12 +9,28 @@ public sealed partial class ThatType
 		public sealed class Tests
 		{
 			[Fact]
+			public async Task Exactly_WhenCountMatches_ShouldSucceed()
+			{
+				Type subject = typeof(ClassWithTwoMarkedProperties);
+
+				async Task Act()
+				{
+					await That(subject).ContainsProperties(properties => properties.With<MarkerAttribute>())
+						.Exactly(2);
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
 			public async Task WhenTypeContainsMatchingProperty_ShouldSucceed()
 			{
 				Type subject = typeof(ClassWithMarkedProperty);
 
 				async Task Act()
-					=> await That(subject).ContainsProperties(properties => properties.With<MarkerAttribute>());
+				{
+					await That(subject).ContainsProperties(properties => properties.With<MarkerAttribute>());
+				}
 
 				await That(Act).DoesNotThrow();
 			}
@@ -25,7 +41,9 @@ public sealed partial class ThatType
 				Type subject = typeof(ClassWithoutMarkedProperty);
 
 				async Task Act()
-					=> await That(subject).ContainsProperties(properties => properties.With<MarkerAttribute>());
+				{
+					await That(subject).ContainsProperties(properties => properties.With<MarkerAttribute>());
+				}
 
 				await That(Act).ThrowsException()
 					.WithMessage("""
@@ -33,18 +51,6 @@ public sealed partial class ThatType
 					             contains properties with ThatType.ContainsProperties.MarkerAttribute at least once,
 					             but it contained 0 matching members in ThatType.ContainsProperties.ClassWithoutMarkedProperty
 					             """);
-			}
-
-			[Fact]
-			public async Task Exactly_WhenCountMatches_ShouldSucceed()
-			{
-				Type subject = typeof(ClassWithTwoMarkedProperties);
-
-				async Task Act()
-					=> await That(subject).ContainsProperties(properties => properties.With<MarkerAttribute>())
-						.Exactly(2);
-
-				await That(Act).DoesNotThrow();
 			}
 		}
 
@@ -56,8 +62,10 @@ public sealed partial class ThatType
 				Type subject = typeof(ClassWithMarkedProperty);
 
 				async Task Act()
-					=> await That(subject).DoesNotComplyWith(it
+				{
+					await That(subject).DoesNotComplyWith(it
 						=> it.ContainsProperties(properties => properties.With<MarkerAttribute>()));
+				}
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.ContainConstructors.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.ContainConstructors.Tests.cs
@@ -1,0 +1,90 @@
+﻿using aweXpect.Reflection.Collections;
+using Xunit.Sdk;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatTypes
+{
+	public sealed class ContainConstructors
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenAllTypesContainMatchingConstructor_ShouldSucceed()
+			{
+				Filtered.Types subject = In.Types<ClassWithMarkedConstructor, ClassWithTwoMarkedConstructors>();
+
+				async Task Act()
+					=> await That(subject).ContainConstructors(constructors => constructors.With<MarkerAttribute>());
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSomeTypeContainsNoMatchingConstructor_ShouldFail()
+			{
+				Filtered.Types subject = In.Types<ClassWithMarkedConstructor, ClassWithoutMarkedConstructor>();
+
+				async Task Act()
+					=> await That(subject).ContainConstructors(constructors => constructors.With<MarkerAttribute>());
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that in types ThatTypes.ContainConstructors.ClassWithMarkedConstructor and ThatTypes.ContainConstructors.ClassWithoutMarkedConstructor
+					             all contain constructors with ThatTypes.ContainConstructors.MarkerAttribute at least once,
+					             but it contained not matching types [
+					               ThatTypes.ContainConstructors.ClassWithoutMarkedConstructor
+					             ]
+					             """);
+			}
+		}
+
+		public sealed class NegatedTests
+		{
+			[Fact]
+			public async Task WhenSomeTypeContainsNoMatchingConstructor_ShouldSucceed()
+			{
+				Filtered.Types subject = In.Types<ClassWithMarkedConstructor, ClassWithoutMarkedConstructor>();
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(they
+						=> they.ContainConstructors(constructors => constructors.With<MarkerAttribute>()));
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+		[AttributeUsage(AttributeTargets.Constructor)]
+		private class MarkerAttribute : Attribute
+		{
+		}
+
+		private class ClassWithMarkedConstructor
+		{
+			[Marker]
+			public ClassWithMarkedConstructor()
+			{
+			}
+		}
+
+		private class ClassWithTwoMarkedConstructors
+		{
+			[Marker]
+			public ClassWithTwoMarkedConstructors()
+			{
+			}
+
+			[Marker]
+			public ClassWithTwoMarkedConstructors(int value)
+			{
+			}
+		}
+
+		private class ClassWithoutMarkedConstructor
+		{
+			public ClassWithoutMarkedConstructor()
+			{
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.ContainEvents.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.ContainEvents.Tests.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using aweXpect.Reflection.Collections;
+using Xunit.Sdk;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatTypes
+{
+	public sealed class ContainEvents
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenAllTypesContainMatchingEvent_ShouldSucceed()
+			{
+				Filtered.Types subject = In.Types<ClassWithMarkedEvent, ClassWithTwoMarkedEvents>();
+
+				async Task Act()
+					=> await That(subject).ContainEvents(events => events.With<MarkerAttribute>());
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSomeTypeContainsNoMatchingEvent_ShouldFail()
+			{
+				Filtered.Types subject = In.Types<ClassWithMarkedEvent, ClassWithoutMarkedEvent>();
+
+				async Task Act()
+					=> await That(subject).ContainEvents(events => events.With<MarkerAttribute>());
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that in types ThatTypes.ContainEvents.ClassWithMarkedEvent and ThatTypes.ContainEvents.ClassWithoutMarkedEvent
+					             all contain events with ThatTypes.ContainEvents.MarkerAttribute at least once,
+					             but it contained not matching types [
+					               ThatTypes.ContainEvents.ClassWithoutMarkedEvent
+					             ]
+					             """);
+			}
+		}
+
+		public sealed class NegatedTests
+		{
+			[Fact]
+			public async Task WhenSomeTypeContainsNoMatchingEvent_ShouldSucceed()
+			{
+				Filtered.Types subject = In.Types<ClassWithMarkedEvent, ClassWithoutMarkedEvent>();
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(they
+						=> they.ContainEvents(events => events.With<MarkerAttribute>()));
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+		[AttributeUsage(AttributeTargets.Event)]
+		private class MarkerAttribute : Attribute
+		{
+		}
+
+		private class ClassWithMarkedEvent
+		{
+			[Marker] public event EventHandler? Something;
+
+			protected virtual void OnSomething() => Something?.Invoke(this, EventArgs.Empty);
+		}
+
+		private class ClassWithTwoMarkedEvents
+		{
+			[Marker] public event EventHandler? First;
+
+			[Marker] public event EventHandler? Second;
+
+			protected virtual void OnFirst() => First?.Invoke(this, EventArgs.Empty);
+			protected virtual void OnSecond() => Second?.Invoke(this, EventArgs.Empty);
+		}
+
+		private class ClassWithoutMarkedEvent
+		{
+			public event EventHandler? Something;
+
+			protected virtual void OnSomething() => Something?.Invoke(this, EventArgs.Empty);
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.ContainFields.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.ContainFields.Tests.cs
@@ -1,0 +1,79 @@
+﻿using aweXpect.Reflection.Collections;
+using Xunit.Sdk;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatTypes
+{
+	public sealed class ContainFields
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenAllTypesContainMatchingField_ShouldSucceed()
+			{
+				Filtered.Types subject = In.Types<ClassWithMarkedField, ClassWithTwoMarkedFields>();
+
+				async Task Act()
+					=> await That(subject).ContainFields(fields => fields.With<MarkerAttribute>());
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSomeTypeContainsNoMatchingField_ShouldFail()
+			{
+				Filtered.Types subject = In.Types<ClassWithMarkedField, ClassWithoutMarkedField>();
+
+				async Task Act()
+					=> await That(subject).ContainFields(fields => fields.With<MarkerAttribute>());
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that in types ThatTypes.ContainFields.ClassWithMarkedField and ThatTypes.ContainFields.ClassWithoutMarkedField
+					             all contain fields with ThatTypes.ContainFields.MarkerAttribute at least once,
+					             but it contained not matching types [
+					               ThatTypes.ContainFields.ClassWithoutMarkedField
+					             ]
+					             """);
+			}
+		}
+
+		public sealed class NegatedTests
+		{
+			[Fact]
+			public async Task WhenSomeTypeContainsNoMatchingField_ShouldSucceed()
+			{
+				Filtered.Types subject = In.Types<ClassWithMarkedField, ClassWithoutMarkedField>();
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(they
+						=> they.ContainFields(fields => fields.With<MarkerAttribute>()));
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+		[AttributeUsage(AttributeTargets.Field)]
+		private class MarkerAttribute : Attribute
+		{
+		}
+
+		private class ClassWithMarkedField
+		{
+			[Marker] public int Value;
+		}
+
+		private class ClassWithTwoMarkedFields
+		{
+			[Marker] public int First;
+
+			[Marker] public int Second;
+		}
+
+		private class ClassWithoutMarkedField
+		{
+			public int Value;
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.ContainFields.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.ContainFields.Tests.cs
@@ -61,19 +61,25 @@ public sealed partial class ThatTypes
 
 		private class ClassWithMarkedField
 		{
+#pragma warning disable CS0649 // Field is never assigned to, and will always have its default value
 			[Marker] public int Value;
+#pragma warning restore CS0649
 		}
 
 		private class ClassWithTwoMarkedFields
 		{
+#pragma warning disable CS0649 // Field is never assigned to, and will always have its default value
 			[Marker] public int First;
 
 			[Marker] public int Second;
+#pragma warning restore CS0649
 		}
 
 		private class ClassWithoutMarkedField
 		{
+#pragma warning disable CS0649 // Field is never assigned to, and will always have its default value
 			public int Value;
+#pragma warning restore CS0649
 		}
 	}
 }

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.ContainMethods.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.ContainMethods.Tests.cs
@@ -1,0 +1,132 @@
+﻿using aweXpect.Reflection.Collections;
+using Xunit.Sdk;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatTypes
+{
+	public sealed class ContainMethods
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenAllTypesContainMatchingMethod_ShouldSucceed()
+			{
+				Filtered.Types subject = In.Types<ClassWithMarkedMethod, ClassWithTwoMarkedMethods>();
+
+				async Task Act()
+					=> await That(subject).ContainMethods(methods => methods.With<MarkerAttribute>());
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSomeTypeContainsNoMatchingMethod_ShouldFail()
+			{
+				Filtered.Types subject = In.Types<ClassWithMarkedMethod, ClassWithoutMarkedMethod>();
+
+				async Task Act()
+					=> await That(subject).ContainMethods(methods => methods.With<MarkerAttribute>());
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that in types ThatTypes.ContainMethods.ClassWithMarkedMethod and ThatTypes.ContainMethods.ClassWithoutMarkedMethod
+					             all contain methods with ThatTypes.ContainMethods.MarkerAttribute at least once,
+					             but it contained not matching types [
+					               ThatTypes.ContainMethods.ClassWithoutMarkedMethod
+					             ]
+					             """);
+			}
+
+			[Fact]
+			public async Task Exactly_WhenAllCountsMatch_ShouldSucceed()
+			{
+				Filtered.Types subject = In.Type<ClassWithTwoMarkedMethods>();
+
+				async Task Act()
+					=> await That(subject).ContainMethods(methods => methods.With<MarkerAttribute>()).Exactly(2);
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task Never_WhenNoTypeContainsMatchingMethod_ShouldSucceed()
+			{
+				Filtered.Types subject = In.Type<ClassWithoutMarkedMethod>();
+
+				async Task Act()
+					=> await That(subject).ContainMethods(methods => methods.With<MarkerAttribute>()).Never();
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+		public sealed class NegatedTests
+		{
+			[Fact]
+			public async Task WhenAllTypesContainMatchingMethod_ShouldFail()
+			{
+				Filtered.Types subject = In.Types<ClassWithMarkedMethod, ClassWithTwoMarkedMethods>();
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(they
+						=> they.ContainMethods(methods => methods.With<MarkerAttribute>()));
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that in types ThatTypes.ContainMethods.ClassWithMarkedMethod and ThatTypes.ContainMethods.ClassWithTwoMarkedMethods
+					             do not all contain methods with ThatTypes.ContainMethods.MarkerAttribute at least once,
+					             but it only contained matching types [
+					               ThatTypes.ContainMethods.ClassWithMarkedMethod,
+					               ThatTypes.ContainMethods.ClassWithTwoMarkedMethods
+					             ]
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenSomeTypeContainsNoMatchingMethod_ShouldSucceed()
+			{
+				Filtered.Types subject = In.Types<ClassWithMarkedMethod, ClassWithoutMarkedMethod>();
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(they
+						=> they.ContainMethods(methods => methods.With<MarkerAttribute>()));
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+		[AttributeUsage(AttributeTargets.Method)]
+		private class MarkerAttribute : Attribute
+		{
+		}
+
+		private class ClassWithMarkedMethod
+		{
+			[Marker]
+			public static void Tagged()
+			{
+			}
+		}
+
+		private class ClassWithTwoMarkedMethods
+		{
+			[Marker]
+			public static void TaggedOne()
+			{
+			}
+
+			[Marker]
+			public static void TaggedTwo()
+			{
+			}
+		}
+
+		private class ClassWithoutMarkedMethod
+		{
+			public static void Untagged()
+			{
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.ContainProperties.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.ContainProperties.Tests.cs
@@ -1,0 +1,79 @@
+﻿using aweXpect.Reflection.Collections;
+using Xunit.Sdk;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatTypes
+{
+	public sealed class ContainProperties
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenAllTypesContainMatchingProperty_ShouldSucceed()
+			{
+				Filtered.Types subject = In.Types<ClassWithMarkedProperty, ClassWithTwoMarkedProperties>();
+
+				async Task Act()
+					=> await That(subject).ContainProperties(properties => properties.With<MarkerAttribute>());
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSomeTypeContainsNoMatchingProperty_ShouldFail()
+			{
+				Filtered.Types subject = In.Types<ClassWithMarkedProperty, ClassWithoutMarkedProperty>();
+
+				async Task Act()
+					=> await That(subject).ContainProperties(properties => properties.With<MarkerAttribute>());
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that in types ThatTypes.ContainProperties.ClassWithMarkedProperty and ThatTypes.ContainProperties.ClassWithoutMarkedProperty
+					             all contain properties with ThatTypes.ContainProperties.MarkerAttribute at least once,
+					             but it contained not matching types [
+					               ThatTypes.ContainProperties.ClassWithoutMarkedProperty
+					             ]
+					             """);
+			}
+		}
+
+		public sealed class NegatedTests
+		{
+			[Fact]
+			public async Task WhenSomeTypeContainsNoMatchingProperty_ShouldSucceed()
+			{
+				Filtered.Types subject = In.Types<ClassWithMarkedProperty, ClassWithoutMarkedProperty>();
+
+				async Task Act()
+					=> await That(subject).DoesNotComplyWith(they
+						=> they.ContainProperties(properties => properties.With<MarkerAttribute>()));
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+		[AttributeUsage(AttributeTargets.Property)]
+		private class MarkerAttribute : Attribute
+		{
+		}
+
+		private class ClassWithMarkedProperty
+		{
+			[Marker] public int Id { get; set; }
+		}
+
+		private class ClassWithTwoMarkedProperties
+		{
+			[Marker] public int Id { get; set; }
+
+			[Marker] public string Name { get; set; } = "";
+		}
+
+		private class ClassWithoutMarkedProperty
+		{
+			public int Id { get; set; }
+		}
+	}
+}


### PR DESCRIPTION
Add assertion counterparts for the five `WhichContain<Member>` type filters, on a single `Type` (`Contains…`) and on collections of types (`Contain…`):

- `ThatType`: `ContainsMethods`, `ContainsProperties`, `ContainsFields`, `ContainsEvents`, `ContainsConstructors`
- `ThatTypes`: `ContainMethods`, `ContainProperties`, `ContainFields`, `ContainEvents`, `ContainConstructors` (`IEnumerable` and `IAsyncEnumerable`)

The new `TypeContainingMembersResult<TThat>` exposes the same quantifier surface as the filters (`Exactly`/`AtLeast`/`AtMost`/`Between`/`LessThan`/`MoreThan`/`Never`/`Once`/`Twice`), defaulting to "at least one matching member".

The counting and description logic is shared with the filters via the new internal `IContainedMembersFilter`, so both surfaces stay in sync.