### PR TITLE
feat: add WithinNamespace filter and assertions for types

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,10 +180,11 @@ await Expect.That(methods).Have<FactAttribute>();
 
 Shared by all types and members.
 
-|                             | Filter                | Assert (single)      | Assert (many)         |
-|-----------------------------|-----------------------|----------------------|-----------------------|
-| by name                     | `.WithName("x")`      | `.HasName("x")`      | `.HaveName("x")`      |
-| by namespace *(types only)* | `.WithNamespace("x")` | `.HasNamespace("x")` | `.HaveNamespace("x")` |
+|                                 | Filter                  | Assert (single)           | Assert (many)              |
+|---------------------------------|-------------------------|---------------------------|----------------------------|
+| by name                         | `.WithName("x")`        | `.HasName("x")`           | `.HaveName("x")`           |
+| by namespace *(types only)*     | `.WithNamespace("x")`   | `.HasNamespace("x")`      | `.HaveNamespace("x")`      |
+| within namespace *(types only)* | `.WithinNamespace("x")` | `.IsWithinNamespace("x")` | `.AreWithinNamespace("x")` |
 
 All name/namespace filters and assertions accept the
 [string matching options](#string-matching-options) (`AsPrefix`, `AsSuffix`, `AsWildcard`, `AsRegex`,
@@ -193,6 +194,11 @@ All name/namespace filters and assertions accept the
 await Expect.That(types).HaveName("Service").AsSuffix();
 await Expect.That(methods).HaveName(m => "On" + m.GetParameters()[0].ParameterType.Name);
 ```
+
+The `WithinNamespace`/`IsWithinNamespace`/`AreWithinNamespace` variants match a namespace and all its
+sub-namespaces (so `Foo.Bar` includes `Foo.Bar.Baz` but not `Foo.BarBaz`). They accept the case and
+white-space options (`IgnoringCase`, …) but not the pattern options (`AsPrefix`, `AsSuffix`, `AsWildcard`,
+`AsRegex`).
 
 ### Types
 

--- a/README.md
+++ b/README.md
@@ -186,7 +186,8 @@ Shared by all types and members.
 | by namespace *(types only)*     | `.WithNamespace("x")`   | `.HasNamespace("x")`      | `.HaveNamespace("x")`      |
 | within namespace *(types only)* | `.WithinNamespace("x")` | `.IsWithinNamespace("x")` | `.AreWithinNamespace("x")` |
 
-All name/namespace filters and assertions accept the
+The name/namespace *equality* filters and assertions (`WithName`, `WithNamespace`, and their
+`Has`/`Have` counterparts) accept the
 [string matching options](#string-matching-options) (`AsPrefix`, `AsSuffix`, `AsWildcard`, `AsRegex`,
 `IgnoringCase`, …). Collection assertions also accept a selector to derive the expected name per item:
 

--- a/README.md
+++ b/README.md
@@ -196,9 +196,10 @@ await Expect.That(methods).HaveName(m => "On" + m.GetParameters()[0].ParameterTy
 ```
 
 The `WithinNamespace`/`IsWithinNamespace`/`AreWithinNamespace` variants match a namespace and all its
-sub-namespaces (so `Foo.Bar` includes `Foo.Bar.Baz` but not `Foo.BarBaz`). They accept the case and
-white-space options (`IgnoringCase`, …) but not the pattern options (`AsPrefix`, `AsSuffix`, `AsWildcard`,
-`AsRegex`).
+sub-namespaces (so `Foo.Bar` includes `Foo.Bar.Baz` but not `Foo.BarBaz`). They compare the namespace
+exactly and case-sensitively and do not support any of the string matching options. Each has a negated
+form — `NotWithinNamespace`, `IsNotWithinNamespace` and `AreNotWithinNamespace` — that matches types
+outside the namespace.
 
 ### Types
 

--- a/Source/aweXpect.Reflection/Filters/TypeFilters.WithinNamespace.cs
+++ b/Source/aweXpect.Reflection/Filters/TypeFilters.WithinNamespace.cs
@@ -1,0 +1,27 @@
+using System;
+using aweXpect.Core;
+using aweXpect.Options;
+using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Helpers;
+
+namespace aweXpect.Reflection;
+
+public static partial class TypeFilters
+{
+	/// <summary>
+	///     Filter for types within the <paramref name="expected" /> namespace (including sub-namespaces).
+	/// </summary>
+	/// <remarks>
+	///     Unlike <see cref="WithNamespace(Filtered.Types, string)" /> with <c>AsPrefix()</c>, this matches the
+	///     <paramref name="expected" /> namespace and its sub-namespaces, but not namespaces that merely start with the same
+	///     text (e.g. <c>Foo.Bar</c> does not include <c>Foo.BarBaz</c>).
+	/// </remarks>
+	public static Filtered.Types.StringEqualityResult WithinNamespace(this Filtered.Types @this, string expected)
+	{
+		StringEqualityOptions options = new();
+		return new Filtered.Types.StringEqualityResult(@this.Which(Filter.Suffix<Type>(
+				type => type.IsWithinNamespace(expected, options),
+				() => $"within namespace {Formatter.Format(expected)}{options} ")),
+			options);
+	}
+}

--- a/Source/aweXpect.Reflection/Filters/TypeFilters.WithinNamespace.cs
+++ b/Source/aweXpect.Reflection/Filters/TypeFilters.WithinNamespace.cs
@@ -1,6 +1,5 @@
-using System;
+﻿using System;
 using aweXpect.Core;
-using aweXpect.Options;
 using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Helpers;
 
@@ -14,14 +13,23 @@ public static partial class TypeFilters
 	/// <remarks>
 	///     Unlike <see cref="WithNamespace(Filtered.Types, string)" /> with <c>AsPrefix()</c>, this matches the
 	///     <paramref name="expected" /> namespace and its sub-namespaces, but not namespaces that merely start with the same
-	///     text (e.g. <c>Foo.Bar</c> does not include <c>Foo.BarBaz</c>).
+	///     text (e.g. <c>Foo.Bar</c> does not include <c>Foo.BarBaz</c>). The comparison is exact and case-sensitive.
 	/// </remarks>
-	public static Filtered.Types.StringEqualityResult WithinNamespace(this Filtered.Types @this, string expected)
-	{
-		StringEqualityOptions options = new();
-		return new Filtered.Types.StringEqualityResult(@this.Which(Filter.Suffix<Type>(
-				type => type.IsWithinNamespace(expected, options),
-				() => $"within namespace {Formatter.Format(expected)}{options} ")),
-			options);
-	}
+	public static Filtered.Types WithinNamespace(this Filtered.Types @this, string expected)
+		=> @this.Which(Filter.Suffix<Type>(
+			type => type.IsWithinNamespace(expected),
+			$"within namespace {Formatter.Format(expected)} "));
+
+	/// <summary>
+	///     Filter for types not within the <paramref name="expected" /> namespace (including sub-namespaces).
+	/// </summary>
+	/// <remarks>
+	///     This is the negation of <see cref="WithinNamespace(Filtered.Types, string)" />: it matches all types that are
+	///     neither in the <paramref name="expected" /> namespace nor in one of its sub-namespaces. The comparison is exact
+	///     and case-sensitive.
+	/// </remarks>
+	public static Filtered.Types NotWithinNamespace(this Filtered.Types @this, string expected)
+		=> @this.Which(Filter.Suffix<Type>(
+			type => !type.IsWithinNamespace(expected),
+			$"not within namespace {Formatter.Format(expected)} "));
 }

--- a/Source/aweXpect.Reflection/Helpers/TypeHelpers.cs
+++ b/Source/aweXpect.Reflection/Helpers/TypeHelpers.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;

--- a/Source/aweXpect.Reflection/Helpers/TypeHelpers.cs
+++ b/Source/aweXpect.Reflection/Helpers/TypeHelpers.cs
@@ -4,9 +4,7 @@ using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text;
-using System.Threading.Tasks;
 using aweXpect.Customization;
-using aweXpect.Options;
 using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Helpers;
@@ -441,16 +439,12 @@ internal static class TypeHelpers
 	///     Unlike a prefix match, <c>Foo.Bar</c> does not consider <c>Foo.BarBaz</c> to be within it, because the next
 	///     character after the match must be a namespace separator (<c>.</c>) or the end of the namespace.
 	/// </remarks>
