### PR TITLE
coverage: kill mutants in Helpers and Formatting internals

### DIFF
--- a/Tests/aweXpect.Reflection.Internal.Tests/Formatting/FormatterRegistrationTests.cs
+++ b/Tests/aweXpect.Reflection.Internal.Tests/Formatting/FormatterRegistrationTests.cs
@@ -21,6 +21,30 @@ public class FormatterRegistrationTests
 	}
 
 	[Fact]
+	public async Task Dispose_WhenNotInitialized_ShouldNotThrow()
+	{
+		// Free the existing singleton so a fresh, never-initialized instance can be created.
+		FormatterRegistration.Instance.Dispose();
+
+		FormatterRegistration fresh = new();
+
+		void Act()
+			=> fresh.Dispose();
+
+		try
+		{
+			// A never-initialized instance must have an empty (not single-null) disposables array,
+			// so disposing it must not throw a NullReferenceException.
+			await That(Act).DoesNotThrow();
+		}
+		finally
+		{
+			// Restore the singleton and re-register all formatters for subsequent tests.
+			FormatterRegistration.Instance.Initialize();
+		}
+	}
+
+	[Fact]
 	public async Task Initialize_ShouldRegisterFormatterForConstructorInfo()
 	{
 		ConstructorInfo constructorInfo = typeof(ConstructorFormatterTests.MyTestClass).GetConstructors().First();

--- a/Tests/aweXpect.Reflection.Internal.Tests/Helpers/AssemblyHelpersTests.cs
+++ b/Tests/aweXpect.Reflection.Internal.Tests/Helpers/AssemblyHelpersTests.cs
@@ -1,9 +1,35 @@
+using System.Reflection;
+using System.Runtime.Versioning;
 using aweXpect.Reflection.Helpers;
 
 namespace aweXpect.Reflection.Internal.Tests.Helpers;
 
 public class AssemblyHelpersTests
 {
+	[Fact]
+	public async Task HasAttribute_WithAttributeType_WithoutPredicate_WhenAttributePresent_ShouldReturnTrue()
+	{
+		Assembly assembly = typeof(AssemblyHelpersTests).Assembly;
+
+		bool result = assembly.HasAttribute(typeof(TargetFrameworkAttribute));
+
+		await That(result).IsTrue();
+	}
+
+	[Fact]
+	public async Task HasAttribute_WithAttributeType_WithPredicate_ShouldReturnPredicateResult()
+	{
+		Assembly assembly = typeof(AssemblyHelpersTests).Assembly;
+
+		bool result1 = assembly.HasAttribute(typeof(TargetFrameworkAttribute),
+			a => ((TargetFrameworkAttribute)a).FrameworkName.Length > 0);
+		bool result2 = assembly.HasAttribute(typeof(TargetFrameworkAttribute),
+			a => ((TargetFrameworkAttribute)a).FrameworkName.Length < 0);
+
+		await That(result1).IsTrue();
+		await That(result2).IsFalse();
+	}
+
 	[Theory]
 	[InlineData(".NETCoreApp,Version=v5.0", "net5.0")]
 	[InlineData(".NETCoreApp,Version=v6.0", "net6.0")]

--- a/Tests/aweXpect.Reflection.Internal.Tests/Helpers/AtIndexMatchTests.cs
+++ b/Tests/aweXpect.Reflection.Internal.Tests/Helpers/AtIndexMatchTests.cs
@@ -1,0 +1,108 @@
+using aweXpect.Options;
+using aweXpect.Reflection.Helpers;
+
+namespace aweXpect.Reflection.Internal.Tests.Helpers;
+
+public sealed class AtIndexMatchTests
+{
+	[Fact]
+	public async Task Constructor_WhenIndexIsNegative_ShouldThrowArgumentOutOfRangeException()
+	{
+		void Act()
+			=> _ = new AtIndexMatch(-1);
+
+		await That(Act).Throws<ArgumentOutOfRangeException>()
+			.WithMessage("*The index must be greater than or equal to 0.*").AsWildcard();
+	}
+
+	[Fact]
+	public async Task GetDescription_ShouldIncludeIndex()
+	{
+		AtIndexMatch sut = new(3);
+
+		await That(sut.GetDescription()).IsEqualTo(" at index 3");
+	}
+
+	[Fact]
+	public async Task OnlySingleIndex_ShouldReturnTrue()
+	{
+		AtIndexMatch sut = new(2);
+
+		await That(sut.OnlySingleIndex()).IsTrue();
+	}
+
+	[Fact]
+	public async Task MatchesIndex_WhenBeforeIndex_ShouldReturnNull()
+	{
+		AtIndexMatch sut = new(2);
+
+		await That(sut.MatchesIndex(1)).IsNull();
+	}
+
+	[Fact]
+	public async Task MatchesIndex_AtIndex_ShouldReturnTrue()
+	{
+		AtIndexMatch sut = new(2);
+
+		await That(sut.MatchesIndex(2)).IsEqualTo(true);
+	}
+
+	[Fact]
+	public async Task MatchesIndex_AfterIndex_ShouldReturnFalse()
+	{
+		AtIndexMatch sut = new(2);
+
+		await That(sut.MatchesIndex(3)).IsEqualTo(false);
+	}
+
+	[Fact]
+	public async Task FromEnd_OnlySingleIndex_ShouldReturnTrue()
+	{
+		CollectionIndexOptions.IMatchFromEnd sut = new AtIndexMatch(2).FromEnd();
+
+		await That(sut.OnlySingleIndex()).IsTrue();
+	}
+
+	[Fact]
+	public async Task FromEnd_GetDescription_ShouldAppendFromEnd()
+	{
+		CollectionIndexOptions.IMatchFromEnd sut = new AtIndexMatch(2).FromEnd();
+
+		await That(sut.GetDescription()).IsEqualTo(" at index 2 from end");
+	}
+
+	[Fact]
+	public async Task FromEnd_MatchesIndex_WhenCountIsNull_ShouldReturnNull()
+	{
+		CollectionIndexOptions.IMatchFromEnd sut = new AtIndexMatch(2).FromEnd();
+
+		await That(sut.MatchesIndex(0, null)).IsNull();
+	}
+
+	[Fact]
+	public async Task FromEnd_MatchesIndex_AtExpectedIndexFromEnd_ShouldReturnTrue()
+	{
+		// _index = 1, count = 5 => expected = 5 - 1 - 1 = 3
+		CollectionIndexOptions.IMatchFromEnd sut = new AtIndexMatch(1).FromEnd();
+
+		await That(sut.MatchesIndex(3, 5)).IsEqualTo(true);
+	}
+
+	[Fact]
+	public async Task FromEnd_MatchesIndex_AfterExpectedIndexFromEnd_ShouldReturnFalse()
+	{
+		// _index = 1, count = 5 => expected = 3
+		CollectionIndexOptions.IMatchFromEnd sut = new AtIndexMatch(1).FromEnd();
+
+		await That(sut.MatchesIndex(4, 5)).IsEqualTo(false);
+	}
+
+	[Fact]
+	public async Task FromEnd_MatchesIndex_BeforeExpectedIndexFromEnd_ShouldReturnNull()
+	{
+		// _index = 1, count = 5 => expected = 3
+		CollectionIndexOptions.IMatchFromEnd sut = new AtIndexMatch(1).FromEnd();
+
+		await That(sut.MatchesIndex(2, 5)).IsNull();
+	}
+}

--- a/Tests/aweXpect.Reflection.Internal.Tests/Helpers/CollectionConstraintResultTests.cs
+++ b/Tests/aweXpect.Reflection.Internal.Tests/Helpers/CollectionConstraintResultTests.cs
@@ -1,0 +1,70 @@
+using System.Collections.Generic;
+using System.Text;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Reflection.Helpers;
+
+namespace aweXpect.Reflection.Internal.Tests.Helpers;
+
+public sealed class CollectionConstraintResultTests
+{
+	[Fact]
+	public async Task Matching_BeforeSettingValue_ShouldBeEmpty()
+	{
+		TestableResult sut = new(ExpectationGrammars.None);
+
+		await That(sut.MatchingElements).IsEmpty();
+		await That(sut.NotMatchingElements).IsEmpty();
+	}
+
+	[Fact]
+	public async Task AppendResult_WhenOutcomeIsUndecided_ShouldAppendCancelledMessage()
+	{
+		TestableResult sut = new(ExpectationGrammars.None);
+		StringBuilder stringBuilder = new();
+
+		sut.AppendResult(stringBuilder);
+
+		await That(stringBuilder.ToString())
+			.IsEqualTo("could not verify, because it was already cancelled");
+	}
+
+	[Fact]
+	public async Task AppendResult_WhenOutcomeIsDecided_ShouldNotAppendCancelledMessage()
+	{
+		TestableResult sut = new(ExpectationGrammars.None);
+		sut.SetMatch([1,], []);
+		StringBuilder stringBuilder = new();
+
+		sut.AppendResult(stringBuilder);
+
+		await That(stringBuilder.ToString()).IsEqualTo("normal-result");
+	}
+
+	private sealed class TestableResult(ExpectationGrammars grammars)
+		: CollectionConstraintResult<int>(grammars)
+	{
+		public int[] MatchingElements => Matching;
+		public int[] NotMatchingElements => NotMatching;
+
+		public void SetMatch(IEnumerable<int> matching, IEnumerable<int> notMatching)
+		{
+			List<int> all = new(matching);
+			HashSet<int> notMatchingSet = new(notMatching);
+			all.AddRange(notMatchingSet);
+			SetValue(all, item => !notMatchingSet.Contains(item));
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("normal-expectation");
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("normal-result");
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("negated-expectation");
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("negated-result");
+	}
+}

--- a/Tests/aweXpect.Reflection.Internal.Tests/Helpers/ConstructorInfoHelpersTests.cs
+++ b/Tests/aweXpect.Reflection.Internal.Tests/Helpers/ConstructorInfoHelpersTests.cs
@@ -92,6 +92,30 @@ public sealed class ConstructorInfoHelpersTests
 		await That(result2).IsFalse();
 	}
 
+	[Fact]
+	public async Task HasAttribute_WithAttributeType_WithoutPredicate_ShouldReturnTrue()
+	{
+		ConstructorInfo constructorInfo = typeof(TestClass).GetDeclaredConstructors()
+			.Single(c => c.GetParameters().Length == 2);
+
+		bool result = constructorInfo.HasAttribute(typeof(DummyAttribute));
+
+		await That(result).IsTrue();
+	}
+
+	[Fact]
+	public async Task HasAttribute_WithAttributeType_WithPredicate_ShouldReturnPredicateResult()
+	{
+		ConstructorInfo constructorInfo = typeof(TestClass).GetDeclaredConstructors()
+			.Single(c => c.GetParameters().Length == 2);
+
+		bool result1 = constructorInfo.HasAttribute(typeof(DummyAttribute), a => ((DummyAttribute)a).Value == 1);
+		bool result2 = constructorInfo.HasAttribute(typeof(DummyAttribute), a => ((DummyAttribute)a).Value == 2);
+
+		await That(result1).IsTrue();
+		await That(result2).IsFalse();
+	}
+
 	[AttributeUsage(AttributeTargets.Constructor)]
 	private class DummyAttribute : Attribute
 	{

--- a/Tests/aweXpect.Reflection.Internal.Tests/Helpers/EventInfoHelpersTests.cs
+++ b/Tests/aweXpect.Reflection.Internal.Tests/Helpers/EventInfoHelpersTests.cs
@@ -48,6 +48,28 @@ public sealed class EventInfoHelpersTests
 		await That(result2).IsFalse();
 	}
 
+	[Fact]
+	public async Task HasAttribute_WithAttributeType_WithoutPredicate_ShouldReturnTrue()
+	{
+		EventInfo eventInfo = typeof(TestClass).GetEvent(nameof(TestClass.Event1WithAttribute))!;
+
+		bool result = eventInfo.HasAttribute(typeof(DummyAttribute));
+
+		await That(result).IsTrue();
+	}
+
+	[Fact]
+	public async Task HasAttribute_WithAttributeType_WithPredicate_ShouldReturnPredicateResult()
+	{
+		EventInfo eventInfo = typeof(TestClass).GetEvent(nameof(TestClass.Event1WithAttribute))!;
+
+		bool result1 = eventInfo.HasAttribute(typeof(DummyAttribute), a => ((DummyAttribute)a).Value == 1);
+		bool result2 = eventInfo.HasAttribute(typeof(DummyAttribute), a => ((DummyAttribute)a).Value == 2);
+
+		await That(result1).IsTrue();
+		await That(result2).IsFalse();
+	}
+
 	[AttributeUsage(AttributeTargets.Event)]
 	private class DummyAttribute : Attribute
 	{

--- a/Tests/aweXpect.Reflection.Internal.Tests/Helpers/FieldInfoHelpersTests.cs
+++ b/Tests/aweXpect.Reflection.Internal.Tests/Helpers/FieldInfoHelpersTests.cs
@@ -98,6 +98,28 @@ public sealed class FieldInfoHelpersTests
 		await That(result2).IsFalse();
 	}
 
+	[Fact]
+	public async Task HasAttribute_WithAttributeType_WithoutPredicate_ShouldReturnTrue()
+	{
+		FieldInfo fieldInfo = typeof(TestClass).GetField(nameof(TestClass.Field1WithAttribute))!;
+
+		bool result = fieldInfo.HasAttribute(typeof(DummyAttribute));
+
+		await That(result).IsTrue();
+	}
+
+	[Fact]
+	public async Task HasAttribute_WithAttributeType_WithPredicate_ShouldReturnPredicateResult()
+	{
+		FieldInfo fieldInfo = typeof(TestClass).GetField(nameof(TestClass.Field1WithAttribute))!;
+
+		bool result1 = fieldInfo.HasAttribute(typeof(DummyAttribute), a => ((DummyAttribute)a).Value == 1);
+		bool result2 = fieldInfo.HasAttribute(typeof(DummyAttribute), a => ((DummyAttribute)a).Value == 2);
+
+		await That(result1).IsTrue();
+		await That(result2).IsFalse();
+	}
+
 	[AttributeUsage(AttributeTargets.Field)]
 	private class DummyAttribute : Attribute
 	{

--- a/Tests/aweXpect.Reflection.Internal.Tests/Helpers/LinqAsyncHelpersTests.cs
+++ b/Tests/aweXpect.Reflection.Internal.Tests/Helpers/LinqAsyncHelpersTests.cs
@@ -1,0 +1,149 @@
+using System.Collections.Generic;
+using System.Linq;
+#if NET8_0_OR_GREATER
+using System.Threading.Tasks;
+#endif
+
+namespace aweXpect.Reflection.Internal.Tests.Helpers;
+
+public sealed class LinqAsyncHelpersTests
+{
+	[Fact]
+	public async Task Split_ShouldSeparateMatchingFromNotMatching()
+	{
+		int[] source = [1, 2, 3, 4,];
+
+		(int[] matching, int[] notMatching) = source.Split(i => i % 2 == 0);
+
+		await That(matching).IsEqualTo([2, 4,]).InAnyOrder();
+		await That(notMatching).IsEqualTo([1, 3,]).InAnyOrder();
+	}
+
+	[Fact]
+	public async Task SplitAsync_ShouldSeparateMatchingFromNotMatching()
+	{
+		int[] source = [1, 2, 3, 4,];
+
+#if NET8_0_OR_GREATER
+		(int[] matching, int[] notMatching) =
+			await source.SplitAsync(i => new ValueTask<bool>(i % 2 == 0));
+#else
+		(int[] matching, int[] notMatching) =
+			await source.SplitAsync(i => Task.FromResult(i % 2 == 0));
+#endif
+
+		await That(matching).IsEqualTo([2, 4,]).InAnyOrder();
+		await That(notMatching).IsEqualTo([1, 3,]).InAnyOrder();
+	}
+
+	[Fact]
+	public async Task SplitWhereAnyAsync_ShouldSeparateBasedOnGeneratedItems()
+	{
+		int[] source = [1, 2, 3,];
+
+		(int[] matching, int[] notMatching) = await source.SplitWhereAnyAsync(
+			i => Enumerable.Range(0, i),
+#if NET8_0_OR_GREATER
+			target => new ValueTask<bool>(target > 0));
+#else
+			target => Task.FromResult(target > 0));
+#endif
+
+		// generator(1) => [0]            => no value > 0 => not matching
+		// generator(2) => [0, 1]         => contains 1   => matching
+		// generator(3) => [0, 1, 2]      => contains 1,2 => matching
+		await That(matching).IsEqualTo([2, 3,]).InAnyOrder();
+		await That(notMatching).IsEqualTo([1,]).InAnyOrder();
+	}
+
+	[Fact]
+	public async Task SplitWhereAnyAsync_WhenGeneratorReturnsNull_ShouldNotMatch()
+	{
+		int[] source = [1, 2,];
+
+		(int[] matching, int[] notMatching) = await source.SplitWhereAnyAsync(
+			i => i == 1 ? null : Enumerable.Range(0, 5),
+#if NET8_0_OR_GREATER
+			target => new ValueTask<bool>(target >= 0));
+#else
+			target => Task.FromResult(target >= 0));
+#endif
+
+		// generator(1) => null => not matching (must not call AnyAsync on null)
+		// generator(2) => [0..4] => contains values >= 0 => matching
+		await That(matching).IsEqualTo([2,]).InAnyOrder();
+		await That(notMatching).IsEqualTo([1,]).InAnyOrder();
+	}
+
+	[Fact]
+	public async Task SplitWhereAnyAsync_WhenGeneratorYieldsNoMatch_ShouldNotMatch()
+	{
+		int[] source = [1, 2,];
+
+		(int[] matching, int[] notMatching) = await source.SplitWhereAnyAsync(
+			_ => Enumerable.Range(0, 3),
+#if NET8_0_OR_GREATER
+			target => new ValueTask<bool>(target > 100));
+#else
+			target => Task.FromResult(target > 100));
+#endif
+
+		// No generated value is > 100 => nothing matches.
+		await That(matching).IsEmpty();
+		await That(notMatching).IsEqualTo([1, 2,]).InAnyOrder();
+	}
+
+#if NET8_0_OR_GREATER
+	[Fact]
+	public async Task Where_ShouldYieldOnlyMatchingItems()
+	{
+		int[] source = [1, 2, 3, 4,];
+
+		List<int> result = new();
+		await foreach (int item in LinqAsyncHelpers.Where(ToAsync(source), i => i % 2 == 0))
+		{
+			result.Add(item);
+		}
+
+		await That(result).IsEqualTo([2, 4,]).InAnyOrder();
+	}
+
+	[Fact]
+	public async Task WhereNotNull_FromEnumerable_ShouldYieldOnlyNonNullItems()
+	{
+		int?[] source = [1, null, 2, null, 3,];
+
+		List<int> result = new();
+		await foreach (int item in source.WhereNotNull())
+		{
+			result.Add(item);
+		}
+
+		await That(result).IsEqualTo([1, 2, 3,]).InAnyOrder();
+	}
+
+	[Fact]
+	public async Task Distinct_ShouldYieldEachItemOnlyOnce()
+	{
+		int[] source = [1, 1, 2, 3, 3, 3,];
+
+		List<int> result = new();
+		await foreach (int item in LinqAsyncHelpers.Distinct(ToAsync(source)))
+		{
+			result.Add(item);
+		}
+
+		await That(result).IsEqualTo([1, 2, 3,]).InAnyOrder();
+		await That(result).HasCount(3);
+	}
+
+	private static async IAsyncEnumerable<T> ToAsync<T>(IEnumerable<T> source)
+	{
+		foreach (T item in source)
+		{
+			await Task.Yield();
+			yield return item;
+		}
+	}
+#endif
+}

