### PR TITLE
coverage: kill surviving HaveParameter mutants on ThatMethods

### DIFF
--- a/Tests/aweXpect.Reflection.Tests/ThatMethods.HaveParameter.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethods.HaveParameter.Tests.cs
@@ -22,6 +22,16 @@ public sealed partial class ThatMethods
 
 			await Task.CompletedTask;
 		}
+
+		private static async IAsyncEnumerable<MethodInfo?> ToAsyncEnumerableNullable(params MethodInfo?[] items)
+		{
+			foreach (MethodInfo? item in items)
+			{
+				yield return item;
+			}
+
+			await Task.CompletedTask;
+		}
 #endif
 		public sealed class Tests
 		{
@@ -150,6 +160,71 @@ public sealed partial class ThatMethods
 					.WithMessage("""
 					             Expected that methods
 					             all have parameter of type int with name "value",
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task HaveParameterByTypeAndName_WhenTypeMatchesButNameDoesNot_ShouldFail()
+			{
+				IEnumerable<MethodInfo> methods = new[]
+				{
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithIntAndString))!, // int "value", string "name"
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithInt))!, // int "value"
+				};
+
+				async Task Act()
+				{
+					await That(methods).HaveParameter<int>("name");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methods
+					             all have parameter of type int with name "name",
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task HaveParameterByTypeParameterAndName_WhenTypeMatchesButNameDoesNot_ShouldFail()
+			{
+				IEnumerable<MethodInfo> methods = new[]
+				{
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithIntAndString))!, // int "value", string "name"
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithInt))!, // int "value"
+				};
+
+				async Task Act()
+				{
+					await That(methods).HaveParameter(typeof(int), "name");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methods
+					             all have parameter of type int with name "name",
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task ByType_WhenMethodIsNull_ShouldFail()
+			{
+				IEnumerable<MethodInfo?> methods = new MethodInfo?[]
+				{
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithInt)), null,
+				};
+
+				async Task Act()
+				{
+					await That(methods).HaveParameter<int>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methods
+					             all have parameter of type int,
 					             but at least one did not
 					             """);
 			}
@@ -312,6 +387,45 @@ public sealed partial class ThatMethods
 					.WithMessage("""
 					             Expected that methods
 					             all have parameter of type int with name "value",
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task AsyncEnumerable_ByTypeParameter_WhenTypeMatchesButNameDoesNot_ShouldFail()
+			{
+				IAsyncEnumerable<MethodInfo> methods = ToAsyncEnumerable(
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithIntAndString))!,
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithInt))!);
+
+				async Task Act()
+				{
+					await That(methods).HaveParameter(typeof(int), "name");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methods
+					             all have parameter of type int with name "name",
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task AsyncEnumerable_ByType_WhenMethodIsNull_ShouldFail()
+			{
+				IAsyncEnumerable<MethodInfo?> methods = ToAsyncEnumerableNullable(
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithInt)), null);
+
+				async Task Act()
+				{
+					await That(methods).HaveParameter(typeof(int));
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methods
+					             all have parameter of type int,
 					             but at least one did not
 					             """);
 			}
@@ -523,6 +637,49 @@ public sealed partial class ThatMethods
 				await That(Act).DoesNotThrow();
 			}
 
+			[Fact]
+			public async Task AtIndex_WhenAllHaveParameterAtIndex_ShouldFailWithIndexDescription()
+			{
+				IEnumerable<MethodInfo> methods = new[]
+				{
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithInt))!, // int at index 0
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithIntAndString))!, // int at index 0
+				};
+
+				async Task Act()
+				{
+					await That(methods).DoesNotComplyWith(they => they.HaveParameter<int>().AtIndex(0));
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methods
+					             not all have parameter of type int at index 0,
+					             but all did
+					             """);
+			}
+
+			[Fact]
+			public async Task WithModifier_WhenAllHaveRefParameter_ShouldFailWithModifierDescription()
+			{
+				IEnumerable<MethodInfo> methods = new[]
+				{
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithRefInt))!, typeof(TestClass).GetMethod(nameof(TestClass.AnotherMethodWithRefInt))!,
+				};
+
+				async Task Act()
+				{
+					await That(methods).DoesNotComplyWith(they => they.HaveRefParameter<int>());
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methods
+					             not all have parameter of type int with ref modifier,
+					             but all did
+					             """);
+			}
+
 #pragma warning disable CA1822
 			// ReSharper disable UnusedParameter.Local
 			// ReSharper disable UnusedMember.Local
