### PR TITLE
coverage: kill mutants for ThatConstructors Have In/Out/Ref parameter

### DIFF
--- a/Tests/aweXpect.Reflection.Tests/ThatConstructors.HaveInParameter.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatConstructors.HaveInParameter.Tests.cs
@@ -46,7 +46,9 @@ public sealed partial class ThatConstructors
 					.WithMessage("""
 					             Expected that constructors
 					             all have an in parameter,
-					             but it contained constructors without an in parameter *
+					             but it contained constructors without an in parameter [
+					               *ClassWithoutModifiers*
+					             ]
 					             """).AsWildcard();
 			}
 
@@ -248,6 +250,430 @@ public sealed partial class ThatConstructors
 				await That(Act).Throws<XunitException>();
 			}
 #endif
+#if NET8_0_OR_GREATER
+			[Fact]
+			public async Task AsyncEnumerable_WhenAllHaveInParameter_ShouldSucceed()
+			{
+				IAsyncEnumerable<ConstructorInfo> constructors = ToAsyncEnumerable(
+					typeof(ClassWithInParameter).GetConstructors().Single(),
+					typeof(AnotherClassWithInParameter).GetConstructors().Single());
+
+				async Task Act()
+				{
+					await That(constructors).HaveInParameter();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task AsyncEnumerable_WhenNotAllHaveInParameter_ShouldFail()
+			{
+				IAsyncEnumerable<ConstructorInfo> constructors = ToAsyncEnumerable(
+					typeof(ClassWithInParameter).GetConstructors().Single(),
+					typeof(ClassWithoutModifiers).GetConstructors().Single());
+
+				async Task Act()
+				{
+					await That(constructors).HaveInParameter();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have an in parameter,
+					             but it contained constructors without an in parameter [
+					               *ClassWithoutModifiers*
+					             ]
+					             """).AsWildcard();
+			}
+			[Fact]
+			public async Task AsyncEnumerable_WhenConstructorHasSomeButNotAllInParameters_ShouldSucceed()
+			{
+				IAsyncEnumerable<ConstructorInfo> constructors = ToAsyncEnumerable(
+					typeof(ClassWithMixedParameters).GetConstructors().Single());
+
+				async Task Act()
+				{
+					await That(constructors).HaveInParameter();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+#endif
+
+			[Fact]
+			public async Task WhenConstructorHasSomeButNotAllInParameters_ShouldSucceed()
+			{
+				IEnumerable<ConstructorInfo> constructors = new[]
+				{
+					typeof(ClassWithMixedParameters).GetConstructors().Single(),
+				};
+
+				async Task Act()
+				{
+					await That(constructors).HaveInParameter();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task Generic_WhenNotAllHaveInParameter_ShouldFail()
+			{
+				IEnumerable<ConstructorInfo> constructors = new[]
+				{
+					typeof(ClassWithInParameter).GetConstructors().Single(),
+					typeof(ClassWithoutModifiers).GetConstructors().Single(),
+				};
+
+				async Task Act()
+				{
+					await That(constructors).HaveInParameter<int>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter of type int with in modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task GenericAndName_WhenNotAllHaveInParameter_ShouldFail()
+			{
+				IEnumerable<ConstructorInfo> constructors = new[]
+				{
+					typeof(ClassWithInParameter).GetConstructors().Single(),
+					typeof(ClassWithoutModifiers).GetConstructors().Single(),
+				};
+
+				async Task Act()
+				{
+					await That(constructors).HaveInParameter<int>("value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter of type int with name "value" with in modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task ByTypeAndName_WhenNotAllHaveInParameter_ShouldFail()
+			{
+				IEnumerable<ConstructorInfo> constructors = new[]
+				{
+					typeof(ClassWithInParameter).GetConstructors().Single(),
+					typeof(ClassWithoutModifiers).GetConstructors().Single(),
+				};
+
+				async Task Act()
+				{
+					await That(constructors).HaveInParameter(typeof(int), "value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter of type int with name "value" with in modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task ByName_WhenNotAllHaveInParameter_ShouldFail()
+			{
+				IEnumerable<ConstructorInfo> constructors = new[]
+				{
+					typeof(ClassWithInParameter).GetConstructors().Single(),
+					typeof(ClassWithoutModifiers).GetConstructors().Single(),
+				};
+
+				async Task Act()
+				{
+					await That(constructors).HaveInParameter("value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter with name "value" with in modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task GenericExactly_WhenNotAllHaveInParameter_ShouldFail()
+			{
+				IEnumerable<ConstructorInfo> constructors = new[]
+				{
+					typeof(ClassWithInParameter).GetConstructors().Single(),
+					typeof(ClassWithoutModifiers).GetConstructors().Single(),
+				};
+
+				async Task Act()
+				{
+					await That(constructors).HaveInParameterExactly<int>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter of exact type int with in modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task ByTypeExactly_WhenNotAllHaveInParameter_ShouldFail()
+			{
+				IEnumerable<ConstructorInfo> constructors = new[]
+				{
+					typeof(ClassWithInParameter).GetConstructors().Single(),
+					typeof(ClassWithoutModifiers).GetConstructors().Single(),
+				};
+
+				async Task Act()
+				{
+					await That(constructors).HaveInParameterExactly(typeof(int));
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter of exact type int with in modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task GenericExactlyAndName_WhenNotAllHaveInParameter_ShouldFail()
+			{
+				IEnumerable<ConstructorInfo> constructors = new[]
+				{
+					typeof(ClassWithInParameter).GetConstructors().Single(),
+					typeof(ClassWithoutModifiers).GetConstructors().Single(),
+				};
+
+				async Task Act()
+				{
+					await That(constructors).HaveInParameterExactly<int>("value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter of exact type int with name "value" with in modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task ByTypeExactlyAndName_WhenNotAllHaveInParameter_ShouldFail()
+			{
+				IEnumerable<ConstructorInfo> constructors = new[]
+				{
+					typeof(ClassWithInParameter).GetConstructors().Single(),
+					typeof(ClassWithoutModifiers).GetConstructors().Single(),
+				};
+
+				async Task Act()
+				{
+					await That(constructors).HaveInParameterExactly(typeof(int), "value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter of exact type int with name "value" with in modifier,
+					             but at least one did not
+					             """);
+			}
+
+#if NET8_0_OR_GREATER
+			[Fact]
+			public async Task AsyncEnumerable_ByType_WhenNotAllHaveInParameter_ShouldFail()
+			{
+				IAsyncEnumerable<ConstructorInfo> constructors = ToAsyncEnumerable(
+					typeof(ClassWithInParameter).GetConstructors().Single(),
+					typeof(ClassWithoutModifiers).GetConstructors().Single());
+
+				async Task Act()
+				{
+					await That(constructors).HaveInParameter(typeof(int));
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter of type int with in modifier,
+					             but at least one did not
+					             """);
+			}
+			[Fact]
+			public async Task AsyncEnumerable_Generic_WhenNotAllHaveInParameter_ShouldFail()
+			{
+				IAsyncEnumerable<ConstructorInfo> constructors = ToAsyncEnumerable(
+					typeof(ClassWithInParameter).GetConstructors().Single(),
+					typeof(ClassWithoutModifiers).GetConstructors().Single());
+
+				async Task Act()
+				{
+					await That(constructors).HaveInParameter<int>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter of type int with in modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task AsyncEnumerable_ByTypeAndName_WhenNotAllHaveInParameter_ShouldFail()
+			{
+				IAsyncEnumerable<ConstructorInfo> constructors = ToAsyncEnumerable(
+					typeof(ClassWithInParameter).GetConstructors().Single(),
+					typeof(ClassWithoutModifiers).GetConstructors().Single());
+
+				async Task Act()
+				{
+					await That(constructors).HaveInParameter(typeof(int), "value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter of type int with name "value" with in modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task AsyncEnumerable_GenericAndName_WhenNotAllHaveInParameter_ShouldFail()
+			{
+				IAsyncEnumerable<ConstructorInfo> constructors = ToAsyncEnumerable(
+					typeof(ClassWithInParameter).GetConstructors().Single(),
+					typeof(ClassWithoutModifiers).GetConstructors().Single());
+
+				async Task Act()
+				{
+					await That(constructors).HaveInParameter<int>("value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter of type int with name "value" with in modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task AsyncEnumerable_ByName_WhenNotAllHaveInParameter_ShouldFail()
+			{
+				IAsyncEnumerable<ConstructorInfo> constructors = ToAsyncEnumerable(
+					typeof(ClassWithInParameter).GetConstructors().Single(),
+					typeof(ClassWithoutModifiers).GetConstructors().Single());
+
+				async Task Act()
+				{
+					await That(constructors).HaveInParameter("value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter with name "value" with in modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task AsyncEnumerable_GenericExactly_WhenNotAllHaveInParameter_ShouldFail()
+			{
+				IAsyncEnumerable<ConstructorInfo> constructors = ToAsyncEnumerable(
+					typeof(ClassWithInParameter).GetConstructors().Single(),
+					typeof(ClassWithoutModifiers).GetConstructors().Single());
+
+				async Task Act()
+				{
+					await That(constructors).HaveInParameterExactly<int>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter of exact type int with in modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task AsyncEnumerable_ByTypeExactly_WhenNotAllHaveInParameter_ShouldFail()
+			{
+				IAsyncEnumerable<ConstructorInfo> constructors = ToAsyncEnumerable(
+					typeof(ClassWithInParameter).GetConstructors().Single(),
+					typeof(ClassWithoutModifiers).GetConstructors().Single());
+
+				async Task Act()
+				{
+					await That(constructors).HaveInParameterExactly(typeof(int));
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter of exact type int with in modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task AsyncEnumerable_GenericExactlyAndName_WhenNotAllHaveInParameter_ShouldFail()
+			{
+				IAsyncEnumerable<ConstructorInfo> constructors = ToAsyncEnumerable(
+					typeof(ClassWithInParameter).GetConstructors().Single(),
+					typeof(ClassWithoutModifiers).GetConstructors().Single());
+
+				async Task Act()
+				{
+					await That(constructors).HaveInParameterExactly<int>("value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter of exact type int with name "value" with in modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task AsyncEnumerable_ByTypeExactlyAndName_WhenNotAllHaveInParameter_ShouldFail()
+			{
+				IAsyncEnumerable<ConstructorInfo> constructors = ToAsyncEnumerable(
+					typeof(ClassWithInParameter).GetConstructors().Single(),
+					typeof(ClassWithoutModifiers).GetConstructors().Single());
+
+				async Task Act()
+				{
+					await That(constructors).HaveInParameterExactly(typeof(int), "value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter of exact type int with name "value" with in modifier,
+					             but at least one did not
+					             """);
+			}
+#endif
 		}
 
 		public sealed class NegatedTests
@@ -270,7 +696,9 @@ public sealed partial class ThatConstructors
 					.WithMessage("""
 					             Expected that constructors
 					             not all have an in parameter,
-					             but it only contained constructors with an in parameter *
+					             but it only contained constructors with an in parameter [
+					               *ClassWithInParameter*
+					             ]
 					             """).AsWildcard();
 			}
 