-#if NET8_0_OR_GREATER
-	public static async ValueTask<bool> IsWithinNamespace(this Type? type, string expected, StringEqualityOptions options)
-#else
-	public static async Task<bool> IsWithinNamespace(this Type? type, string expected, StringEqualityOptions options)
-#endif
+	public static bool IsWithinNamespace(this Type? type, string expected)
 	{
 		string? current = type?.Namespace;
 		while (current is not null)
 		{
-			if (await options.AreConsideredEqual(current, expected))
+			if (string.Equals(current, expected, StringComparison.Ordinal))
 			{
 				return true;
 			}

--- a/Source/aweXpect.Reflection/Helpers/TypeHelpers.cs
+++ b/Source/aweXpect.Reflection/Helpers/TypeHelpers.cs
@@ -1,10 +1,12 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text;
+using System.Threading.Tasks;
 using aweXpect.Customization;
+using aweXpect.Options;
 using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Helpers;
@@ -429,6 +431,35 @@ internal static class TypeHelpers
 		}
 
 		return !forceDirect && type.InheritsFrom(parentType);
+	}
+
+	/// <summary>
+	///     Checks if the <paramref name="type" /> is within the <paramref name="expected" /> namespace, i.e. it has the
+	///     <paramref name="expected" /> namespace or one of its sub-namespaces.
+	/// </summary>
+	/// <remarks>
+	///     Unlike a prefix match, <c>Foo.Bar</c> does not consider <c>Foo.BarBaz</c> to be within it, because the next
+	///     character after the match must be a namespace separator (<c>.</c>) or the end of the namespace.
+	/// </remarks>
+#if NET8_0_OR_GREATER
+	public static async ValueTask<bool> IsWithinNamespace(this Type? type, string expected, StringEqualityOptions options)
+#else
+	public static async Task<bool> IsWithinNamespace(this Type? type, string expected, StringEqualityOptions options)
+#endif
+	{
+		string? current = type?.Namespace;
+		while (current is not null)
+		{
+			if (await options.AreConsideredEqual(current, expected))
+			{
+				return true;
+			}
+
+			int lastSeparator = current.LastIndexOf('.');
+			current = lastSeparator < 0 ? null : current.Substring(0, lastSeparator);
+		}
+
+		return false;
 	}
 
 	public static bool IsReallyClass(this Type? type)

--- a/Source/aweXpect.Reflection/ThatType.IsWithinNamespace.cs
+++ b/Source/aweXpect.Reflection/ThatType.IsWithinNamespace.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Options;
+using aweXpect.Reflection.Helpers;
+using aweXpect.Results;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Reflection;
+
+public static partial class ThatType
+{
+	/// <summary>
+	///     Verifies that the <see cref="Type" /> is within the <paramref name="expected" /> namespace
+	///     (including sub-namespaces).
+	/// </summary>
+	public static StringEqualityResult<Type?, IThat<Type?>> IsWithinNamespace(
+		this IThat<Type?> subject, string expected)
+	{
+		StringEqualityOptions options = new();
+		return new StringEqualityResult<Type?, IThat<Type?>>(subject.Get().ExpectationBuilder.AddConstraint(
+				(it, grammars)
+					=> new IsWithinNamespaceConstraint(it, grammars, expected, options)),
+			subject,
+			options);
+	}
+
+	private sealed class IsWithinNamespaceConstraint(
+		string it,
+		ExpectationGrammars grammars,
+		string expected,
+		StringEqualityOptions options)
+		: ConstraintResult.WithNotNullValue<Type?>(it, grammars),
+			IAsyncConstraint<Type?>
+	{
+		public async Task<ConstraintResult> IsMetBy(Type? actual, CancellationToken cancellationToken)
+		{
+			Actual = actual;
+			Outcome = await actual.IsWithinNamespace(expected, options) ? Outcome.Success : Outcome.Failure;
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("is within namespace ").Append(Formatter.Format(expected)).Append(options);
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append(It).Append(" was in namespace ").Append(Formatter.Format(Actual?.Namespace));
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("is not within namespace ").Append(Formatter.Format(expected)).Append(options);
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+			=> AppendNormalResult(stringBuilder, indentation);
+	}
+}

--- a/Source/aweXpect.Reflection/ThatType.IsWithinNamespace.cs
+++ b/Source/aweXpect.Reflection/ThatType.IsWithinNamespace.cs
@@ -1,14 +1,9 @@
-using System;
+﻿using System;
 using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 using aweXpect.Core;
 using aweXpect.Core.Constraints;
-using aweXpect.Options;
 using aweXpect.Reflection.Helpers;
 using aweXpect.Results;
-
-// ReSharper disable PossibleMultipleEnumeration
 
 namespace aweXpect.Reflection;
 
@@ -18,40 +13,44 @@ public static partial class ThatType
 	///     Verifies that the <see cref="Type" /> is within the <paramref name="expected" /> namespace
 	///     (including sub-namespaces).
 	/// </summary>
-	public static StringEqualityResult<Type?, IThat<Type?>> IsWithinNamespace(
+	public static AndOrResult<Type?, IThat<Type?>> IsWithinNamespace(
 		this IThat<Type?> subject, string expected)
-	{
-		StringEqualityOptions options = new();
-		return new StringEqualityResult<Type?, IThat<Type?>>(subject.Get().ExpectationBuilder.AddConstraint(
-				(it, grammars)
-					=> new IsWithinNamespaceConstraint(it, grammars, expected, options)),
-			subject,
-			options);
-	}
+		=> new(subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new IsWithinNamespaceConstraint(it, grammars, expected)),
+			subject);
+
+	/// <summary>
+	///     Verifies that the <see cref="Type" /> is not within the <paramref name="expected" /> namespace
+	///     (including sub-namespaces).
+	/// </summary>
+	public static AndOrResult<Type?, IThat<Type?>> IsNotWithinNamespace(
+		this IThat<Type?> subject, string expected)
+		=> new(subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new IsWithinNamespaceConstraint(it, grammars, expected).Invert()),
+			subject);
 
 	private sealed class IsWithinNamespaceConstraint(
 		string it,
 		ExpectationGrammars grammars,
-		string expected,
-		StringEqualityOptions options)
+		string expected)
 		: ConstraintResult.WithNotNullValue<Type?>(it, grammars),
