### PR TITLE
coverage: kill mutants in assemblies/assembly version and dependency assertions

### DIFF
--- a/Tests/aweXpect.Reflection.Tests/ThatAssemblies.Have.AttributeTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatAssemblies.Have.AttributeTests.cs
@@ -89,6 +89,112 @@ public sealed partial class ThatAssemblies
 					             """).AsWildcard();
 			}
 
+			[Fact]
+			public async Task WhenNegated_ShouldListMatchingAssemblies()
+			{
+				IEnumerable<Assembly> subjects = new[]
+				{
+					typeof(AttributeTests).Assembly,
+				};
+
+				async Task Act()
+				{
+					await That(subjects).DoesNotComplyWith(they => they.Have<AssemblyTitleAttribute>());
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subjects
+					             not all have AssemblyTitleAttribute,
+					             but it only contained matching assemblies [
+					               aweXpect.Reflection.Tests, Version=*, Culture=neutral, PublicKeyToken=null
+					             ]
+					             """).AsWildcard();
+			}
+
+#if NET8_0_OR_GREATER
+			[Fact]
+			public async Task AsyncEnumerable_WhenAllAssembliesHaveAttribute_ShouldSucceed()
+			{
+				IAsyncEnumerable<Assembly?> subjects = ToAsyncEnumerable(
+					typeof(AttributeTests).Assembly);
+
+				async Task Act()
+				{
+					await That(subjects).Have<AssemblyTitleAttribute>();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task AsyncEnumerable_WhenNotAllAssembliesHaveAttribute_ShouldFail()
+			{
+				IAsyncEnumerable<Assembly?> subjects = ToAsyncEnumerable(
+					typeof(AttributeTests).Assembly);
+
+				async Task Act()
+				{
+					await That(subjects).Have<TestAttribute>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subjects
+					             all have ThatAssemblies.Have.AttributeTests.TestAttribute,
+					             but it contained not matching assemblies [
+					               aweXpect.Reflection.Tests, Version=*, Culture=neutral, PublicKeyToken=null
+					             ]
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task AsyncEnumerable_WithPredicate_WhenNotAllAssembliesMatch_ShouldFail()
+			{
+				IAsyncEnumerable<Assembly?> subjects = ToAsyncEnumerable(
+					typeof(AttributeTests).Assembly);
+
+				async Task Act()
+				{
+					await That(subjects).Have<AssemblyTitleAttribute>(attr => attr.Title == "NonExistentTitle");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subjects
+					             all have AssemblyTitleAttribute matching attr => attr.Title == "NonExistentTitle",
+					             but it contained not matching assemblies [
+					               aweXpect.Reflection.Tests, Version=*, Culture=neutral, PublicKeyToken=null
+					             ]
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task AsyncEnumerable_WithPredicate_WhenAllAssembliesMatch_ShouldSucceed()
+			{
+				IAsyncEnumerable<Assembly?> subjects = ToAsyncEnumerable(
+					typeof(AttributeTests).Assembly);
+
+				async Task Act()
+				{
+					await That(subjects)
+						.Have<AssemblyTitleAttribute>(attr => attr.Title == "aweXpect.Reflection.Tests");
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			private static async IAsyncEnumerable<Assembly?> ToAsyncEnumerable(params Assembly?[] items)
+			{
+				foreach (Assembly? item in items)
+				{
+					yield return item;
+				}
+
+				await Task.CompletedTask;
+			}
+#endif
+
 			[AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
 			private class TestAttribute : Attribute;
 		}

--- a/Tests/aweXpect.Reflection.Tests/ThatAssemblies.HaveDependenciesOnlyOn.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatAssemblies.HaveDependenciesOnlyOn.Tests.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+using System.Reflection;
 using aweXpect.Customization;
 using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
@@ -53,6 +55,86 @@ public sealed partial class ThatAssemblies
 					             all have dependencies only on assemblies equal to "aweXpect.Core",
 					             but it contained assemblies with disallowed dependencies [
 					               aweXpect.Reflection.Tests, Version=*, Culture=neutral, PublicKeyToken=null depends on ["aweXpect.Reflection", "aweXpect"]
+					             ]
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenMultipleAssembliesHaveDisallowedDependencies_ShouldSeparateWithComma()
+			{
+				Filtered.Assemblies subject = In.Assemblies(typeof(In).Assembly, typeof(ThatAssemblies).Assembly);
+
+				async Task Act()
+				{
+					await That(subject).HaveDependenciesOnlyOn("NonExistentAssembly");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that in the assemblies *
+					             all have dependencies only on assemblies equal to "NonExistentAssembly",
+					             but it contained assemblies with disallowed dependencies [
+					               aweXpect.Reflection, Version=* depends on *,
+					               aweXpect.Reflection.Tests, Version=* depends on *
+					             ]
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenNoAllowedAssembliesAreGiven_ShouldDescribeNoAssemblies()
+			{
+				Filtered.Assemblies subject = In.AssemblyContaining<PublicAbstractClass>();
+
+				async Task Act()
+				{
+					await That(subject).HaveDependenciesOnlyOn();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that in assembly containing type PublicAbstractClass
+					             all have dependencies only on no assemblies,
+					             but it contained assemblies with disallowed dependencies *
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenAllowedAssembliesAreGiven_ShouldDescribeAssemblies()
+			{
+				Filtered.Assemblies subject = In.AssemblyContaining<PublicAbstractClass>();
+
+				async Task Act()
+				{
+					await That(subject).HaveDependenciesOnlyOn("First", "Second");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that in assembly containing type PublicAbstractClass
+					             all have dependencies only on assemblies equal to "First" or equal to "Second",
+					             but it contained assemblies with disallowed dependencies *
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenAssemblyIsNull_ShouldFail()
+			{
+				IEnumerable<Assembly?> subject = new Assembly?[]
+				{
+					null,
+				};
+
+				async Task Act()
+				{
+					await That(subject).HaveDependenciesOnlyOn("aweXpect.Core");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             all have dependencies only on assemblies equal to "aweXpect.Core",
+					             but it contained assemblies with disallowed dependencies [
+					               <null> depends on []
 					             ]
 					             """).AsWildcard();
 			}

--- a/Tests/aweXpect.Reflection.Tests/ThatAssemblies.HaveName.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatAssemblies.HaveName.Tests.cs
@@ -45,6 +45,27 @@ public sealed partial class ThatAssemblies
 			}
 
 			[Fact]
+			public async Task WhenMultipleAssembliesDoNotMatchSelector_ShouldSeparateWithComma()
+			{
+				Filtered.Assemblies subject = In.Assemblies(typeof(In).Assembly, typeof(ThatAssemblies).Assembly);
+
+				async Task Act()
+				{
+					await That(subject).HaveName(_ => "WrongName");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that in the assemblies *
+					             all have name matching _ => "WrongName",
+					             but it contained not matching types [
+					               aweXpect.Reflection, Version=* with name "aweXpect.Reflection" instead of "WrongName",
+					               aweXpect.Reflection.Tests, Version=* with name "aweXpect.Reflection.Tests" instead of "WrongName"
+					             ]
+					             """).AsWildcard();
+			}
+
+			[Fact]
 			public async Task WhenSelectorReturnsEachAssemblysOwnName_ShouldSucceed()
 			{
 				Filtered.Assemblies subject = In.AssemblyContaining<PublicAbstractClass>();
@@ -164,7 +185,9 @@ public sealed partial class ThatAssemblies
 					.WithMessage("""
 					             Expected that in assembly containing type PublicAbstractClass
 					             not all have name matching _ => "aweXpect.Reflection.Tests",
-					             but it only contained matching types *
+					             but it only contained matching types [
+					               aweXpect.Reflection.Tests, Version=*, Culture=neutral, PublicKeyToken=null
+					             ]
 					             """).AsWildcard();
 			}
 

--- a/Tests/aweXpect.Reflection.Tests/ThatAssemblies.HaveVersion.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatAssemblies.HaveVersion.Tests.cs
@@ -1,4 +1,5 @@
-﻿using aweXpect.Reflection.Collections;
+﻿using System.Reflection;
+using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 using Xunit.Sdk;
 
@@ -175,6 +176,77 @@ public sealed partial class ThatAssemblies
 					             """).AsWildcard();
 			}
 
+			[Theory]
+			[InlineData("GreaterThan", 0, "greater than")]
+			[InlineData("GreaterThanOrEqualTo", 1, "greater than or equal to")]
+			[InlineData("LessThan", 0, "less than")]
+			[InlineData("LessThanOrEqualTo", -1, "less than or equal to")]
+			[InlineData("EqualTo", 1, "equal to")]
+			[InlineData("NotEqualTo", 0, "not equal to")]
+			public async Task WhenComparisonFails_MessageShouldDescribeComparison(
+				string comparison, int offset, string wording)
+			{
+				Filtered.Assemblies subject = In.AssemblyContaining<PublicAbstractClass>();
+				int major = typeof(PublicAbstractClass).Assembly.GetName().Version!.Major;
+				int expected = major + offset;
+
+				async Task Act()
+				{
+					await (comparison switch
+					{
+						"GreaterThan" => That(subject).HaveVersion().WithMajor.GreaterThan(expected),
+						"GreaterThanOrEqualTo" => That(subject).HaveVersion().WithMajor.GreaterThanOrEqualTo(expected),
+						"LessThan" => That(subject).HaveVersion().WithMajor.LessThan(expected),
+						"LessThanOrEqualTo" => That(subject).HaveVersion().WithMajor.LessThanOrEqualTo(expected),
+						"EqualTo" => That(subject).HaveVersion().WithMajor.EqualTo(expected),
+						_ => That(subject).HaveVersion().WithMajor.NotEqualTo(expected),
+					});
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					             Expected that in assembly containing type PublicAbstractClass
+					             all have major version {wording} {expected},
+					             but it contained assemblies with a non-matching version *
+					             """).AsWildcard();
+			}
+
+			[Theory]
+			[InlineData("major")]
+			[InlineData("minor")]
+			[InlineData("build")]
+			[InlineData("revision")]
+			public async Task WhenComponentDoesNotMatch_MessageShouldNameComponent(string name)
+			{
+				Filtered.Assemblies subject = In.AssemblyContaining<PublicAbstractClass>();
+				Version version = typeof(PublicAbstractClass).Assembly.GetName().Version!;
+				int actual = name switch
+				{
+					"major" => version.Major,
+					"minor" => version.Minor,
+					"build" => version.Build,
+					_ => version.Revision,
+				};
+
+				async Task Act()
+				{
+					await (name switch
+					{
+						"major" => That(subject).HaveVersion().WithMajor.GreaterThan(actual),
+						"minor" => That(subject).HaveVersion().WithMinor.GreaterThan(actual),
+						"build" => That(subject).HaveVersion().WithBuild.GreaterThan(actual),
+						_ => That(subject).HaveVersion().WithRevision.GreaterThan(actual),
+					});
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					             Expected that in assembly containing type PublicAbstractClass
+					             all have {name} version greater than {actual},
+					             but it contained assemblies with a non-matching version *
+					             """).AsWildcard();
+			}
+
 			[Fact]
 			public async Task WhenMultipleComponentsAreCombined_ShouldCombineExpectations()
 			{
@@ -250,6 +322,109 @@ public sealed partial class ThatAssemblies
 				}
 
 				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenComponentDoesNotMatch_ShouldListNonMatchingAssembly()
+			{
+				Filtered.Assemblies subject = In.AssemblyContaining<PublicAbstractClass>();
+
+				async Task Act()
+				{
+					await That(subject).HaveVersion().WithMajor.LessThan(0);
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that in assembly containing type PublicAbstractClass
+					             all have major version less than 0,
+					             but it contained assemblies with a non-matching version [
+					               aweXpect.Reflection.Tests, Version=*, Culture=neutral, PublicKeyToken=null
+					             ]
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenNegatedAndComponentMatches_ShouldListMatchingAssembly()
+			{
+				Filtered.Assemblies subject = In.AssemblyContaining<PublicAbstractClass>();
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(they => they.HaveVersion().WithMajor.GreaterThanOrEqualTo(0));
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that in assembly containing type PublicAbstractClass
+					             not all have major version greater than or equal to 0,
+					             but it only contained assemblies with a matching version [
+					               aweXpect.Reflection.Tests, Version=*, Culture=neutral, PublicKeyToken=null
+					             ]
+					             """).AsWildcard();
+			}
+		}
+
+		public sealed class WithoutVersionTests
+		{
+			[Fact]
+			public async Task WhenAssemblyHasNoVersion_ShouldFail()
+			{
+				Filtered.Assemblies subject = In.Assemblies(new VersionlessAssembly());
+
+				async Task Act()
+				{
+					await That(subject).HaveVersion();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that in the assemblies [VersionlessAssembly]
+					             all have a version,
+					             but it contained assemblies with a non-matching version [
+					               VersionlessAssembly
+					             ]
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenAssemblyHasNoVersion_WithComponent_ShouldFail()
+			{
+				Filtered.Assemblies subject = In.Assemblies(new VersionlessAssembly());
+
+				async Task Act()
+				{
+					await That(subject).HaveVersion().WithMajor.GreaterThanOrEqualTo(0);
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that in the assemblies [VersionlessAssembly]
+					             all have major version greater than or equal to 0,
+					             but it contained assemblies with a non-matching version [
+					               VersionlessAssembly
+					             ]
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenNegatedAndAssemblyHasNoVersion_ShouldSucceed()
+			{
+				Filtered.Assemblies subject = In.Assemblies(new VersionlessAssembly());
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(they => they.HaveVersion());
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			private sealed class VersionlessAssembly : Assembly
+			{
+				public override string FullName => nameof(VersionlessAssembly);
+
+				public override AssemblyName GetName() => new("VersionlessAssembly");
 			}
 		}
 	}

--- a/Tests/aweXpect.Reflection.Tests/ThatAssembly.HasDependenciesOnlyOn.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatAssembly.HasDependenciesOnlyOn.Tests.cs
@@ -69,6 +69,42 @@ public sealed partial class ThatAssembly
 			}
 
 			[Fact]
+			public async Task WhenNoAllowedAssembliesAreGiven_ShouldDescribeNoAssemblies()
+			{
+				Assembly subject = typeof(In).Assembly;
+
+				async Task Act()
+				{
+					await That(subject).HasDependenciesOnlyOn();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has dependencies only on no assemblies,
+					             but it also had dependencies on *
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenMultipleAllowedAssembliesAreGiven_ShouldDescribeAssemblies()
+			{
+				Assembly subject = typeof(PublicAbstractClass).Assembly;
+
+				async Task Act()
+				{
+					await That(subject).HasDependenciesOnlyOn("First", "Second");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has dependencies only on assemblies equal to "First" or equal to "Second",
+					             but it also had dependencies on *
+					             """).AsWildcard();
+			}
+
+			[Fact]
 			public async Task WhenAssemblyIsNull_ShouldFail()
 			{
 				Assembly? subject = null;

--- a/Tests/aweXpect.Reflection.Tests/ThatAssembly.HasVersion.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatAssembly.HasVersion.Tests.cs
@@ -43,6 +43,105 @@ public sealed partial class ThatAssembly
 			}
 		}
 
+		public sealed class NegatedTests
+		{
+			[Fact]
+			public async Task WhenVersionMatches_ShouldFail()
+			{
+				Assembly assembly = typeof(PublicAbstractClass).Assembly;
+				Version actualVersion = assembly.GetName().Version!;
+
+				async Task Act()
+				{
+					await That(assembly).DoesNotComplyWith(it => it.HasVersion(version => version.Major >= 0));
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					             Expected that assembly
+					             does not have version matching version => version.Major >= 0,
+					             but it had version {actualVersion}
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenVersionDoesNotMatch_ShouldSucceed()
+			{
+				Assembly assembly = typeof(PublicAbstractClass).Assembly;
+
+				async Task Act()
+				{
+					await That(assembly).DoesNotComplyWith(it => it.HasVersion(version => version.Major < 0));
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+		public sealed class WithoutVersionTests
+		{
+			[Fact]
+			public async Task WithPredicate_WhenVersionIsNull_ShouldFail()
+			{
+				Assembly assembly = new VersionlessAssembly();
+
+				async Task Act()
+				{
+					await That(assembly).HasVersion(version => version.Major >= 0);
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that assembly
+					             has version matching version => version.Major >= 0,
+					             but it had version <null>
+					             """);
+			}
+
+			[Fact]
+			public async Task WithComponent_WhenVersionIsNull_ShouldFail()
+			{
+				Assembly assembly = new VersionlessAssembly();
+
+				async Task Act()
+				{
+					await That(assembly).HasVersion().WithMajor.GreaterThanOrEqualTo(0);
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that assembly
+					             has major version greater than or equal to 0,
+					             but it had no version
+					             """);
+			}
+
+			[Fact]
+			public async Task WithoutComponent_WhenVersionIsNull_ShouldFail()
+			{
+				Assembly assembly = new VersionlessAssembly();
+
+				async Task Act()
+				{
+					await That(assembly).HasVersion();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that assembly
+					             has a version,
+					             but it had no version
+					             """);
+			}
+
+			private sealed class VersionlessAssembly : Assembly
+			{
+				public override string FullName => nameof(VersionlessAssembly);
+
+				public override AssemblyName GetName() => new("VersionlessAssembly");
+			}
+		}
+
 		public sealed class ComponentTests
 		{
 			[Fact]


### PR DESCRIPTION
Add and strengthen tests for ThatAssemblies.* and ThatAssembly.* to cover surviving and uncovered mutants reported by Stryker:

- Have: async-enumerable overloads, exact negated-result listing.
- HaveVersion / HasVersion: versionless-assembly failure paths (null version), negated predicate result, per-component/comparison message wording.
- HaveName: multi-item comma separator and negated selector matching list.
- HaveDependenciesOnlyOn / HasDependenciesOnlyOn: multi-item separator, null-assembly violation listing, empty/multi allowed description wording.