### PR TITLE
feat: add version assertions and filters for assemblies

### DIFF
--- a/Source/aweXpect.Reflection/Filters/AssemblyFilters.WithVersion.cs
+++ b/Source/aweXpect.Reflection/Filters/AssemblyFilters.WithVersion.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Helpers;
+
+namespace aweXpect.Reflection;
+
+public static partial class AssemblyFilters
+{
+	/// <summary>
+	///     Filter for assemblies with a <see cref="AssemblyName.Version" /> that satisfies the
+	///     <paramref name="predicate" />.
+	/// </summary>
+	public static Filtered.Assemblies WithVersion(this Filtered.Assemblies @this,
+		Func<Version, bool> predicate,
+		[CallerArgumentExpression(nameof(predicate))]
+		string doNotPopulateThisValue = "")
+	{
+		IChangeableFilter<Assembly> filter = Filter.Suffix<Assembly>(
+			assembly => assembly.GetName().Version is { } version && predicate(version),
+			$" with version matching {doNotPopulateThisValue.TrimCommonWhiteSpace()}");
+		return @this.Which(filter);
+	}
+
+	/// <summary>
+	///     Filter for assemblies by individual components of their <see cref="AssemblyName.Version" />.
+	/// </summary>
+	public static AssembliesWithVersion WithVersion(this Filtered.Assemblies @this)
+	{
+		IChangeableFilter<Assembly> filter = Filter.Suffix<Assembly>(_ => true, "");
+		return new AssembliesWithVersion(@this.Which(filter), filter);
+	}
+
+	/// <summary>
+	///     Filter for assemblies by individual components of their <see cref="AssemblyName.Version" />.
+	/// </summary>
+	public class AssembliesWithVersion(Filtered.Assemblies inner, IChangeableFilter<Assembly> filter)
+		: Filtered.Assemblies(inner)
+	{
+		/// <summary>
+		///     Compares the <see cref="Version.Major" /> version component.
+		/// </summary>
+		public VersionComponent WithMajor => new(this, filter, "major", version => version.Major);
+
+		/// <summary>
+		///     Compares the <see cref="Version.Minor" /> version component.
+		/// </summary>
+		public VersionComponent WithMinor => new(this, filter, "minor", version => version.Minor);
+
+		/// <summary>
+		///     Compares the <see cref="Version.Build" /> version component.
+		/// </summary>
+		public VersionComponent WithBuild => new(this, filter, "build", version => version.Build);
+
+		/// <summary>
+		///     Compares the <see cref="Version.Revision" /> version component.
+		/// </summary>
+		public VersionComponent WithRevision => new(this, filter, "revision", version => version.Revision);
+	}
+
+	/// <summary>
+	///     Comparison of a single component of the <see cref="AssemblyName.Version" />.
+	/// </summary>
+	public class VersionComponent(
+		AssembliesWithVersion owner,
+		IChangeableFilter<Assembly> filter,
+		string component,
+		Func<Version, int> selector)
+	{
+		/// <summary>
+		///     The component is greater than the <paramref name="expected" /> value.
+		/// </summary>
+		public AssembliesWithVersion GreaterThan(int expected)
+			=> Apply(value => value > expected, $"greater than {expected}");
+
+		/// <summary>
+		///     The component is greater than or equal to the <paramref name="expected" /> value.
+		/// </summary>
+		public AssembliesWithVersion GreaterThanOrEqualTo(int expected)
+			=> Apply(value => value >= expected, $"greater than or equal to {expected}");
+
+		/// <summary>
+		///     The component is less than the <paramref name="expected" /> value.
+		/// </summary>
+		public AssembliesWithVersion LessThan(int expected)
+			=> Apply(value => value < expected, $"less than {expected}");
+
+		/// <summary>
+		///     The component is less than or equal to the <paramref name="expected" /> value.
+		/// </summary>
+		public AssembliesWithVersion LessThanOrEqualTo(int expected)
+			=> Apply(value => value <= expected, $"less than or equal to {expected}");
+
+		/// <summary>
+		///     The component is equal to the <paramref name="expected" /> value.
+		/// </summary>
+		public AssembliesWithVersion EqualTo(int expected)
+			=> Apply(value => value == expected, $"equal to {expected}");
+
+		/// <summary>
+		///     The component is not equal to the <paramref name="expected" /> value.
+		/// </summary>
+		public AssembliesWithVersion NotEqualTo(int expected)
+			=> Apply(value => value != expected, $"not equal to {expected}");
+
+		private AssembliesWithVersion Apply(Func<int, bool> comparison, string comparisonText)
+		{
+			filter.UpdateFilter(
+				(result, assembly)
+					=> result && assembly.GetName().Version is { } version && comparison(selector(version)),
+				description => $"{description} with {component} version {comparisonText}");
+			return owner;
+		}
+	}
+}

--- a/Source/aweXpect.Reflection/ThatAssemblies.HaveVersion.cs
+++ b/Source/aweXpect.Reflection/ThatAssemblies.HaveVersion.cs
@@ -1,0 +1,304 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Text;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Reflection.Helpers;
+using aweXpect.Results;
+#if NET8_0_OR_GREATER
+using System.Threading;
+using System.Threading.Tasks;
+#endif
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Reflection;
+
+public static partial class ThatAssemblies
+{
+	/// <summary>
+	///     Verifies that all items in the filtered collection of <see cref="Assembly" /> have
+	///     a <see cref="AssemblyName.Version" /> that satisfies the <paramref name="predicate" />.
+	/// </summary>
+	public static AndOrResult<IEnumerable<Assembly?>, IThat<IEnumerable<Assembly?>>> HaveVersion(
+		this IThat<IEnumerable<Assembly?>> subject,
+		Func<Version, bool> predicate,
+		[CallerArgumentExpression(nameof(predicate))]
+		string doNotPopulateThisValue = "")
+		=> new(subject.Get().ExpectationBuilder.AddConstraint<IEnumerable<Assembly?>>((it, grammars)
+				=> new HaveVersionConstraint(it, grammars, predicate, doNotPopulateThisValue.TrimCommonWhiteSpace())),
+			subject);
+
+#if NET8_0_OR_GREATER
+	/// <summary>
+	///     Verifies that all items in the filtered collection of <see cref="Assembly" /> have
+	///     a <see cref="AssemblyName.Version" /> that satisfies the <paramref name="predicate" />.
+	/// </summary>
+	public static AndOrResult<IAsyncEnumerable<Assembly?>, IThat<IAsyncEnumerable<Assembly?>>> HaveVersion(
+		this IThat<IAsyncEnumerable<Assembly?>> subject,
+		Func<Version, bool> predicate,
+		[CallerArgumentExpression(nameof(predicate))]
+		string doNotPopulateThisValue = "")
+		=> new(subject.Get().ExpectationBuilder.AddConstraint<IAsyncEnumerable<Assembly?>>((it, grammars)
+				=> new HaveVersionConstraint(it, grammars, predicate, doNotPopulateThisValue.TrimCommonWhiteSpace())),
+			subject);
+#endif
+
+	/// <summary>
+	///     Verifies the individual components of the <see cref="AssemblyName.Version" /> of all items in the filtered
+	///     collection of <see cref="Assembly" />.
+	/// </summary>
+	public static HaveVersionResult<IEnumerable<Assembly?>> HaveVersion(this IThat<IEnumerable<Assembly?>> subject)
+		=> new(subject, (expectationBuilder, checks)
+			=> expectationBuilder.AddConstraint<IEnumerable<Assembly?>>((it, grammars)
+				=> new HaveVersionComponentsConstraint(it, grammars, checks)));
+
+#if NET8_0_OR_GREATER
+	/// <summary>
+	///     Verifies the individual components of the <see cref="AssemblyName.Version" /> of all items in the filtered
+	///     collection of <see cref="Assembly" />.
+	/// </summary>
+	public static HaveVersionResult<IAsyncEnumerable<Assembly?>> HaveVersion(
+		this IThat<IAsyncEnumerable<Assembly?>> subject)
+		=> new(subject, (expectationBuilder, checks)
+			=> expectationBuilder.AddConstraint<IAsyncEnumerable<Assembly?>>((it, grammars)
+				=> new HaveVersionComponentsConstraint(it, grammars, checks)));
+#endif
+
+	/// <summary>
+	///     The result of verifying the <see cref="AssemblyName.Version" /> of a collection of <see cref="Assembly" />,
+	///     allowing comparisons on the individual version components.
+	/// </summary>
+	public class HaveVersionResult<TCollection> : AndOrResult<TCollection, IThat<TCollection>>
+	{
+		private readonly List<VersionComponentCheck> _checks = [];
+
+		internal HaveVersionResult(IThat<TCollection> subject,
+			Func<ExpectationBuilder, List<VersionComponentCheck>, ExpectationBuilder> addConstraint)
+			: this(subject, subject.Get().ExpectationBuilder, addConstraint)
+		{
+		}
+
+		private HaveVersionResult(IThat<TCollection> subject, ExpectationBuilder expectationBuilder,
+			Func<ExpectationBuilder, List<VersionComponentCheck>, ExpectationBuilder> addConstraint)
+			: base(expectationBuilder, subject)
+		{
+			addConstraint(expectationBuilder, _checks);
+		}
+
+		/// <summary>
+		///     Compares the <see cref="Version.Major" /> version component.
+		/// </summary>
+		public VersionComponentResult<TCollection> WithMajor => new(this, "major version", version => version.Major);
+
+		/// <summary>
+		///     Compares the <see cref="Version.Minor" /> version component.
+		/// </summary>
+		public VersionComponentResult<TCollection> WithMinor => new(this, "minor version", version => version.Minor);
+
+		/// <summary>
+		///     Compares the <see cref="Version.Build" /> version component.
+		/// </summary>
+		public VersionComponentResult<TCollection> WithBuild => new(this, "build version", version => version.Build);
+
+		/// <summary>
+		///     Compares the <see cref="Version.Revision" /> version component.
+		/// </summary>
+		public VersionComponentResult<TCollection> WithRevision
+			=> new(this, "revision version", version => version.Revision);
+
+		internal HaveVersionResult<TCollection> Add(string component, string comparisonText,
+			Func<Version, int> selector, Func<int, bool> comparison)
+		{
+			_checks.Add(new VersionComponentCheck(component, comparisonText, selector, comparison));
+			return this;
+		}
+	}
+
+	/// <summary>
+	///     Comparison of a single component of the <see cref="AssemblyName.Version" /> for all items in a collection of
+	///     <see cref="Assembly" />.
+	/// </summary>
+	public class VersionComponentResult<TCollection>(
+		HaveVersionResult<TCollection> owner,
+		string component,
+		Func<Version, int> selector)
+	{
+		/// <summary>
+		///     The component is greater than the <paramref name="expected" /> value.
+		/// </summary>
+		public HaveVersionResult<TCollection> GreaterThan(int expected)
+			=> owner.Add(component, $"greater than {expected}", selector, value => value > expected);
+
+		/// <summary>
+		///     The component is greater than or equal to the <paramref name="expected" /> value.
+		/// </summary>
+		public HaveVersionResult<TCollection> GreaterThanOrEqualTo(int expected)
+			=> owner.Add(component, $"greater than or equal to {expected}", selector, value => value >= expected);
+
+		/// <summary>
+		///     The component is less than the <paramref name="expected" /> value.
+		/// </summary>
+		public HaveVersionResult<TCollection> LessThan(int expected)
+			=> owner.Add(component, $"less than {expected}", selector, value => value < expected);
+
+		/// <summary>
+		///     The component is less than or equal to the <paramref name="expected" /> value.
+		/// </summary>
+		public HaveVersionResult<TCollection> LessThanOrEqualTo(int expected)
+			=> owner.Add(component, $"less than or equal to {expected}", selector, value => value <= expected);
+
+		/// <summary>
+		///     The component is equal to the <paramref name="expected" /> value.
+		/// </summary>
+		public HaveVersionResult<TCollection> EqualTo(int expected)
+			=> owner.Add(component, $"equal to {expected}", selector, value => value == expected);
+
+		/// <summary>
+		///     The component is not equal to the <paramref name="expected" /> value.
+		/// </summary>
+		public HaveVersionResult<TCollection> NotEqualTo(int expected)
+			=> owner.Add(component, $"not equal to {expected}", selector, value => value != expected);
+	}
+
+	internal sealed class VersionComponentCheck(
+		string component,
+		string comparisonText,
+		Func<Version, int> selector,
+		Func<int, bool> comparison)
+	{
+		public string Component { get; } = component;
+		public string ComparisonText { get; } = comparisonText;
+		public Func<Version, int> Selector { get; } = selector;
+		public Func<int, bool> Comparison { get; } = comparison;
+	}
+
+	private sealed class HaveVersionComponentsConstraint(
+		string it,
+		ExpectationGrammars grammars,
+		List<VersionComponentCheck> checks)
+		: CollectionConstraintResult<Assembly?>(grammars),
+			IValueConstraint<IEnumerable<Assembly?>>
+#if NET8_0_OR_GREATER
+			, IAsyncConstraint<IAsyncEnumerable<Assembly?>>
+#endif
+	{
+#if NET8_0_OR_GREATER
+		public async Task<ConstraintResult> IsMetBy(IAsyncEnumerable<Assembly?> actual,
+			CancellationToken cancellationToken)
+			=> await SetAsyncValue(actual, Matches);
+#endif
+
+		public ConstraintResult IsMetBy(IEnumerable<Assembly?> actual)
+			=> SetValue(actual, Matches);
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			if (checks.Count == 0)
+			{
+				stringBuilder.Append("all have a version");
+				return;
+			}
+
+			stringBuilder.Append("all have ");
+			AppendComponents(stringBuilder);
+		}
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(it).Append(" contained assemblies with a non-matching version ");
+			Formatter.Format(stringBuilder, NotMatching, FormattingOptions.Indented(indentation));
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			if (checks.Count == 0)
+			{
+				stringBuilder.Append("not all have a version");
+				return;
+			}
+
+			stringBuilder.Append("not all have ");
+			AppendComponents(stringBuilder);
+		}
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(it).Append(" only contained assemblies with a matching version ");
+			Formatter.Format(stringBuilder, Matching, FormattingOptions.Indented(indentation));
+		}
+
+		private bool Matches(Assembly? assembly)
+		{
+			Version? version = assembly?.GetName().Version;
+			if (version is null)
+			{
+				return false;
+			}
+
+			foreach (VersionComponentCheck check in checks)
+			{
+				if (!check.Comparison(check.Selector(version)))
+				{
+					return false;
+				}
+			}
+
+			return true;
+		}
+
+		private void AppendComponents(StringBuilder stringBuilder)
+		{
+			for (int i = 0; i < checks.Count; i++)
+			{
+				if (i > 0)
+				{
+					stringBuilder.Append(" and ");
+				}
+
+				stringBuilder.Append(checks[i].Component).Append(' ').Append(checks[i].ComparisonText);
+			}
+		}
+	}
+
+	private sealed class HaveVersionConstraint(
+		string it,
+		ExpectationGrammars grammars,
+		Func<Version, bool> predicate,
+		string predicateExpression)
+		: CollectionConstraintResult<Assembly?>(grammars),
+			IValueConstraint<IEnumerable<Assembly?>>
+#if NET8_0_OR_GREATER
+			, IAsyncConstraint<IAsyncEnumerable<Assembly?>>
+#endif
+	{
+#if NET8_0_OR_GREATER
+		public async Task<ConstraintResult> IsMetBy(IAsyncEnumerable<Assembly?> actual,
+			CancellationToken cancellationToken)
+			=> await SetAsyncValue(actual, assembly => assembly?.GetName().Version is { } version && predicate(version));
+#endif
+
+		public ConstraintResult IsMetBy(IEnumerable<Assembly?> actual)
+			=> SetValue(actual, assembly => assembly?.GetName().Version is { } version && predicate(version));
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("all have version matching ").Append(predicateExpression);
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(it).Append(" contained assemblies with a non-matching version ");
+			Formatter.Format(stringBuilder, NotMatching, FormattingOptions.Indented(indentation));
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("not all have version matching ").Append(predicateExpression);
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(it).Append(" only contained assemblies with a matching version ");
+			Formatter.Format(stringBuilder, Matching, FormattingOptions.Indented(indentation));
+		}
+	}
+}

