### PR TITLE
coverage: cover synchronous IEnumerable<Type?> paths for ThatTypes assertions

### DIFF
--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.AreEnums.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.AreEnums.Tests.cs
@@ -1,4 +1,6 @@
-﻿using aweXpect.Reflection.Collections;
+﻿using System.Collections.Generic;
+using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Tests.TestHelpers.Types;
 using Xunit.Sdk;
 
 namespace aweXpect.Reflection.Tests;
@@ -34,6 +36,48 @@ public sealed partial class ThatTypes
 			{
 				Filtered.Types subject = In.AssemblyContaining<AreEnums>().Types()
 					.Which(type => type.IsEnum);
+
+				async Task Act()
+				{
+					await That(subject).AreEnums();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+		public sealed class TypeTests
+		{
+			[Fact]
+			public async Task WhenEnumerableContainsNonEnumType_ShouldFail()
+			{
+				IEnumerable<Type?> subject = new[]
+				{
+					typeof(PublicEnum), typeof(PublicClass),
+				};
+
+				async Task Act()
+				{
+					await That(subject).AreEnums();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             are all enums,
+					             but it contained other types [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenEnumerableContainsOnlyEnumTypes_ShouldSucceed()
+			{
+				IEnumerable<Type?> subject = new[]
+				{
+					typeof(PublicEnum),
+				};
 
 				async Task Act()
 				{

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.AreGeneric.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.AreGeneric.Tests.cs
@@ -1,4 +1,6 @@
-﻿using aweXpect.Reflection.Collections;
+﻿using System.Collections.Generic;
+using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Tests.TestHelpers.Types;
 using Xunit.Sdk;
 
 namespace aweXpect.Reflection.Tests;
@@ -7,6 +9,48 @@ public sealed partial class ThatTypes
 {
 	public sealed partial class AreGeneric
 	{
+		public sealed class TypeTests
+		{
+			[Fact]
+			public async Task WhenEnumerableContainsNonGenericType_ShouldFail()
+			{
+				IEnumerable<Type?> subject = new[]
+				{
+					typeof(PublicGenericClass<>), typeof(PublicClass),
+				};
+
+				async Task Act()
+				{
+					await That(subject).AreGeneric();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             are all generic,
+					             but it contained not matching types [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenEnumerableContainsOnlyGenericTypes_ShouldSucceed()
+			{
+				IEnumerable<Type?> subject = new[]
+				{
+					typeof(PublicGenericClass<>),
+				};
+
+				async Task Act()
+				{
+					await That(subject).AreGeneric();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
 		public sealed class Tests
 		{
 			[Fact]

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.AreInterfaces.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.AreInterfaces.Tests.cs
@@ -1,4 +1,6 @@
-﻿using aweXpect.Reflection.Collections;
+﻿using System.Collections.Generic;
+using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Tests.TestHelpers.Types;
 using Xunit.Sdk;
 
 namespace aweXpect.Reflection.Tests;
@@ -7,6 +9,48 @@ public sealed partial class ThatTypes
 {
 	public sealed class AreInterfaces
 	{
+		public sealed class TypeTests
+		{
+			[Fact]
+			public async Task WhenEnumerableContainsNonInterfaceType_ShouldFail()
+			{
+				IEnumerable<Type?> subject = new[]
+				{
+					typeof(IPublicInterface), typeof(PublicClass),
+				};
+
+				async Task Act()
+				{
+					await That(subject).AreInterfaces();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             are all interfaces,
+					             but it contained other types [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenEnumerableContainsOnlyInterfaceTypes_ShouldSucceed()
+			{
+				IEnumerable<Type?> subject = new[]
+				{
+					typeof(IPublicInterface),
+				};
+
+				async Task Act()
+				{
+					await That(subject).AreInterfaces();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
 		public sealed class Tests
 		{
 			[Fact]

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.AreNested.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.AreNested.Tests.cs
@@ -1,4 +1,6 @@
-﻿using aweXpect.Reflection.Collections;
+﻿using System.Collections.Generic;
+using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Tests.TestHelpers.Types;
 using Xunit.Sdk;
 
 namespace aweXpect.Reflection.Tests;
@@ -7,6 +9,48 @@ public sealed partial class ThatTypes
 {
 	public sealed class AreNested
 	{
+		public sealed class TypeTests
+		{
+			[Fact]
+			public async Task WhenEnumerableContainsNonNestedType_ShouldFail()
+			{
+				IEnumerable<Type?> subject = new[]
+				{
+					typeof(Container.PublicNestedClass), typeof(PublicClass),
+				};
+
+				async Task Act()
+				{
+					await That(subject).AreNested();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             are all nested,
+					             but it contained non-nested types [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenEnumerableContainsOnlyNestedTypes_ShouldSucceed()
+			{
+				IEnumerable<Type?> subject = new[]
+				{
+					typeof(Container.PublicNestedClass),
+				};
+
+				async Task Act()
+				{
+					await That(subject).AreNested();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
 		public sealed class Tests
 		{
 			[Fact]

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.AreNotAbstract.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.AreNotAbstract.Tests.cs
@@ -1,4 +1,6 @@
-﻿using aweXpect.Reflection.Collections;
+﻿using System.Collections.Generic;
+using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Tests.TestHelpers.Types;
 using Xunit.Sdk;
 
 namespace aweXpect.Reflection.Tests;
@@ -7,6 +9,48 @@ public sealed partial class ThatTypes
 {
 	public sealed class AreNotAbstract
 	{
+		public sealed class TypeTests
+		{
+			[Fact]
+			public async Task WhenEnumerableContainsAbstractType_ShouldFail()
+			{
+				IEnumerable<Type?> subject = new[]
+				{
+					typeof(PublicClass), typeof(PublicAbstractClass),
+				};
+
+				async Task Act()
+				{
+					await That(subject).AreNotAbstract();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             are all not abstract,
+					             but it contained abstract types [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenEnumerableContainsNoAbstractTypes_ShouldSucceed()
+			{
+				IEnumerable<Type?> subject = new[]
+				{
+					typeof(PublicSealedClass),
+				};
+
+				async Task Act()
+				{
+					await That(subject).AreNotAbstract();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
 		public sealed class Tests
 		{
 			[Fact]

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.AreNotClasses.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.AreNotClasses.Tests.cs
@@ -1,5 +1,7 @@
-﻿using aweXpect.Reflection.Collections;
+﻿using System.Collections.Generic;
+using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Tests.TestHelpers;
+using aweXpect.Reflection.Tests.TestHelpers.Types;
 using Xunit.Sdk;
 
 namespace aweXpect.Reflection.Tests;
@@ -8,6 +10,48 @@ public sealed partial class ThatTypes
 {
 	public sealed class AreNotClasses
 	{
+		public sealed class TypeTests
+		{
+			[Fact]
+			public async Task WhenEnumerableContainsClassType_ShouldFail()
+			{
+				IEnumerable<Type?> subject = new[]
+				{
+					typeof(IPublicInterface), typeof(PublicClass),
+				};
+
+				async Task Act()
+				{
+					await That(subject).AreNotClasses();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             are all not classes,
+					             but it contained classes [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenEnumerableContainsNoClassTypes_ShouldSucceed()
+			{
+				IEnumerable<Type?> subject = new[]
+				{
+					typeof(IPublicInterface),
+				};
+
+				async Task Act()
+				{
+					await That(subject).AreNotClasses();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
 		public sealed class Tests
 		{
 			[Fact]

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.AreNotEnums.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.AreNotEnums.Tests.cs
@@ -1,4 +1,6 @@
-﻿using aweXpect.Reflection.Collections;
+﻿using System.Collections.Generic;
+using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Tests.TestHelpers.Types;
 using Xunit.Sdk;
 
 namespace aweXpect.Reflection.Tests;
@@ -7,6 +9,48 @@ public sealed partial class ThatTypes
 {
 	public sealed class AreNotEnums
 	{
+		public sealed class TypeTests
+		{
+			[Fact]
+			public async Task WhenEnumerableContainsEnumType_ShouldFail()
+			{
+				IEnumerable<Type?> subject = new[]
+				{
+					typeof(PublicClass), typeof(PublicEnum),
+				};
+
+				async Task Act()
+				{
+					await That(subject).AreNotEnums();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             are all not enums,
+					             but it contained enums [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenEnumerableContainsNoEnumTypes_ShouldSucceed()
+			{
+				IEnumerable<Type?> subject = new[]
+				{
+					typeof(PublicClass),
+				};
+
+				async Task Act()
+				{
+					await That(subject).AreNotEnums();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
 		public sealed class Tests
 		{
 			[Fact]

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.AreNotGeneric.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.AreNotGeneric.Tests.cs
@@ -1,4 +1,6 @@
-﻿using aweXpect.Reflection.Collections;
+﻿using System.Collections.Generic;
+using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Tests.TestHelpers.Types;
 using Xunit.Sdk;
 
 namespace aweXpect.Reflection.Tests;
@@ -7,6 +9,48 @@ public sealed partial class ThatTypes
 {
 	public sealed class AreNotGeneric
 	{
+		public sealed class TypeTests
+		{
+			[Fact]
+			public async Task WhenEnumerableContainsGenericType_ShouldFail()
+			{
+				IEnumerable<Type?> subject = new[]
+				{
+					typeof(PublicClass), typeof(PublicGenericClass<>),
+				};
+
+				async Task Act()
+				{
+					await That(subject).AreNotGeneric();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             are all not generic,
+					             but it contained generic types [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenEnumerableContainsNoGenericTypes_ShouldSucceed()
+			{
+				IEnumerable<Type?> subject = new[]
+				{
+					typeof(PublicClass),
+				};
+
+				async Task Act()
+				{
+					await That(subject).AreNotGeneric();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
 		public sealed class Tests
 		{
 			[Fact]

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.AreNotInterfaces.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.AreNotInterfaces.Tests.cs
@@ -1,4 +1,6 @@
-﻿using aweXpect.Reflection.Collections;
+﻿using System.Collections.Generic;
+using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Tests.TestHelpers.Types;
 using Xunit.Sdk;
 
 namespace aweXpect.Reflection.Tests;
@@ -7,6 +9,48 @@ public sealed partial class ThatTypes
 {
 	public sealed class AreNotInterfaces
 	{
+		public sealed class TypeTests
+		{
+			[Fact]
+			public async Task WhenEnumerableContainsInterfaceType_ShouldFail()
+			{
+				IEnumerable<Type?> subject = new[]
+				{
+					typeof(PublicClass), typeof(IPublicInterface),
+				};
+
+				async Task Act()
+				{
+					await That(subject).AreNotInterfaces();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             are all not interfaces,
+					             but it contained interfaces [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenEnumerableContainsNoInterfaceTypes_ShouldSucceed()
+			{
+				IEnumerable<Type?> subject = new[]
+				{
+					typeof(PublicClass),
+				};
+
+				async Task Act()
+				{
+					await That(subject).AreNotInterfaces();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
 		public sealed class Tests
 		{
 			[Fact]

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.AreNotNested.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.AreNotNested.Tests.cs
@@ -1,4 +1,6 @@
-﻿using aweXpect.Reflection.Collections;
+﻿using System.Collections.Generic;
+using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Tests.TestHelpers.Types;
 using Xunit.Sdk;
 
 namespace aweXpect.Reflection.Tests;
@@ -7,6 +9,48 @@ public sealed partial class ThatTypes
 {
 	public sealed class AreNotNested
 	{
+		public sealed class TypeTests
+		{
+			[Fact]
+			public async Task WhenEnumerableContainsNestedType_ShouldFail()
+			{
+				IEnumerable<Type?> subject = new[]
+				{
+					typeof(PublicClass), typeof(Container.PublicNestedClass),
+				};
+
+				async Task Act()
+				{
+					await That(subject).AreNotNested();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             are all not nested,
+					             but it contained nested types [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenEnumerableContainsNoNestedTypes_ShouldSucceed()
+			{
+				IEnumerable<Type?> subject = new[]
+				{
+					typeof(PublicClass),
+				};
+
+				async Task Act()
+				{
+					await That(subject).AreNotNested();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
 		public sealed class Tests
 		{
 			[Fact]

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.AreNotRecordStructs.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.AreNotRecordStructs.Tests.cs
@@ -1,5 +1,7 @@
-﻿using aweXpect.Reflection.Collections;
+﻿using System.Collections.Generic;
+using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Tests.TestHelpers;
+using aweXpect.Reflection.Tests.TestHelpers.Types;
 using Xunit.Sdk;
 
 namespace aweXpect.Reflection.Tests;
@@ -8,6 +10,48 @@ public sealed partial class ThatTypes
 {
 	public sealed class AreNotRecordStructs
 	{
+		public sealed class TypeTests
+		{
+			[Fact]
+			public async Task WhenEnumerableContainsRecordStructType_ShouldFail()
+			{
+				IEnumerable<Type?> subject = new[]
+				{
+					typeof(IPublicInterface), typeof(PublicRecordStruct),
+				};
+
+				async Task Act()
+				{
+					await That(subject).AreNotRecordStructs();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             are all not record structs,
+					             but it contained record structs [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenEnumerableContainsNoRecordStructTypes_ShouldSucceed()
+			{
+				IEnumerable<Type?> subject = new[]
+				{
+					typeof(IPublicInterface),
+				};
+
+				async Task Act()
+				{
+					await That(subject).AreNotRecordStructs();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
 		public sealed class Tests
 		{
 			[Fact]

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.AreNotRecords.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.AreNotRecords.Tests.cs
@@ -1,5 +1,7 @@
-﻿using aweXpect.Reflection.Collections;
+﻿using System.Collections.Generic;
+using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Tests.TestHelpers;
+using aweXpect.Reflection.Tests.TestHelpers.Types;
 using Xunit.Sdk;
 
 namespace aweXpect.Reflection.Tests;
@@ -8,6 +10,48 @@ public sealed partial class ThatTypes
 {
 	public sealed class AreNotRecords
 	{
+		public sealed class TypeTests
+		{
+			[Fact]
+			public async Task WhenEnumerableContainsRecordType_ShouldFail()
+			{
+				IEnumerable<Type?> subject = new[]
+				{
+					typeof(IPublicInterface), typeof(PublicRecord),
+				};
+
+				async Task Act()
+				{
+					await That(subject).AreNotRecords();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             are all not records,
+					             but it contained records [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenEnumerableContainsNoRecordTypes_ShouldSucceed()
+			{
+				IEnumerable<Type?> subject = new[]
+				{
+					typeof(IPublicInterface),
+				};
+
+				async Task Act()
+				{
+					await That(subject).AreNotRecords();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
 		public sealed class Tests
 		{
 			[Fact]

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.AreNotSealed.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.AreNotSealed.Tests.cs
@@ -1,4 +1,6 @@
-﻿using aweXpect.Reflection.Collections;
+﻿using System.Collections.Generic;
+using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Tests.TestHelpers.Types;
 using Xunit.Sdk;
 
 namespace aweXpect.Reflection.Tests;
@@ -7,6 +9,48 @@ public sealed partial class ThatTypes
 {
 	public sealed class AreNotSealed
 	{
+		public sealed class TypeTests
+		{
+			[Fact]
+			public async Task WhenEnumerableContainsSealedType_ShouldFail()
+			{
+				IEnumerable<Type?> subject = new[]
+				{
+					typeof(PublicAbstractClass), typeof(PublicSealedClass),
+				};
+
+				async Task Act()
+				{
+					await That(subject).AreNotSealed();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             are all not sealed,
+					             but it contained sealed types [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenEnumerableContainsNoSealedTypes_ShouldSucceed()
+			{
+				IEnumerable<Type?> subject = new[]
+				{
+					typeof(PublicAbstractClass),
+				};
+
+				async Task Act()
+				{
+					await That(subject).AreNotSealed();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
 		public sealed class Tests
 		{
 			[Fact]

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.AreNotStatic.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.AreNotStatic.Tests.cs
@@ -1,4 +1,7 @@
-﻿using aweXpect.Reflection.Collections;
+﻿using System.Collections.Generic;
+using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Tests.TestHelpers.Types;
+using Xunit.Sdk;
 
 namespace aweXpect.Reflection.Tests;
 
@@ -6,6 +9,48 @@ public sealed partial class ThatTypes
 {
 	public sealed class AreNotStatic
 	{
+		public sealed class TypeTests
+		{
+			[Fact]
+			public async Task WhenEnumerableContainsStaticType_ShouldFail()
+			{
+				IEnumerable<Type?> subject = new[]
+				{
+					typeof(PublicSealedClass), typeof(PublicStaticClass),
+				};
+
+				async Task Act()
+				{
+					await That(subject).AreNotStatic();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             are all not static,
+					             but it contained static types [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenEnumerableContainsNoStaticTypes_ShouldSucceed()
+			{
+				IEnumerable<Type?> subject = new[]
+				{
+					typeof(PublicSealedClass),
+				};
+
+				async Task Act()
+				{
+					await That(subject).AreNotStatic();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
 		public sealed class Tests
 		{
 			[Fact]

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.AreNotStructs.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.AreNotStructs.Tests.cs
@@ -1,5 +1,7 @@
-﻿using aweXpect.Reflection.Collections;
+﻿using System.Collections.Generic;
+using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Tests.TestHelpers;
+using aweXpect.Reflection.Tests.TestHelpers.Types;
 using Xunit.Sdk;
 
 namespace aweXpect.Reflection.Tests;
@@ -8,6 +10,48 @@ public sealed partial class ThatTypes
 {
 	public sealed class AreNotStructs
 	{
+		public sealed class TypeTests
+		{
+			[Fact]
+			public async Task WhenEnumerableContainsStructType_ShouldFail()
+			{
+				IEnumerable<Type?> subject = new[]
+				{
+					typeof(IPublicInterface), typeof(PublicStruct),
+				};
+
+				async Task Act()
+				{
+					await That(subject).AreNotStructs();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             are all not structs,
+					             but it contained structs [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenEnumerableContainsNoStructTypes_ShouldSucceed()
+			{
+				IEnumerable<Type?> subject = new[]
+				{
+					typeof(IPublicInterface),
+				};
+
+				async Task Act()
+				{
+					await That(subject).AreNotStructs();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
 		public sealed class Tests
 		{
 			[Fact]

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.ContainMethods.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.ContainMethods.Tests.cs
@@ -1,4 +1,5 @@
-﻿using aweXpect.Reflection.Collections;
+﻿using System.Collections.Generic;
+using aweXpect.Reflection.Collections;
 using Xunit.Sdk;
 
 namespace aweXpect.Reflection.Tests;
@@ -7,6 +8,65 @@ public sealed partial class ThatTypes
 {
 	public sealed class ContainMethods
 	{
+		public sealed class TypeTests
+		{
+			[Fact]
+			public async Task WhenAllTypesContainMatchingMethod_ShouldSucceed()
+			{
+				IEnumerable<Type?> subject = new[]
+				{
+					typeof(ClassWithMarkedMethod), typeof(ClassWithTwoMarkedMethods),
+				};
+
+				async Task Act()
+					=> await That(subject).ContainMethods(methods => methods.With<MarkerAttribute>());
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenEnumerableContainsNullType_ShouldFail()
+			{
+				IEnumerable<Type?> subject = new[]
+				{
+					typeof(ClassWithMarkedMethod), null,
+				};
+
+				async Task Act()
+					=> await That(subject).ContainMethods(methods => methods.With<MarkerAttribute>());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             all contain methods with ThatTypes.ContainMethods.MarkerAttribute at least once,
+					             but it contained not matching types [
+					               <null>
+					             ]
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenSomeTypeContainsNoMatchingMethod_ShouldFail()
+			{
+				IEnumerable<Type?> subject = new[]
+				{
+					typeof(ClassWithMarkedMethod), typeof(ClassWithoutMarkedMethod),
+				};
+
+				async Task Act()
+					=> await That(subject).ContainMethods(methods => methods.With<MarkerAttribute>());
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             all contain methods with ThatTypes.ContainMethods.MarkerAttribute at least once,
+					             but it contained not matching types [
+					               ThatTypes.ContainMethods.ClassWithoutMarkedMethod
+					             ]
+					             """);
+			}
+		}
+
 		public sealed class Tests
 		{
 			[Fact]

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.DoNotInheritFrom.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.DoNotInheritFrom.Tests.cs
@@ -207,6 +207,30 @@ public sealed partial class ThatTypes
 			}
 
 			[Fact]
+			public async Task WhenTypesInheritDirectly_WithForceDirect_ShouldFail()
+			{
+				IEnumerable<Type?> subject = new[]
+				{
+					typeof(DerivedClass1),
+				};
+				Type baseType = typeof(BaseClass);
+
+				async Task Act()
+				{
+					await That(subject).DoNotInheritFrom(baseType, true);
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             all do not inherit directly from ThatTypes.BaseClass,
+					             but it contained types that inherit directly from ThatTypes.BaseClass [
+					               ThatTypes.DerivedClass1
+					             ]
+					             """);
+			}
+
+			[Fact]
 			public async Task WhenNoTypesInherit_ShouldSucceed()
 			{
 				Filtered.Types subject = In.Types(typeof(UnrelatedClass), typeof(GenericTests));

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.HaveNamespace.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.HaveNamespace.Tests.cs
@@ -1,4 +1,6 @@
-﻿using aweXpect.Reflection.Collections;
+﻿using System.Collections.Generic;
+using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Tests.TestHelpers.Types;
 using Xunit.Sdk;
 
 namespace aweXpect.Reflection.Tests;
@@ -7,6 +9,48 @@ public sealed partial class ThatTypes
 {
 	public sealed class HaveNamespace
 	{
+		public sealed class TypeTests
+		{
+			[Fact]
+			public async Task WhenEnumerableContainsTypeWithDifferentNamespace_ShouldFail()
+			{
+				IEnumerable<Type?> subject = new[]
+				{
+					typeof(PublicClass), typeof(ThatTypes),
+				};
+
+				async Task Act()
+				{
+					await That(subject).HaveNamespace("aweXpect.Reflection.Tests.TestHelpers.Types");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             all have namespace equal to "aweXpect.Reflection.Tests.Test…",
+					             but it contained not matching types [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenEnumerableTypesHaveNamespace_ShouldSucceed()
+			{
+				IEnumerable<Type?> subject = new[]
+				{
+					typeof(PublicClass), typeof(PublicEnum),
+				};
+
+				async Task Act()
+				{
+					await That(subject).HaveNamespace("aweXpect.Reflection.Tests.TestHelpers.Types");
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
 		public sealed class Tests
 		{
 			[Fact]


### PR DESCRIPTION
Add array-based (IEnumerable<Type?>) tests so the synchronous IsMetBy overloads of the type-collection constraints are exercised. Filtered.Types implements IAsyncEnumerable on net8.0+, so the existing tests only hit the async constraint paths, leaving the sync equality/negation lambdas (AreEnums/AreNotEnums/AreInterfaces/AreNested/AreGeneric and the AreNot abstract/class/sealed/static/struct/record/recordstruct variants) without coverage.

Also cover the ThatTypes.ContainMethods null-element branch and sync factory, the ThatTypes.HaveNamespace sync factory, and a forceDirect failure for DoNotInheritFrom that renders the "directly " fragment.