-			IAsyncConstraint<Type?>
+			IValueConstraint<Type?>
 	{
-		public async Task<ConstraintResult> IsMetBy(Type? actual, CancellationToken cancellationToken)
+		public ConstraintResult IsMetBy(Type? actual)
 		{
 			Actual = actual;
-			Outcome = await actual.IsWithinNamespace(expected, options) ? Outcome.Success : Outcome.Failure;
+			Outcome = actual.IsWithinNamespace(expected) ? Outcome.Success : Outcome.Failure;
 			return this;
 		}
 
 		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
-			=> stringBuilder.Append("is within namespace ").Append(Formatter.Format(expected)).Append(options);
+			=> stringBuilder.Append("is within namespace ").Append(Formatter.Format(expected));
 
 		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
-			=> stringBuilder.Append(It).Append(" was in namespace ").Append(Formatter.Format(Actual?.Namespace));
+			=> stringBuilder.Append(It).Append(" was in namespace ").Append(Formatter.Format(Actual!.Namespace));
 
 		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
-			=> stringBuilder.Append("is not within namespace ").Append(Formatter.Format(expected)).Append(options);
+			=> stringBuilder.Append("is not within namespace ").Append(Formatter.Format(expected));
 
 		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
 			=> AppendNormalResult(stringBuilder, indentation);

--- a/Source/aweXpect.Reflection/ThatTypes.AreWithinNamespace.cs
+++ b/Source/aweXpect.Reflection/ThatTypes.AreWithinNamespace.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Options;
+using aweXpect.Reflection.Helpers;
+using aweXpect.Results;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Reflection;
+
+public static partial class ThatTypes
+{
+	/// <summary>
+	///     Verifies that all items in the filtered collection of <see cref="Type" /> are within
+	///     the <paramref name="expected" /> namespace (including sub-namespaces).
+	/// </summary>
+	public static StringEqualityResult<IEnumerable<Type?>, IThat<IEnumerable<Type?>>> AreWithinNamespace(
+		this IThat<IEnumerable<Type?>> subject, string expected)
+	{
+		StringEqualityOptions options = new();
+		return new StringEqualityResult<IEnumerable<Type?>, IThat<IEnumerable<Type?>>>(subject.Get()
+				.ExpectationBuilder.AddConstraint<IEnumerable<Type?>>((it, grammars)
+					=> new AreWithinNamespaceConstraint(it, grammars, expected, options)),
+			subject,
+			options);
+	}
+
+#if NET8_0_OR_GREATER
+	/// <summary>
+	///     Verifies that all items in the filtered collection of <see cref="Type" /> are within
+	///     the <paramref name="expected" /> namespace (including sub-namespaces).
+	/// </summary>
+	public static StringEqualityResult<IAsyncEnumerable<Type?>, IThat<IAsyncEnumerable<Type?>>> AreWithinNamespace(
+		this IThat<IAsyncEnumerable<Type?>> subject, string expected)
+	{
+		StringEqualityOptions options = new();
+		return new StringEqualityResult<IAsyncEnumerable<Type?>, IThat<IAsyncEnumerable<Type?>>>(subject.Get()
+				.ExpectationBuilder.AddConstraint<IAsyncEnumerable<Type?>>((it, grammars)
+					=> new AreWithinNamespaceConstraint(it, grammars, expected, options)),
+			subject,
+			options);
+	}
+#endif
+
+	private sealed class AreWithinNamespaceConstraint(
+		string it,
+		ExpectationGrammars grammars,
+		string expected,
+		StringEqualityOptions options)
+		: CollectionConstraintResult<Type?>(grammars),
+			IAsyncConstraint<IEnumerable<Type?>>
+#if NET8_0_OR_GREATER
+			, IAsyncConstraint<IAsyncEnumerable<Type?>>
+#endif
+	{
+#if NET8_0_OR_GREATER
+		public async Task<ConstraintResult> IsMetBy(IAsyncEnumerable<Type?> actual, CancellationToken cancellationToken)
+			=> await SetAsyncValue(actual, type => type.IsWithinNamespace(expected, options));
+#endif
+
+		public async Task<ConstraintResult> IsMetBy(IEnumerable<Type?> actual, CancellationToken cancellationToken)
+			=> await SetValue(actual, type => type.IsWithinNamespace(expected, options));
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("all are within namespace ").Append(Formatter.Format(expected)).Append(options);
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(it).Append(" contained not matching types ");
+			Formatter.Format(stringBuilder, NotMatching, FormattingOptions.Indented(indentation));
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("not all are within namespace ").Append(Formatter.Format(expected)).Append(options);
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(it).Append(" only contained matching types ");
+			Formatter.Format(stringBuilder, Matching, FormattingOptions.Indented(indentation));
+		}
+	}
+}

--- a/Source/aweXpect.Reflection/ThatTypes.AreWithinNamespace.cs
+++ b/Source/aweXpect.Reflection/ThatTypes.AreWithinNamespace.cs
@@ -1,11 +1,12 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Text;
+#if NET8_0_OR_GREATER
 using System.Threading;
 using System.Threading.Tasks;
+#endif
 using aweXpect.Core;
 using aweXpect.Core.Constraints;
-using aweXpect.Options;
 using aweXpect.Reflection.Helpers;
 using aweXpect.Results;
 
@@ -19,55 +20,66 @@ public static partial class ThatTypes
 	///     Verifies that all items in the filtered collection of <see cref="Type" /> are within
 	///     the <paramref name="expected" /> namespace (including sub-namespaces).
 	/// </summary>
