### PR TITLE
docs: document Version.Build/Revision -1 behavior and cover negated component result

### DIFF
--- a/Source/aweXpect.Reflection/Filters/AssemblyFilters.WithVersion.cs
+++ b/Source/aweXpect.Reflection/Filters/AssemblyFilters.WithVersion.cs
@@ -51,11 +51,13 @@ public static partial class AssemblyFilters
 		/// <summary>
 		///     Compares the <see cref="Version.Build" /> version component.
 		/// </summary>
+		/// <remarks>The build component is <c>-1</c> when it is absent from the version.</remarks>
 		public VersionComponent WithBuild => new(this, filter, "build", version => version.Build);
 
 		/// <summary>
 		///     Compares the <see cref="Version.Revision" /> version component.
 		/// </summary>
+		/// <remarks>The revision component is <c>-1</c> when it is absent from the version.</remarks>
 		public VersionComponent WithRevision => new(this, filter, "revision", version => version.Revision);
 	}
 

--- a/Source/aweXpect.Reflection/ThatAssemblies.HaveVersion.cs
+++ b/Source/aweXpect.Reflection/ThatAssemblies.HaveVersion.cs
@@ -101,11 +101,13 @@ public static partial class ThatAssemblies
 		/// <summary>
 		///     Compares the <see cref="Version.Build" /> version component.
 		/// </summary>
+		/// <remarks>The build component is <c>-1</c> when it is absent from the version.</remarks>
 		public VersionComponentResult<TCollection> WithBuild => new(this, "build version", version => version.Build);
 
 		/// <summary>
 		///     Compares the <see cref="Version.Revision" /> version component.
 		/// </summary>
+		/// <remarks>The revision component is <c>-1</c> when it is absent from the version.</remarks>
 		public VersionComponentResult<TCollection> WithRevision
 			=> new(this, "revision version", version => version.Revision);
 

--- a/Source/aweXpect.Reflection/ThatAssembly.HasVersion.cs
+++ b/Source/aweXpect.Reflection/ThatAssembly.HasVersion.cs
@@ -63,11 +63,13 @@ public static partial class ThatAssembly
 		/// <summary>
 		///     Compares the <see cref="Version.Build" /> version component.
 		/// </summary>
+		/// <remarks>The build component is <c>-1</c> when it is absent from the version.</remarks>
 		public VersionComponent WithBuild => new(this, "build version", version => version.Build);
 
 		/// <summary>
 		///     Compares the <see cref="Version.Revision" /> version component.
 		/// </summary>
+		/// <remarks>The revision component is <c>-1</c> when it is absent from the version.</remarks>
 		public VersionComponent WithRevision => new(this, "revision version", version => version.Revision);
 
 		internal HasVersionResult Add(string component, string comparisonText, Func<Version, int> selector,

--- a/Tests/aweXpect.Reflection.Tests/ThatAssembly.HasVersion.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatAssembly.HasVersion.Tests.cs
@@ -284,6 +284,25 @@ public sealed partial class ThatAssembly
 			}
 
 			[Fact]
