### PR TITLE
chore: update aweXpect.Core version to 2.32.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="aweXpect" Version="2.34.0" />
-    <PackageVersion Include="aweXpect.Core" Version="2.31.1" />
+    <PackageVersion Include="aweXpect.Core" Version="2.32.0" />
   </ItemGroup>
   <ItemGroup>
     <PackageVersion Include="Nullable" Version="1.3.1" />

--- a/Tests/aweXpect.Reflection.Tests/Filters/AssemblyFilters.WhichHaveDependenciesOnlyOn.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/AssemblyFilters.WhichHaveDependenciesOnlyOn.Tests.cs
@@ -8,16 +8,6 @@ public sealed partial class AssemblyFilters
 {
 	public sealed class WhichHaveDependenciesOnlyOn
 	{
-		/// <summary>
-		///     Excludes the framework facade assemblies that differ between target frameworks (e.g. <c>netstandard</c> on
-		///     <c>net48</c>), so that the tests only have to whitelist the actual non-framework dependencies.
-		/// </summary>
-		private static CustomizationLifetime ExcludeFrameworkAssemblies()
-			=> Customize.aweXpect.Reflection().ExcludedAssemblyPrefixes
-				.Set([
-					.. Customize.aweXpect.Reflection().ExcludedAssemblyPrefixes.Get(), "netstandard", "WindowsBase",
-				]);
-
 		public sealed class Tests
 		{
 			[Fact]
@@ -45,8 +35,6 @@ public sealed partial class AssemblyFilters
 			[Fact]
 			public async Task ShouldFilterForAssembliesDependingOnlyOnAllowed()
 			{
-				using CustomizationLifetime _ = ExcludeFrameworkAssemblies();
-
 				Filtered.Assemblies assemblies = In.Assemblies(typeof(In).Assembly)
 					.WhichHaveDependenciesOnlyOn("aweXpect.Core");
 
@@ -56,8 +44,6 @@ public sealed partial class AssemblyFilters
 			[Fact]
 			public async Task ShouldSupportAsWildcard()
 			{
-				using CustomizationLifetime _ = ExcludeFrameworkAssemblies();
-
 				Filtered.Assemblies assemblies = In.Assemblies(typeof(In).Assembly)
 					.WhichHaveDependenciesOnlyOn("aweXpect.*").AsWildcard();
 
@@ -67,8 +53,6 @@ public sealed partial class AssemblyFilters
 			[Fact]
 			public async Task ShouldSupportIgnoringCase()
 			{
-				using CustomizationLifetime _ = ExcludeFrameworkAssemblies();
-
 				Filtered.Assemblies assemblies = In.Assemblies(typeof(In).Assembly)
 					.WhichHaveDependenciesOnlyOn("awexpect.core").IgnoringCase();
 

--- a/Tests/aweXpect.Reflection.Tests/InTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/InTests.cs
@@ -13,7 +13,7 @@ public sealed class InTests
 	{
 		Filtered.Assemblies sut = In.AllLoadedAssemblies();
 
-		await That(sut).HasCount().AtLeast(5);
+		await That(sut).HasCount().AtLeast(4);
 		await That(sut).All().Satisfy(x => !x.FullName!.StartsWith("System."));
 		await That(sut.GetDescription()).IsEqualTo("in all loaded assemblies");
 	}

--- a/Tests/aweXpect.Reflection.Tests/ThatAssemblies.HaveDependenciesOnlyOn.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatAssemblies.HaveDependenciesOnlyOn.Tests.cs
@@ -9,23 +9,11 @@ public sealed partial class ThatAssemblies
 {
 	public sealed class HaveDependenciesOnlyOn
 	{
-		/// <summary>
-		///     Excludes the framework facade assemblies that differ between target frameworks (e.g. <c>netstandard</c> on
-		///     <c>net48</c>), so that the tests only have to whitelist the actual non-framework dependencies.
-		/// </summary>
-		private static CustomizationLifetime ExcludeFrameworkAssemblies()
-			=> Customize.aweXpect.Reflection().ExcludedAssemblyPrefixes
-				.Set([
-					.. Customize.aweXpect.Reflection().ExcludedAssemblyPrefixes.Get(), "netstandard", "WindowsBase",
-				]);
-
 		public sealed class Tests
 		{
 			[Fact]
 			public async Task WhenAllAssembliesDependOnlyOnAllowed_ShouldSucceed()
 			{
-				using CustomizationLifetime _ = ExcludeFrameworkAssemblies();
-
 				Filtered.Assemblies subject = In.Assemblies(typeof(In).Assembly);
 
 				async Task Act()
@@ -39,8 +27,6 @@ public sealed partial class ThatAssemblies
 			[Fact]
 			public async Task WhenAllowedMatchesAsWildcard_ShouldSucceed()
 			{
-				using CustomizationLifetime _ = ExcludeFrameworkAssemblies();
-
 				Filtered.Assemblies subject = In.Assemblies(typeof(In).Assembly);
 
 				async Task Act()
@@ -54,8 +40,6 @@ public sealed partial class ThatAssemblies
 			[Fact]
 			public async Task WhenAnAssemblyDependsOnDisallowedAssembly_ShouldFail()
 			{
-				using CustomizationLifetime _ = ExcludeFrameworkAssemblies();
-
 				Filtered.Assemblies subject = In.AssemblyContaining<PublicAbstractClass>();
 
 				async Task Act()
@@ -79,8 +63,6 @@ public sealed partial class ThatAssemblies
 			[Fact]
 			public async Task WhenAllAssembliesDependOnlyOnAllowed_ShouldFail()
 			{
-				using CustomizationLifetime _ = ExcludeFrameworkAssemblies();
-
 				Filtered.Assemblies subject = In.Assemblies(typeof(In).Assembly);
 
 				async Task Act()

--- a/Tests/aweXpect.Reflection.Tests/ThatAssembly.HasDependenciesOnlyOn.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatAssembly.HasDependenciesOnlyOn.Tests.cs
@@ -9,23 +9,11 @@ public sealed partial class ThatAssembly
 {
 	public sealed class HasDependenciesOnlyOn
 	{
-		/// <summary>
-		///     Excludes the framework facade assemblies that differ between target frameworks (e.g. <c>netstandard</c> on
-		///     <c>net48</c>), so that the tests only have to whitelist the actual non-framework dependencies.
-		/// </summary>
-		private static CustomizationLifetime ExcludeFrameworkAssemblies()
-			=> Customize.aweXpect.Reflection().ExcludedAssemblyPrefixes
-				.Set([
-					.. Customize.aweXpect.Reflection().ExcludedAssemblyPrefixes.Get(), "netstandard", "WindowsBase",
-				]);
-
 		public sealed class Tests
 		{
 			[Fact]
 			public async Task WhenAllowedMatchesAsWildcard_ShouldSucceed()
 			{
-				using CustomizationLifetime _ = ExcludeFrameworkAssemblies();
-
 				Assembly subject = typeof(In).Assembly;
 
 				async Task Act()
@@ -39,8 +27,6 @@ public sealed partial class ThatAssembly
 			[Fact]
 			public async Task WhenAllowedMatchesIgnoringCase_ShouldSucceed()
 			{
-				using CustomizationLifetime _ = ExcludeFrameworkAssemblies();
-
 				Assembly subject = typeof(In).Assembly;
 
 				async Task Act()
@@ -72,8 +58,6 @@ public sealed partial class ThatAssembly
 			[Fact]
 			public async Task WhenAssemblyDependsOnlyOnAllowed_ShouldSucceed()
 			{
-				using CustomizationLifetime _ = ExcludeFrameworkAssemblies();
-
 				Assembly subject = typeof(In).Assembly;
 
 				async Task Act()
@@ -121,8 +105,6 @@ public sealed partial class ThatAssembly
 			[Fact]
 			public async Task WhenAssemblyDependsOnlyOnAllowed_ShouldFail()
 			{
-				using CustomizationLifetime _ = ExcludeFrameworkAssemblies();
-
 				Assembly subject = typeof(In).Assembly;
 
 				async Task Act()


### PR DESCRIPTION
And remove test workaround ("WindowsBase" and "netstandard" are now excluded per default)