@@ -326,6 +754,14 @@ public sealed partial class ThatConstructors
 			{
 			}
 		}
+
+		private class ClassWithMixedParameters
+		{
+			public ClassWithMixedParameters(in int value, string other)
+			{
+			}
+		}
+
 		// ReSharper restore UnusedMember.Local
 		// ReSharper restore UnusedParameter.Local
 	}

--- a/Tests/aweXpect.Reflection.Tests/ThatConstructors.HaveOutParameter.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatConstructors.HaveOutParameter.Tests.cs
@@ -46,7 +46,9 @@ public sealed partial class ThatConstructors
 					.WithMessage("""
 					             Expected that constructors
 					             all have an out parameter,
-					             but it contained constructors without an out parameter *
+					             but it contained constructors without an out parameter [
+					               *ClassWithoutModifiers*
+					             ]
 					             """).AsWildcard();
 			}
 
@@ -248,6 +250,430 @@ public sealed partial class ThatConstructors
 				await That(Act).Throws<XunitException>();
 			}
 #endif
+#if NET8_0_OR_GREATER
+			[Fact]
+			public async Task AsyncEnumerable_WhenAllHaveOutParameter_ShouldSucceed()
+			{
+				IAsyncEnumerable<ConstructorInfo> constructors = ToAsyncEnumerable(
+					typeof(ClassWithOutParameter).GetConstructors().Single(),
+					typeof(AnotherClassWithOutParameter).GetConstructors().Single());
+
+				async Task Act()
+				{
+					await That(constructors).HaveOutParameter();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task AsyncEnumerable_WhenNotAllHaveOutParameter_ShouldFail()
+			{
+				IAsyncEnumerable<ConstructorInfo> constructors = ToAsyncEnumerable(
+					typeof(ClassWithOutParameter).GetConstructors().Single(),
+					typeof(ClassWithoutModifiers).GetConstructors().Single());
+
+				async Task Act()
+				{
+					await That(constructors).HaveOutParameter();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have an out parameter,
+					             but it contained constructors without an out parameter [
+					               *ClassWithoutModifiers*
+					             ]
+					             """).AsWildcard();
+			}
+			[Fact]
+			public async Task AsyncEnumerable_WhenConstructorHasSomeButNotAllOutParameters_ShouldSucceed()
+			{
+				IAsyncEnumerable<ConstructorInfo> constructors = ToAsyncEnumerable(
+					typeof(ClassWithMixedParameters).GetConstructors().Single());
+
+				async Task Act()
+				{
+					await That(constructors).HaveOutParameter();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+#endif
+
+			[Fact]
+			public async Task WhenConstructorHasSomeButNotAllOutParameters_ShouldSucceed()
+			{
+				IEnumerable<ConstructorInfo> constructors = new[]
+				{
+					typeof(ClassWithMixedParameters).GetConstructors().Single(),
+				};
+
+				async Task Act()
+				{
+					await That(constructors).HaveOutParameter();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task Generic_WhenNotAllHaveOutParameter_ShouldFail()
+			{
+				IEnumerable<ConstructorInfo> constructors = new[]
+				{
+					typeof(ClassWithOutParameter).GetConstructors().Single(),
+					typeof(ClassWithoutModifiers).GetConstructors().Single(),
+				};
+
+				async Task Act()
+				{
+					await That(constructors).HaveOutParameter<int>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter of type int with out modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task GenericAndName_WhenNotAllHaveOutParameter_ShouldFail()
+			{
+				IEnumerable<ConstructorInfo> constructors = new[]
+				{
+					typeof(ClassWithOutParameter).GetConstructors().Single(),
+					typeof(ClassWithoutModifiers).GetConstructors().Single(),
+				};
+
+				async Task Act()
+				{
+					await That(constructors).HaveOutParameter<int>("value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter of type int with name "value" with out modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task ByTypeAndName_WhenNotAllHaveOutParameter_ShouldFail()
+			{
+				IEnumerable<ConstructorInfo> constructors = new[]
+				{
+					typeof(ClassWithOutParameter).GetConstructors().Single(),
+					typeof(ClassWithoutModifiers).GetConstructors().Single(),
+				};
+
+				async Task Act()
+				{
+					await That(constructors).HaveOutParameter(typeof(int), "value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter of type int with name "value" with out modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task ByName_WhenNotAllHaveOutParameter_ShouldFail()
+			{
+				IEnumerable<ConstructorInfo> constructors = new[]
+				{
+					typeof(ClassWithOutParameter).GetConstructors().Single(),
+					typeof(ClassWithoutModifiers).GetConstructors().Single(),
+				};
+
+				async Task Act()
+				{
+					await That(constructors).HaveOutParameter("value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter with name "value" with out modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task GenericExactly_WhenNotAllHaveOutParameter_ShouldFail()
+			{
+				IEnumerable<ConstructorInfo> constructors = new[]
+				{
+					typeof(ClassWithOutParameter).GetConstructors().Single(),
+					typeof(ClassWithoutModifiers).GetConstructors().Single(),
+				};
+
+				async Task Act()
+				{
+					await That(constructors).HaveOutParameterExactly<int>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter of exact type int with out modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task ByTypeExactly_WhenNotAllHaveOutParameter_ShouldFail()
+			{
+				IEnumerable<ConstructorInfo> constructors = new[]
+				{
+					typeof(ClassWithOutParameter).GetConstructors().Single(),
+					typeof(ClassWithoutModifiers).GetConstructors().Single(),
+				};
+
+				async Task Act()
+				{
+					await That(constructors).HaveOutParameterExactly(typeof(int));
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter of exact type int with out modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task GenericExactlyAndName_WhenNotAllHaveOutParameter_ShouldFail()
+			{
+				IEnumerable<ConstructorInfo> constructors = new[]
+				{
+					typeof(ClassWithOutParameter).GetConstructors().Single(),
+					typeof(ClassWithoutModifiers).GetConstructors().Single(),
+				};
+
+				async Task Act()
+				{
+					await That(constructors).HaveOutParameterExactly<int>("value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter of exact type int with name "value" with out modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task ByTypeExactlyAndName_WhenNotAllHaveOutParameter_ShouldFail()
+			{
+				IEnumerable<ConstructorInfo> constructors = new[]
+				{
+					typeof(ClassWithOutParameter).GetConstructors().Single(),
+					typeof(ClassWithoutModifiers).GetConstructors().Single(),
+				};
+
+				async Task Act()
+				{
+					await That(constructors).HaveOutParameterExactly(typeof(int), "value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter of exact type int with name "value" with out modifier,
+					             but at least one did not
+					             """);
+			}
+
+#if NET8_0_OR_GREATER
+			[Fact]
+			public async Task AsyncEnumerable_ByType_WhenNotAllHaveOutParameter_ShouldFail()
+			{
+				IAsyncEnumerable<ConstructorInfo> constructors = ToAsyncEnumerable(
+					typeof(ClassWithOutParameter).GetConstructors().Single(),
+					typeof(ClassWithoutModifiers).GetConstructors().Single());
+
+				async Task Act()
+				{
+					await That(constructors).HaveOutParameter(typeof(int));
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter of type int with out modifier,
+					             but at least one did not
+					             """);
+			}
+			[Fact]
+			public async Task AsyncEnumerable_Generic_WhenNotAllHaveOutParameter_ShouldFail()
+			{
+				IAsyncEnumerable<ConstructorInfo> constructors = ToAsyncEnumerable(
+					typeof(ClassWithOutParameter).GetConstructors().Single(),
+					typeof(ClassWithoutModifiers).GetConstructors().Single());
+
+				async Task Act()
+				{
+					await That(constructors).HaveOutParameter<int>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter of type int with out modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task AsyncEnumerable_ByTypeAndName_WhenNotAllHaveOutParameter_ShouldFail()
+			{
+				IAsyncEnumerable<ConstructorInfo> constructors = ToAsyncEnumerable(
+					typeof(ClassWithOutParameter).GetConstructors().Single(),
+					typeof(ClassWithoutModifiers).GetConstructors().Single());
+
+				async Task Act()
+				{
+					await That(constructors).HaveOutParameter(typeof(int), "value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter of type int with name "value" with out modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task AsyncEnumerable_GenericAndName_WhenNotAllHaveOutParameter_ShouldFail()
+			{
+				IAsyncEnumerable<ConstructorInfo> constructors = ToAsyncEnumerable(
+					typeof(ClassWithOutParameter).GetConstructors().Single(),
+					typeof(ClassWithoutModifiers).GetConstructors().Single());
+
+				async Task Act()
+				{
+					await That(constructors).HaveOutParameter<int>("value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter of type int with name "value" with out modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task AsyncEnumerable_ByName_WhenNotAllHaveOutParameter_ShouldFail()
+			{
+				IAsyncEnumerable<ConstructorInfo> constructors = ToAsyncEnumerable(
+					typeof(ClassWithOutParameter).GetConstructors().Single(),
+					typeof(ClassWithoutModifiers).GetConstructors().Single());
+
+				async Task Act()
+				{
+					await That(constructors).HaveOutParameter("value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter with name "value" with out modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task AsyncEnumerable_GenericExactly_WhenNotAllHaveOutParameter_ShouldFail()
+			{
+				IAsyncEnumerable<ConstructorInfo> constructors = ToAsyncEnumerable(
+					typeof(ClassWithOutParameter).GetConstructors().Single(),
+					typeof(ClassWithoutModifiers).GetConstructors().Single());
+
+				async Task Act()
+				{
+					await That(constructors).HaveOutParameterExactly<int>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter of exact type int with out modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task AsyncEnumerable_ByTypeExactly_WhenNotAllHaveOutParameter_ShouldFail()
+			{
+				IAsyncEnumerable<ConstructorInfo> constructors = ToAsyncEnumerable(
+					typeof(ClassWithOutParameter).GetConstructors().Single(),
+					typeof(ClassWithoutModifiers).GetConstructors().Single());
+
+				async Task Act()
+				{
+					await That(constructors).HaveOutParameterExactly(typeof(int));
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter of exact type int with out modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task AsyncEnumerable_GenericExactlyAndName_WhenNotAllHaveOutParameter_ShouldFail()
+			{
+				IAsyncEnumerable<ConstructorInfo> constructors = ToAsyncEnumerable(
+					typeof(ClassWithOutParameter).GetConstructors().Single(),
+					typeof(ClassWithoutModifiers).GetConstructors().Single());
+
+				async Task Act()
+				{
+					await That(constructors).HaveOutParameterExactly<int>("value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter of exact type int with name "value" with out modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task AsyncEnumerable_ByTypeExactlyAndName_WhenNotAllHaveOutParameter_ShouldFail()
+			{
+				IAsyncEnumerable<ConstructorInfo> constructors = ToAsyncEnumerable(
+					typeof(ClassWithOutParameter).GetConstructors().Single(),
+					typeof(ClassWithoutModifiers).GetConstructors().Single());
+
+				async Task Act()
+				{
+					await That(constructors).HaveOutParameterExactly(typeof(int), "value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter of exact type int with name "value" with out modifier,
+					             but at least one did not
+					             """);
+			}
+#endif
 		}
 
 		public sealed class NegatedTests
@@ -270,7 +696,9 @@ public sealed partial class ThatConstructors
 					.WithMessage("""
 					             Expected that constructors
 					             not all have an out parameter,
-					             but it only contained constructors with an out parameter *
+					             but it only contained constructors with an out parameter [
+					               *ClassWithOutParameter*
+					             ]
 					             """).AsWildcard();
 			}
 
