### PR TITLE
feat: exclude compiler-generated members by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -509,3 +509,34 @@ using (Customize.aweXpect.Reflection().ExcludedAssemblyPrefixes
     // In.AllLoadedAssemblies() applies the custom prefixes within this scope
 }
 ```
+
+### Compiler-generated members
+
+By default, compiler-generated types and members are **excluded** from every navigation
+(`.Types()`, `.Methods()`, `.Fields()`, …). This hides closures, async/iterator state machines,
+anonymous types, local functions, auto-property backing fields and the generated members of records
+(`ToString`, `Equals`, `<Clone>$`, the copy-constructor, …), so convention tests see only the members
+you actually wrote.
+
+Opt specific kinds back in with the `[Flags]` enum `CompilerGeneratedMembers`
+(`None`, `Types`, `Constructors`, `Methods`, `Properties`, `Fields`, `Events`, `All`):
+
+```csharp
+using (Customize.aweXpect.Reflection().IncludedCompilerGeneratedMembers()
+    .Set(CompilerGeneratedMembers.Types | CompilerGeneratedMembers.Methods))
+{
+    // closures, state machines and compiler-generated methods are now visible
+}
+```
+
+Operators (`op_*`) and property/event accessors (`get_`, `set_`, `add_`, `remove_`) are *user-written*
+but likewise excluded by default. Include them via the separate `SpecialNameMembers` enum
+(`None`, `Operators`, `Accessors`, `All`), which only affects `.Methods()`:
+
+```csharp
+using (Customize.aweXpect.Reflection().IncludedSpecialNameMembers()
+    .Set(SpecialNameMembers.Operators))
+{
+    // operator methods are now visible in .Methods()
+}
+```

--- a/Source/aweXpect.Reflection/Collections/Filtered.Types.cs
+++ b/Source/aweXpect.Reflection/Collections/Filtered.Types.cs
@@ -4,7 +4,9 @@ using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
 using aweXpect.Core;
+using aweXpect.Customization;
 using aweXpect.Options;
+using aweXpect.Reflection.Helpers;
 
 // ReSharper disable MemberHidesStaticFromOuterClass
 
@@ -209,14 +211,20 @@ public static partial class Filtered
 		/// </remarks>
 		private static IEnumerable<Type> GetLoadableTypes(Assembly assembly)
 		{
+			IEnumerable<Type> types;
 			try
 			{
-				return assembly.GetTypes();
+				types = assembly.GetTypes();
 			}
 			catch (ReflectionTypeLoadException exception)
 			{
-				return exception.Types.Where(type => type is not null)!;
+				types = exception.Types.Where(type => type is not null)!;
 			}
+
+			CompilerGeneratedMembers included = Customize.aweXpect.Reflection()
+				.IncludedCompilerGeneratedMembers().Get();
+			return types.Where(type => !type.IsCompilerGenerated() ||
+			                           included.HasFlag(CompilerGeneratedMembers.Types));
 		}
 
 		/// <summary>

--- a/Source/aweXpect.Reflection/Customization/CompilerGeneratedMembers.cs
+++ b/Source/aweXpect.Reflection/Customization/CompilerGeneratedMembers.cs
@@ -1,0 +1,56 @@
+﻿using System;
+
+namespace aweXpect.Customization;
+
+/// <summary>
+///     The kinds of compiler-generated members that are included when reflecting over types and members.
+/// </summary>
+/// <remarks>
+///     By default, compiler-generated members (e.g. closures, state machines, record members, backing fields) are
+///     excluded. Use these flags to opt specific kinds back in via
+///     <see cref="ReflectionCustomizationExtensions.IncludedCompilerGeneratedMembers" />.
+/// </remarks>
+[Flags]
+public enum CompilerGeneratedMembers
+{
+	/// <summary>
+	///     No compiler-generated members are included (the default).
+	/// </summary>
+	None = 0,
+
+	/// <summary>
+	///     Include compiler-generated types (e.g. closures, async/iterator state machines, anonymous types).
+	/// </summary>
+	Types = 1 << 0,
+
+	/// <summary>
+	///     Include compiler-generated constructors (e.g. the copy-constructor of a record).
+	/// </summary>
+	Constructors = 1 << 1,
+
+	/// <summary>
+	///     Include compiler-generated methods (e.g. local functions, lambda bodies, record members such as
+	///     <c>ToString</c>, <c>Equals</c>, <c>&lt;Clone&gt;$</c>, <c>Deconstruct</c> and <c>PrintMembers</c>).
+	/// </summary>
+	Methods = 1 << 2,
+
+	/// <summary>
+	///     Include compiler-generated properties (e.g. the <c>EqualityContract</c> of a record).
+	/// </summary>
+	Properties = 1 << 3,
+
+	/// <summary>
+	///     Include compiler-generated fields (e.g. auto-property backing fields or cached-delegate fields).
+	/// </summary>
+	Fields = 1 << 4,
+
+	/// <summary>
+	///     Include compiler-generated events.
+	/// </summary>
+	Events = 1 << 5,
+
+	/// <summary>
+	///     Include all compiler-generated members.
+	/// </summary>
+	All = Types | Constructors | Methods | Properties | Fields | Events,
+}

--- a/Source/aweXpect.Reflection/Customization/ReflectionCustomizationExtensions.cs
+++ b/Source/aweXpect.Reflection/Customization/ReflectionCustomizationExtensions.cs
@@ -1,0 +1,46 @@
+﻿namespace aweXpect.Customization;
+
+/// <summary>
+///     Extensions for <see cref="AwexpectCustomization.ReflectionCustomization" /> to control which
+///     normally-hidden members are included when reflecting over types and members.
+/// </summary>
+public static class ReflectionCustomizationExtensions
+{
+	private const string CompilerGeneratedKey = "Reflection.IncludedCompilerGeneratedMembers";
+	private const string SpecialNameKey = "Reflection.IncludedSpecialNameMembers";
+
+	/// <summary>
+	///     The compiler-generated members that are included when reflecting over types and members.
+	/// </summary>
+	/// <remarks>
+	///     Defaults to <see cref="CompilerGeneratedMembers.None" />, so that all compiler-generated members are excluded.
+	/// </remarks>
+	public static ICustomizationValueSetter<CompilerGeneratedMembers> IncludedCompilerGeneratedMembers(
+		this AwexpectCustomization.ReflectionCustomization reflection)
+		=> new CustomizationValue<CompilerGeneratedMembers>(
+			(IAwexpectCustomization)Customize.aweXpect, CompilerGeneratedKey, CompilerGeneratedMembers.None);
+
+	/// <summary>
+	///     The special-name methods (operators and accessors) that are included when reflecting over methods.
+	/// </summary>
+	/// <remarks>
+	///     Defaults to <see cref="SpecialNameMembers.None" />, so that all special-name methods are excluded.
+	/// </remarks>
+	public static ICustomizationValueSetter<SpecialNameMembers> IncludedSpecialNameMembers(
+		this AwexpectCustomization.ReflectionCustomization reflection)
+		=> new CustomizationValue<SpecialNameMembers>(
+			(IAwexpectCustomization)Customize.aweXpect, SpecialNameKey, SpecialNameMembers.None);
+
+	private sealed class CustomizationValue<TValue>(
+		IAwexpectCustomization customization,
+		string key,
+		TValue defaultValue)
+		: ICustomizationValueSetter<TValue>
+	{
+		/// <inheritdoc cref="ICustomizationValueSetter{TValue}.Get()" />
+		public TValue Get() => customization.Get(key, defaultValue);
+
+		/// <inheritdoc cref="ICustomizationValueSetter{TValue}.Set(TValue)" />
+		public CustomizationLifetime Set(TValue value) => customization.Set(key, value);
+	}
+}

--- a/Source/aweXpect.Reflection/Customization/SpecialNameMembers.cs
+++ b/Source/aweXpect.Reflection/Customization/SpecialNameMembers.cs
@@ -1,0 +1,37 @@
+﻿using System;
+
+namespace aweXpect.Customization;
+
+/// <summary>
+///     The kinds of special-name methods that are included when reflecting over methods.
+/// </summary>
+/// <remarks>
+///     By default, special-name methods (operators and property/event accessors) are excluded. Use these flags to opt
+///     specific kinds back in via <see cref="ReflectionCustomizationExtensions.IncludedSpecialNameMembers" />.
+///     <para />
+///     Unlike <see cref="CompilerGeneratedMembers" />, these members are user-written but are nonetheless hidden by
+///     default because they are not normally reflected over directly.
+/// </remarks>
+[Flags]
+public enum SpecialNameMembers
+{
+	/// <summary>
+	///     No special-name methods are included (the default).
+	/// </summary>
+	None = 0,
+
+	/// <summary>
+	///     Include operator methods (e.g. <c>op_Equality</c>, <c>op_Addition</c>, …).
+	/// </summary>
+	Operators = 1 << 0,
+
+	/// <summary>
+	///     Include property and event accessor methods (<c>get_</c>, <c>set_</c>, <c>add_</c>, <c>remove_</c>).
+	/// </summary>
+	Accessors = 1 << 1,
+
+	/// <summary>
+	///     Include all special-name methods.
+	/// </summary>
+	All = Operators | Accessors,
+}

--- a/Source/aweXpect.Reflection/Helpers/TypeHelpers.cs
+++ b/Source/aweXpect.Reflection/Helpers/TypeHelpers.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text;
+using aweXpect.Customization;
 using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Helpers;
@@ -21,12 +22,16 @@ internal static class TypeHelpers
 	{
 		try
 		{
+			CompilerGeneratedMembers included = IncludedCompilerGeneratedMembers;
 			return type
 				.GetConstructors(BindingFlags.DeclaredOnly |
 				                 BindingFlags.NonPublic |
 				                 BindingFlags.Public |
 				                 BindingFlags.Instance |
-				                 BindingFlags.Static);
+				                 BindingFlags.Static)
+				.Where(m => !m.IsCompilerGenerated() ||
+				            included.HasFlag(CompilerGeneratedMembers.Constructors))
+				.ToArray();
 		}
 		catch (Exception exception) when (exception
 			                                  is TypeLoadException
@@ -45,11 +50,15 @@ internal static class TypeHelpers
 	{
 		try
 		{
+			CompilerGeneratedMembers included = IncludedCompilerGeneratedMembers;
 			return type
 				.GetEvents(BindingFlags.DeclaredOnly |
 				           BindingFlags.NonPublic |
 				           BindingFlags.Public |
-				           BindingFlags.Instance);
+				           BindingFlags.Instance)
+				.Where(m => !m.IsCompilerGenerated() ||
+				            included.HasFlag(CompilerGeneratedMembers.Events))
+				.ToArray();
 		}
 		catch (Exception exception) when (exception
 			                                  is TypeLoadException
@@ -68,6 +77,7 @@ internal static class TypeHelpers
 	{
 		try
 		{
+			CompilerGeneratedMembers included = IncludedCompilerGeneratedMembers;
 			return type
 				.GetFields(BindingFlags.DeclaredOnly |
 				           BindingFlags.NonPublic |
@@ -75,7 +85,8 @@ internal static class TypeHelpers
 				           BindingFlags.Instance |
 				           BindingFlags.Static)
 				.Where(m => !m.IsSpecialName)
-				.Where(m => !m.Name.EndsWith("__BackingField"))
+				.Where(m => !m.IsCompilerGenerated() ||
+				            included.HasFlag(CompilerGeneratedMembers.Fields))
 				.ToArray();
 		}
 		catch (Exception exception) when (exception
@@ -95,6 +106,8 @@ internal static class TypeHelpers
 	{
 		try
 		{
+			CompilerGeneratedMembers includedCompilerGenerated = IncludedCompilerGeneratedMembers;
+			SpecialNameMembers includedSpecialName = IncludedSpecialNameMembers;
 			return type
 				.GetMethods(BindingFlags.DeclaredOnly |
 				            BindingFlags.NonPublic |
@@ -102,7 +115,7 @@ internal static class TypeHelpers
 				            BindingFlags.Static |
 				            BindingFlags.Instance |
 				            BindingFlags.Static)
-				.Where(m => !m.IsSpecialName)
+				.Where(m => IncludeMethod(m, includedCompilerGenerated, includedSpecialName))
 				.ToArray();
 		}
 		catch (Exception exception) when (exception
@@ -122,6 +135,7 @@ internal static class TypeHelpers
 	{
 		try
 		{
+			CompilerGeneratedMembers included = IncludedCompilerGeneratedMembers;
 			return type
 				.GetProperties(BindingFlags.DeclaredOnly |
 				               BindingFlags.NonPublic |
@@ -130,6 +144,8 @@ internal static class TypeHelpers
 				               BindingFlags.Instance |
 				               BindingFlags.Static)
 				.Where(m => !m.IsSpecialName)
+				.Where(m => !m.IsCompilerGenerated() ||
+				            included.HasFlag(CompilerGeneratedMembers.Properties))
 				.ToArray();
 		}
 		catch (Exception exception) when (exception
@@ -139,6 +155,59 @@ internal static class TypeHelpers
 		{
 			return [];
 		}
+	}
+
+	/// <summary>
+	///     The compiler-generated members that are currently included via customization.
+	/// </summary>
+	private static CompilerGeneratedMembers IncludedCompilerGeneratedMembers
+		=> Customize.aweXpect.Reflection().IncludedCompilerGeneratedMembers().Get();
+
+	/// <summary>
+	///     The special-name methods that are currently included via customization.
+	/// </summary>
+	private static SpecialNameMembers IncludedSpecialNameMembers
+		=> Customize.aweXpect.Reflection().IncludedSpecialNameMembers().Get();
+
+	/// <summary>
+	///     Determines whether the <paramref name="member" /> (or any of its declaring types) is compiler-generated.
+	/// </summary>
+	public static bool IsCompilerGenerated(this MemberInfo member)
+	{
+		for (Type? type = member as Type ?? member.DeclaringType;
+		     type is not null;
+		     type = type.DeclaringType)
+		{
+			if (type.IsDefined(typeof(CompilerGeneratedAttribute), false))
+			{
+				return true;
+			}
+		}
+
+		return member.IsDefined(typeof(CompilerGeneratedAttribute), false);
+	}
+
+	private static bool IncludeMethod(
+		MethodInfo method,
+		CompilerGeneratedMembers includedCompilerGenerated,
+		SpecialNameMembers includedSpecialName)
+	{
+		if (method.IsSpecialName)
+		{
+			bool isOperator = method.Name.StartsWith("op_", StringComparison.Ordinal);
+			if (isOperator
+				    ? includedSpecialName.HasFlag(SpecialNameMembers.Operators)
+				    : includedSpecialName.HasFlag(SpecialNameMembers.Accessors))
+			{
+				return true;
+			}
+
+			return method.IsCompilerGenerated() &&
+			       includedCompilerGenerated.HasFlag(CompilerGeneratedMembers.Methods);
+		}
+
+		return !method.IsCompilerGenerated() ||
+		       includedCompilerGenerated.HasFlag(CompilerGeneratedMembers.Methods);
 	}
 
 	/// <summary>

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net10.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net10.0.txt
@@ -1,6 +1,34 @@
 [assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/Testably/aweXpect.Reflection.git")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"aweXpect.Reflection.Internal.Tests, PublicKey=00240000048000009400000006020000002400005253413100040000010001002ddc851a03b64bc2a64705e04ea47777e669695d8afed80f7544ff34fc699706a9f99f8385085bd675508e4c2acb917b7e1c9984da918c3fab585850a8a5b013c1d1780e1bb9e1e46656d965fc35bfc237a929c2c94e2e998d66ca44ee0a526245ef3f97dd136efe2e657b244b5f9f4a233fe656d659dddd811ba6bbed6817c1")]
 [assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v10.0", FrameworkDisplayName=".NET 10.0")]
+namespace aweXpect.Customization
+{
+    [System.Flags]
+    public enum CompilerGeneratedMembers
+    {
+        None = 0,
+        Types = 1,
+        Constructors = 2,
+        Methods = 4,
+        Properties = 8,
+        Fields = 16,
+        Events = 32,
+        All = 63,
+    }
+    public static class ReflectionCustomizationExtensions
+    {
+        public static aweXpect.Customization.ICustomizationValueSetter<aweXpect.Customization.CompilerGeneratedMembers> IncludedCompilerGeneratedMembers(this aweXpect.Customization.AwexpectCustomization.ReflectionCustomization reflection) { }
+        public static aweXpect.Customization.ICustomizationValueSetter<aweXpect.Customization.SpecialNameMembers> IncludedSpecialNameMembers(this aweXpect.Customization.AwexpectCustomization.ReflectionCustomization reflection) { }
+    }
+    [System.Flags]
+    public enum SpecialNameMembers
+    {
+        None = 0,
+        Operators = 1,
+        Accessors = 2,
+        All = 3,
+    }
+}
 namespace aweXpect.Reflection
 {
     public static class AssemblyFilters

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net8.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net8.0.txt
@@ -1,6 +1,34 @@
 [assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/Testably/aweXpect.Reflection.git")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"aweXpect.Reflection.Internal.Tests, PublicKey=00240000048000009400000006020000002400005253413100040000010001002ddc851a03b64bc2a64705e04ea47777e669695d8afed80f7544ff34fc699706a9f99f8385085bd675508e4c2acb917b7e1c9984da918c3fab585850a8a5b013c1d1780e1bb9e1e46656d965fc35bfc237a929c2c94e2e998d66ca44ee0a526245ef3f97dd136efe2e657b244b5f9f4a233fe656d659dddd811ba6bbed6817c1")]
 [assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v8.0", FrameworkDisplayName=".NET 8.0")]
+namespace aweXpect.Customization
+{
+    [System.Flags]
+    public enum CompilerGeneratedMembers
+    {
+        None = 0,
+        Types = 1,
+        Constructors = 2,
+        Methods = 4,
+        Properties = 8,
+        Fields = 16,
+        Events = 32,
+        All = 63,
+    }
+    public static class ReflectionCustomizationExtensions
+    {
+        public static aweXpect.Customization.ICustomizationValueSetter<aweXpect.Customization.CompilerGeneratedMembers> IncludedCompilerGeneratedMembers(this aweXpect.Customization.AwexpectCustomization.ReflectionCustomization reflection) { }
+        public static aweXpect.Customization.ICustomizationValueSetter<aweXpect.Customization.SpecialNameMembers> IncludedSpecialNameMembers(this aweXpect.Customization.AwexpectCustomization.ReflectionCustomization reflection) { }
+    }
+    [System.Flags]
+    public enum SpecialNameMembers
+    {
+        None = 0,
+        Operators = 1,
+        Accessors = 2,
+        All = 3,
+    }
+}
 namespace aweXpect.Reflection
 {
     public static class AssemblyFilters

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_netstandard2.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_netstandard2.0.txt
@@ -1,6 +1,34 @@
 [assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/Testably/aweXpect.Reflection.git")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"aweXpect.Reflection.Internal.Tests, PublicKey=00240000048000009400000006020000002400005253413100040000010001002ddc851a03b64bc2a64705e04ea47777e669695d8afed80f7544ff34fc699706a9f99f8385085bd675508e4c2acb917b7e1c9984da918c3fab585850a8a5b013c1d1780e1bb9e1e46656d965fc35bfc237a929c2c94e2e998d66ca44ee0a526245ef3f97dd136efe2e657b244b5f9f4a233fe656d659dddd811ba6bbed6817c1")]
 [assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName=".NET Standard 2.0")]
+namespace aweXpect.Customization
+{
+    [System.Flags]
+    public enum CompilerGeneratedMembers
+    {
+        None = 0,
+        Types = 1,
+        Constructors = 2,
+        Methods = 4,
+        Properties = 8,
+        Fields = 16,
+        Events = 32,
+        All = 63,
+    }
+    public static class ReflectionCustomizationExtensions
+    {
+        public static aweXpect.Customization.ICustomizationValueSetter<aweXpect.Customization.CompilerGeneratedMembers> IncludedCompilerGeneratedMembers(this aweXpect.Customization.AwexpectCustomization.ReflectionCustomization reflection) { }
+        public static aweXpect.Customization.ICustomizationValueSetter<aweXpect.Customization.SpecialNameMembers> IncludedSpecialNameMembers(this aweXpect.Customization.AwexpectCustomization.ReflectionCustomization reflection) { }
+    }
+    [System.Flags]
+    public enum SpecialNameMembers
+    {
+        None = 0,
+        Operators = 1,
+        Accessors = 2,
+        All = 3,
+    }
+}
 namespace aweXpect.Reflection
 {
     public static class AssemblyFilters

--- a/Tests/aweXpect.Reflection.Tests/CompilerGeneratedFilteringTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/CompilerGeneratedFilteringTests.cs
@@ -1,0 +1,150 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using aweXpect.Customization;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed class CompilerGeneratedFilteringTests
+{
+	[Fact]
+	public async Task Types_ShouldExcludeCompilerGeneratedTypesByDefault()
+	{
+		IReadOnlyList<Type> types = await GetTypes();
+
+		await That(types).All().Satisfy(t => !t.IsDefined(typeof(CompilerGeneratedAttribute), false));
+		await That(types).Contains(t => t == typeof(Sample));
+	}
+
+	[Fact]
+	public async Task Types_WhenIncludingCompilerGenerated_ShouldContainStateMachinesAndClosures()
+	{
+		using (Customize.aweXpect.Reflection().IncludedCompilerGeneratedMembers()
+			       .Set(CompilerGeneratedMembers.Types))
+		{
+			IReadOnlyList<Type> types = await GetTypes();
+
+			await That(types).Contains(t => t.Name.StartsWith("<>c")); // closure
+			await That(types).Contains(t => t.Name.Contains("AsyncMethod")); // async state machine
+		}
+	}
+
+	[Fact]
+	public async Task Methods_ShouldExcludeLocalFunctionsByDefault()
+	{
+		IReadOnlyList<MethodInfo> methods = await GetMethods<Sample>();
+
+		await That(methods).None().Satisfy(m => m.Name.Contains("g__Local"));
+		await That(methods).Contains(m => m.Name == nameof(Sample.UsesLocalFunction));
+	}
+
+	[Fact]
+	public async Task Methods_WhenIncludingMethods_ShouldContainLocalFunctions()
+	{
+		using (Customize.aweXpect.Reflection().IncludedCompilerGeneratedMembers()
+			       .Set(CompilerGeneratedMembers.Methods))
+		{
+			IReadOnlyList<MethodInfo> methods = await GetMethods<Sample>();
+
+			await That(methods).Contains(m => m.Name.Contains("g__Local"));
+		}
+	}
+
+	[Fact]
+	public async Task Methods_ShouldExcludeRecordMembersByDefault()
+	{
+		IReadOnlyList<MethodInfo> methods = await GetMethods<SampleRecord>();
+
+		await That(methods).None().Satisfy(m => m.Name == "<Clone>$");
+		await That(methods).None().Satisfy(m => m.Name == "PrintMembers");
+	}
+
+	[Fact]
+	public async Task Methods_WhenIncludingOperators_ShouldContainOperatorMethods()
+	{
+		// Operators are special-name, not compiler-generated => controlled by IncludedSpecialNameMembers.
+		IReadOnlyList<MethodInfo> withoutOperators = await GetMethods<SampleRecord>();
+		await That(withoutOperators).None().Satisfy(m => m.Name == "op_Equality");
+
+		using (Customize.aweXpect.Reflection().IncludedSpecialNameMembers()
+			       .Set(SpecialNameMembers.Operators))
+		{
+			IReadOnlyList<MethodInfo> withOperators = await GetMethods<SampleRecord>();
+
+			await That(withOperators).Contains(m => m.Name == "op_Equality");
+		}
+	}
+
+	[Fact]
+	public async Task Constructors_WhenIncludingConstructors_ShouldContainRecordCopyConstructor()
+	{
+		IReadOnlyList<ConstructorInfo> withoutCopy = await GetConstructors<SampleRecord>();
+		await That(withoutCopy).None()
+			.Satisfy(c => c.GetParameters().Any(p => p.ParameterType == typeof(SampleRecord)));
+
+		using (Customize.aweXpect.Reflection().IncludedCompilerGeneratedMembers()
+			       .Set(CompilerGeneratedMembers.Constructors))
+		{
+			IReadOnlyList<ConstructorInfo> withCopy = await GetConstructors<SampleRecord>();
+
+			await That(withCopy)
+				.Contains(c => c.GetParameters().Any(p => p.ParameterType == typeof(SampleRecord)));
+		}
+	}
+
+	private static async Task<IReadOnlyList<Type>> GetTypes()
+	{
+		List<Type> types = await ToList(In.AssemblyContaining<Sample>().Types());
+		return types
+			.Where(t => t.FullName!.Contains(nameof(CompilerGeneratedFilteringTests)))
+			.ToList();
+	}
+
+	private static async Task<IReadOnlyList<MethodInfo>> GetMethods<T>()
+		=> await ToList(In.Type<T>().Methods());
+
+	private static async Task<IReadOnlyList<ConstructorInfo>> GetConstructors<T>()
+		=> await ToList(In.Type<T>().Constructors());
+
+#if NET8_0_OR_GREATER
+	private static async Task<List<T>> ToList<T>(System.Collections.Generic.IAsyncEnumerable<T> source)
+	{
+		List<T> result = new();
+		await foreach (T item in source)
+		{
+			result.Add(item);
+		}
+
+		return result;
+	}
+#else
+	private static Task<List<T>> ToList<T>(IEnumerable<T> source)
+		=> Task.FromResult(source.ToList());
+#endif
+
+#pragma warning disable CA1822
+#pragma warning disable CS1998
+	public class Sample
+	{
+		public int UsesLocalFunction()
+		{
+			return Local();
+			int Local() => 42;
+		}
+
+		public async Task<int> AsyncMethod()
+		{
+			await Task.Yield();
+			return 1;
+		}
+	}
+
+	public record SampleRecord
+	{
+		public int Value { get; set; }
+		public string Name { get; set; } = "";
+	}
+}


### PR DESCRIPTION
Compiler-generated types and members (closures, async/iterator state machines, anonymous types, local functions, auto-property backing fields and the generated members of records) are now excluded from every navigation (.Types(), .Methods(), .Fields(), ...), so convention tests only see the members actually written in source.

Add two opt-in flags enums via local customization extensions:
- CompilerGeneratedMembers (Types, Constructors, Methods, Properties, Fields, Events, All) controls the [CompilerGenerated] axis.
- SpecialNameMembers (Operators, Accessors, All) re-includes user-written special-name methods in .Methods().

Both default to None (current behavior of hiding these members). The fragile "__BackingField" name check is replaced by a real CompilerGeneratedAttribute test that also walks declaring types.

**BEHAVIORAL CHANGE:**
records, closures, state machines and operators are no longer returned unless opted back in via the new customizations.