+			public async Task WhenComponentMatches_MessageShouldIncludeResult()
+			{
+				Assembly assembly = typeof(PublicAbstractClass).Assembly;
+				Version version = typeof(PublicAbstractClass).Assembly.GetName().Version!;
+
+				async Task Act()
+				{
+					await That(assembly).DoesNotComplyWith(it => it.HasVersion().WithMajor.GreaterThanOrEqualTo(0));
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					             Expected that assembly
+					             does not have major version greater than or equal to 0,
+					             but it had version {version}
+					             """);
+			}
+
+			[Fact]
 			public async Task WhenComponentMatches_ShouldFail()
 			{
 				Assembly assembly = typeof(PublicAbstractClass).Assembly;

--- a/Tests/aweXpect.Reflection.Tests/ThatAssembly.HasVersion.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatAssembly.HasVersion.Tests.cs
@@ -14,6 +14,7 @@ public sealed partial class ThatAssembly
 			public async Task WhenVersionDoesNotMatch_ShouldFail()
 			{
 				Assembly assembly = typeof(PublicAbstractClass).Assembly;
+				Version actualVersion = assembly.GetName().Version!;
 
 				async Task Act()
 				{
@@ -21,11 +22,11 @@ public sealed partial class ThatAssembly
 				}
 
 				await That(Act).Throws<XunitException>()
-					.WithMessage("""
+					.WithMessage($"""
 					             Expected that assembly
 					             has version matching version => version.Major < 0,
-					             but it had version *
-					             """).AsWildcard();
+					             but it had version {actualVersion}
+					             """);
 			}
 
 			[Fact]
@@ -111,8 +112,11 @@ public sealed partial class ThatAssembly
 				}
 
 				await That(Act).Throws<XunitException>()
-					.WithMessage($"*has major version {wording} {expected}*but it had major version {major}*")
-					.AsWildcard();
+					.WithMessage($"""
+					             Expected that assembly
+					             has major version {wording} {expected},
+					             but it had major version {major}
+					             """);
 			}
 
 			[Theory]
@@ -200,14 +204,18 @@ public sealed partial class ThatAssembly
 				}
 
 				await That(Act).Throws<XunitException>()
-					.WithMessage($"*has {name} version greater than {actual}*but it had {name} version {actual}*")
-					.AsWildcard();
+					.WithMessage($"""
+					             Expected that assembly
+					             has {name} version greater than {actual},
+					             but it had {name} version {actual}
+					             """);
 			}
 
 			[Fact]
 			public async Task WhenComponentDoesNotMatch_ShouldFail()
 			{
 				Assembly assembly = typeof(PublicAbstractClass).Assembly;
+				int major = assembly.GetName().Version!.Major;
 
 				async Task Act()
 				{
@@ -215,11 +223,11 @@ public sealed partial class ThatAssembly
 				}
 
 				await That(Act).Throws<XunitException>()
-					.WithMessage("""
+					.WithMessage($"""
 					             Expected that assembly
 					             has major version less than 0,
-					             but it had major version *
-					             """).AsWildcard();
+					             but it had major version {major}
+					             """);
 			}
 
 			[Fact]
@@ -249,9 +257,11 @@ public sealed partial class ThatAssembly
 				}
 
 				await That(Act).Throws<XunitException>()
-					.WithMessage(
-						$"*has major version equal to {version.Major} and minor version greater than {version.Minor}*but it had minor version {version.Minor}*")
-					.AsWildcard();
+					.WithMessage($"""
+					             Expected that assembly
+					             has major version equal to {version.Major} and minor version greater than {version.Minor},
+					             but it had minor version {version.Minor}
+					             """);
 			}
 
 			[Fact]
@@ -284,10 +294,10 @@ public sealed partial class ThatAssembly
 			}
 
 			[Fact]
-			public async Task WhenComponentMatches_MessageShouldIncludeResult()
+			public async Task WhenComponentMatches_ShouldFail()
 			{
 				Assembly assembly = typeof(PublicAbstractClass).Assembly;
-				Version version = typeof(PublicAbstractClass).Assembly.GetName().Version!;
+				Version version = assembly.GetName().Version!;
 
 				async Task Act()
 				{
@@ -303,23 +313,10 @@ public sealed partial class ThatAssembly
 			}
 
 			[Fact]
-			public async Task WhenComponentMatches_ShouldFail()
-			{
-				Assembly assembly = typeof(PublicAbstractClass).Assembly;
-
-				async Task Act()
-				{
-					await That(assembly).DoesNotComplyWith(it => it.HasVersion().WithMajor.GreaterThanOrEqualTo(0));
-				}
-
-				await That(Act).Throws<XunitException>()
-					.WithMessage("*does not have major version greater than or equal to 0*").AsWildcard();
-			}
-
-			[Fact]
 			public async Task WhenVersionExists_ShouldFail()
 			{
 				Assembly assembly = typeof(PublicAbstractClass).Assembly;
+				Version version = assembly.GetName().Version!;
 
 				async Task Act()
 				{
@@ -327,7 +324,11 @@ public sealed partial class ThatAssembly
 				}
 
 				await That(Act).Throws<XunitException>()
-					.WithMessage("*does not have a version*").AsWildcard();
+					.WithMessage($"""
+					             Expected that assembly
+					             does not have a version,
+					             but it had version {version}
+					             """);
 			}
 		}
 	}


### PR DESCRIPTION
Add a one-line remark to the WithBuild/WithRevision members of the assembly version APIs noting that the build/revision component is -1 when absent from the version (per System.Version semantics), and add a test asserting the full failure message of a negated component constraint (expectation + result line).