--- a/Tests/aweXpect.Reflection.Internal.Tests/Helpers/MethodInfoHelpersTests.cs
+++ b/Tests/aweXpect.Reflection.Internal.Tests/Helpers/MethodInfoHelpersTests.cs
@@ -110,6 +110,28 @@ public sealed class MethodInfoHelpersTests
 		await That(result2).IsFalse();
 	}
 
+	[Fact]
+	public async Task HasAttribute_WithAttributeType_WithoutPredicate_ShouldReturnTrue()
+	{
+		MethodInfo methodInfo = typeof(TestClass).GetMethod(nameof(TestClass.Method1WithAttribute))!;
+
+		bool result = methodInfo.HasAttribute(typeof(DummyAttribute));
+
+		await That(result).IsTrue();
+	}
+
+	[Fact]
+	public async Task HasAttribute_WithAttributeType_WithPredicate_ShouldReturnPredicateResult()
+	{
+		MethodInfo methodInfo = typeof(TestClass).GetMethod(nameof(TestClass.Method1WithAttribute))!;
+
+		bool result1 = methodInfo.HasAttribute(typeof(DummyAttribute), a => ((DummyAttribute)a).Value == 1);
+		bool result2 = methodInfo.HasAttribute(typeof(DummyAttribute), a => ((DummyAttribute)a).Value == 2);
+
+		await That(result1).IsTrue();
+		await That(result2).IsFalse();
+	}
+
 	[AttributeUsage(AttributeTargets.Method)]
 	private class DummyAttribute : Attribute
 	{

--- a/Tests/aweXpect.Reflection.Internal.Tests/Helpers/PropertyInfoHelpersTests.cs
+++ b/Tests/aweXpect.Reflection.Internal.Tests/Helpers/PropertyInfoHelpersTests.cs
@@ -127,6 +127,63 @@ public sealed class PropertyInfoHelpersTests
 		await That(result2).IsFalse();
 	}
 