@@ -328,6 +756,15 @@ public sealed partial class ThatConstructors
 			{
 			}
 		}
+
+		private class ClassWithMixedParameters
+		{
+			public ClassWithMixedParameters(out int value, string other)
+			{
+				value = 0;
+			}
+		}
+
 		// ReSharper restore UnusedMember.Local
 		// ReSharper restore UnusedParameter.Local
 	}

--- a/Tests/aweXpect.Reflection.Tests/ThatConstructors.HaveRefParameter.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatConstructors.HaveRefParameter.Tests.cs
@@ -46,7 +46,9 @@ public sealed partial class ThatConstructors
 					.WithMessage("""
 					             Expected that constructors
 					             all have a ref parameter,
-					             but it contained constructors without a ref parameter *
+					             but it contained constructors without a ref parameter [
+					               *ClassWithoutModifiers*
+					             ]
 					             """).AsWildcard();
 			}
 
@@ -248,6 +250,430 @@ public sealed partial class ThatConstructors
 				await That(Act).Throws<XunitException>();
 			}
 #endif
+#if NET8_0_OR_GREATER
+			[Fact]
+			public async Task AsyncEnumerable_WhenAllHaveRefParameter_ShouldSucceed()
+			{
+				IAsyncEnumerable<ConstructorInfo> constructors = ToAsyncEnumerable(
+					typeof(ClassWithRefParameter).GetConstructors().Single(),
+					typeof(AnotherClassWithRefParameter).GetConstructors().Single());
+
+				async Task Act()
+				{
+					await That(constructors).HaveRefParameter();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task AsyncEnumerable_WhenNotAllHaveRefParameter_ShouldFail()
+			{
+				IAsyncEnumerable<ConstructorInfo> constructors = ToAsyncEnumerable(
+					typeof(ClassWithRefParameter).GetConstructors().Single(),
+					typeof(ClassWithoutModifiers).GetConstructors().Single());
+
+				async Task Act()
+				{
+					await That(constructors).HaveRefParameter();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have a ref parameter,
+					             but it contained constructors without a ref parameter [
+					               *ClassWithoutModifiers*
+					             ]
+					             """).AsWildcard();
+			}
+			[Fact]
+			public async Task AsyncEnumerable_WhenConstructorHasSomeButNotAllRefParameters_ShouldSucceed()
+			{
+				IAsyncEnumerable<ConstructorInfo> constructors = ToAsyncEnumerable(
+					typeof(ClassWithMixedParameters).GetConstructors().Single());
+
+				async Task Act()
+				{
+					await That(constructors).HaveRefParameter();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+#endif
+
+			[Fact]
+			public async Task WhenConstructorHasSomeButNotAllRefParameters_ShouldSucceed()
+			{
+				IEnumerable<ConstructorInfo> constructors = new[]
+				{
+					typeof(ClassWithMixedParameters).GetConstructors().Single(),
+				};
+
+				async Task Act()
+				{
+					await That(constructors).HaveRefParameter();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task Generic_WhenNotAllHaveRefParameter_ShouldFail()
+			{
+				IEnumerable<ConstructorInfo> constructors = new[]
+				{
+					typeof(ClassWithRefParameter).GetConstructors().Single(),
+					typeof(ClassWithoutModifiers).GetConstructors().Single(),
+				};
+
+				async Task Act()
+				{
+					await That(constructors).HaveRefParameter<int>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter of type int with ref modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task GenericAndName_WhenNotAllHaveRefParameter_ShouldFail()
+			{
+				IEnumerable<ConstructorInfo> constructors = new[]
+				{
+					typeof(ClassWithRefParameter).GetConstructors().Single(),
+					typeof(ClassWithoutModifiers).GetConstructors().Single(),
+				};
+
+				async Task Act()
+				{
+					await That(constructors).HaveRefParameter<int>("value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter of type int with name "value" with ref modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task ByTypeAndName_WhenNotAllHaveRefParameter_ShouldFail()
+			{
+				IEnumerable<ConstructorInfo> constructors = new[]
+				{
+					typeof(ClassWithRefParameter).GetConstructors().Single(),
+					typeof(ClassWithoutModifiers).GetConstructors().Single(),
+				};
+
+				async Task Act()
+				{
+					await That(constructors).HaveRefParameter(typeof(int), "value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter of type int with name "value" with ref modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task ByName_WhenNotAllHaveRefParameter_ShouldFail()
+			{
+				IEnumerable<ConstructorInfo> constructors = new[]
+				{
+					typeof(ClassWithRefParameter).GetConstructors().Single(),
+					typeof(ClassWithoutModifiers).GetConstructors().Single(),
+				};
+
+				async Task Act()
+				{
+					await That(constructors).HaveRefParameter("value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter with name "value" with ref modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task GenericExactly_WhenNotAllHaveRefParameter_ShouldFail()
+			{
+				IEnumerable<ConstructorInfo> constructors = new[]
+				{
+					typeof(ClassWithRefParameter).GetConstructors().Single(),
+					typeof(ClassWithoutModifiers).GetConstructors().Single(),
+				};
+
+				async Task Act()
+				{
+					await That(constructors).HaveRefParameterExactly<int>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter of exact type int with ref modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task ByTypeExactly_WhenNotAllHaveRefParameter_ShouldFail()
+			{
+				IEnumerable<ConstructorInfo> constructors = new[]
+				{
+					typeof(ClassWithRefParameter).GetConstructors().Single(),
+					typeof(ClassWithoutModifiers).GetConstructors().Single(),
+				};
+
+				async Task Act()
+				{
+					await That(constructors).HaveRefParameterExactly(typeof(int));
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter of exact type int with ref modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task GenericExactlyAndName_WhenNotAllHaveRefParameter_ShouldFail()
+			{
+				IEnumerable<ConstructorInfo> constructors = new[]
+				{
+					typeof(ClassWithRefParameter).GetConstructors().Single(),
+					typeof(ClassWithoutModifiers).GetConstructors().Single(),
+				};
+
+				async Task Act()
+				{
+					await That(constructors).HaveRefParameterExactly<int>("value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter of exact type int with name "value" with ref modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task ByTypeExactlyAndName_WhenNotAllHaveRefParameter_ShouldFail()
+			{
+				IEnumerable<ConstructorInfo> constructors = new[]
+				{
+					typeof(ClassWithRefParameter).GetConstructors().Single(),
+					typeof(ClassWithoutModifiers).GetConstructors().Single(),
+				};
+
+				async Task Act()
+				{
+					await That(constructors).HaveRefParameterExactly(typeof(int), "value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter of exact type int with name "value" with ref modifier,
+					             but at least one did not
+					             """);
+			}
+
+#if NET8_0_OR_GREATER
+			[Fact]
+			public async Task AsyncEnumerable_ByType_WhenNotAllHaveRefParameter_ShouldFail()
+			{
+				IAsyncEnumerable<ConstructorInfo> constructors = ToAsyncEnumerable(
+					typeof(ClassWithRefParameter).GetConstructors().Single(),
+					typeof(ClassWithoutModifiers).GetConstructors().Single());
+
+				async Task Act()
+				{
+					await That(constructors).HaveRefParameter(typeof(int));
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter of type int with ref modifier,
+					             but at least one did not
+					             """);
+			}
+			[Fact]
+			public async Task AsyncEnumerable_Generic_WhenNotAllHaveRefParameter_ShouldFail()
+			{
+				IAsyncEnumerable<ConstructorInfo> constructors = ToAsyncEnumerable(
+					typeof(ClassWithRefParameter).GetConstructors().Single(),
+					typeof(ClassWithoutModifiers).GetConstructors().Single());
+
+				async Task Act()
+				{
+					await That(constructors).HaveRefParameter<int>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter of type int with ref modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task AsyncEnumerable_ByTypeAndName_WhenNotAllHaveRefParameter_ShouldFail()
+			{
+				IAsyncEnumerable<ConstructorInfo> constructors = ToAsyncEnumerable(
+					typeof(ClassWithRefParameter).GetConstructors().Single(),
+					typeof(ClassWithoutModifiers).GetConstructors().Single());
+
+				async Task Act()
+				{
+					await That(constructors).HaveRefParameter(typeof(int), "value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter of type int with name "value" with ref modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task AsyncEnumerable_GenericAndName_WhenNotAllHaveRefParameter_ShouldFail()
+			{
+				IAsyncEnumerable<ConstructorInfo> constructors = ToAsyncEnumerable(
+					typeof(ClassWithRefParameter).GetConstructors().Single(),
+					typeof(ClassWithoutModifiers).GetConstructors().Single());
+
+				async Task Act()
+				{
+					await That(constructors).HaveRefParameter<int>("value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter of type int with name "value" with ref modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task AsyncEnumerable_ByName_WhenNotAllHaveRefParameter_ShouldFail()
+			{
+				IAsyncEnumerable<ConstructorInfo> constructors = ToAsyncEnumerable(
+					typeof(ClassWithRefParameter).GetConstructors().Single(),
+					typeof(ClassWithoutModifiers).GetConstructors().Single());
+
+				async Task Act()
+				{
+					await That(constructors).HaveRefParameter("value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter with name "value" with ref modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task AsyncEnumerable_GenericExactly_WhenNotAllHaveRefParameter_ShouldFail()
+			{
+				IAsyncEnumerable<ConstructorInfo> constructors = ToAsyncEnumerable(
+					typeof(ClassWithRefParameter).GetConstructors().Single(),
+					typeof(ClassWithoutModifiers).GetConstructors().Single());
+
+				async Task Act()
+				{
+					await That(constructors).HaveRefParameterExactly<int>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter of exact type int with ref modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task AsyncEnumerable_ByTypeExactly_WhenNotAllHaveRefParameter_ShouldFail()
+			{
+				IAsyncEnumerable<ConstructorInfo> constructors = ToAsyncEnumerable(
+					typeof(ClassWithRefParameter).GetConstructors().Single(),
+					typeof(ClassWithoutModifiers).GetConstructors().Single());
+
+				async Task Act()
+				{
+					await That(constructors).HaveRefParameterExactly(typeof(int));
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter of exact type int with ref modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task AsyncEnumerable_GenericExactlyAndName_WhenNotAllHaveRefParameter_ShouldFail()
+			{
+				IAsyncEnumerable<ConstructorInfo> constructors = ToAsyncEnumerable(
+					typeof(ClassWithRefParameter).GetConstructors().Single(),
+					typeof(ClassWithoutModifiers).GetConstructors().Single());
+
+				async Task Act()
+				{
+					await That(constructors).HaveRefParameterExactly<int>("value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter of exact type int with name "value" with ref modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task AsyncEnumerable_ByTypeExactlyAndName_WhenNotAllHaveRefParameter_ShouldFail()
+			{
+				IAsyncEnumerable<ConstructorInfo> constructors = ToAsyncEnumerable(
+					typeof(ClassWithRefParameter).GetConstructors().Single(),
+					typeof(ClassWithoutModifiers).GetConstructors().Single());
+
+				async Task Act()
+				{
+					await That(constructors).HaveRefParameterExactly(typeof(int), "value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter of exact type int with name "value" with ref modifier,
+					             but at least one did not
+					             """);
+			}
+#endif
 		}
 
 		public sealed class NegatedTests
@@ -270,7 +696,9 @@ public sealed partial class ThatConstructors
 					.WithMessage("""
 					             Expected that constructors
 					             not all have a ref parameter,
-					             but it only contained constructors with a ref parameter *
+					             but it only contained constructors with a ref parameter [
+					               *ClassWithRefParameter*
+					             ]
 					             """).AsWildcard();
 			}
 
@@ -328,6 +756,15 @@ public sealed partial class ThatConstructors
 			{
 			}
 		}
+
+		private class ClassWithMixedParameters
+		{
+			public ClassWithMixedParameters(ref int value, string other)
+			{
+				value = 0;
+			}
+		}
+
 		// ReSharper restore UnusedMember.Local
 		// ReSharper restore UnusedParameter.Local
 	}


### PR DESCRIPTION
Add failure-message tests covering every HaveIn/Out/RefParameter overload (generic, type, name, exact variants; sync and async) so the per-overload "with in/out/ref modifier" description strings are pinned. Add mixed-parameter fixtures and sync+async success tests to distinguish Any() from All() on the no-argument constraint, and strengthen the no-arg failure and negated tests to assert the formatted constructor list so the Formatter.Format statements are covered.