@@ -533,6 +690,8 @@ public sealed partial class ThatMethods
 				public void MethodWithIntAndString(int value, string name) { }
 				public void MethodWithStream(Stream stream) { }
 				public void MethodWithMemoryStream(MemoryStream stream) { }
+				public void MethodWithRefInt(ref int value) => value = 0;
+				public void AnotherMethodWithRefInt(ref int number) => number = 0;
 			}
 			// ReSharper restore UnusedParameter.Local
 			// ReSharper restore UnusedMember.Local

--- a/Tests/aweXpect.Reflection.Tests/ThatMethods.HaveParameterCount.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethods.HaveParameterCount.Tests.cs
@@ -8,6 +8,18 @@ public sealed partial class ThatMethods
 {
 	public sealed class HaveParameterCount
 	{
+#if NET8_0_OR_GREATER
+		private static async IAsyncEnumerable<MethodInfo> ToAsyncEnumerable(params MethodInfo[] items)
+		{
+			foreach (MethodInfo item in items)
+			{
+				yield return item;
+			}
+
+			await Task.CompletedTask;
+		}
+#endif
+
 		public sealed class Tests
 		{
 			[Fact]
@@ -43,9 +55,67 @@ public sealed partial class ThatMethods
 					.WithMessage("""
 					             Expected that methods
 					             all have 2 parameters,
+					             but it contained methods with a different number of parameters *MethodWithInt(*
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenExpectingOneParameter_ShouldIncludeSingularDescription()
+			{
+				IEnumerable<MethodInfo> methods = new[]
+				{
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithIntAndString))!, typeof(TestClass).GetMethod(nameof(TestClass.MethodWithStringAndInt))!,
+				};
+
+				async Task Act()
+				{
+					await That(methods).HaveParameterCount(1);
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methods
+					             all have one parameter,
 					             but it contained methods with a different number of parameters *
 					             """).AsWildcard();
 			}
+
+#if NET8_0_OR_GREATER
+			[Fact]
+			public async Task AsyncEnumerable_WhenAllHaveExpectedCount_ShouldSucceed()
+			{
+				IAsyncEnumerable<MethodInfo> methods = ToAsyncEnumerable(
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithIntAndString))!,
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithStringAndInt))!);
+
+				async Task Act()
+				{
+					await That(methods).HaveParameterCount(2);
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task AsyncEnumerable_WhenNotAllHaveExpectedCount_ShouldFail()
+			{
+				IAsyncEnumerable<MethodInfo> methods = ToAsyncEnumerable(
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithIntAndString))!,
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithInt))!);
+
+				async Task Act()
+				{
+					await That(methods).HaveParameterCount(2);
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methods
+					             all have 2 parameters,
+					             but it contained methods with a different number of parameters *MethodWithInt(*
+					             """).AsWildcard();
+			}
+#endif
 		}
 
 		public sealed class NegatedTests
@@ -67,7 +137,7 @@ public sealed partial class ThatMethods
 					.WithMessage("""
 					             Expected that methods
 					             not all have 2 parameters,
-					             but it only contained methods with 2 parameters *
+					             but it only contained methods with 2 parameters *MethodWithIntAndString(*
 					             """).AsWildcard();
 			}
 

--- a/Tests/aweXpect.Reflection.Tests/ThatMethods.HaveParameterExactly.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethods.HaveParameterExactly.Tests.cs
@@ -79,6 +79,90 @@ public sealed partial class ThatMethods
 			}
 
 			[Fact]
+			public async Task WithName_WhenSubtypeParameterMatchesName_ShouldFail()
+			{
+				IEnumerable<MethodInfo> methods = new[]
+				{
+					typeof(TestClass).GetMethod(nameof(TestClass.FirstMethodWithStream))!, typeof(TestClass).GetMethod(nameof(TestClass.MethodWithMemoryStream))!, // MemoryStream is not exactly Stream
+				};
+
+				async Task Act()
+				{
+					await That(methods).HaveParameterExactly<Stream>("stream");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methods
+					             all have parameter of exact type Stream with name "stream",
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task WithName_WhenExactTypeButNameDoesNotMatch_ShouldFail()
+			{
+				IEnumerable<MethodInfo> methods = new[]
+				{
+					typeof(TestClass).GetMethod(nameof(TestClass.FirstMethodWithStream))!, typeof(TestClass).GetMethod(nameof(TestClass.SecondMethodWithStream))!,
+				};
+
+				async Task Act()
+				{
+					await That(methods).HaveParameterExactly<Stream>("other");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methods
+					             all have parameter of exact type Stream with name "other",
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task WithType_WhenSubtypeParameterMatchesName_ShouldFail()
+			{
+				IEnumerable<MethodInfo> methods = new[]
+				{
+					typeof(TestClass).GetMethod(nameof(TestClass.FirstMethodWithStream))!, typeof(TestClass).GetMethod(nameof(TestClass.MethodWithMemoryStream))!, // MemoryStream is not exactly Stream
+				};
+
+				async Task Act()
+				{
+					await That(methods).HaveParameterExactly(typeof(Stream), "stream");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methods
+					             all have parameter of exact type Stream with name "stream",
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task WithType_WhenExactTypeButNameDoesNotMatch_ShouldFail()
+			{
+				IEnumerable<MethodInfo> methods = new[]
+				{
+					typeof(TestClass).GetMethod(nameof(TestClass.FirstMethodWithStream))!, typeof(TestClass).GetMethod(nameof(TestClass.SecondMethodWithStream))!,
+				};
+
+				async Task Act()
+				{
+					await That(methods).HaveParameterExactly(typeof(Stream), "other");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methods
+					             all have parameter of exact type Stream with name "other",
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
 			public async Task WithType_WhenAllHaveExactType_ShouldSucceed()
 			{
 				IEnumerable<MethodInfo> methods = new[]
@@ -174,7 +258,52 @@ public sealed partial class ThatMethods
 					await That(methods).HaveParameterExactly<Stream>();
 				}
 
-				await That(Act).Throws<XunitException>();
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methods
+					             all have parameter of exact type Stream,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task AsyncEnumerable_WithName_WhenSubtypeParameterMatchesName_ShouldFail()
+			{
+				IAsyncEnumerable<MethodInfo> methods = ToAsyncEnumerable(
+					typeof(TestClass).GetMethod(nameof(TestClass.FirstMethodWithStream))!,
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithMemoryStream))!);
+
+				async Task Act()
+				{
+					await That(methods).HaveParameterExactly<Stream>("stream");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methods
+					             all have parameter of exact type Stream with name "stream",
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task AsyncEnumerable_WithName_WhenExactTypeButNameDoesNotMatch_ShouldFail()
+			{
+				IAsyncEnumerable<MethodInfo> methods = ToAsyncEnumerable(
+					typeof(TestClass).GetMethod(nameof(TestClass.FirstMethodWithStream))!,
+					typeof(TestClass).GetMethod(nameof(TestClass.SecondMethodWithStream))!);
+
+				async Task Act()
+				{
+					await That(methods).HaveParameterExactly<Stream>("other");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methods
+					             all have parameter of exact type Stream with name "other",
+					             but at least one did not
+					             """);
 			}
 
 			[Fact]
@@ -219,7 +348,52 @@ public sealed partial class ThatMethods
 					await That(methods).HaveParameterExactly(typeof(Stream));
 				}
 