+	[Fact]
+	public async Task HasAttribute_WithAttributeType_WithoutPredicate_ShouldReturnTrue()
+	{
+		PropertyInfo propertyInfo =
+			typeof(TestClass).GetProperty(nameof(TestClass.Property1WithAttribute))!;
+
+		bool result = propertyInfo.HasAttribute(typeof(DummyAttribute));
+
+		await That(result).IsTrue();
+	}
+
+	[Fact]
+	public async Task HasAttribute_WithAttributeType_WithPredicate_ShouldReturnPredicateResult()
+	{
+		PropertyInfo propertyInfo =
+			typeof(TestClass).GetProperty(nameof(TestClass.Property1WithAttribute))!;
+
+		bool result1 = propertyInfo.HasAttribute(typeof(DummyAttribute), a => ((DummyAttribute)a).Value == 1);
+		bool result2 = propertyInfo.HasAttribute(typeof(DummyAttribute), a => ((DummyAttribute)a).Value == 2);
+
+		await That(result1).IsTrue();
+		await That(result2).IsFalse();
+	}
+
+	[Fact]
+	public async Task IsReallyStatic_WhenOnlyGetterIsStatic_ShouldReturnTrue()
+	{
+		PropertyInfo propertyInfo = typeof(StaticAccessorTestClass)
+			.GetProperty(nameof(StaticAccessorTestClass.StaticGetOnlyProperty))!;
+
+		bool result = propertyInfo.IsReallyStatic();
+
+		await That(result).IsTrue();
+	}
+
+	[Fact]
+	public async Task IsReallyStatic_WhenOnlySetterIsStatic_ShouldReturnTrue()
+	{
+		PropertyInfo propertyInfo = typeof(StaticAccessorTestClass)
+			.GetProperty(nameof(StaticAccessorTestClass.StaticSetOnlyProperty))!;
+
+		bool result = propertyInfo.IsReallyStatic();
+
+		await That(result).IsTrue();
+	}
+
+	[Fact]
+	public async Task IsReallyStatic_WhenInstanceProperty_ShouldReturnFalse()
+	{
+		PropertyInfo propertyInfo = typeof(StaticAccessorTestClass)
+			.GetProperty(nameof(StaticAccessorTestClass.InstanceProperty))!;
+
+		bool result = propertyInfo.IsReallyStatic();
+
+		await That(result).IsFalse();
+	}
+
 	[AttributeUsage(AttributeTargets.Property)]
 	private class DummyAttribute : Attribute
 	{
@@ -162,5 +219,19 @@ public sealed class PropertyInfoHelpersTests
 		public int PublicProperty { get; set; }
 		public int PublicPropertyWithPrivateSetter { get; private set; }
 		public int PublicPropertyWithPrivateGetter { private get; set; }
+	}
+
+	private class StaticAccessorTestClass
+	{
+		private static int _staticSetOnly;
+
+		public static int StaticGetOnlyProperty => 1;
+
+		public static int StaticSetOnlyProperty
+		{
+			set => _staticSetOnly = value;
+		}
+
+		public int InstanceProperty { get; set; }
 	}
 }