--- a/Source/aweXpect.Reflection/ThatAssembly.HasVersion.cs
+++ b/Source/aweXpect.Reflection/ThatAssembly.HasVersion.cs
@@ -1,0 +1,258 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Text;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Reflection.Helpers;
+using aweXpect.Results;
+
+namespace aweXpect.Reflection;
+
+public static partial class ThatAssembly
+{
+	/// <summary>
+	///     Verifies that the <see cref="Assembly" /> has a <see cref="AssemblyName.Version" /> that
+	///     satisfies the <paramref name="predicate" />.
+	/// </summary>
+	public static AndOrResult<Assembly?, IThat<Assembly?>> HasVersion(
+		this IThat<Assembly?> subject,
+		Func<Version, bool> predicate,
+		[CallerArgumentExpression(nameof(predicate))]
+		string doNotPopulateThisValue = "")
+		=> new(subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new HasVersionConstraint(it, grammars, predicate, doNotPopulateThisValue.TrimCommonWhiteSpace())),
+			subject);
+
+	/// <summary>
+	///     Verifies the individual components of the <see cref="AssemblyName.Version" /> of the <see cref="Assembly" />.
+	/// </summary>
+	public static HasVersionResult HasVersion(this IThat<Assembly?> subject)
+		=> new(subject);
+
+	/// <summary>
+	///     The result of verifying the <see cref="AssemblyName.Version" /> of an <see cref="Assembly" />,
+	///     allowing comparisons on its individual components.
+	/// </summary>
+	public class HasVersionResult : AndOrResult<Assembly?, IThat<Assembly?>>
+	{
+		private readonly List<VersionComponentCheck> _checks = [];
+
+		internal HasVersionResult(IThat<Assembly?> subject)
+			: this(subject, subject.Get().ExpectationBuilder)
+		{
+		}
+
+		private HasVersionResult(IThat<Assembly?> subject, ExpectationBuilder expectationBuilder)
+			: base(expectationBuilder, subject)
+		{
+			expectationBuilder.AddConstraint((it, grammars) => new HasVersionComponentsConstraint(it, grammars, _checks));
+		}
+
+		/// <summary>
+		///     Compares the <see cref="Version.Major" /> version component.
+		/// </summary>
+		public VersionComponent WithMajor => new(this, "major version", version => version.Major);
+
+		/// <summary>
+		///     Compares the <see cref="Version.Minor" /> version component.
+		/// </summary>
+		public VersionComponent WithMinor => new(this, "minor version", version => version.Minor);
+
+		/// <summary>
+		///     Compares the <see cref="Version.Build" /> version component.
+		/// </summary>
+		public VersionComponent WithBuild => new(this, "build version", version => version.Build);
+
+		/// <summary>
+		///     Compares the <see cref="Version.Revision" /> version component.
+		/// </summary>
+		public VersionComponent WithRevision => new(this, "revision version", version => version.Revision);
+
+		internal HasVersionResult Add(string component, string comparisonText, Func<Version, int> selector,
+			Func<int, bool> comparison)
+		{
+			_checks.Add(new VersionComponentCheck(component, comparisonText, selector, comparison));
+			return this;
+		}
+	}
+
+	/// <summary>
+	///     Comparison of a single component of the <see cref="AssemblyName.Version" /> of an <see cref="Assembly" />.
+	/// </summary>
+	public class VersionComponent(HasVersionResult owner, string component, Func<Version, int> selector)
+	{
+		/// <summary>
+		///     The component is greater than the <paramref name="expected" /> value.
+		/// </summary>
+		public HasVersionResult GreaterThan(int expected)
+			=> owner.Add(component, $"greater than {expected}", selector, value => value > expected);
+
+		/// <summary>
+		///     The component is greater than or equal to the <paramref name="expected" /> value.
+		/// </summary>
+		public HasVersionResult GreaterThanOrEqualTo(int expected)
+			=> owner.Add(component, $"greater than or equal to {expected}", selector, value => value >= expected);
+
+		/// <summary>
+		///     The component is less than the <paramref name="expected" /> value.
+		/// </summary>
+		public HasVersionResult LessThan(int expected)
+			=> owner.Add(component, $"less than {expected}", selector, value => value < expected);
+
+		/// <summary>
+		///     The component is less than or equal to the <paramref name="expected" /> value.
+		/// </summary>
+		public HasVersionResult LessThanOrEqualTo(int expected)
+			=> owner.Add(component, $"less than or equal to {expected}", selector, value => value <= expected);
+
+		/// <summary>
+		///     The component is equal to the <paramref name="expected" /> value.
+		/// </summary>
+		public HasVersionResult EqualTo(int expected)
+			=> owner.Add(component, $"equal to {expected}", selector, value => value == expected);
+
+		/// <summary>
+		///     The component is not equal to the <paramref name="expected" /> value.
+		/// </summary>
+		public HasVersionResult NotEqualTo(int expected)
+			=> owner.Add(component, $"not equal to {expected}", selector, value => value != expected);
+	}
+
+	private sealed class VersionComponentCheck(
+		string component,
+		string comparisonText,
+		Func<Version, int> selector,
+		Func<int, bool> comparison)
+	{
+		public string Component { get; } = component;
+		public string ComparisonText { get; } = comparisonText;
+		public Func<Version, int> Selector { get; } = selector;
+		public Func<int, bool> Comparison { get; } = comparison;
+	}
+
+	private sealed class HasVersionComponentsConstraint(
+		string it,
+		ExpectationGrammars grammars,
+		List<VersionComponentCheck> checks)
+		: ConstraintResult.WithNotNullValue<Assembly?>(it, grammars),
+			IValueConstraint<Assembly?>
+	{
+		private VersionComponentCheck? _failed;
+		private Version? _version;
+
+		public ConstraintResult IsMetBy(Assembly? actual)
+		{
+			Actual = actual;
+			_version = actual?.GetName().Version;
+			_failed = null;
+			if (_version is null)
+			{
+				Outcome = Outcome.Failure;
+				return this;
+			}
+
+			foreach (VersionComponentCheck check in checks)
+			{
+				if (!check.Comparison(check.Selector(_version)))
+				{
+					_failed = check;
+					Outcome = Outcome.Failure;
+					return this;
+				}
+			}
+
+			Outcome = Outcome.Success;
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			if (checks.Count == 0)
+			{
+				stringBuilder.Append("has a version");
+				return;
+			}
+
+			stringBuilder.Append("has ");
+			AppendComponents(stringBuilder);
+		}
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			if (_version is null)
+			{
+				stringBuilder.Append(It).Append(" had no version");
+				return;
+			}
+
+			if (_failed is { } failed)
+			{
+				stringBuilder.Append(It).Append(" had ").Append(failed.Component).Append(' ');
+				Formatter.Format(stringBuilder, failed.Selector(_version));
+				return;
+			}
+
+			stringBuilder.Append(It).Append(" had version ").Append(Formatter.Format(_version));
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			if (checks.Count == 0)
+			{
+				stringBuilder.Append("does not have a version");
+				return;
+			}
+
+			stringBuilder.Append("does not have ");
+			AppendComponents(stringBuilder);
+		}
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+			=> AppendNormalResult(stringBuilder, indentation);
+
+		private void AppendComponents(StringBuilder stringBuilder)
+		{
+			for (int i = 0; i < checks.Count; i++)
+			{
+				if (i > 0)
+				{
+					stringBuilder.Append(" and ");
+				}
+
+				stringBuilder.Append(checks[i].Component).Append(' ').Append(checks[i].ComparisonText);
+			}
+		}
+	}
+
+	private sealed class HasVersionConstraint(
+		string it,
+		ExpectationGrammars grammars,
+		Func<Version, bool> predicate,
+		string predicateExpression)
+		: ConstraintResult.WithNotNullValue<Assembly?>(it, grammars),
+			IValueConstraint<Assembly?>
+	{
+		public ConstraintResult IsMetBy(Assembly? actual)
+		{
+			Actual = actual;
+			Outcome = actual?.GetName().Version is { } version && predicate(version)
+				? Outcome.Success
+				: Outcome.Failure;
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("has version matching ").Append(predicateExpression);
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append(It).Append(" had version ").Append(Formatter.Format(Actual?.GetName().Version));
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("does not have version matching ").Append(predicateExpression);
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append(It).Append(" had version ").Append(Formatter.Format(Actual?.GetName().Version));
+	}
+}

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net10.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net10.0.txt
@@ -41,6 +41,8 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.AssemblyFilters.AssembliesWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Assemblies @this, System.Func<TAttribute, bool>? predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Collections.Filtered.Assemblies.StringEqualityResultType WithName(this aweXpect.Reflection.Collections.Filtered.Assemblies @this, string expected) { }
+        public static aweXpect.Reflection.AssemblyFilters.AssembliesWithVersion WithVersion(this aweXpect.Reflection.Collections.Filtered.Assemblies @this) { }
+        public static aweXpect.Reflection.Collections.Filtered.Assemblies WithVersion(this aweXpect.Reflection.Collections.Filtered.Assemblies @this, System.Func<System.Version, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public class AssembliesWith : aweXpect.Reflection.Collections.Filtered.Assemblies
         {
             public AssembliesWith(aweXpect.Reflection.Collections.Filtered.Assemblies inner, aweXpect.Reflection.Collections.IChangeableFilter<System.Reflection.Assembly> filter) { }
@@ -48,6 +50,24 @@ namespace aweXpect.Reflection
                 where TAttribute : System.Attribute { }
             public aweXpect.Reflection.AssemblyFilters.AssembliesWith OrWith<TAttribute>(System.Func<TAttribute, bool>? predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
                 where TAttribute : System.Attribute { }
+        }
+        public class AssembliesWithVersion : aweXpect.Reflection.Collections.Filtered.Assemblies
+        {
+            public AssembliesWithVersion(aweXpect.Reflection.Collections.Filtered.Assemblies inner, aweXpect.Reflection.Collections.IChangeableFilter<System.Reflection.Assembly> filter) { }
+            public aweXpect.Reflection.AssemblyFilters.VersionComponent WithBuild { get; }
+            public aweXpect.Reflection.AssemblyFilters.VersionComponent WithMajor { get; }
+            public aweXpect.Reflection.AssemblyFilters.VersionComponent WithMinor { get; }
+            public aweXpect.Reflection.AssemblyFilters.VersionComponent WithRevision { get; }
+        }
+        public class VersionComponent
+        {
+            public VersionComponent(aweXpect.Reflection.AssemblyFilters.AssembliesWithVersion owner, aweXpect.Reflection.Collections.IChangeableFilter<System.Reflection.Assembly> filter, string component, System.Func<System.Version, int> selector) { }
+            public aweXpect.Reflection.AssemblyFilters.AssembliesWithVersion EqualTo(int expected) { }
+            public aweXpect.Reflection.AssemblyFilters.AssembliesWithVersion GreaterThan(int expected) { }
+            public aweXpect.Reflection.AssemblyFilters.AssembliesWithVersion GreaterThanOrEqualTo(int expected) { }
+            public aweXpect.Reflection.AssemblyFilters.AssembliesWithVersion LessThan(int expected) { }
+            public aweXpect.Reflection.AssemblyFilters.AssembliesWithVersion LessThanOrEqualTo(int expected) { }
+            public aweXpect.Reflection.AssemblyFilters.AssembliesWithVersion NotEqualTo(int expected) { }
         }
     }
     public static class ConstructorFilters
@@ -455,6 +475,27 @@ namespace aweXpect.Reflection
         public static aweXpect.Results.StringEqualityTypeResult<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>>> HaveName(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>> subject, System.Func<System.Reflection.Assembly?, string> expectedNameSelector, [System.Runtime.CompilerServices.CallerArgumentExpression("expectedNameSelector")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Results.StringEqualityTypeResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.Assembly?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.Assembly?>>> HaveNoDependencyOn(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.Assembly?>> subject, string unexpected) { }
         public static aweXpect.Results.StringEqualityTypeResult<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>>> HaveNoDependencyOn(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>> subject, string unexpected) { }
+        public static aweXpect.Reflection.ThatAssemblies.HaveVersionResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.Assembly?>> HaveVersion(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.Assembly?>> subject) { }
+        public static aweXpect.Reflection.ThatAssemblies.HaveVersionResult<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>> HaveVersion(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.Assembly?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.Assembly?>>> HaveVersion(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.Assembly?>> subject, System.Func<System.Version, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>>> HaveVersion(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>> subject, System.Func<System.Version, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
+        public class HaveVersionResult<TCollection> : aweXpect.Results.AndOrResult<TCollection, aweXpect.Core.IThat<TCollection>>
+        {
+            public aweXpect.Reflection.ThatAssemblies.VersionComponentResult<TCollection> WithBuild { get; }
+            public aweXpect.Reflection.ThatAssemblies.VersionComponentResult<TCollection> WithMajor { get; }
+            public aweXpect.Reflection.ThatAssemblies.VersionComponentResult<TCollection> WithMinor { get; }
+            public aweXpect.Reflection.ThatAssemblies.VersionComponentResult<TCollection> WithRevision { get; }
+        }
+        public class VersionComponentResult<TCollection>
+        {
+            public VersionComponentResult(aweXpect.Reflection.ThatAssemblies.HaveVersionResult<TCollection> owner, string component, System.Func<System.Version, int> selector) { }
+            public aweXpect.Reflection.ThatAssemblies.HaveVersionResult<TCollection> EqualTo(int expected) { }
+            public aweXpect.Reflection.ThatAssemblies.HaveVersionResult<TCollection> GreaterThan(int expected) { }
+            public aweXpect.Reflection.ThatAssemblies.HaveVersionResult<TCollection> GreaterThanOrEqualTo(int expected) { }
+            public aweXpect.Reflection.ThatAssemblies.HaveVersionResult<TCollection> LessThan(int expected) { }
+            public aweXpect.Reflection.ThatAssemblies.HaveVersionResult<TCollection> LessThanOrEqualTo(int expected) { }
+            public aweXpect.Reflection.ThatAssemblies.HaveVersionResult<TCollection> NotEqualTo(int expected) { }
+        }
     }
     public static class ThatAssembly
     {
@@ -465,6 +506,25 @@ namespace aweXpect.Reflection
         public static aweXpect.Results.StringEqualityTypeResult<System.Reflection.Assembly?, aweXpect.Core.IThat<System.Reflection.Assembly?>> HasADependencyOn(this aweXpect.Core.IThat<System.Reflection.Assembly?> subject, string expected) { }
         public static aweXpect.Results.StringEqualityTypeResult<System.Reflection.Assembly?, aweXpect.Core.IThat<System.Reflection.Assembly?>> HasName(this aweXpect.Core.IThat<System.Reflection.Assembly?> subject, string expected) { }
         public static aweXpect.Results.StringEqualityTypeResult<System.Reflection.Assembly?, aweXpect.Core.IThat<System.Reflection.Assembly?>> HasNoDependencyOn(this aweXpect.Core.IThat<System.Reflection.Assembly?> subject, string unexpected) { }
+        public static aweXpect.Reflection.ThatAssembly.HasVersionResult HasVersion(this aweXpect.Core.IThat<System.Reflection.Assembly?> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Reflection.Assembly?, aweXpect.Core.IThat<System.Reflection.Assembly?>> HasVersion(this aweXpect.Core.IThat<System.Reflection.Assembly?> subject, System.Func<System.Version, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
+        public class HasVersionResult : aweXpect.Results.AndOrResult<System.Reflection.Assembly?, aweXpect.Core.IThat<System.Reflection.Assembly?>>
+        {
+            public aweXpect.Reflection.ThatAssembly.VersionComponent WithBuild { get; }
+            public aweXpect.Reflection.ThatAssembly.VersionComponent WithMajor { get; }
+            public aweXpect.Reflection.ThatAssembly.VersionComponent WithMinor { get; }
+            public aweXpect.Reflection.ThatAssembly.VersionComponent WithRevision { get; }
+        }
+        public class VersionComponent
+        {
+            public VersionComponent(aweXpect.Reflection.ThatAssembly.HasVersionResult owner, string component, System.Func<System.Version, int> selector) { }
+            public aweXpect.Reflection.ThatAssembly.HasVersionResult EqualTo(int expected) { }
+            public aweXpect.Reflection.ThatAssembly.HasVersionResult GreaterThan(int expected) { }
+            public aweXpect.Reflection.ThatAssembly.HasVersionResult GreaterThanOrEqualTo(int expected) { }
+            public aweXpect.Reflection.ThatAssembly.HasVersionResult LessThan(int expected) { }
+            public aweXpect.Reflection.ThatAssembly.HasVersionResult LessThanOrEqualTo(int expected) { }
+            public aweXpect.Reflection.ThatAssembly.HasVersionResult NotEqualTo(int expected) { }
+        }
     }
     public static class ThatConstructor
     {

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net8.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net8.0.txt
@@ -41,6 +41,8 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.AssemblyFilters.AssembliesWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Assemblies @this, System.Func<TAttribute, bool>? predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Collections.Filtered.Assemblies.StringEqualityResultType WithName(this aweXpect.Reflection.Collections.Filtered.Assemblies @this, string expected) { }
+        public static aweXpect.Reflection.AssemblyFilters.AssembliesWithVersion WithVersion(this aweXpect.Reflection.Collections.Filtered.Assemblies @this) { }
+        public static aweXpect.Reflection.Collections.Filtered.Assemblies WithVersion(this aweXpect.Reflection.Collections.Filtered.Assemblies @this, System.Func<System.Version, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public class AssembliesWith : aweXpect.Reflection.Collections.Filtered.Assemblies
         {
             public AssembliesWith(aweXpect.Reflection.Collections.Filtered.Assemblies inner, aweXpect.Reflection.Collections.IChangeableFilter<System.Reflection.Assembly> filter) { }
@@ -48,6 +50,24 @@ namespace aweXpect.Reflection
                 where TAttribute : System.Attribute { }
             public aweXpect.Reflection.AssemblyFilters.AssembliesWith OrWith<TAttribute>(System.Func<TAttribute, bool>? predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
                 where TAttribute : System.Attribute { }
+        }
+        public class AssembliesWithVersion : aweXpect.Reflection.Collections.Filtered.Assemblies
+        {
+            public AssembliesWithVersion(aweXpect.Reflection.Collections.Filtered.Assemblies inner, aweXpect.Reflection.Collections.IChangeableFilter<System.Reflection.Assembly> filter) { }
+            public aweXpect.Reflection.AssemblyFilters.VersionComponent WithBuild { get; }
+            public aweXpect.Reflection.AssemblyFilters.VersionComponent WithMajor { get; }
+            public aweXpect.Reflection.AssemblyFilters.VersionComponent WithMinor { get; }
+            public aweXpect.Reflection.AssemblyFilters.VersionComponent WithRevision { get; }
+        }
+        public class VersionComponent
+        {
+            public VersionComponent(aweXpect.Reflection.AssemblyFilters.AssembliesWithVersion owner, aweXpect.Reflection.Collections.IChangeableFilter<System.Reflection.Assembly> filter, string component, System.Func<System.Version, int> selector) { }
+            public aweXpect.Reflection.AssemblyFilters.AssembliesWithVersion EqualTo(int expected) { }
+            public aweXpect.Reflection.AssemblyFilters.AssembliesWithVersion GreaterThan(int expected) { }
+            public aweXpect.Reflection.AssemblyFilters.AssembliesWithVersion GreaterThanOrEqualTo(int expected) { }
+            public aweXpect.Reflection.AssemblyFilters.AssembliesWithVersion LessThan(int expected) { }
+            public aweXpect.Reflection.AssemblyFilters.AssembliesWithVersion LessThanOrEqualTo(int expected) { }
+            public aweXpect.Reflection.AssemblyFilters.AssembliesWithVersion NotEqualTo(int expected) { }
         }
     }
     public static class ConstructorFilters
@@ -455,6 +475,27 @@ namespace aweXpect.Reflection
         public static aweXpect.Results.StringEqualityTypeResult<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>>> HaveName(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>> subject, System.Func<System.Reflection.Assembly?, string> expectedNameSelector, [System.Runtime.CompilerServices.CallerArgumentExpression("expectedNameSelector")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Results.StringEqualityTypeResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.Assembly?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.Assembly?>>> HaveNoDependencyOn(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.Assembly?>> subject, string unexpected) { }
         public static aweXpect.Results.StringEqualityTypeResult<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>>> HaveNoDependencyOn(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>> subject, string unexpected) { }
+        public static aweXpect.Reflection.ThatAssemblies.HaveVersionResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.Assembly?>> HaveVersion(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.Assembly?>> subject) { }
+        public static aweXpect.Reflection.ThatAssemblies.HaveVersionResult<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>> HaveVersion(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.Assembly?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.Assembly?>>> HaveVersion(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.Assembly?>> subject, System.Func<System.Version, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>>> HaveVersion(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>> subject, System.Func<System.Version, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
+        public class HaveVersionResult<TCollection> : aweXpect.Results.AndOrResult<TCollection, aweXpect.Core.IThat<TCollection>>
+        {
+            public aweXpect.Reflection.ThatAssemblies.VersionComponentResult<TCollection> WithBuild { get; }
+            public aweXpect.Reflection.ThatAssemblies.VersionComponentResult<TCollection> WithMajor { get; }
+            public aweXpect.Reflection.ThatAssemblies.VersionComponentResult<TCollection> WithMinor { get; }
+            public aweXpect.Reflection.ThatAssemblies.VersionComponentResult<TCollection> WithRevision { get; }
+        }
+        public class VersionComponentResult<TCollection>
+        {
+            public VersionComponentResult(aweXpect.Reflection.ThatAssemblies.HaveVersionResult<TCollection> owner, string component, System.Func<System.Version, int> selector) { }
+            public aweXpect.Reflection.ThatAssemblies.HaveVersionResult<TCollection> EqualTo(int expected) { }
+            public aweXpect.Reflection.ThatAssemblies.HaveVersionResult<TCollection> GreaterThan(int expected) { }
+            public aweXpect.Reflection.ThatAssemblies.HaveVersionResult<TCollection> GreaterThanOrEqualTo(int expected) { }
+            public aweXpect.Reflection.ThatAssemblies.HaveVersionResult<TCollection> LessThan(int expected) { }
+            public aweXpect.Reflection.ThatAssemblies.HaveVersionResult<TCollection> LessThanOrEqualTo(int expected) { }
+            public aweXpect.Reflection.ThatAssemblies.HaveVersionResult<TCollection> NotEqualTo(int expected) { }
+        }
     }
     public static class ThatAssembly
     {
@@ -465,6 +506,25 @@ namespace aweXpect.Reflection
         public static aweXpect.Results.StringEqualityTypeResult<System.Reflection.Assembly?, aweXpect.Core.IThat<System.Reflection.Assembly?>> HasADependencyOn(this aweXpect.Core.IThat<System.Reflection.Assembly?> subject, string expected) { }
         public static aweXpect.Results.StringEqualityTypeResult<System.Reflection.Assembly?, aweXpect.Core.IThat<System.Reflection.Assembly?>> HasName(this aweXpect.Core.IThat<System.Reflection.Assembly?> subject, string expected) { }
         public static aweXpect.Results.StringEqualityTypeResult<System.Reflection.Assembly?, aweXpect.Core.IThat<System.Reflection.Assembly?>> HasNoDependencyOn(this aweXpect.Core.IThat<System.Reflection.Assembly?> subject, string unexpected) { }
+        public static aweXpect.Reflection.ThatAssembly.HasVersionResult HasVersion(this aweXpect.Core.IThat<System.Reflection.Assembly?> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Reflection.Assembly?, aweXpect.Core.IThat<System.Reflection.Assembly?>> HasVersion(this aweXpect.Core.IThat<System.Reflection.Assembly?> subject, System.Func<System.Version, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
+        public class HasVersionResult : aweXpect.Results.AndOrResult<System.Reflection.Assembly?, aweXpect.Core.IThat<System.Reflection.Assembly?>>
+        {
+            public aweXpect.Reflection.ThatAssembly.VersionComponent WithBuild { get; }
+            public aweXpect.Reflection.ThatAssembly.VersionComponent WithMajor { get; }
+            public aweXpect.Reflection.ThatAssembly.VersionComponent WithMinor { get; }
+            public aweXpect.Reflection.ThatAssembly.VersionComponent WithRevision { get; }
+        }
+        public class VersionComponent
+        {
+            public VersionComponent(aweXpect.Reflection.ThatAssembly.HasVersionResult owner, string component, System.Func<System.Version, int> selector) { }
+            public aweXpect.Reflection.ThatAssembly.HasVersionResult EqualTo(int expected) { }
+            public aweXpect.Reflection.ThatAssembly.HasVersionResult GreaterThan(int expected) { }
+            public aweXpect.Reflection.ThatAssembly.HasVersionResult GreaterThanOrEqualTo(int expected) { }
+            public aweXpect.Reflection.ThatAssembly.HasVersionResult LessThan(int expected) { }
+            public aweXpect.Reflection.ThatAssembly.HasVersionResult LessThanOrEqualTo(int expected) { }
+            public aweXpect.Reflection.ThatAssembly.HasVersionResult NotEqualTo(int expected) { }
+        }
     }
     public static class ThatConstructor
     {

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_netstandard2.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_netstandard2.0.txt
@@ -41,6 +41,8 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.AssemblyFilters.AssembliesWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Assemblies @this, System.Func<TAttribute, bool>? predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Collections.Filtered.Assemblies.StringEqualityResultType WithName(this aweXpect.Reflection.Collections.Filtered.Assemblies @this, string expected) { }
+        public static aweXpect.Reflection.AssemblyFilters.AssembliesWithVersion WithVersion(this aweXpect.Reflection.Collections.Filtered.Assemblies @this) { }
+        public static aweXpect.Reflection.Collections.Filtered.Assemblies WithVersion(this aweXpect.Reflection.Collections.Filtered.Assemblies @this, System.Func<System.Version, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public class AssembliesWith : aweXpect.Reflection.Collections.Filtered.Assemblies
         {
             public AssembliesWith(aweXpect.Reflection.Collections.Filtered.Assemblies inner, aweXpect.Reflection.Collections.IChangeableFilter<System.Reflection.Assembly> filter) { }
@@ -48,6 +50,24 @@ namespace aweXpect.Reflection
                 where TAttribute : System.Attribute { }
             public aweXpect.Reflection.AssemblyFilters.AssembliesWith OrWith<TAttribute>(System.Func<TAttribute, bool>? predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
                 where TAttribute : System.Attribute { }
+        }
+        public class AssembliesWithVersion : aweXpect.Reflection.Collections.Filtered.Assemblies
+        {
+            public AssembliesWithVersion(aweXpect.Reflection.Collections.Filtered.Assemblies inner, aweXpect.Reflection.Collections.IChangeableFilter<System.Reflection.Assembly> filter) { }
+            public aweXpect.Reflection.AssemblyFilters.VersionComponent WithBuild { get; }
+            public aweXpect.Reflection.AssemblyFilters.VersionComponent WithMajor { get; }
+            public aweXpect.Reflection.AssemblyFilters.VersionComponent WithMinor { get; }
+            public aweXpect.Reflection.AssemblyFilters.VersionComponent WithRevision { get; }
+        }
+        public class VersionComponent
+        {
+            public VersionComponent(aweXpect.Reflection.AssemblyFilters.AssembliesWithVersion owner, aweXpect.Reflection.Collections.IChangeableFilter<System.Reflection.Assembly> filter, string component, System.Func<System.Version, int> selector) { }
+            public aweXpect.Reflection.AssemblyFilters.AssembliesWithVersion EqualTo(int expected) { }
+            public aweXpect.Reflection.AssemblyFilters.AssembliesWithVersion GreaterThan(int expected) { }
+            public aweXpect.Reflection.AssemblyFilters.AssembliesWithVersion GreaterThanOrEqualTo(int expected) { }
+            public aweXpect.Reflection.AssemblyFilters.AssembliesWithVersion LessThan(int expected) { }
+            public aweXpect.Reflection.AssemblyFilters.AssembliesWithVersion LessThanOrEqualTo(int expected) { }
+            public aweXpect.Reflection.AssemblyFilters.AssembliesWithVersion NotEqualTo(int expected) { }
         }
     }
     public static class ConstructorFilters
@@ -447,6 +467,25 @@ namespace aweXpect.Reflection
         public static aweXpect.Results.StringEqualityTypeResult<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>>> HaveName(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>> subject, string expected) { }
         public static aweXpect.Results.StringEqualityTypeResult<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>>> HaveName(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>> subject, System.Func<System.Reflection.Assembly?, string> expectedNameSelector, [System.Runtime.CompilerServices.CallerArgumentExpression("expectedNameSelector")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Results.StringEqualityTypeResult<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>>> HaveNoDependencyOn(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>> subject, string unexpected) { }
+        public static aweXpect.Reflection.ThatAssemblies.HaveVersionResult<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>> HaveVersion(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>>> HaveVersion(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>> subject, System.Func<System.Version, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
+        public class HaveVersionResult<TCollection> : aweXpect.Results.AndOrResult<TCollection, aweXpect.Core.IThat<TCollection>>
+        {
+            public aweXpect.Reflection.ThatAssemblies.VersionComponentResult<TCollection> WithBuild { get; }
+            public aweXpect.Reflection.ThatAssemblies.VersionComponentResult<TCollection> WithMajor { get; }
+            public aweXpect.Reflection.ThatAssemblies.VersionComponentResult<TCollection> WithMinor { get; }
+            public aweXpect.Reflection.ThatAssemblies.VersionComponentResult<TCollection> WithRevision { get; }
+        }
+        public class VersionComponentResult<TCollection>
+        {
+            public VersionComponentResult(aweXpect.Reflection.ThatAssemblies.HaveVersionResult<TCollection> owner, string component, System.Func<System.Version, int> selector) { }
+            public aweXpect.Reflection.ThatAssemblies.HaveVersionResult<TCollection> EqualTo(int expected) { }
+            public aweXpect.Reflection.ThatAssemblies.HaveVersionResult<TCollection> GreaterThan(int expected) { }
+            public aweXpect.Reflection.ThatAssemblies.HaveVersionResult<TCollection> GreaterThanOrEqualTo(int expected) { }
+            public aweXpect.Reflection.ThatAssemblies.HaveVersionResult<TCollection> LessThan(int expected) { }
+            public aweXpect.Reflection.ThatAssemblies.HaveVersionResult<TCollection> LessThanOrEqualTo(int expected) { }
+            public aweXpect.Reflection.ThatAssemblies.HaveVersionResult<TCollection> NotEqualTo(int expected) { }
+        }
     }
     public static class ThatAssembly
     {
@@ -457,6 +496,25 @@ namespace aweXpect.Reflection
         public static aweXpect.Results.StringEqualityTypeResult<System.Reflection.Assembly?, aweXpect.Core.IThat<System.Reflection.Assembly?>> HasADependencyOn(this aweXpect.Core.IThat<System.Reflection.Assembly?> subject, string expected) { }
         public static aweXpect.Results.StringEqualityTypeResult<System.Reflection.Assembly?, aweXpect.Core.IThat<System.Reflection.Assembly?>> HasName(this aweXpect.Core.IThat<System.Reflection.Assembly?> subject, string expected) { }
         public static aweXpect.Results.StringEqualityTypeResult<System.Reflection.Assembly?, aweXpect.Core.IThat<System.Reflection.Assembly?>> HasNoDependencyOn(this aweXpect.Core.IThat<System.Reflection.Assembly?> subject, string unexpected) { }
+        public static aweXpect.Reflection.ThatAssembly.HasVersionResult HasVersion(this aweXpect.Core.IThat<System.Reflection.Assembly?> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Reflection.Assembly?, aweXpect.Core.IThat<System.Reflection.Assembly?>> HasVersion(this aweXpect.Core.IThat<System.Reflection.Assembly?> subject, System.Func<System.Version, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
+        public class HasVersionResult : aweXpect.Results.AndOrResult<System.Reflection.Assembly?, aweXpect.Core.IThat<System.Reflection.Assembly?>>
+        {
+            public aweXpect.Reflection.ThatAssembly.VersionComponent WithBuild { get; }
+            public aweXpect.Reflection.ThatAssembly.VersionComponent WithMajor { get; }
+            public aweXpect.Reflection.ThatAssembly.VersionComponent WithMinor { get; }
+            public aweXpect.Reflection.ThatAssembly.VersionComponent WithRevision { get; }
+        }
+        public class VersionComponent
+        {
+            public VersionComponent(aweXpect.Reflection.ThatAssembly.HasVersionResult owner, string component, System.Func<System.Version, int> selector) { }
+            public aweXpect.Reflection.ThatAssembly.HasVersionResult EqualTo(int expected) { }
+            public aweXpect.Reflection.ThatAssembly.HasVersionResult GreaterThan(int expected) { }
+            public aweXpect.Reflection.ThatAssembly.HasVersionResult GreaterThanOrEqualTo(int expected) { }
+            public aweXpect.Reflection.ThatAssembly.HasVersionResult LessThan(int expected) { }
+            public aweXpect.Reflection.ThatAssembly.HasVersionResult LessThanOrEqualTo(int expected) { }
+            public aweXpect.Reflection.ThatAssembly.HasVersionResult NotEqualTo(int expected) { }
+        }
     }
     public static class ThatConstructor
     {

--- a/Tests/aweXpect.Reflection.Tests/Filters/AssemblyFilters.WithVersion.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/AssemblyFilters.WithVersion.Tests.cs
@@ -1,0 +1,121 @@
+using aweXpect.Reflection.Collections;
+
+namespace aweXpect.Reflection.Tests.Filters;
+
+public sealed partial class AssemblyFilters
+{
+	public sealed class WithVersion
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task ShouldFilterForAssembliesWithMatchingVersion()
+			{
+				Filtered.Assemblies assemblies = In.AllLoadedAssemblies()
+					.WithVersion(version => version.Major >= 0);
+
+				await That(assemblies).IsNotEmpty();
+				await That(assemblies.GetDescription())
+					.IsEqualTo("in all loaded assemblies with version matching version => version.Major >= 0");
+			}
+
+			[Fact]
+			public async Task ShouldNotMatchWhenPredicateIsNeverTrue()
+			{
+				Filtered.Assemblies assemblies = In.AllLoadedAssemblies()
+					.WithVersion(version => version.Major < 0);
+
+				await That(assemblies).IsEmpty();
+			}
+		}
+
+		public sealed class ComponentTests
+		{
+			[Fact]
+			public async Task MultipleComponents_ShouldCombineWithAnd()
+			{
+				Filtered.Assemblies assemblies = In.AllLoadedAssemblies()
+					.WithVersion().WithMajor.GreaterThanOrEqualTo(0).WithMinor.LessThan(100000);
+
+				await That(assemblies).IsNotEmpty();
+				await That(assemblies.GetDescription())
+					.IsEqualTo(
+						"in all loaded assemblies with major version greater than or equal to 0 with minor version less than 100000");
+			}
+
+			[Theory]
+			[InlineData("GreaterThan", 5, "greater than 5")]
+			[InlineData("GreaterThanOrEqualTo", 5, "greater than or equal to 5")]
+			[InlineData("LessThan", 5, "less than 5")]
+			[InlineData("LessThanOrEqualTo", 5, "less than or equal to 5")]
+			[InlineData("EqualTo", 5, "equal to 5")]
+			[InlineData("NotEqualTo", 5, "not equal to 5")]
+			public async Task ShouldDescribeComparison(string comparison, int expected, string expectedText)
+			{
+				Reflection.AssemblyFilters.VersionComponent major = In.AllLoadedAssemblies().WithVersion().WithMajor;
+				Filtered.Assemblies assemblies = comparison switch
+				{
+					"GreaterThan" => major.GreaterThan(expected),
+					"GreaterThanOrEqualTo" => major.GreaterThanOrEqualTo(expected),
+					"LessThan" => major.LessThan(expected),
+					"LessThanOrEqualTo" => major.LessThanOrEqualTo(expected),
+					"EqualTo" => major.EqualTo(expected),
+					_ => major.NotEqualTo(expected),
+				};
+
+				await That(assemblies.GetDescription())
+					.IsEqualTo($"in all loaded assemblies with major version {expectedText}");
+			}
+
+			[Theory]
+			[InlineData("major")]
+			[InlineData("minor")]
+			[InlineData("build")]
+			[InlineData("revision")]
+			public async Task ShouldDescribeComponent(string name)
+			{
+				Reflection.AssemblyFilters.AssembliesWithVersion version = In.AllLoadedAssemblies().WithVersion();
+				Reflection.AssemblyFilters.VersionComponent component = name switch
+				{
+					"major" => version.WithMajor,
+					"minor" => version.WithMinor,
+					"build" => version.WithBuild,
+					_ => version.WithRevision,
+				};
+				Filtered.Assemblies assemblies = component.GreaterThanOrEqualTo(0);
+
+				await That(assemblies.GetDescription())
+					.IsEqualTo($"in all loaded assemblies with {name} version greater than or equal to 0");
+			}
+
+			[Fact]
+			public async Task WhenComparisonIsNeverTrue_ShouldNotMatch()
+			{
+				Filtered.Assemblies assemblies = In.AllLoadedAssemblies()
+					.WithVersion().WithMajor.LessThan(0);
+
+				await That(assemblies).IsEmpty();
+			}
+
+			[Fact]
+			public async Task WithMajor_GreaterThanLargeValue_ShouldNotMatch()
+			{
+				Filtered.Assemblies assemblies = In.AllLoadedAssemblies()
+					.WithVersion().WithMajor.GreaterThan(100000);
+
+				await That(assemblies).IsEmpty();
+			}
+
+			[Fact]
+			public async Task WithMajor_ShouldFilterAndDescribe()
+			{
+				Filtered.Assemblies assemblies = In.AllLoadedAssemblies()
+					.WithVersion().WithMajor.GreaterThanOrEqualTo(0);
+
+				await That(assemblies).IsNotEmpty();
+				await That(assemblies.GetDescription())
+					.IsEqualTo("in all loaded assemblies with major version greater than or equal to 0");
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatAssemblies.HaveVersion.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatAssemblies.HaveVersion.Tests.cs
@@ -82,14 +82,15 @@ public sealed partial class ThatAssemblies
 			public async Task ShouldSupportAllComponents()
 			{
 				Filtered.Assemblies subject = In.AssemblyContaining<PublicAbstractClass>();
+				Version version = typeof(PublicAbstractClass).Assembly.GetName().Version!;
 
 				async Task Act()
 				{
 					await That(subject).HaveVersion()
-						.WithMajor.GreaterThanOrEqualTo(0)
-						.WithMinor.GreaterThanOrEqualTo(0)
-						.WithBuild.GreaterThanOrEqualTo(0)
-						.WithRevision.GreaterThanOrEqualTo(0);
+						.WithMajor.EqualTo(version.Major)
+						.WithMinor.EqualTo(version.Minor)
+						.WithBuild.EqualTo(version.Build)
+						.WithRevision.EqualTo(version.Revision);
 				}
 
 				await That(Act).DoesNotThrow();
@@ -99,16 +100,17 @@ public sealed partial class ThatAssemblies
 			public async Task WhenAllComparisonsAreSatisfied_ShouldSucceed()
 			{
 				Filtered.Assemblies subject = In.AssemblyContaining<PublicAbstractClass>();
+				int major = typeof(PublicAbstractClass).Assembly.GetName().Version!.Major;
 
 				async Task Act()
 				{
 					await That(subject).HaveVersion()
-						.WithMajor.GreaterThan(0)
-						.WithMajor.GreaterThanOrEqualTo(1)
-						.WithMajor.LessThan(2)
-						.WithMajor.LessThanOrEqualTo(1)
-						.WithMajor.EqualTo(1)
-						.WithMajor.NotEqualTo(0);
+						.WithMajor.GreaterThan(major - 1)
+						.WithMajor.GreaterThanOrEqualTo(major)
+						.WithMajor.LessThan(major + 1)
+						.WithMajor.LessThanOrEqualTo(major)
+						.WithMajor.EqualTo(major)
+						.WithMajor.NotEqualTo(major + 1);
 				}
 
 				await That(Act).DoesNotThrow();
@@ -128,18 +130,19 @@ public sealed partial class ThatAssemblies
 			}
 
 			[Theory]
-			[InlineData("GreaterThan", 1)]
-			[InlineData("GreaterThanOrEqualTo", 2)]
-			[InlineData("LessThan", 1)]
-			[InlineData("LessThanOrEqualTo", 0)]
-			[InlineData("EqualTo", 2)]
-			[InlineData("NotEqualTo", 1)]
-			public async Task WhenComparisonIsNotSatisfied_ShouldFail(string comparison, int expected)
+			[InlineData("GreaterThan", 0)]
+			[InlineData("GreaterThanOrEqualTo", 1)]
+			[InlineData("LessThan", 0)]
+			[InlineData("LessThanOrEqualTo", -1)]
+			[InlineData("EqualTo", 1)]
+			[InlineData("NotEqualTo", 0)]
+			public async Task WhenComparisonIsNotSatisfied_ShouldFail(string comparison, int offset)
 			{
 				Filtered.Assemblies subject = In.AssemblyContaining<PublicAbstractClass>();
 
 				async Task Act()
 				{
+					int expected = typeof(PublicAbstractClass).Assembly.GetName().Version!.Major + offset;
 					await (comparison switch
 					{
 						"GreaterThan" => That(subject).HaveVersion().WithMajor.GreaterThan(expected),
@@ -176,15 +179,18 @@ public sealed partial class ThatAssemblies
 			public async Task WhenMultipleComponentsAreCombined_ShouldCombineExpectations()
 			{
 				Filtered.Assemblies subject = In.AssemblyContaining<PublicAbstractClass>();
+				Version version = typeof(PublicAbstractClass).Assembly.GetName().Version!;
 
 				async Task Act()
 				{
-					await That(subject).HaveVersion().WithMajor.GreaterThan(0).WithMinor.GreaterThan(0);
+					await That(subject).HaveVersion()
+						.WithMajor.EqualTo(version.Major)
+						.WithMinor.GreaterThan(version.Minor);
 				}
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage(
-						"*all have major version greater than 0 and minor version greater than 0*non-matching version*")
+						$"*all have major version equal to {version.Major} and minor version greater than {version.Minor}*non-matching version*")
 					.AsWildcard();
 			}
 

--- a/Tests/aweXpect.Reflection.Tests/ThatAssemblies.HaveVersion.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatAssemblies.HaveVersion.Tests.cs
@@ -1,0 +1,250 @@
+﻿using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Tests.TestHelpers.Types;
+using Xunit.Sdk;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatAssemblies
+{
+	public sealed class HaveVersion
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenAllVersionsMatch_ShouldSucceed()
+			{
+				Filtered.Assemblies subject = In.AssemblyContaining<PublicAbstractClass>();
+
+				async Task Act()
+				{
+					await That(subject).HaveVersion(version => version.Major >= 0);
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenVersionDoesNotMatch_ShouldFail()
+			{
+				Filtered.Assemblies subject = In.AssemblyContaining<PublicAbstractClass>();
+
+				async Task Act()
+				{
+					await That(subject).HaveVersion(version => version.Major < 0);
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that in assembly containing type PublicAbstractClass
+					             all have version matching version => version.Major < 0,
+					             but it contained assemblies with a non-matching version *
+					             """).AsWildcard();
+			}
+		}
+
+		public sealed class NegatedTests
+		{
+			[Fact]
+			public async Task WhenAllVersionsMatch_ShouldFail()
+			{
+				Filtered.Assemblies subject = In.AssemblyContaining<PublicAbstractClass>();
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(they => they.HaveVersion(version => version.Major >= 0));
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that in assembly containing type PublicAbstractClass
+					             not all have version matching version => version.Major >= 0,
+					             but it only contained assemblies with a matching version *
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenVersionDoesNotMatch_ShouldSucceed()
+			{
+				Filtered.Assemblies subject = In.AssemblyContaining<PublicAbstractClass>();
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(they => they.HaveVersion(version => version.Major < 0));
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+		public sealed class ComponentTests
+		{
+			[Fact]
+			public async Task ShouldSupportAllComponents()
+			{
+				Filtered.Assemblies subject = In.AssemblyContaining<PublicAbstractClass>();
+
+				async Task Act()
+				{
+					await That(subject).HaveVersion()
+						.WithMajor.GreaterThanOrEqualTo(0)
+						.WithMinor.GreaterThanOrEqualTo(0)
+						.WithBuild.GreaterThanOrEqualTo(0)
+						.WithRevision.GreaterThanOrEqualTo(0);
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenAllComparisonsAreSatisfied_ShouldSucceed()
+			{
+				Filtered.Assemblies subject = In.AssemblyContaining<PublicAbstractClass>();
+
+				async Task Act()
+				{
+					await That(subject).HaveVersion()
+						.WithMajor.GreaterThan(0)
+						.WithMajor.GreaterThanOrEqualTo(1)
+						.WithMajor.LessThan(2)
+						.WithMajor.LessThanOrEqualTo(1)
+						.WithMajor.EqualTo(1)
+						.WithMajor.NotEqualTo(0);
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenAllComponentsMatch_ShouldSucceed()
+			{
+				Filtered.Assemblies subject = In.AssemblyContaining<PublicAbstractClass>();
+
+				async Task Act()
+				{
+					await That(subject).HaveVersion().WithMajor.GreaterThanOrEqualTo(0);
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
+			[InlineData("GreaterThan", 1)]
+			[InlineData("GreaterThanOrEqualTo", 2)]
+			[InlineData("LessThan", 1)]
+			[InlineData("LessThanOrEqualTo", 0)]
+			[InlineData("EqualTo", 2)]
+			[InlineData("NotEqualTo", 1)]
+			public async Task WhenComparisonIsNotSatisfied_ShouldFail(string comparison, int expected)
+			{
+				Filtered.Assemblies subject = In.AssemblyContaining<PublicAbstractClass>();
+
+				async Task Act()
+				{
+					await (comparison switch
+					{
+						"GreaterThan" => That(subject).HaveVersion().WithMajor.GreaterThan(expected),
+						"GreaterThanOrEqualTo" => That(subject).HaveVersion().WithMajor.GreaterThanOrEqualTo(expected),
+						"LessThan" => That(subject).HaveVersion().WithMajor.LessThan(expected),
+						"LessThanOrEqualTo" => That(subject).HaveVersion().WithMajor.LessThanOrEqualTo(expected),
+						"EqualTo" => That(subject).HaveVersion().WithMajor.EqualTo(expected),
+						_ => That(subject).HaveVersion().WithMajor.NotEqualTo(expected),
+					});
+				}
+
+				await That(Act).Throws<XunitException>();
+			}
+
+			[Fact]
+			public async Task WhenComponentDoesNotMatch_ShouldFail()
+			{
+				Filtered.Assemblies subject = In.AssemblyContaining<PublicAbstractClass>();
+
+				async Task Act()
+				{
+					await That(subject).HaveVersion().WithMajor.LessThan(0);
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that in assembly containing type PublicAbstractClass
+					             all have major version less than 0,
+					             but it contained assemblies with a non-matching version *
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenMultipleComponentsAreCombined_ShouldCombineExpectations()
+			{
+				Filtered.Assemblies subject = In.AssemblyContaining<PublicAbstractClass>();
+
+				async Task Act()
+				{
+					await That(subject).HaveVersion().WithMajor.GreaterThan(0).WithMinor.GreaterThan(0);
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage(
+						"*all have major version greater than 0 and minor version greater than 0*non-matching version*")
+					.AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenNegatedAndAllComponentsMatch_ShouldFail()
+			{
+				Filtered.Assemblies subject = In.AssemblyContaining<PublicAbstractClass>();
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(they => they.HaveVersion().WithMajor.GreaterThanOrEqualTo(0));
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that in assembly containing type PublicAbstractClass
+					             not all have major version greater than or equal to 0,
+					             but it only contained assemblies with a matching version *
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenNegatedAndAllVersionsExist_ShouldFail()
+			{
+				Filtered.Assemblies subject = In.AssemblyContaining<PublicAbstractClass>();
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(they => they.HaveVersion());
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("*not all have a version*").AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenNegatedAndComponentDoesNotMatch_ShouldSucceed()
+			{
+				Filtered.Assemblies subject = In.AssemblyContaining<PublicAbstractClass>();
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(they => they.HaveVersion().WithMajor.LessThan(0));
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WithoutComponent_ShouldVerifyThatAllVersionsExist()
+			{
+				Filtered.Assemblies subject = In.AssemblyContaining<PublicAbstractClass>();
+
+				async Task Act()
+				{
+					await That(subject).HaveVersion();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatAssembly.HasVersion.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatAssembly.HasVersion.Tests.cs
@@ -49,13 +49,15 @@ public sealed partial class ThatAssembly
 			{
 				Assembly assembly = typeof(PublicAbstractClass).Assembly;
 
+				Version version = assembly.GetName().Version!;
+
 				async Task Act()
 				{
 					await That(assembly).HasVersion()
-						.WithMajor.GreaterThanOrEqualTo(0)
-						.WithMinor.GreaterThanOrEqualTo(0)
-						.WithBuild.GreaterThanOrEqualTo(0)
-						.WithRevision.GreaterThanOrEqualTo(0);
+						.WithMajor.EqualTo(version.Major)
+						.WithMinor.EqualTo(version.Minor)
+						.WithBuild.EqualTo(version.Build)
+						.WithRevision.EqualTo(version.Revision);
 				}
 
 				await That(Act).DoesNotThrow();
@@ -65,32 +67,35 @@ public sealed partial class ThatAssembly
 			public async Task WhenAllComparisonsAreSatisfied_ShouldSucceed()
 			{
 				Assembly assembly = typeof(PublicAbstractClass).Assembly;
+				int major = assembly.GetName().Version!.Major;
 
 				async Task Act()
 				{
 					await That(assembly).HasVersion()
-						.WithMajor.GreaterThan(0)
-						.WithMajor.GreaterThanOrEqualTo(1)
-						.WithMajor.LessThan(2)
-						.WithMajor.LessThanOrEqualTo(1)
-						.WithMajor.EqualTo(1)
-						.WithMajor.NotEqualTo(0);
+						.WithMajor.GreaterThan(major - 1)
+						.WithMajor.GreaterThanOrEqualTo(major)
+						.WithMajor.LessThan(major + 1)
+						.WithMajor.LessThanOrEqualTo(major)
+						.WithMajor.EqualTo(major)
+						.WithMajor.NotEqualTo(major + 1);
 				}
 
 				await That(Act).DoesNotThrow();
 			}
 
 			[Theory]
-			[InlineData("GreaterThan", 5, "greater than 5")]
-			[InlineData("GreaterThanOrEqualTo", 5, "greater than or equal to 5")]
-			[InlineData("LessThan", 0, "less than 0")]
-			[InlineData("LessThanOrEqualTo", 0, "less than or equal to 0")]
-			[InlineData("EqualTo", 5, "equal to 5")]
-			[InlineData("NotEqualTo", 1, "not equal to 1")]
+			[InlineData("GreaterThan", 0, "greater than")]
+			[InlineData("GreaterThanOrEqualTo", 1, "greater than or equal to")]
+			[InlineData("LessThan", 0, "less than")]
+			[InlineData("LessThanOrEqualTo", -1, "less than or equal to")]
+			[InlineData("EqualTo", 1, "equal to")]
+			[InlineData("NotEqualTo", 0, "not equal to")]
 			public async Task WhenComparisonFails_MessageShouldDescribeComparison(
-				string comparison, int expected, string expectedText)
+				string comparison, int offset, string wording)
 			{
 				Assembly assembly = typeof(PublicAbstractClass).Assembly;
+				int major = assembly.GetName().Version!.Major;
+				int expected = major + offset;
 
 				async Task Act()
 				{
@@ -106,22 +111,24 @@ public sealed partial class ThatAssembly
 				}
 
 				await That(Act).Throws<XunitException>()
-					.WithMessage($"*has major version {expectedText}*but it had major version 1*").AsWildcard();
+					.WithMessage($"*has major version {wording} {expected}*but it had major version {major}*")
+					.AsWildcard();
 			}
 
 			[Theory]
-			[InlineData("GreaterThan", 1)]
-			[InlineData("GreaterThanOrEqualTo", 2)]
-			[InlineData("LessThan", 1)]
-			[InlineData("LessThanOrEqualTo", 0)]
-			[InlineData("EqualTo", 2)]
-			[InlineData("NotEqualTo", 1)]
-			public async Task WhenComparisonIsNotSatisfied_ShouldFail(string comparison, int expected)
+			[InlineData("GreaterThan", 0)]
+			[InlineData("GreaterThanOrEqualTo", 1)]
+			[InlineData("LessThan", 0)]
+			[InlineData("LessThanOrEqualTo", -1)]
+			[InlineData("EqualTo", 1)]
+			[InlineData("NotEqualTo", 0)]
+			public async Task WhenComparisonIsNotSatisfied_ShouldFail(string comparison, int offset)
 			{
 				Assembly assembly = typeof(PublicAbstractClass).Assembly;
 
 				async Task Act()
 				{
+					int expected = assembly.GetName().Version!.Major + offset;
 					await (comparison switch
 					{
 						"GreaterThan" => That(assembly).HasVersion().WithMajor.GreaterThan(expected),
@@ -137,18 +144,19 @@ public sealed partial class ThatAssembly
 			}
 
 			[Theory]
-			[InlineData("GreaterThan", 0)]
-			[InlineData("GreaterThanOrEqualTo", 1)]
-			[InlineData("LessThan", 2)]
-			[InlineData("LessThanOrEqualTo", 1)]
-			[InlineData("EqualTo", 1)]
-			[InlineData("NotEqualTo", 0)]
-			public async Task WhenComparisonIsSatisfied_ShouldSucceed(string comparison, int expected)
+			[InlineData("GreaterThan", -1)]
+			[InlineData("GreaterThanOrEqualTo", 0)]
+			[InlineData("LessThan", 1)]
+			[InlineData("LessThanOrEqualTo", 0)]
+			[InlineData("EqualTo", 0)]
+			[InlineData("NotEqualTo", 1)]
+			public async Task WhenComparisonIsSatisfied_ShouldSucceed(string comparison, int offset)
 			{
 				Assembly assembly = typeof(PublicAbstractClass).Assembly;
 
 				async Task Act()
 				{
+					int expected = assembly.GetName().Version!.Major + offset;
 					await (comparison switch
 					{
 						"GreaterThan" => That(assembly).HasVersion().WithMajor.GreaterThan(expected),
@@ -164,28 +172,36 @@ public sealed partial class ThatAssembly
 			}
 
 			[Theory]
-			[InlineData("major", "major version", "1")]
-			[InlineData("minor", "minor version", "0")]
-			[InlineData("build", "build version", "0")]
-			[InlineData("revision", "revision version", "0")]
-			public async Task WhenComponentDoesNotMatch_MessageShouldNameComponent(
-				string name, string text, string actual)
+			[InlineData("major")]
+			[InlineData("minor")]
+			[InlineData("build")]
+			[InlineData("revision")]
+			public async Task WhenComponentDoesNotMatch_MessageShouldNameComponent(string name)
 			{
 				Assembly assembly = typeof(PublicAbstractClass).Assembly;
+				Version version = assembly.GetName().Version!;
+				int actual = name switch
+				{
+					"major" => version.Major,
+					"minor" => version.Minor,
+					"build" => version.Build,
+					_ => version.Revision,
+				};
 
 				async Task Act()
 				{
 					await (name switch
 					{
-						"major" => That(assembly).HasVersion().WithMajor.EqualTo(99),
-						"minor" => That(assembly).HasVersion().WithMinor.EqualTo(99),
-						"build" => That(assembly).HasVersion().WithBuild.EqualTo(99),
-						_ => That(assembly).HasVersion().WithRevision.EqualTo(99),
+						"major" => That(assembly).HasVersion().WithMajor.GreaterThan(actual),
+						"minor" => That(assembly).HasVersion().WithMinor.GreaterThan(actual),
+						"build" => That(assembly).HasVersion().WithBuild.GreaterThan(actual),
+						_ => That(assembly).HasVersion().WithRevision.GreaterThan(actual),
 					});
 				}
 
 				await That(Act).Throws<XunitException>()
-					.WithMessage($"*has {text} equal to 99*but it had {text} {actual}*").AsWildcard();
+					.WithMessage($"*has {name} version greater than {actual}*but it had {name} version {actual}*")
+					.AsWildcard();
 			}
 
 			[Fact]
@@ -223,15 +239,18 @@ public sealed partial class ThatAssembly
 			public async Task WhenMultipleComponentsAreCombined_ShouldReportFailingComponent()
 			{
 				Assembly assembly = typeof(PublicAbstractClass).Assembly;
+				Version version = assembly.GetName().Version!;
 
 				async Task Act()
 				{
-					await That(assembly).HasVersion().WithMajor.GreaterThan(0).WithMinor.GreaterThan(0);
+					await That(assembly).HasVersion()
+						.WithMajor.EqualTo(version.Major)
+						.WithMinor.GreaterThan(version.Minor);
 				}
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage(
-						"*has major version greater than 0 and minor version greater than 0*but it had minor version 0*")
+						$"*has major version equal to {version.Major} and minor version greater than {version.Minor}*but it had minor version {version.Minor}*")
 					.AsWildcard();
 			}
 
@@ -258,7 +277,7 @@ public sealed partial class ThatAssembly
 
 				async Task Act()
 				{
-					await That(assembly).DoesNotComplyWith(it => it.HasVersion().WithMajor.GreaterThan(1));
+					await That(assembly).DoesNotComplyWith(it => it.HasVersion().WithMajor.LessThan(0));
 				}
 
 				await That(Act).DoesNotThrow();
@@ -271,11 +290,11 @@ public sealed partial class ThatAssembly
 
 				async Task Act()
 				{
-					await That(assembly).DoesNotComplyWith(it => it.HasVersion().WithMajor.GreaterThan(0));
+					await That(assembly).DoesNotComplyWith(it => it.HasVersion().WithMajor.GreaterThanOrEqualTo(0));
 				}
 
 				await That(Act).Throws<XunitException>()
-					.WithMessage("*does not have major version greater than 0*").AsWildcard();
+					.WithMessage("*does not have major version greater than or equal to 0*").AsWildcard();
 			}
 
 			[Fact]

--- a/Tests/aweXpect.Reflection.Tests/ThatAssembly.HasVersion.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatAssembly.HasVersion.Tests.cs
@@ -1,0 +1,296 @@
+﻿using System.Reflection;
+using aweXpect.Reflection.Tests.TestHelpers.Types;
+using Xunit.Sdk;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatAssembly
+{
+	public sealed class HasVersion
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenVersionDoesNotMatch_ShouldFail()
+			{
+				Assembly assembly = typeof(PublicAbstractClass).Assembly;
+
+				async Task Act()
+				{
+					await That(assembly).HasVersion(version => version.Major < 0);
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that assembly
+					             has version matching version => version.Major < 0,
+					             but it had version *
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenVersionMatches_ShouldSucceed()
+			{
+				Assembly assembly = typeof(PublicAbstractClass).Assembly;
+
+				async Task Act()
+				{
+					await That(assembly).HasVersion(version => version.Major >= 0);
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+		public sealed class ComponentTests
+		{
+			[Fact]
+			public async Task ShouldSupportAllComponents()
+			{
+				Assembly assembly = typeof(PublicAbstractClass).Assembly;
+
+				async Task Act()
+				{
+					await That(assembly).HasVersion()
+						.WithMajor.GreaterThanOrEqualTo(0)
+						.WithMinor.GreaterThanOrEqualTo(0)
+						.WithBuild.GreaterThanOrEqualTo(0)
+						.WithRevision.GreaterThanOrEqualTo(0);
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenAllComparisonsAreSatisfied_ShouldSucceed()
+			{
+				Assembly assembly = typeof(PublicAbstractClass).Assembly;
+
+				async Task Act()
+				{
+					await That(assembly).HasVersion()
+						.WithMajor.GreaterThan(0)
+						.WithMajor.GreaterThanOrEqualTo(1)
+						.WithMajor.LessThan(2)
+						.WithMajor.LessThanOrEqualTo(1)
+						.WithMajor.EqualTo(1)
+						.WithMajor.NotEqualTo(0);
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
+			[InlineData("GreaterThan", 5, "greater than 5")]
+			[InlineData("GreaterThanOrEqualTo", 5, "greater than or equal to 5")]
+			[InlineData("LessThan", 0, "less than 0")]
+			[InlineData("LessThanOrEqualTo", 0, "less than or equal to 0")]
+			[InlineData("EqualTo", 5, "equal to 5")]
+			[InlineData("NotEqualTo", 1, "not equal to 1")]
+			public async Task WhenComparisonFails_MessageShouldDescribeComparison(
+				string comparison, int expected, string expectedText)
+			{
+				Assembly assembly = typeof(PublicAbstractClass).Assembly;
+
+				async Task Act()
+				{
+					await (comparison switch
+					{
+						"GreaterThan" => That(assembly).HasVersion().WithMajor.GreaterThan(expected),
+						"GreaterThanOrEqualTo" => That(assembly).HasVersion().WithMajor.GreaterThanOrEqualTo(expected),
+						"LessThan" => That(assembly).HasVersion().WithMajor.LessThan(expected),
+						"LessThanOrEqualTo" => That(assembly).HasVersion().WithMajor.LessThanOrEqualTo(expected),
+						"EqualTo" => That(assembly).HasVersion().WithMajor.EqualTo(expected),
+						_ => That(assembly).HasVersion().WithMajor.NotEqualTo(expected),
+					});
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"*has major version {expectedText}*but it had major version 1*").AsWildcard();
+			}
+
+			[Theory]
+			[InlineData("GreaterThan", 1)]
+			[InlineData("GreaterThanOrEqualTo", 2)]
+			[InlineData("LessThan", 1)]
+			[InlineData("LessThanOrEqualTo", 0)]
+			[InlineData("EqualTo", 2)]
+			[InlineData("NotEqualTo", 1)]
+			public async Task WhenComparisonIsNotSatisfied_ShouldFail(string comparison, int expected)
+			{
+				Assembly assembly = typeof(PublicAbstractClass).Assembly;
+
+				async Task Act()
+				{
+					await (comparison switch
+					{
+						"GreaterThan" => That(assembly).HasVersion().WithMajor.GreaterThan(expected),
+						"GreaterThanOrEqualTo" => That(assembly).HasVersion().WithMajor.GreaterThanOrEqualTo(expected),
+						"LessThan" => That(assembly).HasVersion().WithMajor.LessThan(expected),
+						"LessThanOrEqualTo" => That(assembly).HasVersion().WithMajor.LessThanOrEqualTo(expected),
+						"EqualTo" => That(assembly).HasVersion().WithMajor.EqualTo(expected),
+						_ => That(assembly).HasVersion().WithMajor.NotEqualTo(expected),
+					});
+				}
+
+				await That(Act).Throws<XunitException>();
+			}
+
+			[Theory]
+			[InlineData("GreaterThan", 0)]
+			[InlineData("GreaterThanOrEqualTo", 1)]
+			[InlineData("LessThan", 2)]
+			[InlineData("LessThanOrEqualTo", 1)]
+			[InlineData("EqualTo", 1)]
+			[InlineData("NotEqualTo", 0)]
+			public async Task WhenComparisonIsSatisfied_ShouldSucceed(string comparison, int expected)
+			{
+				Assembly assembly = typeof(PublicAbstractClass).Assembly;
+
+				async Task Act()
+				{
+					await (comparison switch
+					{
+						"GreaterThan" => That(assembly).HasVersion().WithMajor.GreaterThan(expected),
+						"GreaterThanOrEqualTo" => That(assembly).HasVersion().WithMajor.GreaterThanOrEqualTo(expected),
+						"LessThan" => That(assembly).HasVersion().WithMajor.LessThan(expected),
+						"LessThanOrEqualTo" => That(assembly).HasVersion().WithMajor.LessThanOrEqualTo(expected),
+						"EqualTo" => That(assembly).HasVersion().WithMajor.EqualTo(expected),
+						_ => That(assembly).HasVersion().WithMajor.NotEqualTo(expected),
+					});
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
+			[InlineData("major", "major version", "1")]
+			[InlineData("minor", "minor version", "0")]
+			[InlineData("build", "build version", "0")]
+			[InlineData("revision", "revision version", "0")]
+			public async Task WhenComponentDoesNotMatch_MessageShouldNameComponent(
+				string name, string text, string actual)
+			{
+				Assembly assembly = typeof(PublicAbstractClass).Assembly;
+
+				async Task Act()
+				{
+					await (name switch
+					{
+						"major" => That(assembly).HasVersion().WithMajor.EqualTo(99),
+						"minor" => That(assembly).HasVersion().WithMinor.EqualTo(99),
+						"build" => That(assembly).HasVersion().WithBuild.EqualTo(99),
+						_ => That(assembly).HasVersion().WithRevision.EqualTo(99),
+					});
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"*has {text} equal to 99*but it had {text} {actual}*").AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenComponentDoesNotMatch_ShouldFail()
+			{
+				Assembly assembly = typeof(PublicAbstractClass).Assembly;
+
+				async Task Act()
+				{
+					await That(assembly).HasVersion().WithMajor.LessThan(0);
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that assembly
+					             has major version less than 0,
+					             but it had major version *
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenComponentMatches_ShouldSucceed()
+			{
+				Assembly assembly = typeof(PublicAbstractClass).Assembly;
+
+				async Task Act()
+				{
+					await That(assembly).HasVersion().WithMajor.GreaterThanOrEqualTo(0);
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenMultipleComponentsAreCombined_ShouldReportFailingComponent()
+			{
+				Assembly assembly = typeof(PublicAbstractClass).Assembly;
+
+				async Task Act()
+				{
+					await That(assembly).HasVersion().WithMajor.GreaterThan(0).WithMinor.GreaterThan(0);
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage(
+						"*has major version greater than 0 and minor version greater than 0*but it had minor version 0*")
+					.AsWildcard();
+			}
+
+			[Fact]
+			public async Task WithoutComponent_ShouldVerifyThatVersionExists()
+			{
+				Assembly assembly = typeof(PublicAbstractClass).Assembly;
+
+				async Task Act()
+				{
+					await That(assembly).HasVersion();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+		public sealed class NegatedComponentTests
+		{
+			[Fact]
+			public async Task WhenComponentDoesNotMatch_ShouldSucceed()
+			{
+				Assembly assembly = typeof(PublicAbstractClass).Assembly;
+
+				async Task Act()
+				{
+					await That(assembly).DoesNotComplyWith(it => it.HasVersion().WithMajor.GreaterThan(1));
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenComponentMatches_ShouldFail()
+			{
+				Assembly assembly = typeof(PublicAbstractClass).Assembly;
+
+				async Task Act()
+				{
+					await That(assembly).DoesNotComplyWith(it => it.HasVersion().WithMajor.GreaterThan(0));
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("*does not have major version greater than 0*").AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenVersionExists_ShouldFail()
+			{
+				Assembly assembly = typeof(PublicAbstractClass).Assembly;
+
+				async Task Act()
+				{
+					await That(assembly).DoesNotComplyWith(it => it.HasVersion());
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("*does not have a version*").AsWildcard();
+			}
+		}
+	}
+}


### PR DESCRIPTION
Add `HasVersion()`/`HaveVersion()` assertions and a `WithVersion()` filter for assemblies, exposing the individual `Major`/`Minor`/`Build`/`Revision` components of `AssemblyName.Version`.

- `That(assembly).HasVersion()` and `That(assemblies).HaveVersion()` return a result that is awaitable on its own (verifying the version is not null) and re-exposes `WithMajor`/`WithMinor`/`WithBuild`/`WithRevision`, each allowing the numeric comparisons `GreaterThan`/`GreaterThanOrEqualTo`/`LessThan`/ `LessThanOrEqualTo`/`EqualTo`/`NotEqualTo`.
- Components chain directly (e.g. `.WithMajor.GreaterThan(0).WithMinor...`); the accumulated comparisons are evaluated by a single constraint that reads the version once.
- Filters get matching richness: `WithVersion(Func<Version,bool>)` and `WithVersion().WithMajor.GreaterThan(0)`.
- Keeps the `Func<Version,bool>` predicate overloads for assertions and filters.