-				await That(Act).Throws<XunitException>();
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methods
+					             all have parameter of exact type Stream,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task AsyncEnumerable_WithTypeAndName_WhenSubtypeParameterMatchesName_ShouldFail()
+			{
+				IAsyncEnumerable<MethodInfo> methods = ToAsyncEnumerable(
+					typeof(TestClass).GetMethod(nameof(TestClass.FirstMethodWithStream))!,
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithMemoryStream))!);
+
+				async Task Act()
+				{
+					await That(methods).HaveParameterExactly(typeof(Stream), "stream");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methods
+					             all have parameter of exact type Stream with name "stream",
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task AsyncEnumerable_WithTypeAndName_WhenExactTypeButNameDoesNotMatch_ShouldFail()
+			{
+				IAsyncEnumerable<MethodInfo> methods = ToAsyncEnumerable(
+					typeof(TestClass).GetMethod(nameof(TestClass.FirstMethodWithStream))!,
+					typeof(TestClass).GetMethod(nameof(TestClass.SecondMethodWithStream))!);
+
+				async Task Act()
+				{
+					await That(methods).HaveParameterExactly(typeof(Stream), "other");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methods
+					             all have parameter of exact type Stream with name "other",
+					             but at least one did not
+					             """);
 			}
 #endif
 		}


### PR DESCRIPTION
Strengthen the ThatMethods.HaveParameter, .HaveParameterExactly and .HaveParameterCount test suites to cover Stryker mutants that previously survived or had no coverage:

- exact-type vs subtype name/type assertions (exactType flag)
- name-predicate removal cases (type matches but name does not)
- null MethodInfo element handling
- async IAsyncEnumerable overloads (count + parameter)
- negated index/modifier description messages
- singular "one parameter" count description

No production code changed.