### PR TITLE
coverage: kill AssemblyFilters/TypeFilters/Options/Results mutants

### DIFF
--- a/Tests/aweXpect.Reflection.Tests/Filters/AssemblyFilters.WhichHaveDependenciesOnlyOn.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/AssemblyFilters.WhichHaveDependenciesOnlyOn.Tests.cs
@@ -22,6 +22,17 @@ public sealed partial class AssemblyFilters
 			}
 
 			[Fact]
+			public async Task ShouldDescribeTheFilterForNoAllowedAssemblies()
+			{
+				Filtered.Assemblies assemblies = In.AssemblyContaining<PublicAbstractClass>()
+					.WhichHaveDependenciesOnlyOn();
+
+				await That(assemblies.GetDescription())
+					.IsEqualTo(
+						"in assembly containing type PublicAbstractClass which have dependencies only on no assemblies");
+			}
+
+			[Fact]
 			public async Task ShouldDescribeTheFilterForMultipleAllowedAssemblies()
 			{
 				Filtered.Assemblies assemblies = In.AssemblyContaining<PublicAbstractClass>()

--- a/Tests/aweXpect.Reflection.Tests/Filters/AssemblyFilters.With.AttributeTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/AssemblyFilters.With.AttributeTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Reflection;
 using aweXpect.Reflection.Collections;
 
@@ -7,8 +8,28 @@ public sealed partial class AssemblyFilters
 {
 	public sealed class With
 	{
+		/// <summary>
+		///     A custom attribute that is never applied to any assembly, used to verify
+		///     <c>OrWith</c> alternatives.
+		/// </summary>
+		[AttributeUsage(AttributeTargets.Assembly)]
+		private sealed class NeverAppliedAssemblyAttribute : Attribute;
+
 		public sealed class AttributeTests
 		{
+			[Fact]
+			public async Task WithPredicate_WhenInheritIsSetToFalse_ShouldDescribeAsDirect()
+			{
+				Filtered.Assemblies assemblies = In.AllLoadedAssemblies()
+					.With<AssemblyTitleAttribute>(attribute => attribute.Title == "aweXpect.Reflection.Tests",
+						false);
+
+				await That(assemblies).HasSingle().Which.IsEqualTo(typeof(AssemblyFilters).Assembly);
+				await That(assemblies.GetDescription())
+					.IsEqualTo(
+						"in all loaded assemblies with direct AssemblyTitleAttribute matching attribute => attribute.Title == \"aweXpect.Reflection.Tests\"");
+			}
+
 			[Fact]
 			public async Task ShouldFilterForAssembliesWithAttribute()
 			{
@@ -49,6 +70,43 @@ public sealed partial class AssemblyFilters
 		public sealed class OrWithAttributeTests
 		{
 			[Fact]
+			public async Task OrWithoutPredicate_ShouldDescribeBothAttributes()
+			{
+				Filtered.Assemblies assemblies = In.AllLoadedAssemblies()
+					.With<AssemblyTitleAttribute>()
+					.OrWith<NeverAppliedAssemblyAttribute>();
+
+				await That(assemblies.GetDescription())
+					.IsEqualTo(
+						"in all loaded assemblies with AssemblyTitleAttribute or with AssemblyFilters.With.NeverAppliedAssemblyAttribute")
+					.AsPrefix();
+			}
+
+			[Fact]
+			public async Task OrWithoutPredicate_WhenInheritIsSetToFalse_ShouldDescribeAsDirect()
+			{
+				Filtered.Assemblies assemblies = In.AllLoadedAssemblies()
+					.With<AssemblyTitleAttribute>()
+					.OrWith<NeverAppliedAssemblyAttribute>(false);
+
+				await That(assemblies.GetDescription())
+					.IsEqualTo(
+						"in all loaded assemblies with AssemblyTitleAttribute or with direct AssemblyFilters.With.NeverAppliedAssemblyAttribute")
+					.AsPrefix();
+			}
+
+			[Fact]
+			public async Task OrWithoutPredicate_ShouldKeepAssembliesMatchingOnlyTheFirstAttribute()
+			{
+				Filtered.Assemblies assemblies = In.AllLoadedAssemblies()
+					.With<AssemblyTitleAttribute>()
+					.OrWith<NeverAppliedAssemblyAttribute>();
+
+				// No assembly has the NeverAppliedAssemblyAttribute, so an "and" semantic would yield none.
+				await That(assemblies).HasCount().AtLeast(2);
+			}
+
+			[Fact]
 			public async Task ShouldFilterForAssembliesWithEitherAttribute()
 			{
 				Filtered.Assemblies assemblies = In.AllLoadedAssemblies()
@@ -62,6 +120,18 @@ public sealed partial class AssemblyFilters
 				await That(assemblies.GetDescription())
 					.IsEqualTo(
 						"in all loaded assemblies with AssemblyTitleAttribute matching attribute => attribute.Title == \"aweXpect.Reflection.Tests\" or with AssemblyTitleAttribute matching attribute => attribute.Title == \"aweXpect.Reflection\"");
+			}
+
+			[Fact]
+			public async Task OrWithPredicate_WhenInheritIsSetToFalse_ShouldDescribeAsDirect()
+			{
+				Filtered.Assemblies assemblies = In.AllLoadedAssemblies()
+					.With<AssemblyTitleAttribute>(attribute => attribute.Title == "aweXpect.Reflection.Tests")
+					.OrWith<AssemblyTitleAttribute>(attribute => attribute.Title == "aweXpect.Reflection", false);
+
+				await That(assemblies.GetDescription())
+					.IsEqualTo(
+						"in all loaded assemblies with AssemblyTitleAttribute matching attribute => attribute.Title == \"aweXpect.Reflection.Tests\" or with direct AssemblyTitleAttribute matching attribute => attribute.Title == \"aweXpect.Reflection\"");
 			}
 		}
 	}

--- a/Tests/aweXpect.Reflection.Tests/Filters/AssemblyFilters.WithVersion.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/AssemblyFilters.WithVersion.Tests.cs
@@ -1,4 +1,6 @@
+using System.Reflection;
 using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Tests.TestHelpers.Types;
 
 namespace aweXpect.Reflection.Tests.Filters;
 
@@ -104,6 +106,75 @@ public sealed partial class AssemblyFilters
 					.WithVersion().WithMajor.GreaterThan(100000);
 
 				await That(assemblies).IsEmpty();
+			}
+
+			[Fact]
+			public async Task GreaterThan_ShouldNotMatchTheBoundaryValue()
+			{
+				Assembly assembly = typeof(PublicAbstractClass).Assembly;
+				int major = assembly.GetName().Version!.Major;
+
+				Filtered.Assemblies excluded = In.Assemblies(assembly).WithVersion().WithMajor.GreaterThan(major);
+				Filtered.Assemblies included = In.Assemblies(assembly).WithVersion().WithMajor.GreaterThan(major - 1);
+
+				await That(excluded).IsEmpty();
+				await That(included).HasSingle().Which.IsEqualTo(assembly);
+			}
+
+			[Fact]
+			public async Task GreaterThanOrEqualTo_ShouldMatchTheBoundaryValue()
+			{
+				Assembly assembly = typeof(PublicAbstractClass).Assembly;
+				int major = assembly.GetName().Version!.Major;
+
+				Filtered.Assemblies included =
+					In.Assemblies(assembly).WithVersion().WithMajor.GreaterThanOrEqualTo(major);
+				Filtered.Assemblies excluded =
+					In.Assemblies(assembly).WithVersion().WithMajor.GreaterThanOrEqualTo(major + 1);
+
+				await That(included).HasSingle().Which.IsEqualTo(assembly);
+				await That(excluded).IsEmpty();
+			}
+
+			[Fact]
+			public async Task LessThanOrEqualTo_ShouldMatchTheBoundaryValue()
+			{
+				Assembly assembly = typeof(PublicAbstractClass).Assembly;
+				int major = assembly.GetName().Version!.Major;
+
+				Filtered.Assemblies included =
+					In.Assemblies(assembly).WithVersion().WithMajor.LessThanOrEqualTo(major);
+				Filtered.Assemblies excluded =
+					In.Assemblies(assembly).WithVersion().WithMajor.LessThanOrEqualTo(major - 1);
+
+				await That(included).HasSingle().Which.IsEqualTo(assembly);
+				await That(excluded).IsEmpty();
+			}
+
+			[Fact]
+			public async Task EqualTo_ShouldMatchOnlyTheExactValue()
+			{
+				Assembly assembly = typeof(PublicAbstractClass).Assembly;
+				int major = assembly.GetName().Version!.Major;
+
+				Filtered.Assemblies included = In.Assemblies(assembly).WithVersion().WithMajor.EqualTo(major);
+				Filtered.Assemblies excluded = In.Assemblies(assembly).WithVersion().WithMajor.EqualTo(major + 1);
+
+				await That(included).HasSingle().Which.IsEqualTo(assembly);
+				await That(excluded).IsEmpty();
+			}
+
+			[Fact]
+			public async Task NotEqualTo_ShouldMatchEverythingExceptTheExactValue()
+			{
+				Assembly assembly = typeof(PublicAbstractClass).Assembly;
+				int major = assembly.GetName().Version!.Major;
+
+				Filtered.Assemblies excluded = In.Assemblies(assembly).WithVersion().WithMajor.NotEqualTo(major);
+				Filtered.Assemblies included = In.Assemblies(assembly).WithVersion().WithMajor.NotEqualTo(major + 1);
+
+				await That(excluded).IsEmpty();
+				await That(included).HasSingle().Which.IsEqualTo(assembly);
 			}
 
 			[Fact]

--- a/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichContainMethods.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichContainMethods.Tests.cs
@@ -19,12 +19,102 @@ public sealed partial class TypeFilters
 			}
 
 			[Fact]
+			public async Task AtLeastTimes_ShouldFilterForTypesWithAtLeastTheCount()
+			{
+				Filtered.Types types = In.Types<TaggedClass, TwiceTaggedClass, UntaggedClass>()
+					.WhichContainMethods(methods => methods.With<MarkerAttribute>()).AtLeast(2);
+
+				await That(types).IsEqualTo([typeof(TwiceTaggedClass),]).InAnyOrder();
+			}
+
+			[Fact]
+			public async Task AtLeastFluent_ShouldFilterForTypesWithAtLeastTheCount()
+			{
+				Filtered.Types types = In.Types<TaggedClass, TwiceTaggedClass, UntaggedClass>()
+					.WhichContainMethods(methods => methods.With<MarkerAttribute>()).AtLeast().Twice();
+
+				await That(types).IsEqualTo([typeof(TwiceTaggedClass),]).InAnyOrder();
+			}
+
+			[Fact]
+			public async Task AtMostFluent_ShouldFilterForTypesWithAtMostTheCount()
+			{
+				Filtered.Types types = In.Types<TaggedClass, TwiceTaggedClass, UntaggedClass>()
+					.WhichContainMethods(methods => methods.With<MarkerAttribute>()).AtMost().Once();
+
+				await That(types).IsEqualTo([typeof(TaggedClass), typeof(UntaggedClass),]).InAnyOrder();
+			}
+
+			[Fact]
 			public async Task Between_ShouldFilterForTypesWithinTheRange()
 			{
 				Filtered.Types types = In.Types<TaggedClass, TwiceTaggedClass, UntaggedClass>()
 					.WhichContainMethods(methods => methods.With<MarkerAttribute>()).Between(1).And(2);
 
 				await That(types).IsEqualTo([typeof(TaggedClass), typeof(TwiceTaggedClass),]).InAnyOrder();
+			}
+
+			[Fact]
+			public async Task Between_ShouldExcludeTypesOutsideTheRange()
+			{
+				Filtered.Types types = In.Types<TaggedClass, TwiceTaggedClass, UntaggedClass>()
+					.WhichContainMethods(methods => methods.With<MarkerAttribute>()).Between(2).And(2);
+
+				await That(types).IsEqualTo([typeof(TwiceTaggedClass),]).InAnyOrder();
+			}
+
+			[Fact]
+			public async Task LessThanFluent_ShouldFilterForTypesWithLessThanTheCount()
+			{
+				Filtered.Types types = In.Types<TaggedClass, TwiceTaggedClass, UntaggedClass>()
+					.WhichContainMethods(methods => methods.With<MarkerAttribute>()).LessThan().Twice();
+
+				await That(types).IsEqualTo([typeof(TaggedClass), typeof(UntaggedClass),]).InAnyOrder();
+			}
+
+			[Fact]
+			public async Task LessThanTimes_ShouldFilterForTypesWithLessThanTheCount()
+			{
+				Filtered.Types types = In.Types<TaggedClass, TwiceTaggedClass, UntaggedClass>()
+					.WhichContainMethods(methods => methods.With<MarkerAttribute>()).LessThan(2);
+
+				await That(types).IsEqualTo([typeof(TaggedClass), typeof(UntaggedClass),]).InAnyOrder();
+			}
+
+			[Fact]
+			public async Task MoreThanFluent_ShouldFilterForTypesWithMoreThanTheCount()
+			{
+				Filtered.Types types = In.Types<TaggedClass, TwiceTaggedClass, UntaggedClass>()
+					.WhichContainMethods(methods => methods.With<MarkerAttribute>()).MoreThan().Once();
+
+				await That(types).IsEqualTo([typeof(TwiceTaggedClass),]).InAnyOrder();
+			}
+
+			[Fact]
+			public async Task MoreThanTimes_ShouldFilterForTypesWithMoreThanTheCount()
+			{
+				Filtered.Types types = In.Types<TaggedClass, TwiceTaggedClass, UntaggedClass>()
+					.WhichContainMethods(methods => methods.With<MarkerAttribute>()).MoreThan(1);
+
+				await That(types).IsEqualTo([typeof(TwiceTaggedClass),]).InAnyOrder();
+			}
+
+			[Fact]
+			public async Task Once_ShouldFilterForTypesWithExactlyOneMatch()
+			{
+				Filtered.Types types = In.Types<TaggedClass, TwiceTaggedClass, UntaggedClass>()
+					.WhichContainMethods(methods => methods.With<MarkerAttribute>()).Once();
+
+				await That(types).IsEqualTo([typeof(TaggedClass),]).InAnyOrder();
+			}
+
+			[Fact]
+			public async Task Twice_ShouldFilterForTypesWithExactlyTwoMatches()
+			{
+				Filtered.Types types = In.Types<TaggedClass, TwiceTaggedClass, UntaggedClass>()
+					.WhichContainMethods(methods => methods.With<MarkerAttribute>()).Twice();
+
+				await That(types).IsEqualTo([typeof(TwiceTaggedClass),]).InAnyOrder();
 			}
 
 			[Fact]
@@ -118,6 +208,22 @@ public sealed partial class TypeFilters
 					.IsEqualTo(
 						"types which contain methods with TypeFilters.WhichContainMethods.MarkerAttribute or with TypeFilters.WhichContainMethods.OtherAttribute at least once ")
 					.AsPrefix();
+			}
+
+			[Fact]
+			public async Task ShouldStripTrailingInFromTheInnerMembersDescription()
+			{
+				Filtered.Types types = In.AssemblyContaining<MarkerAttribute>().Types()
+					.WhichContainMethods(methods => methods.With<MarkerAttribute>());
+
+				// The inner probe description ("methods with …MarkerAttribute in ") has its
+				// trailing "in " removed before being embedded into the type description, so the
+				// members fragment reads exactly "…MarkerAttribute at least once " with no chopped
+				// characters around "MarkerAttribute".
+				await That(types.GetDescription())
+					.IsEqualTo(
+						"*which contain methods with TypeFilters.WhichContainMethods.MarkerAttribute at least once *")
+					.AsWildcard();
 			}
 		}
 