-	public static StringEqualityResult<IEnumerable<Type?>, IThat<IEnumerable<Type?>>> AreWithinNamespace(
+	public static AndOrResult<IEnumerable<Type?>, IThat<IEnumerable<Type?>>> AreWithinNamespace(
 		this IThat<IEnumerable<Type?>> subject, string expected)
-	{
-		StringEqualityOptions options = new();
-		return new StringEqualityResult<IEnumerable<Type?>, IThat<IEnumerable<Type?>>>(subject.Get()
-				.ExpectationBuilder.AddConstraint<IEnumerable<Type?>>((it, grammars)
-					=> new AreWithinNamespaceConstraint(it, grammars, expected, options)),
-			subject,
-			options);
-	}
+		=> new(subject.Get().ExpectationBuilder.AddConstraint<IEnumerable<Type?>>((it, grammars)
+				=> new AreWithinNamespaceConstraint(it, grammars, expected)),
+			subject);
 
 #if NET8_0_OR_GREATER
 	/// <summary>
 	///     Verifies that all items in the filtered collection of <see cref="Type" /> are within
 	///     the <paramref name="expected" /> namespace (including sub-namespaces).
 	/// </summary>
-	public static StringEqualityResult<IAsyncEnumerable<Type?>, IThat<IAsyncEnumerable<Type?>>> AreWithinNamespace(
+	public static AndOrResult<IAsyncEnumerable<Type?>, IThat<IAsyncEnumerable<Type?>>> AreWithinNamespace(
 		this IThat<IAsyncEnumerable<Type?>> subject, string expected)
-	{
-		StringEqualityOptions options = new();
-		return new StringEqualityResult<IAsyncEnumerable<Type?>, IThat<IAsyncEnumerable<Type?>>>(subject.Get()
-				.ExpectationBuilder.AddConstraint<IAsyncEnumerable<Type?>>((it, grammars)
-					=> new AreWithinNamespaceConstraint(it, grammars, expected, options)),
-			subject,
-			options);
-	}
+		=> new(subject.Get().ExpectationBuilder.AddConstraint<IAsyncEnumerable<Type?>>((it, grammars)
+				=> new AreWithinNamespaceConstraint(it, grammars, expected)),
+			subject);
+#endif
+
+	/// <summary>
+	///     Verifies that all items in the filtered collection of <see cref="Type" /> are not within
+	///     the <paramref name="expected" /> namespace (including sub-namespaces).
+	/// </summary>
+	public static AndOrResult<IEnumerable<Type?>, IThat<IEnumerable<Type?>>> AreNotWithinNamespace(
+		this IThat<IEnumerable<Type?>> subject, string expected)
+		=> new(subject.Get().ExpectationBuilder.AddConstraint<IEnumerable<Type?>>((it, grammars)
+				=> new AreNotWithinNamespaceConstraint(it, grammars, expected)),
+			subject);
+
+#if NET8_0_OR_GREATER
+	/// <summary>
+	///     Verifies that all items in the filtered collection of <see cref="Type" /> are not within
+	///     the <paramref name="expected" /> namespace (including sub-namespaces).
+	/// </summary>
+	public static AndOrResult<IAsyncEnumerable<Type?>, IThat<IAsyncEnumerable<Type?>>> AreNotWithinNamespace(
+		this IThat<IAsyncEnumerable<Type?>> subject, string expected)
+		=> new(subject.Get().ExpectationBuilder.AddConstraint<IAsyncEnumerable<Type?>>((it, grammars)
+				=> new AreNotWithinNamespaceConstraint(it, grammars, expected)),
+			subject);
 #endif
 
 	private sealed class AreWithinNamespaceConstraint(
 		string it,
 		ExpectationGrammars grammars,
-		string expected,
-		StringEqualityOptions options)
+		string expected)
 		: CollectionConstraintResult<Type?>(grammars),
-			IAsyncConstraint<IEnumerable<Type?>>
+			IValueConstraint<IEnumerable<Type?>>
 #if NET8_0_OR_GREATER
 			, IAsyncConstraint<IAsyncEnumerable<Type?>>
 #endif
 	{
 #if NET8_0_OR_GREATER
 		public async Task<ConstraintResult> IsMetBy(IAsyncEnumerable<Type?> actual, CancellationToken cancellationToken)
-			=> await SetAsyncValue(actual, type => type.IsWithinNamespace(expected, options));
+			=> await SetAsyncValue(actual, type => type.IsWithinNamespace(expected));
 #endif
 
-		public async Task<ConstraintResult> IsMetBy(IEnumerable<Type?> actual, CancellationToken cancellationToken)
-			=> await SetValue(actual, type => type.IsWithinNamespace(expected, options));
+		public ConstraintResult IsMetBy(IEnumerable<Type?> actual)
+			=> SetValue(actual, type => type.IsWithinNamespace(expected));
 
 		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
-			=> stringBuilder.Append("all are within namespace ").Append(Formatter.Format(expected)).Append(options);
+			=> stringBuilder.Append("are all within namespace ").Append(Formatter.Format(expected));
 
 		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
 		{
@@ -76,7 +88,44 @@ public static partial class ThatTypes
 		}
 
 		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
-			=> stringBuilder.Append("not all are within namespace ").Append(Formatter.Format(expected)).Append(options);
+			=> stringBuilder.Append("are not all within namespace ").Append(Formatter.Format(expected));
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(it).Append(" only contained matching types ");
+			Formatter.Format(stringBuilder, Matching, FormattingOptions.Indented(indentation));
+		}
+	}
+
+	private sealed class AreNotWithinNamespaceConstraint(
+		string it,
+		ExpectationGrammars grammars,
+		string expected)
+		: CollectionConstraintResult<Type?>(grammars),
+			IValueConstraint<IEnumerable<Type?>>
+#if NET8_0_OR_GREATER
+			, IAsyncConstraint<IAsyncEnumerable<Type?>>
+#endif
+	{
+#if NET8_0_OR_GREATER
+		public async Task<ConstraintResult> IsMetBy(IAsyncEnumerable<Type?> actual, CancellationToken cancellationToken)
+			=> await SetAsyncValue(actual, type => !type.IsWithinNamespace(expected));
+#endif
+
+		public ConstraintResult IsMetBy(IEnumerable<Type?> actual)
+			=> SetValue(actual, type => !type.IsWithinNamespace(expected));
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("are all not within namespace ").Append(Formatter.Format(expected));
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(it).Append(" contained not matching types ");
+			Formatter.Format(stringBuilder, NotMatching, FormattingOptions.Indented(indentation));
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("also contain a type within namespace ").Append(Formatter.Format(expected));
 
 		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
 		{

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net10.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net10.0.txt
@@ -1340,6 +1340,7 @@ namespace aweXpect.Reflection
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsNotStatic(this aweXpect.Core.IThat<System.Type?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsSealed(this aweXpect.Core.IThat<System.Type?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsStatic(this aweXpect.Core.IThat<System.Type?> subject) { }
+        public static aweXpect.Results.StringEqualityResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsWithinNamespace(this aweXpect.Core.IThat<System.Type?> subject, string expected) { }
     }
     public static class ThatTypes
     {
@@ -1387,6 +1388,8 @@ namespace aweXpect.Reflection
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreStatic(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>>> AreStructs(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreStructs(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
+        public static aweXpect.Results.StringEqualityResult<System.Collections.Generic.IAsyncEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>>> AreWithinNamespace(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>> subject, string expected) { }
+        public static aweXpect.Results.StringEqualityResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreWithinNamespace(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject, string expected) { }
         public static aweXpect.Reflection.Results.TypeContainingMembersResult<System.Collections.Generic.IAsyncEnumerable<System.Type?>> ContainConstructors(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>> subject, System.Func<aweXpect.Reflection.Collections.Filtered.Constructors, aweXpect.Reflection.Collections.Filtered.Constructors> filter) { }
         public static aweXpect.Reflection.Results.TypeContainingMembersResult<System.Collections.Generic.IEnumerable<System.Type?>> ContainConstructors(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject, System.Func<aweXpect.Reflection.Collections.Filtered.Constructors, aweXpect.Reflection.Collections.Filtered.Constructors> filter) { }
         public static aweXpect.Reflection.Results.TypeContainingMembersResult<System.Collections.Generic.IAsyncEnumerable<System.Type?>> ContainEvents(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>> subject, System.Func<aweXpect.Reflection.Collections.Filtered.Events, aweXpect.Reflection.Collections.Filtered.Events> filter) { }
@@ -1468,6 +1471,7 @@ namespace aweXpect.Reflection
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Collections.Filtered.Types.StringEqualityResultType WithName(this aweXpect.Reflection.Collections.Filtered.Types @this, string expected) { }
         public static aweXpect.Reflection.Collections.Filtered.Types.StringEqualityResultType WithNamespace(this aweXpect.Reflection.Collections.Filtered.Types @this, string expected) { }
+        public static aweXpect.Reflection.Collections.Filtered.Types.StringEqualityResult WithinNamespace(this aweXpect.Reflection.Collections.Filtered.Types @this, string expected) { }
         public class GenericTypes : aweXpect.Reflection.Collections.Filtered.Types
         {
             public GenericTypes(aweXpect.Reflection.Collections.Filtered.Types inner) { }

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net10.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net10.0.txt
@@ -1338,9 +1338,10 @@ namespace aweXpect.Reflection
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsNotNested(this aweXpect.Core.IThat<System.Type?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsNotSealed(this aweXpect.Core.IThat<System.Type?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsNotStatic(this aweXpect.Core.IThat<System.Type?> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsNotWithinNamespace(this aweXpect.Core.IThat<System.Type?> subject, string expected) { }
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsSealed(this aweXpect.Core.IThat<System.Type?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsStatic(this aweXpect.Core.IThat<System.Type?> subject) { }
-        public static aweXpect.Results.StringEqualityResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsWithinNamespace(this aweXpect.Core.IThat<System.Type?> subject, string expected) { }
+        public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsWithinNamespace(this aweXpect.Core.IThat<System.Type?> subject, string expected) { }
     }
     public static class ThatTypes
     {
@@ -1378,6 +1379,8 @@ namespace aweXpect.Reflection
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreNotStatic(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>>> AreNotStructs(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreNotStructs(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>>> AreNotWithinNamespace(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>> subject, string expected) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreNotWithinNamespace(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject, string expected) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>>> AreRecordStructs(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreRecordStructs(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>>> AreRecords(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>> subject) { }
@@ -1388,8 +1391,8 @@ namespace aweXpect.Reflection
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreStatic(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>>> AreStructs(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreStructs(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
-        public static aweXpect.Results.StringEqualityResult<System.Collections.Generic.IAsyncEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>>> AreWithinNamespace(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>> subject, string expected) { }
-        public static aweXpect.Results.StringEqualityResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreWithinNamespace(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject, string expected) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>>> AreWithinNamespace(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>> subject, string expected) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreWithinNamespace(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject, string expected) { }
         public static aweXpect.Reflection.Results.TypeContainingMembersResult<System.Collections.Generic.IAsyncEnumerable<System.Type?>> ContainConstructors(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>> subject, System.Func<aweXpect.Reflection.Collections.Filtered.Constructors, aweXpect.Reflection.Collections.Filtered.Constructors> filter) { }
         public static aweXpect.Reflection.Results.TypeContainingMembersResult<System.Collections.Generic.IEnumerable<System.Type?>> ContainConstructors(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject, System.Func<aweXpect.Reflection.Collections.Filtered.Constructors, aweXpect.Reflection.Collections.Filtered.Constructors> filter) { }
         public static aweXpect.Reflection.Results.TypeContainingMembersResult<System.Collections.Generic.IAsyncEnumerable<System.Type?>> ContainEvents(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>> subject, System.Func<aweXpect.Reflection.Collections.Filtered.Events, aweXpect.Reflection.Collections.Filtered.Events> filter) { }
@@ -1421,6 +1424,7 @@ namespace aweXpect.Reflection
     }
     public static class TypeFilters
     {
+        public static aweXpect.Reflection.Collections.Filtered.Types NotWithinNamespace(this aweXpect.Reflection.Collections.Filtered.Types @this, string expected) { }
         public static aweXpect.Reflection.Collections.Filtered.Types Which(this aweXpect.Reflection.Collections.Filtered.Types @this, System.Func<System.Type, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAre(this aweXpect.Reflection.Collections.Filtered.Types @this, aweXpect.Reflection.Collections.AccessModifiers accessModifier) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreAbstract(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
@@ -1471,7 +1475,7 @@ namespace aweXpect.Reflection
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Collections.Filtered.Types.StringEqualityResultType WithName(this aweXpect.Reflection.Collections.Filtered.Types @this, string expected) { }
         public static aweXpect.Reflection.Collections.Filtered.Types.StringEqualityResultType WithNamespace(this aweXpect.Reflection.Collections.Filtered.Types @this, string expected) { }
-        public static aweXpect.Reflection.Collections.Filtered.Types.StringEqualityResult WithinNamespace(this aweXpect.Reflection.Collections.Filtered.Types @this, string expected) { }
+        public static aweXpect.Reflection.Collections.Filtered.Types WithinNamespace(this aweXpect.Reflection.Collections.Filtered.Types @this, string expected) { }
         public class GenericTypes : aweXpect.Reflection.Collections.Filtered.Types
         {
             public GenericTypes(aweXpect.Reflection.Collections.Filtered.Types inner) { }

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net8.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net8.0.txt
@@ -1340,6 +1340,7 @@ namespace aweXpect.Reflection
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsNotStatic(this aweXpect.Core.IThat<System.Type?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsSealed(this aweXpect.Core.IThat<System.Type?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsStatic(this aweXpect.Core.IThat<System.Type?> subject) { }
+        public static aweXpect.Results.StringEqualityResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsWithinNamespace(this aweXpect.Core.IThat<System.Type?> subject, string expected) { }
     }
     public static class ThatTypes
     {
@@ -1387,6 +1388,8 @@ namespace aweXpect.Reflection
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreStatic(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>>> AreStructs(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreStructs(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
+        public static aweXpect.Results.StringEqualityResult<System.Collections.Generic.IAsyncEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>>> AreWithinNamespace(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>> subject, string expected) { }
+        public static aweXpect.Results.StringEqualityResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreWithinNamespace(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject, string expected) { }
         public static aweXpect.Reflection.Results.TypeContainingMembersResult<System.Collections.Generic.IAsyncEnumerable<System.Type?>> ContainConstructors(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>> subject, System.Func<aweXpect.Reflection.Collections.Filtered.Constructors, aweXpect.Reflection.Collections.Filtered.Constructors> filter) { }
         public static aweXpect.Reflection.Results.TypeContainingMembersResult<System.Collections.Generic.IEnumerable<System.Type?>> ContainConstructors(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject, System.Func<aweXpect.Reflection.Collections.Filtered.Constructors, aweXpect.Reflection.Collections.Filtered.Constructors> filter) { }
         public static aweXpect.Reflection.Results.TypeContainingMembersResult<System.Collections.Generic.IAsyncEnumerable<System.Type?>> ContainEvents(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>> subject, System.Func<aweXpect.Reflection.Collections.Filtered.Events, aweXpect.Reflection.Collections.Filtered.Events> filter) { }
@@ -1468,6 +1471,7 @@ namespace aweXpect.Reflection
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Collections.Filtered.Types.StringEqualityResultType WithName(this aweXpect.Reflection.Collections.Filtered.Types @this, string expected) { }
         public static aweXpect.Reflection.Collections.Filtered.Types.StringEqualityResultType WithNamespace(this aweXpect.Reflection.Collections.Filtered.Types @this, string expected) { }
+        public static aweXpect.Reflection.Collections.Filtered.Types.StringEqualityResult WithinNamespace(this aweXpect.Reflection.Collections.Filtered.Types @this, string expected) { }
         public class GenericTypes : aweXpect.Reflection.Collections.Filtered.Types
         {
             public GenericTypes(aweXpect.Reflection.Collections.Filtered.Types inner) { }

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net8.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net8.0.txt
@@ -1338,9 +1338,10 @@ namespace aweXpect.Reflection
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsNotNested(this aweXpect.Core.IThat<System.Type?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsNotSealed(this aweXpect.Core.IThat<System.Type?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsNotStatic(this aweXpect.Core.IThat<System.Type?> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsNotWithinNamespace(this aweXpect.Core.IThat<System.Type?> subject, string expected) { }
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsSealed(this aweXpect.Core.IThat<System.Type?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsStatic(this aweXpect.Core.IThat<System.Type?> subject) { }
-        public static aweXpect.Results.StringEqualityResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsWithinNamespace(this aweXpect.Core.IThat<System.Type?> subject, string expected) { }
+        public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsWithinNamespace(this aweXpect.Core.IThat<System.Type?> subject, string expected) { }
     }
     public static class ThatTypes
     {
@@ -1378,6 +1379,8 @@ namespace aweXpect.Reflection
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreNotStatic(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>>> AreNotStructs(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreNotStructs(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>>> AreNotWithinNamespace(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>> subject, string expected) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreNotWithinNamespace(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject, string expected) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>>> AreRecordStructs(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreRecordStructs(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>>> AreRecords(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>> subject) { }
@@ -1388,8 +1391,8 @@ namespace aweXpect.Reflection
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreStatic(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>>> AreStructs(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreStructs(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
-        public static aweXpect.Results.StringEqualityResult<System.Collections.Generic.IAsyncEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>>> AreWithinNamespace(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>> subject, string expected) { }
-        public static aweXpect.Results.StringEqualityResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreWithinNamespace(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject, string expected) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>>> AreWithinNamespace(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>> subject, string expected) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreWithinNamespace(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject, string expected) { }
         public static aweXpect.Reflection.Results.TypeContainingMembersResult<System.Collections.Generic.IAsyncEnumerable<System.Type?>> ContainConstructors(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>> subject, System.Func<aweXpect.Reflection.Collections.Filtered.Constructors, aweXpect.Reflection.Collections.Filtered.Constructors> filter) { }
         public static aweXpect.Reflection.Results.TypeContainingMembersResult<System.Collections.Generic.IEnumerable<System.Type?>> ContainConstructors(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject, System.Func<aweXpect.Reflection.Collections.Filtered.Constructors, aweXpect.Reflection.Collections.Filtered.Constructors> filter) { }
         public static aweXpect.Reflection.Results.TypeContainingMembersResult<System.Collections.Generic.IAsyncEnumerable<System.Type?>> ContainEvents(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>> subject, System.Func<aweXpect.Reflection.Collections.Filtered.Events, aweXpect.Reflection.Collections.Filtered.Events> filter) { }
@@ -1421,6 +1424,7 @@ namespace aweXpect.Reflection
     }
     public static class TypeFilters
     {
+        public static aweXpect.Reflection.Collections.Filtered.Types NotWithinNamespace(this aweXpect.Reflection.Collections.Filtered.Types @this, string expected) { }
         public static aweXpect.Reflection.Collections.Filtered.Types Which(this aweXpect.Reflection.Collections.Filtered.Types @this, System.Func<System.Type, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAre(this aweXpect.Reflection.Collections.Filtered.Types @this, aweXpect.Reflection.Collections.AccessModifiers accessModifier) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreAbstract(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
@@ -1471,7 +1475,7 @@ namespace aweXpect.Reflection
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Collections.Filtered.Types.StringEqualityResultType WithName(this aweXpect.Reflection.Collections.Filtered.Types @this, string expected) { }
         public static aweXpect.Reflection.Collections.Filtered.Types.StringEqualityResultType WithNamespace(this aweXpect.Reflection.Collections.Filtered.Types @this, string expected) { }
-        public static aweXpect.Reflection.Collections.Filtered.Types.StringEqualityResult WithinNamespace(this aweXpect.Reflection.Collections.Filtered.Types @this, string expected) { }
+        public static aweXpect.Reflection.Collections.Filtered.Types WithinNamespace(this aweXpect.Reflection.Collections.Filtered.Types @this, string expected) { }
         public class GenericTypes : aweXpect.Reflection.Collections.Filtered.Types
         {
             public GenericTypes(aweXpect.Reflection.Collections.Filtered.Types inner) { }

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_netstandard2.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_netstandard2.0.txt
@@ -1119,6 +1119,7 @@ namespace aweXpect.Reflection
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsNotStatic(this aweXpect.Core.IThat<System.Type?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsSealed(this aweXpect.Core.IThat<System.Type?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsStatic(this aweXpect.Core.IThat<System.Type?> subject) { }
+        public static aweXpect.Results.StringEqualityResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsWithinNamespace(this aweXpect.Core.IThat<System.Type?> subject, string expected) { }
     }
     public static class ThatTypes
     {
@@ -1144,6 +1145,7 @@ namespace aweXpect.Reflection
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreSealed(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreStatic(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreStructs(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
+        public static aweXpect.Results.StringEqualityResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreWithinNamespace(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject, string expected) { }
         public static aweXpect.Reflection.Results.TypeContainingMembersResult<System.Collections.Generic.IEnumerable<System.Type?>> ContainConstructors(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject, System.Func<aweXpect.Reflection.Collections.Filtered.Constructors, aweXpect.Reflection.Collections.Filtered.Constructors> filter) { }
         public static aweXpect.Reflection.Results.TypeContainingMembersResult<System.Collections.Generic.IEnumerable<System.Type?>> ContainEvents(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject, System.Func<aweXpect.Reflection.Collections.Filtered.Events, aweXpect.Reflection.Collections.Filtered.Events> filter) { }
         public static aweXpect.Reflection.Results.TypeContainingMembersResult<System.Collections.Generic.IEnumerable<System.Type?>> ContainFields(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject, System.Func<aweXpect.Reflection.Collections.Filtered.Fields, aweXpect.Reflection.Collections.Filtered.Fields> filter) { }
@@ -1211,6 +1213,7 @@ namespace aweXpect.Reflection
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Collections.Filtered.Types.StringEqualityResultType WithName(this aweXpect.Reflection.Collections.Filtered.Types @this, string expected) { }
         public static aweXpect.Reflection.Collections.Filtered.Types.StringEqualityResultType WithNamespace(this aweXpect.Reflection.Collections.Filtered.Types @this, string expected) { }
+        public static aweXpect.Reflection.Collections.Filtered.Types.StringEqualityResult WithinNamespace(this aweXpect.Reflection.Collections.Filtered.Types @this, string expected) { }
         public class GenericTypes : aweXpect.Reflection.Collections.Filtered.Types
         {
             public GenericTypes(aweXpect.Reflection.Collections.Filtered.Types inner) { }

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_netstandard2.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_netstandard2.0.txt
@@ -1117,9 +1117,10 @@ namespace aweXpect.Reflection
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsNotNested(this aweXpect.Core.IThat<System.Type?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsNotSealed(this aweXpect.Core.IThat<System.Type?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsNotStatic(this aweXpect.Core.IThat<System.Type?> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsNotWithinNamespace(this aweXpect.Core.IThat<System.Type?> subject, string expected) { }
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsSealed(this aweXpect.Core.IThat<System.Type?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsStatic(this aweXpect.Core.IThat<System.Type?> subject) { }
-        public static aweXpect.Results.StringEqualityResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsWithinNamespace(this aweXpect.Core.IThat<System.Type?> subject, string expected) { }
+        public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsWithinNamespace(this aweXpect.Core.IThat<System.Type?> subject, string expected) { }
     }
     public static class ThatTypes
     {
@@ -1140,12 +1141,13 @@ namespace aweXpect.Reflection
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreNotSealed(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreNotStatic(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreNotStructs(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreNotWithinNamespace(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject, string expected) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreRecordStructs(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreRecords(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreSealed(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreStatic(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreStructs(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
-        public static aweXpect.Results.StringEqualityResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreWithinNamespace(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject, string expected) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreWithinNamespace(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject, string expected) { }
         public static aweXpect.Reflection.Results.TypeContainingMembersResult<System.Collections.Generic.IEnumerable<System.Type?>> ContainConstructors(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject, System.Func<aweXpect.Reflection.Collections.Filtered.Constructors, aweXpect.Reflection.Collections.Filtered.Constructors> filter) { }
         public static aweXpect.Reflection.Results.TypeContainingMembersResult<System.Collections.Generic.IEnumerable<System.Type?>> ContainEvents(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject, System.Func<aweXpect.Reflection.Collections.Filtered.Events, aweXpect.Reflection.Collections.Filtered.Events> filter) { }
         public static aweXpect.Reflection.Results.TypeContainingMembersResult<System.Collections.Generic.IEnumerable<System.Type?>> ContainFields(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject, System.Func<aweXpect.Reflection.Collections.Filtered.Fields, aweXpect.Reflection.Collections.Filtered.Fields> filter) { }
@@ -1163,6 +1165,7 @@ namespace aweXpect.Reflection
     }
     public static class TypeFilters
     {
+        public static aweXpect.Reflection.Collections.Filtered.Types NotWithinNamespace(this aweXpect.Reflection.Collections.Filtered.Types @this, string expected) { }
         public static aweXpect.Reflection.Collections.Filtered.Types Which(this aweXpect.Reflection.Collections.Filtered.Types @this, System.Func<System.Type, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAre(this aweXpect.Reflection.Collections.Filtered.Types @this, aweXpect.Reflection.Collections.AccessModifiers accessModifier) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreAbstract(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
@@ -1213,7 +1216,7 @@ namespace aweXpect.Reflection
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Collections.Filtered.Types.StringEqualityResultType WithName(this aweXpect.Reflection.Collections.Filtered.Types @this, string expected) { }
         public static aweXpect.Reflection.Collections.Filtered.Types.StringEqualityResultType WithNamespace(this aweXpect.Reflection.Collections.Filtered.Types @this, string expected) { }
-        public static aweXpect.Reflection.Collections.Filtered.Types.StringEqualityResult WithinNamespace(this aweXpect.Reflection.Collections.Filtered.Types @this, string expected) { }
+        public static aweXpect.Reflection.Collections.Filtered.Types WithinNamespace(this aweXpect.Reflection.Collections.Filtered.Types @this, string expected) { }
         public class GenericTypes : aweXpect.Reflection.Collections.Filtered.Types
         {
             public GenericTypes(aweXpect.Reflection.Collections.Filtered.Types inner) { }

--- a/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.NotWithinNamespace.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.NotWithinNamespace.Tests.cs
@@ -1,0 +1,31 @@
+﻿using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope;
+using aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope.Nested;
+using aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScopeSibling;
+
+namespace aweXpect.Reflection.Tests.Filters;
+
+public sealed partial class TypeFilters
+{
+	public sealed class NotWithinNamespace
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task ShouldFilterForTypesNotWithinNamespaceIncludingSubNamespaces()
+			{
+				Filtered.Types types = In.AssemblyContaining<AssemblyFilters>()
+					.Types().NotWithinNamespace(
+						"aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope");
+
+				await That(types).DoesNotContain(typeof(ClassInNamespaceScope));
+				await That(types).DoesNotContain(typeof(ClassInNestedNamespaceScope));
+				await That(types).Contains(typeof(ClassInSiblingNamespaceScope));
+				await That(types.GetDescription())
+					.IsEqualTo(
+						"types not within namespace \"aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope\" in assembly")
+					.AsPrefix();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WithinNamespace.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WithinNamespace.Tests.cs
@@ -1,0 +1,57 @@
+using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope;
+using aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope.Nested;
+using aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScopeSibling;
+
+namespace aweXpect.Reflection.Tests.Filters;
+
+public sealed partial class TypeFilters
+{
+	public sealed class WithinNamespace
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task ShouldExcludeNamespacesThatOnlyShareThePrefix()
+			{
+				Filtered.Types types = In.AssemblyContaining<AssemblyFilters>()
+					.Types().WithinNamespace(
+						"aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope");
+
+				await That(types).DoesNotContain(typeof(ClassInSiblingNamespaceScope));
+			}
+
+			[Fact]
+			public async Task ShouldFilterForTypesWithinNamespaceIncludingSubNamespaces()
+			{
+				Filtered.Types types = In.AssemblyContaining<AssemblyFilters>()
+					.Types().WithinNamespace(
+						"aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope");
+
+				await That(types).Contains(typeof(ClassInNamespaceScope));
+				await That(types).Contains(typeof(ClassInNestedNamespaceScope));
+				await That(types).DoesNotContain(typeof(ClassInSiblingNamespaceScope));
+				await That(types.GetDescription())
+					.IsEqualTo(
+						"types within namespace \"aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope\" in assembly")
+					.AsPrefix();
+			}
+
+			[Fact]
+			public async Task ShouldSupportIgnoringCase()
+			{
+				Filtered.Types types = In.AssemblyContaining<AssemblyFilters>()
+					.Types().WithinNamespace(
+						"aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope".ToLowerInvariant())
+					.IgnoringCase();
+
+				await That(types).Contains(typeof(ClassInNamespaceScope));
+				await That(types).Contains(typeof(ClassInNestedNamespaceScope));
+				await That(types.GetDescription())
+					.IsEqualTo(
+						"types within namespace \"awexpect.reflection.tests.testhelpers.types.namespacescope\" ignoring case in assembly")
+					.AsPrefix();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WithinNamespace.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WithinNamespace.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope;
 using aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope.Nested;
 using aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScopeSibling;
@@ -34,22 +34,6 @@ public sealed partial class TypeFilters
 				await That(types.GetDescription())
 					.IsEqualTo(
 						"types within namespace \"aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope\" in assembly")
-					.AsPrefix();
-			}
-
-			[Fact]
-			public async Task ShouldSupportIgnoringCase()
-			{
-				Filtered.Types types = In.AssemblyContaining<AssemblyFilters>()
-					.Types().WithinNamespace(
-						"aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope".ToLowerInvariant())
-					.IgnoringCase();
-
-				await That(types).Contains(typeof(ClassInNamespaceScope));
-				await That(types).Contains(typeof(ClassInNestedNamespaceScope));
-				await That(types.GetDescription())
-					.IsEqualTo(
-						"types within namespace \"awexpect.reflection.tests.testhelpers.types.namespacescope\" ignoring case in assembly")
 					.AsPrefix();
 			}
 		}

--- a/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/ClassInNamespaceScope.cs
+++ b/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/ClassInNamespaceScope.cs
@@ -1,0 +1,5 @@
+// ReSharper disable once CheckNamespace
+
+namespace aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope;
+
+public class ClassInNamespaceScope;

--- a/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/ClassInNestedNamespaceScope.cs
+++ b/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/ClassInNestedNamespaceScope.cs
@@ -1,0 +1,5 @@
+// ReSharper disable once CheckNamespace
+
+namespace aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope.Nested;
+
+public class ClassInNestedNamespaceScope;

--- a/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/ClassInSiblingNamespaceScope.cs
+++ b/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/ClassInSiblingNamespaceScope.cs
@@ -1,0 +1,5 @@
+// ReSharper disable once CheckNamespace
+
+namespace aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScopeSibling;
+
+public class ClassInSiblingNamespaceScope;

--- a/Tests/aweXpect.Reflection.Tests/ThatType.IsNotWithinNamespace.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatType.IsNotWithinNamespace.Tests.cs
@@ -1,0 +1,98 @@
+﻿using aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope.Nested;
+using aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScopeSibling;
+using Xunit.Sdk;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatType
+{
+	public sealed class IsNotWithinNamespace
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenTypeIsWithinNamespace_ShouldFail()
+			{
+				Type subject = typeof(ClassInNestedNamespaceScope);
+
+				async Task Act()
+				{
+					await That(subject)
+						.IsNotWithinNamespace("aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is not within namespace "aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope",
+					             but it was in namespace "aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope.Nested"
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenTypeIsWithinNamespace_ShouldSucceedWithNegatedAssertion()
+			{
+				Type subject = typeof(ClassInNestedNamespaceScope);
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(it
+						=> it.IsNotWithinNamespace("aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope"));
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenTypeIsNotWithinNamespace_ShouldFailWithNegatedAssertion()
+			{
+				Type subject = typeof(ClassInSiblingNamespaceScope);
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(it
+						=> it.IsNotWithinNamespace("aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope"));
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is within namespace "aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope",
+					             but it was in namespace "aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScopeSibling"
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenTypeIsNotWithinNamespace_ShouldSucceed()
+			{
+				Type subject = typeof(ClassInSiblingNamespaceScope);
+
+				async Task Act()
+				{
+					await That(subject)
+						.IsNotWithinNamespace("aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope");
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenTypeIsNull_ShouldFail()
+			{
+				Type? subject = null;
+
+				async Task Act()
+				{
+					await That(subject).IsNotWithinNamespace("foo");
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             is not within namespace "foo",
+					             but it was <null>
+					             """);
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatType.IsWithinNamespace.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatType.IsWithinNamespace.Tests.cs
@@ -1,0 +1,127 @@
+using aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope;
+using aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope.Nested;
+using aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScopeSibling;
+using Xunit.Sdk;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatType
+{
+	public sealed class IsWithinNamespace
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenTypeHasExactNamespace_ShouldSucceed()
+			{
+				Type subject = typeof(ClassInNamespaceScope);
+
+				async Task Act()
+				{
+					await That(subject)
+						.IsWithinNamespace("aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope");
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenTypeIsInSubNamespace_ShouldSucceed()
+			{
+				Type subject = typeof(ClassInNestedNamespaceScope);
+
+				async Task Act()
+				{
+					await That(subject)
+						.IsWithinNamespace("aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope");
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenTypeIsNull_ShouldFail()
+			{
+				Type? subject = null;
+
+				async Task Act()
+				{
+					await That(subject).IsWithinNamespace("foo");
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             is within namespace "foo",
+					             but it was <null>
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenTypeMatchesIgnoringCase_ShouldSucceed()
+			{
+				Type subject = typeof(ClassInNestedNamespaceScope);
+
+				async Task Act()
+				{
+					await That(subject)
+						.IsWithinNamespace("AWEXPECT.REFLECTION.TESTS.TESTHELPERS.TYPES.NAMESPACESCOPE")
+						.IgnoringCase();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenTypeOnlySharesPrefix_ShouldFail()
+			{
+				Type subject = typeof(ClassInSiblingNamespaceScope);
+
+				async Task Act()
+				{
+					await That(subject)
+						.IsWithinNamespace("aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is within namespace "aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope",
+					             but it was in namespace "aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScopeSibling"
+					             """);
+			}
+		}
+
+		public sealed class NegatedTests
+		{
+			[Fact]
+			public async Task WhenTypeIsNotWithinNamespace_ShouldSucceed()
+			{
+				Type subject = typeof(ClassInSiblingNamespaceScope);
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(it
+						=> it.IsWithinNamespace("aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope"));
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenTypeIsWithinNamespace_ShouldFail()
+			{
+				Type subject = typeof(ClassInNestedNamespaceScope);
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(it
+						=> it.IsWithinNamespace("aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope"));
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("*is not within namespace*NamespaceScope*").AsWildcard();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatType.IsWithinNamespace.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatType.IsWithinNamespace.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope;
+﻿using aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope;
 using aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope.Nested;
 using aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScopeSibling;
 using Xunit.Sdk;
@@ -58,18 +58,22 @@ public sealed partial class ThatType
 			}
 
 			[Fact]
-			public async Task WhenTypeMatchesIgnoringCase_ShouldSucceed()
+			public async Task WhenNamespaceDiffersOnlyByCase_ShouldFail()
 			{
 				Type subject = typeof(ClassInNestedNamespaceScope);
 
 				async Task Act()
 				{
 					await That(subject)
-						.IsWithinNamespace("AWEXPECT.REFLECTION.TESTS.TESTHELPERS.TYPES.NAMESPACESCOPE")
-						.IgnoringCase();
+						.IsWithinNamespace("AWEXPECT.REFLECTION.TESTS.TESTHELPERS.TYPES.NAMESPACESCOPE");
 				}
 
-				await That(Act).DoesNotThrow();
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is within namespace "AWEXPECT.REFLECTION.TESTS.TESTHELPERS.TYPES.NAMESPACESCOPE",
+					             but it was in namespace "aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope.Nested"
+					             """);
 			}
 
 			[Fact]

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.AreNotWithinNamespace.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.AreNotWithinNamespace.Tests.cs
@@ -1,5 +1,8 @@
 ﻿using System.Collections.Generic;
 using aweXpect.Reflection.Collections;
+#if NET8_0_OR_GREATER
+using aweXpect.Reflection.Tests.TestHelpers;
+#endif
 using aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope;
 using aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope.Nested;
 using aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScopeSibling;
@@ -65,6 +68,46 @@ public sealed partial class ThatTypes
 						"*are all not within namespace*but it contained not matching types*ClassInNestedNamespaceScope*")
 					.AsWildcard();
 			}
+
+#if NET8_0_OR_GREATER
+			[Fact]
+			public async Task WhenAsyncEnumerableTypesAreNotWithinNamespace_ShouldSucceed()
+			{
+				IAsyncEnumerable<Type?> subject = new Type?[]
+				{
+					typeof(ClassInSiblingNamespaceScope),
+				}.ToTestAsyncEnumerable();
+
+				async Task Act()
+				{
+					await That(subject)
+						.AreNotWithinNamespace("aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope");
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenAsyncEnumerableContainsTypeWithinNamespace_ShouldFail()
+			{
+				IAsyncEnumerable<Type?> subject = new Type?[]
+				{
+					typeof(ClassInSiblingNamespaceScope),
+					typeof(ClassInNestedNamespaceScope),
+				}.ToTestAsyncEnumerable();
+
+				async Task Act()
+				{
+					await That(subject)
+						.AreNotWithinNamespace("aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage(
+						"*are all not within namespace*but it contained not matching types*ClassInNestedNamespaceScope*")
+					.AsWildcard();
+			}
+#endif
 		}
 
 		public sealed class NegatedTests

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.AreNotWithinNamespace.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.AreNotWithinNamespace.Tests.cs
@@ -1,0 +1,107 @@
+﻿using System.Collections.Generic;
+using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope;
+using aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope.Nested;
+using aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScopeSibling;
+using Xunit.Sdk;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatTypes
+{
+	public sealed class AreNotWithinNamespace
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenTypesAreNotWithinNamespace_ShouldSucceed()
+			{
+				Filtered.Types subject = In.AssemblyContaining<Tests>()
+					.Types().NotWithinNamespace("aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope");
+
+				async Task Act()
+				{
+					await That(subject)
+						.AreNotWithinNamespace("aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope");
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenEnumerableTypesAreNotWithinNamespace_ShouldSucceed()
+			{
+				IEnumerable<Type?> subject =
+				[
+					typeof(ClassInSiblingNamespaceScope),
+				];
+
+				async Task Act()
+				{
+					await That(subject)
+						.AreNotWithinNamespace("aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope");
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenEnumerableContainsTypeWithinNamespace_ShouldFail()
+			{
+				IEnumerable<Type?> subject =
+				[
+					typeof(ClassInSiblingNamespaceScope),
+					typeof(ClassInNestedNamespaceScope),
+				];
+
+				async Task Act()
+				{
+					await That(subject)
+						.AreNotWithinNamespace("aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage(
+						"*are all not within namespace*but it contained not matching types*ClassInNestedNamespaceScope*")
+					.AsWildcard();
+			}
+		}
+
+		public sealed class NegatedTests
+		{
+			[Fact]
+			public async Task WhenTypesAreNotWithinNamespace_ShouldFail()
+			{
+				Filtered.Types subject = In.AssemblyContaining<Tests>()
+					.Types().NotWithinNamespace("aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope");
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(they
+						=> they.AreNotWithinNamespace("aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope"));
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("*also contain a type within namespace*NamespaceScope*").AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenEnumerableContainsTypeWithinNamespace_ShouldSucceed()
+			{
+				IEnumerable<Type?> subject =
+				[
+					typeof(ClassInNamespaceScope),
+					typeof(ClassInNestedNamespaceScope),
+				];
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(they
+						=> they.AreNotWithinNamespace("aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope"));
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.AreWithinNamespace.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.AreWithinNamespace.Tests.cs
@@ -1,0 +1,70 @@
+using aweXpect.Reflection.Collections;
+using Xunit.Sdk;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatTypes
+{
+	public sealed class AreWithinNamespace
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenTypesAreWithinNamespace_ShouldSucceed()
+			{
+				Filtered.Types subject = In.AssemblyContaining<Tests>()
+					.Types().WithinNamespace("aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope");
+
+				async Task Act()
+				{
+					await That(subject)
+						.AreWithinNamespace("aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope");
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenTypesContainTypeInOtherNamespace_ShouldFail()
+			{
+				Filtered.Types subject = In.AssemblyContaining<Tests>()
+					.Types().WithNamespace("aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope")
+					.AsPrefix();
+
+				async Task Act()
+				{
+					await That(subject)
+						.AreWithinNamespace("aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that types with namespace starting with "aweXpect.Reflection.Tests.Test…" in assembly containing type ThatTypes.AreWithinNamespace.Tests
+					             all are within namespace "aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope",
+					             but it contained not matching types [
+					               *ClassInSiblingNamespaceScope*
+					             ]
+					             """).AsWildcard();
+			}
+		}
+
+		public sealed class NegatedTests
+		{
+			[Fact]
+			public async Task WhenTypesAreWithinNamespace_ShouldFail()
+			{
+				Filtered.Types subject = In.AssemblyContaining<Tests>()
+					.Types().WithinNamespace("aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope");
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(they
+						=> they.AreWithinNamespace("aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope"));
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("*not all are within namespace*NamespaceScope*").AsWildcard();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.AreWithinNamespace.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.AreWithinNamespace.Tests.cs
@@ -1,5 +1,8 @@
 ﻿using System.Collections.Generic;
 using aweXpect.Reflection.Collections;
+#if NET8_0_OR_GREATER
+using aweXpect.Reflection.Tests.TestHelpers;
+#endif
 using aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope;
 using aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope.Nested;
 using aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScopeSibling;
@@ -88,6 +91,46 @@ public sealed partial class ThatTypes
 					.WithMessage("*are all within namespace*but it contained not matching types*ClassInSiblingNamespaceScope*")
 					.AsWildcard();
 			}
+
+#if NET8_0_OR_GREATER
+			[Fact]
+			public async Task WhenAsyncEnumerableTypesAreWithinNamespace_ShouldSucceed()
+			{
+				IAsyncEnumerable<Type?> subject = new Type?[]
+				{
+					typeof(ClassInNamespaceScope),
+					typeof(ClassInNestedNamespaceScope),
+				}.ToTestAsyncEnumerable();
+
+				async Task Act()
+				{
+					await That(subject)
+						.AreWithinNamespace("aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope");
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenAsyncEnumerableContainsTypeInOtherNamespace_ShouldFail()
+			{
+				IAsyncEnumerable<Type?> subject = new Type?[]
+				{
+					typeof(ClassInNamespaceScope),
+					typeof(ClassInSiblingNamespaceScope),
+				}.ToTestAsyncEnumerable();
+
+				async Task Act()
+				{
+					await That(subject)
+						.AreWithinNamespace("aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("*are all within namespace*but it contained not matching types*ClassInSiblingNamespaceScope*")
+					.AsWildcard();
+			}
+#endif
 		}
 
 		public sealed class NegatedTests

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.AreWithinNamespace.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.AreWithinNamespace.Tests.cs
@@ -1,4 +1,8 @@
+﻿using System.Collections.Generic;
 using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope;
+using aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope.Nested;
+using aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScopeSibling;
 using Xunit.Sdk;
 
 namespace aweXpect.Reflection.Tests;
@@ -40,11 +44,49 @@ public sealed partial class ThatTypes
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
 					             Expected that types with namespace starting with "aweXpect.Reflection.Tests.Test…" in assembly containing type ThatTypes.AreWithinNamespace.Tests
-					             all are within namespace "aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope",
+					             are all within namespace "aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope",
 					             but it contained not matching types [
 					               *ClassInSiblingNamespaceScope*
 					             ]
 					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenEnumerableTypesAreWithinNamespace_ShouldSucceed()
+			{
+				IEnumerable<Type?> subject =
+				[
+					typeof(ClassInNamespaceScope),
+					typeof(ClassInNestedNamespaceScope),
+				];
+
+				async Task Act()
+				{
+					await That(subject)
+						.AreWithinNamespace("aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope");
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenEnumerableContainsTypeInOtherNamespace_ShouldFail()
+			{
+				IEnumerable<Type?> subject =
+				[
+					typeof(ClassInNamespaceScope),
+					typeof(ClassInSiblingNamespaceScope),
+				];
+
+				async Task Act()
+				{
+					await That(subject)
+						.AreWithinNamespace("aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("*are all within namespace*but it contained not matching types*ClassInSiblingNamespaceScope*")
+					.AsWildcard();
 			}
 		}
 
@@ -63,7 +105,7 @@ public sealed partial class ThatTypes
 				}
 
 				await That(Act).Throws<XunitException>()
-					.WithMessage("*not all are within namespace*NamespaceScope*").AsWildcard();
+					.WithMessage("*are not all within namespace*NamespaceScope*").AsWildcard();
 			}
 		}
 	}


### PR DESCRIPTION
Add a dedicated namespace-hierarchy DSL that matches a namespace and all its sub-namespaces, without the prefix ambiguity of .WithNamespace("Foo.Bar").AsPrefix() (which also matches Foo.BarBaz):

- Filter:          .WithinNamespace("Foo.Bar")
- Assert (single): .IsWithinNamespace("Foo.Bar")
- Assert (many):   .AreWithinNamespace("Foo.Bar")

Matching walks the type's namespace up its ancestor chain and compares each level via StringEqualityOptions, so the match boundary always falls on a namespace separator. The case/white-space options (IgnoringCase, …) are supported, but the pattern options (AsPrefix/AsSuffix/AsWildcard/ AsRegex) are intentionally excluded.

---

- *Closes #233*