### PR TITLE
coverage: kill mutants for ThatConstructors HaveParameter/Exactly/Count

### DIFF
--- a/Tests/aweXpect.Reflection.Tests/ThatConstructors.HaveParameter.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatConstructors.HaveParameter.Tests.cs
@@ -22,9 +22,98 @@ public sealed partial class ThatConstructors
 
 			await Task.CompletedTask;
 		}
+
+		private static async IAsyncEnumerable<ConstructorInfo?> ToAsyncEnumerableNullable(params ConstructorInfo?[] items)
+		{
+			foreach (ConstructorInfo? item in items)
+			{
+				yield return item;
+			}
+
+			await Task.CompletedTask;
+		}
 #endif
 		public sealed class Tests
 		{
+			[Fact]
+			public async Task HaveParameterByType_WhenConstructorIsNull_ShouldFail()
+			{
+				IEnumerable<ConstructorInfo?> constructors = new ConstructorInfo?[]
+				{
+					null,
+				};
+
+				async Task Act()
+				{
+					await That(constructors).HaveParameter<int>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter of type int,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task HaveParameterByTypeAndName_WhenTypeMatchesButNameDiffers_ShouldFail()
+			{
+				IEnumerable<ConstructorInfo> constructors = new[]
+				{
+					typeof(TestClass).GetConstructor([typeof(int), typeof(string),])!, // int parameter named "value"
+				};
+
+				async Task Act()
+				{
+					await That(constructors).HaveParameter<int>("count");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter of type int with name "count",
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task HaveParameterByTypeInstanceAndName_WhenTypeMatchesButNameDiffers_ShouldFail()
+			{
+				IEnumerable<ConstructorInfo> constructors = new[]
+				{
+					typeof(TestClass).GetConstructor([typeof(int), typeof(string),])!, // int parameter named "value"
+				};
+
+				async Task Act()
+				{
+					await That(constructors).HaveParameter(typeof(int), "count");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter of type int with name "count",
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task HaveParameterByType_WhenMatchingParameterIsNotAtFirstIndex_ShouldSucceed()
+			{
+				IEnumerable<ConstructorInfo> constructors = new[]
+				{
+					typeof(TestClass).GetConstructor([typeof(string), typeof(int),])!, // int at index 1, no index constraint
+				};
+
+				async Task Act()
+				{
+					await That(constructors).HaveParameter<int>();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
 			[Fact]
 			public async Task HaveParameterByName_WhenAllHaveParameter_ShouldSucceed()
 			{
@@ -244,6 +333,76 @@ public sealed partial class ThatConstructors
 
 #if NET8_0_OR_GREATER
 			[Fact]
+			public async Task AsyncEnumerable_ByType_WhenConstructorIsNull_ShouldFail()
+			{
+				IAsyncEnumerable<ConstructorInfo?> constructors = ToAsyncEnumerableNullable([null,]);
+
+				async Task Act()
+				{
+					await That(constructors).HaveParameter(typeof(int));
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter of type int,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task AsyncEnumerable_ByTypeAndName_WhenTypeMatchesButNameDiffers_ShouldFail()
+			{
+				IAsyncEnumerable<ConstructorInfo> constructors = ToAsyncEnumerable(
+					typeof(TestClass).GetConstructor([typeof(int), typeof(string),])!); // int parameter named "value"
+
+				async Task Act()
+				{
+					await That(constructors).HaveParameter(typeof(int), "count");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter of type int with name "count",
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task AsyncEnumerable_ByTypeAndNameGeneric_WhenTypeMatchesButNameDiffers_ShouldFail()
+			{
+				IAsyncEnumerable<ConstructorInfo> constructors = ToAsyncEnumerable(
+					typeof(TestClass).GetConstructor([typeof(int), typeof(string),])!); // int parameter named "value"
+
+				async Task Act()
+				{
+					await That(constructors).HaveParameter<int>("count");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter of type int with name "count",
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task AsyncEnumerable_ByType_WhenMatchingParameterIsNotAtFirstIndex_ShouldSucceed()
+			{
+				IAsyncEnumerable<ConstructorInfo> constructors = ToAsyncEnumerable(
+					typeof(TestClass).GetConstructor([typeof(string), typeof(int),])!); // int at index 1, no index constraint
+
+				async Task Act()
+				{
+					await That(constructors).HaveParameter(typeof(int));
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
 			public async Task AsyncEnumerable_ByType_WhenAllHaveParameter_ShouldSucceed()
 			{
 				IAsyncEnumerable<ConstructorInfo> constructors = ToAsyncEnumerable(
@@ -321,6 +480,7 @@ public sealed partial class ThatConstructors
 				public TestClass(int value) { }
 				public TestClass(string name) { }
 				public TestClass(int value, string name) { }
+				public TestClass(string name, int value) { }
 				public TestClass(Stream stream) { }
 				public TestClass(MemoryStream stream) { }
 			}
@@ -330,6 +490,48 @@ public sealed partial class ThatConstructors
 
 		public sealed class NegatedTests
 		{
+			[Fact]
+			public async Task AtIndex_WhenAllHaveParameterAtIndex_ShouldFailWithIndexInExpectation()
+			{
+				IEnumerable<ConstructorInfo> constructors = new[]
+				{
+					typeof(TestClass).GetConstructor([typeof(int), typeof(string),])!, // int at index 0
+				};
+
+				async Task Act()
+				{
+					await That(constructors).DoesNotComplyWith(they => they.HaveParameter<int>().AtIndex(0));
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             not all have parameter of type int at index 0,
+					             but all did
+					             """);
+			}
+
+			[Fact]
+			public async Task Modifier_WhenAllHaveModifierParameter_ShouldFailWithModifierInExpectation()
+			{
+				IEnumerable<ConstructorInfo> constructors = new[]
+				{
+					typeof(ModifierClass).GetConstructors()[0], // in int parameter
+				};
+
+				async Task Act()
+				{
+					await That(constructors).DoesNotComplyWith(they => they.HaveInParameter<int>());
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             not all have parameter of type int with in modifier,
+					             but all did
+					             """);
+			}
+
 			[Fact]
 			public async Task HaveParameterByName_WhenAllHaveParameter_ShouldFail()
 			{
@@ -524,6 +726,11 @@ public sealed partial class ThatConstructors
 				public TestClass(int value, string name) { }
 				public TestClass(Stream stream) { }
 				public TestClass(MemoryStream stream) { }
+			}
+
+			private class ModifierClass
+			{
+				public ModifierClass(in int value) { }
 			}
 			// ReSharper restore UnusedParameter.Local
 			// ReSharper restore UnusedMember.Local

--- a/Tests/aweXpect.Reflection.Tests/ThatConstructors.HaveParameterCount.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatConstructors.HaveParameterCount.Tests.cs
@@ -8,8 +8,101 @@ public sealed partial class ThatConstructors
 {
 	public sealed class HaveParameterCount
 	{
+#if NET8_0_OR_GREATER
+		private static async IAsyncEnumerable<ConstructorInfo> ToAsyncEnumerable(params ConstructorInfo[] items)
+		{
+			foreach (ConstructorInfo item in items)
+			{
+				yield return item;
+			}
+
+			await Task.CompletedTask;
+		}
+#endif
+
 		public sealed class Tests
 		{
+			[Fact]
+			public async Task WhenNotAllHaveExpectedCount_ShouldListNotMatchingConstructors()
+			{
+				IEnumerable<ConstructorInfo> constructors = new[]
+				{
+					typeof(TestClass).GetConstructor([typeof(int),])!,
+				};
+
+				async Task Act()
+				{
+					await That(constructors).HaveParameterCount(2);
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have 2 parameters,
+					             but it contained constructors with a different number of parameters [
+					               ThatConstructors.HaveParameterCount.TestClass(int value)
+					             ]
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenExpectingOneParameter_ShouldMentionOneParameterInExpectation()
+			{
+				IEnumerable<ConstructorInfo> constructors = new[]
+				{
+					typeof(TestClass).GetConstructor([typeof(int), typeof(string),])!,
+				};
+
+				async Task Act()
+				{
+					await That(constructors).HaveParameterCount(1);
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have one parameter,
+					             but it contained constructors with a different number of parameters *
+					             """).AsWildcard();
+			}
+
+#if NET8_0_OR_GREATER
+			[Fact]
+			public async Task AsyncEnumerable_WhenAllHaveExpectedCount_ShouldSucceed()
+			{
+				IAsyncEnumerable<ConstructorInfo> constructors = ToAsyncEnumerable(
+					typeof(TestClass).GetConstructor([typeof(int), typeof(string),])!,
+					typeof(TestClass).GetConstructor([typeof(string), typeof(int),])!);
+
+				async Task Act()
+				{
+					await That(constructors).HaveParameterCount(2);
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task AsyncEnumerable_WhenNotAllHaveExpectedCount_ShouldFail()
+			{
+				IAsyncEnumerable<ConstructorInfo> constructors = ToAsyncEnumerable(
+					typeof(TestClass).GetConstructor([typeof(int), typeof(string),])!,
+					typeof(TestClass).GetConstructor([typeof(int),])!);
+
+				async Task Act()
+				{
+					await That(constructors).HaveParameterCount(2);
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have 2 parameters,
+					             but it contained constructors with a different number of parameters *
+					             """).AsWildcard();
+			}
+#endif
+
 			[Fact]
 			public async Task WhenAllHaveExpectedCount_ShouldSucceed()
 			{
@@ -69,6 +162,29 @@ public sealed partial class ThatConstructors
 					             not all have 2 parameters,
 					             but it only contained constructors with 2 parameters *
 					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenAllHaveExpectedCount_ShouldListMatchingConstructors()
+			{
+				IEnumerable<ConstructorInfo> constructors = new[]
+				{
+					typeof(TestClass).GetConstructor([typeof(int), typeof(string),])!,
+				};
+
+				async Task Act()
+				{
+					await That(constructors).DoesNotComplyWith(they => they.HaveParameterCount(2));
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             not all have 2 parameters,
+					             but it only contained constructors with 2 parameters [
+					               ThatConstructors.HaveParameterCount.TestClass(int value, string name)
+					             ]
+					             """);
 			}
 
 			[Fact]

--- a/Tests/aweXpect.Reflection.Tests/ThatConstructors.HaveParameterExactly.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatConstructors.HaveParameterExactly.Tests.cs
@@ -131,6 +131,90 @@ public sealed partial class ThatConstructors
 					             """);
 			}
 
+			[Fact]
+			public async Task WhenAnyParameterIsSubtypeWithName_ShouldFail()
+			{
+				IEnumerable<ConstructorInfo> constructors = new[]
+				{
+					typeof(TestClass).GetConstructor([typeof(Stream),])!,
+				};
+
+				async Task Act()
+				{
+					await That(constructors).HaveParameterExactly<IDisposable>("stream");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter of exact type IDisposable with name "stream",
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenAnyParameterIsSubtypeByTypeWithName_ShouldFail()
+			{
+				IEnumerable<ConstructorInfo> constructors = new[]
+				{
+					typeof(TestClass).GetConstructor([typeof(Stream),])!,
+				};
+
+				async Task Act()
+				{
+					await That(constructors).HaveParameterExactly(typeof(IDisposable), "stream");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter of exact type IDisposable with name "stream",
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenExactTypeMatchesButNameDiffers_ShouldFail()
+			{
+				IEnumerable<ConstructorInfo> constructors = new[]
+				{
+					typeof(TestClass).GetConstructor([typeof(Stream),])!, // Stream parameter named "stream"
+				};
+
+				async Task Act()
+				{
+					await That(constructors).HaveParameterExactly<Stream>("other");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter of exact type Stream with name "other",
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenExactTypeMatchesButNameDiffersByType_ShouldFail()
+			{
+				IEnumerable<ConstructorInfo> constructors = new[]
+				{
+					typeof(TestClass).GetConstructor([typeof(Stream),])!, // Stream parameter named "stream"
+				};
+
+				async Task Act()
+				{
+					await That(constructors).HaveParameterExactly(typeof(Stream), "other");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter of exact type Stream with name "other",
+					             but at least one did not
+					             """);
+			}
+
 #if NET8_0_OR_GREATER
 			[Fact]
 			public async Task AsyncEnumerable_WhenAllHaveParameterExactly_ShouldSucceed()
@@ -172,7 +256,12 @@ public sealed partial class ThatConstructors
 					await That(constructors).HaveParameterExactly<IDisposable>();
 				}
 
-				await That(Act).Throws<XunitException>();
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter of exact type IDisposable,
+					             but at least one did not
+					             """);
 			}
 
 			[Fact]
@@ -215,7 +304,88 @@ public sealed partial class ThatConstructors
 					await That(constructors).HaveParameterExactly(typeof(IDisposable));
 				}
 
-				await That(Act).Throws<XunitException>();
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter of exact type IDisposable,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task AsyncEnumerable_WhenAnyParameterIsSubtypeWithName_ShouldFail()
+			{
+				IAsyncEnumerable<ConstructorInfo> constructors = ToAsyncEnumerable(
+					typeof(TestClass).GetConstructor([typeof(Stream),])!);
+
+				async Task Act()
+				{
+					await That(constructors).HaveParameterExactly<IDisposable>("stream");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter of exact type IDisposable with name "stream",
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task AsyncEnumerable_WhenAnyParameterIsSubtypeByTypeWithName_ShouldFail()
+			{
+				IAsyncEnumerable<ConstructorInfo> constructors = ToAsyncEnumerable(
+					typeof(TestClass).GetConstructor([typeof(Stream),])!);
+
+				async Task Act()
+				{
+					await That(constructors).HaveParameterExactly(typeof(IDisposable), "stream");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter of exact type IDisposable with name "stream",
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task AsyncEnumerable_WhenExactTypeMatchesButNameDiffers_ShouldFail()
+			{
+				IAsyncEnumerable<ConstructorInfo> constructors = ToAsyncEnumerable(
+					typeof(TestClass).GetConstructor([typeof(Stream),])!); // Stream parameter named "stream"
+
+				async Task Act()
+				{
+					await That(constructors).HaveParameterExactly<Stream>("other");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter of exact type Stream with name "other",
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task AsyncEnumerable_WhenExactTypeMatchesButNameDiffersByType_ShouldFail()
+			{
+				IAsyncEnumerable<ConstructorInfo> constructors = ToAsyncEnumerable(
+					typeof(TestClass).GetConstructor([typeof(Stream),])!); // Stream parameter named "stream"
+
+				async Task Act()
+				{
+					await That(constructors).HaveParameterExactly(typeof(Stream), "other");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter of exact type Stream with name "other",
+					             but at least one did not
+					             """);
 			}
 #endif
 		}


### PR DESCRIPTION
Add assertion-path tests covering surviving and uncovered mutants in ThatConstructors.HaveParameter, HaveParameterExactly and HaveParameterCount:

- null constructor handling (sync + async)
- name predicate (AddPredicate) for type+name overloads where the type matches but the name differs
- exact-type vs subtype behaviour and 'of exact type' message for the name and async overloads (forceDirect / exactType booleans)
- negated index and modifier expectation text (AtIndex / HaveInParameter)
- ParameterCountDescription 'one parameter' and the async count equality
- exact NotMatching/Matching constructor formatting in HaveParameterCount