--- a/Tests/aweXpect.Reflection.Tests/ThatMethod.HasParameter.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethod.HasParameter.Tests.cs
@@ -476,6 +476,91 @@ public sealed partial class ThatMethod
 				await That(Act).DoesNotThrow();
 			}
 
+			[Fact]
+			public async Task WithDefaultValue_WhenParameterHasNoDefault_ShouldFail()
+			{
+				MethodInfo methodInfo = typeof(TestClass).GetMethod(nameof(TestClass.MethodWithIntAndString))!;
+
+				async Task Act()
+				{
+					await That(methodInfo).HasParameter<string>().WithDefaultValue();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methodInfo
+					             has parameter of type string,
+					             but it did not
+					             """);
+			}
+
+			[Fact]
+			public async Task WithoutDefaultValue_WhenParameterHasDefault_ShouldFail()
+			{
+				MethodInfo methodInfo = typeof(TestClass).GetMethod(nameof(TestClass.MethodWithDefaults))!;
+
+				async Task Act()
+				{
+					await That(methodInfo).HasParameter<string>().WithoutDefaultValue();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methodInfo
+					             has parameter of type string,
+					             but it did not
+					             """);
+			}
+
+			[Fact]
+			public async Task WithDefaultValueOfValue_WhenParameterHasMatchingDefault_ShouldSucceed()
+			{
+				MethodInfo methodInfo = typeof(TestClass).GetMethod(nameof(TestClass.MethodWithDefaults))!;
+
+				async Task Act()
+				{
+					await That(methodInfo).HasParameter<string>().WithDefaultValue("default");
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WithDefaultValueOfValue_WhenParameterHasDifferentDefault_ShouldFail()
+			{
+				MethodInfo methodInfo = typeof(TestClass).GetMethod(nameof(TestClass.MethodWithDefaults))!;
+
+				async Task Act()
+				{
+					await That(methodInfo).HasParameter<string>().WithDefaultValue("other");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methodInfo
+					             has parameter of type string,
+					             but it did not
+					             """);
+			}
+
+			[Fact]
+			public async Task WithDefaultValueOfValue_WhenParameterHasNoDefault_ShouldFail()
+			{
+				MethodInfo methodInfo = typeof(TestClass).GetMethod(nameof(TestClass.MethodWithIntAndString))!;
+
+				async Task Act()
+				{
+					await That(methodInfo).HasParameter<string>().WithDefaultValue("default");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methodInfo
+					             has parameter of type string,
+					             but it did not
+					             """);
+			}
+
 #pragma warning disable CA1822
 			// ReSharper disable UnusedParameter.Local
 			// ReSharper disable UnusedMember.Local

--- a/Tests/aweXpect.Reflection.Tests/ThatType.ContainsMethods.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatType.ContainsMethods.Tests.cs
@@ -290,6 +290,196 @@ public sealed partial class ThatType
 					             but it contained 2 matching members in ThatType.ContainsMethods.ClassWithTwoMarkedMethods
 					             """);
 			}
+
+			[Fact]
+			public async Task AtLeast_Fluent_WhenCountIsInsufficient_ShouldFail()
+			{
+				Type subject = typeof(ClassWithMarkedMethod);
+
+				async Task Act()
+				{
+					await That(subject).ContainsMethods(methods => methods.With<MarkerAttribute>())
+						.AtLeast().Twice();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             contains methods with ThatType.ContainsMethods.MarkerAttribute at least twice,
+					             but it contained 1 matching member in ThatType.ContainsMethods.ClassWithMarkedMethod
+					             """);
+			}
+
+			[Fact]
+			public async Task AtLeast_Times_WhenCountIsInsufficient_ShouldFail()
+			{
+				Type subject = typeof(ClassWithMarkedMethod);
+
+				async Task Act()
+				{
+					await That(subject).ContainsMethods(methods => methods.With<MarkerAttribute>())
+						.AtLeast(2);
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             contains methods with ThatType.ContainsMethods.MarkerAttribute at least twice,
+					             but it contained 1 matching member in ThatType.ContainsMethods.ClassWithMarkedMethod
+					             """);
+			}
+
+			[Fact]
+			public async Task AtMost_Times_WhenCountExceedsLimit_ShouldFail()
+			{
+				Type subject = typeof(ClassWithTwoMarkedMethods);
+
+				async Task Act()
+				{
+					await That(subject).ContainsMethods(methods => methods.With<MarkerAttribute>())
+						.AtMost(1);
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             contains methods with ThatType.ContainsMethods.MarkerAttribute at most once,
+					             but it contained 2 matching members in ThatType.ContainsMethods.ClassWithTwoMarkedMethods
+					             """);
+			}
+
+			[Fact]
+			public async Task Between_And_WhenCountIsBelowRange_ShouldFail()
+			{
+				Type subject = typeof(ClassWithMarkedMethod);
+
+				async Task Act()
+				{
+					await That(subject).ContainsMethods(methods => methods.With<MarkerAttribute>())
+						.Between(2).And(3);
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             contains methods with ThatType.ContainsMethods.MarkerAttribute between 2 and 3 times,
+					             but it contained 1 matching member in ThatType.ContainsMethods.ClassWithMarkedMethod
+					             """);
+			}
+
+			[Fact]
+			public async Task LessThan_Fluent_WhenCountReachesLimit_ShouldFail()
+			{
+				Type subject = typeof(ClassWithTwoMarkedMethods);
+
+				async Task Act()
+				{
+					await That(subject).ContainsMethods(methods => methods.With<MarkerAttribute>())
+						.LessThan().Twice();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             contains methods with ThatType.ContainsMethods.MarkerAttribute less than twice,
+					             but it contained 2 matching members in ThatType.ContainsMethods.ClassWithTwoMarkedMethods
+					             """);
+			}
+
+			[Fact]
+			public async Task LessThan_Times_WhenCountReachesLimit_ShouldFail()
+			{
+				Type subject = typeof(ClassWithTwoMarkedMethods);
+
+				async Task Act()
+				{
+					await That(subject).ContainsMethods(methods => methods.With<MarkerAttribute>())
+						.LessThan(2);
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             contains methods with ThatType.ContainsMethods.MarkerAttribute less than twice,
+					             but it contained 2 matching members in ThatType.ContainsMethods.ClassWithTwoMarkedMethods
+					             """);
+			}
+
+			[Fact]
+			public async Task MoreThan_Fluent_WhenCountReachesLimit_ShouldFail()
+			{
+				Type subject = typeof(ClassWithTwoMarkedMethods);
+
+				async Task Act()
+				{
+					await That(subject).ContainsMethods(methods => methods.With<MarkerAttribute>())
+						.MoreThan().Twice();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             contains methods with ThatType.ContainsMethods.MarkerAttribute more than twice,
+					             but it contained 2 matching members in ThatType.ContainsMethods.ClassWithTwoMarkedMethods
+					             """);
+			}
+
+			[Fact]
+			public async Task MoreThan_Times_WhenCountReachesLimit_ShouldFail()
+			{
+				Type subject = typeof(ClassWithTwoMarkedMethods);
+
+				async Task Act()
+				{
+					await That(subject).ContainsMethods(methods => methods.With<MarkerAttribute>())
+						.MoreThan(2);
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             contains methods with ThatType.ContainsMethods.MarkerAttribute more than twice,
+					             but it contained 2 matching members in ThatType.ContainsMethods.ClassWithTwoMarkedMethods
+					             """);
+			}
+
+			[Fact]
+			public async Task Once_WhenCountIsTwo_ShouldFail()
+			{
+				Type subject = typeof(ClassWithTwoMarkedMethods);
+
+				async Task Act()
+				{
+					await That(subject).ContainsMethods(methods => methods.With<MarkerAttribute>())
+						.Once();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             contains methods with ThatType.ContainsMethods.MarkerAttribute exactly once,
+					             but it contained 2 matching members in ThatType.ContainsMethods.ClassWithTwoMarkedMethods
+					             """);
+			}
+
+			[Fact]
+			public async Task Twice_WhenCountIsOne_ShouldFail()
+			{
+				Type subject = typeof(ClassWithMarkedMethod);
+
+				async Task Act()
+				{
+					await That(subject).ContainsMethods(methods => methods.With<MarkerAttribute>())
+						.Twice();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             contains methods with ThatType.ContainsMethods.MarkerAttribute exactly twice,
+					             but it contained 1 matching member in ThatType.ContainsMethods.ClassWithMarkedMethod
+					             """);
+			}
 		}
 
 		public sealed class NegatedTests


### PR DESCRIPTION
Add tests targeting surviving and uncovered mutants:
- AssemblyFilters.WhichHaveDependenciesOnlyOn: no-allowed-assemblies description
- AssemblyFilters.With: predicate/OrWith direct (inherit:false) descriptions and OrWith || semantics
- AssemblyFilters.WithVersion: boundary tests for >, >=, <=, ==, != component comparisons
- TypeFilters.TypesContainingMembers: fluent/Times quantifier overloads and members-description stripping
- TypeContainingMembersResult: failing-case quantifier tests (AtLeast/AtMost/Between/LessThan/MoreThan/Once/Twice)
- ParameterCollectionResult: failing WithDefaultValue/WithoutDefaultValue/WithDefaultValue(value) cases