--- a/Tests/aweXpect.Reflection.Internal.Tests/Helpers/StringHelperTests.cs
+++ b/Tests/aweXpect.Reflection.Internal.Tests/Helpers/StringHelperTests.cs
@@ -48,6 +48,20 @@ public class StringHelperTests
 	}
 
 	[Fact]
+	public async Task WhenLaterLineEndsWithButDoesNotStartWithCommonWhiteSpace_ShouldTrimCommonPrefix()
+	{
+		// line[1] = "  bar" => common white-space is the two leading spaces.
+		// line[2] = "x  " starts with 'x' (not the common prefix) but ends with two spaces.
+		// The common prefix must be truncated based on a leading-character comparison
+		// (StartsWith), not a trailing one (EndsWith).
+		string input = "foo\n  bar\nx  ";
+
+		string result = input.TrimCommonWhiteSpace();
+
+		await That(result).IsEqualTo("foo\n  bar\nx  ");
+	}
+
+	[Fact]
 	public async Task WhenLinesHaveSomeCommonWhiteSpace_ShouldTrim()
 	{
 		string input = """

--- a/Tests/aweXpect.Reflection.Internal.Tests/Helpers/TypeHelpersTests.cs
+++ b/Tests/aweXpect.Reflection.Internal.Tests/Helpers/TypeHelpersTests.cs
@@ -1,6 +1,9 @@
 ﻿using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
+using aweXpect.Customization;
 using aweXpect.Reflection.Helpers;
 
 namespace aweXpect.Reflection.Internal.Tests.Helpers;
@@ -93,6 +96,120 @@ public sealed class TypeHelpersTests
 
 		await That(result1).IsTrue();
 		await That(result2).IsFalse();
+	}
+
+	[Fact]
+	public async Task HasAttribute_WithAttributeType_WithoutPredicate_ShouldReturnTrue()
+	{
+		Type type = typeof(TestClassWithAttribute);
+
+		bool result = type.HasAttribute(typeof(DummyAttribute));
+
+		await That(result).IsTrue();
+	}
+
+	[Fact]
+	public async Task HasAttribute_WithAttributeType_WithPredicate_ShouldReturnPredicateResult()
+	{
+		Type type = typeof(TestClassWithAttribute);
+
+		bool result1 = type.HasAttribute(typeof(DummyAttribute), a => ((DummyAttribute)a).Value == 1);
+		bool result2 = type.HasAttribute(typeof(DummyAttribute), a => ((DummyAttribute)a).Value == 2);
+
+		await That(result1).IsTrue();
+		await That(result2).IsFalse();
+	}
+
+	[Fact]
+	public async Task IsCompilerGenerated_ForNormalType_ShouldReturnFalse()
+	{
+		bool result = typeof(TestClassWithoutAttribute).IsCompilerGenerated();
+
+		await That(result).IsFalse();
+	}
+
+	[Fact]
+	public async Task IsCompilerGenerated_ForNormalMethod_ShouldReturnFalse()
+	{
+		MethodInfo method =
+			typeof(TestClassWithAttribute).GetMethod(nameof(TestClassWithAttribute.Method1WithoutAttribute))!;
+
+		bool result = method.IsCompilerGenerated();
+
+		await That(result).IsFalse();
+	}
+
+	[Fact]
+	public async Task IsCompilerGenerated_ForMethodMarkedCompilerGenerated_ShouldReturnTrue()
+	{
+		MethodInfo method =
+			typeof(TestClassWithoutAttribute).GetMethod(nameof(TestClassWithoutAttribute.MarkedMethod))!;
+
+		bool result = method.IsCompilerGenerated();
+
+		await That(result).IsTrue();
+	}
+
+	[Fact]
+	public async Task IsCompilerGenerated_ForMethodInCompilerGeneratedType_ShouldReturnTrue()
+	{
+		MethodInfo method =
+			typeof(CompilerGeneratedContainer).GetMethod(nameof(CompilerGeneratedContainer.UnmarkedMethod))!;
+
+		bool result = method.IsCompilerGenerated();
+
+		await That(result).IsTrue();
+	}
+
+	[Fact]
+	public async Task Implements_DirectInterface_ForceDirect_ShouldReturnTrue()
+	{
+		Type sut = typeof(BaseImplementingFoo);
+
+		await That(sut.Implements(typeof(IFooInterface), forceDirect: true)).IsTrue();
+	}
+
+	[Fact]
+	public async Task Implements_InheritedInterface_ForceDirect_ShouldReturnFalse()
+	{
+		Type sut = typeof(DerivedImplementingFoo);
+
+		await That(sut.Implements(typeof(IFooInterface), forceDirect: false)).IsTrue();
+		await That(sut.Implements(typeof(IFooInterface), forceDirect: true)).IsFalse();
+	}
+
+	[Fact]
+	public async Task Implements_OpenGenericInterface_ShouldReturnTrue()
+	{
+		Type sut = typeof(ImplementsClosedGeneric);
+
+		await That(sut.Implements(typeof(IGenericInterface<>))).IsTrue();
+	}
+
+	[Fact]
+	public async Task GetDeclaredMethods_WithOnlyOperatorsIncluded_ShouldContainOperatorButNotAccessor()
+	{
+		using (Customize.aweXpect.Reflection().IncludedSpecialNameMembers()
+			       .Set(SpecialNameMembers.Operators))
+		{
+			MethodInfo[] methods = typeof(OperatorAndAccessorTestClass).GetDeclaredMethods();
+
+			await That(methods).Contains(m => m.Name == "op_Addition");
+			await That(methods).None().Satisfy(m => m.Name == "get_Value");
+		}
+	}
+
+	[Fact]
+	public async Task GetDeclaredMethods_WithOnlyAccessorsIncluded_ShouldContainAccessorButNotOperator()
+	{
+		using (Customize.aweXpect.Reflection().IncludedSpecialNameMembers()
+			       .Set(SpecialNameMembers.Accessors))
+		{
+			MethodInfo[] methods = typeof(OperatorAndAccessorTestClass).GetDeclaredMethods();
+
+			await That(methods).Contains(m => m.Name == "get_Value");
+			await That(methods).None().Satisfy(m => m.Name == "op_Addition");
+		}
 	}
 
 	[Theory]
@@ -222,6 +339,40 @@ public sealed class TypeHelpersTests
 	{
 	}
 
+	private interface IGenericInterface<T>
+	{
+	}
+
+	private sealed class ImplementsClosedGeneric : IGenericInterface<int>
+	{
+	}
+
+	private class BaseImplementingFoo : IFooInterface
+	{
+	}
+
+	private sealed class DerivedImplementingFoo : BaseImplementingFoo
+	{
+	}
+
+	[CompilerGenerated]
+	private sealed class CompilerGeneratedContainer
+	{
+		public void UnmarkedMethod()
+			=> throw new NotSupportedException();
+	}
+
+#pragma warning disable CA1822
+	private sealed class OperatorAndAccessorTestClass
+	{
+		public int Value { get; set; }
+
+		public static OperatorAndAccessorTestClass operator +(
+			OperatorAndAccessorTestClass left, OperatorAndAccessorTestClass right)
+			=> left;
+	}
+#pragma warning restore CA1822
+
 	private sealed class ThrowingType(Type inner, Exception exception) : TypeDelegator(inner)
 	{
 		public override ConstructorInfo[] GetConstructors(BindingFlags bindingAttr) => throw exception;
@@ -253,6 +404,10 @@ public sealed class TypeHelpersTests
 
 		[Dummy(2)]
 		public void Method2WithAttribute()
+			=> throw new NotSupportedException();
+
+		[CompilerGenerated]
+		public void MarkedMethod()
 			=> throw new NotSupportedException();
 	}
 


### PR DESCRIPTION
Add and extend tests in the Internal.Tests project to cover surviving and no-coverage mutants in the internal Helpers/* and Formatting/* code:

- HasAttribute(Type) overloads (Assembly/Constructor/Event/Field/Method/ Property/Type helpers): cover the predicate-less '?? true' path.
- PropertyInfoHelpers.IsReallyStatic: static get-only / set-only properties to pin the '||' between getter and setter accessors.
- TypeHelpers: IsCompilerGenerated (Type vs member, declaring-type loop), Implements (forceDirect Except, open generic interface), and operator vs accessor special-name handling via GetDeclaredMethods.
- StringHelpers.TrimCommonWhiteSpace: StartsWith-vs-EndsWith common prefix.
- AtIndexMatch: from-beginning and from-end MatchesIndex boundaries, OnlySingleIndex, descriptions and the count-null guard.
- CollectionConstraintResult: empty Matching/NotMatching defaults and the undecided (cancelled) result message.
- LinqAsyncHelpers: Split/SplitAsync/SplitWhereAnyAsync separation incl. null/empty generator cases, and Where/WhereNotNull/Distinct (net8+).
- FormatterRegistration: disposing a never-initialized instance must not throw (empty disposables array).