### PR TITLE
coverage: kill mutants in ConstructorFilters With-parameter family

### DIFF
--- a/Tests/aweXpect.Reflection.Tests/Filters/ConstructorFilters.WithInParameter.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/ConstructorFilters.WithInParameter.Tests.cs
@@ -59,11 +59,109 @@ public sealed partial class ConstructorFilters
 			}
 		}
 
+		public sealed class DescriptionTests
+		{
+			[Fact]
+			public async Task ParameterlessFilter_ShouldMatchConstructorWithOnlySomeInParameters()
+			{
+				Filtered.Constructors constructors = In.AssemblyContaining<AssemblyFilters>()
+					.Constructors().WithInParameter();
+
+				await That(constructors).Contains(MixedConstructor());
+			}
+
+			[Fact]
+			public async Task OfType_ShouldDescribeWithInModifier()
+			{
+				Filtered.Constructors constructors = In.AssemblyContaining<AssemblyFilters>()
+					.Constructors().WithInParameter<int>();
+
+				await That(constructors.GetDescription()).Contains("with in modifier");
+			}
+
+			[Fact]
+			public async Task OfTypeWithName_ShouldDescribeWithInModifier()
+			{
+				Filtered.Constructors constructors = In.AssemblyContaining<AssemblyFilters>()
+					.Constructors().WithInParameter<int>("value");
+
+				await That(constructors.GetDescription()).Contains("with in modifier");
+			}
+
+			[Fact]
+			public async Task ByName_ShouldDescribeWithInModifier()
+			{
+				Filtered.Constructors constructors = In.AssemblyContaining<AssemblyFilters>()
+					.Constructors().WithInParameter("value");
+
+				await That(constructors.GetDescription()).Contains("with in modifier");
+			}
+
+			[Fact]
+			public async Task ExactlyOfType_ShouldDescribeWithInModifier()
+			{
+				Filtered.Constructors constructors = In.AssemblyContaining<AssemblyFilters>()
+					.Constructors().WithInParameterExactly<int>();
+
+				await That(constructors.GetDescription()).Contains("with in modifier");
+			}
+
+			[Fact]
+			public async Task ExactlyOfTypeWithName_ShouldDescribeWithInModifier()
+			{
+				Filtered.Constructors constructors = In.AssemblyContaining<AssemblyFilters>()
+					.Constructors().WithInParameterExactly<int>("value");
+
+				await That(constructors.GetDescription()).Contains("with in modifier");
+			}
+
+#pragma warning disable CA2263
+			[Fact]
+			public async Task OfType_UsingType_ShouldDescribeWithInModifier()
+			{
+				Filtered.Constructors constructors = In.AssemblyContaining<AssemblyFilters>()
+					.Constructors().WithInParameter(typeof(int));
+
+				await That(constructors.GetDescription()).Contains("with in modifier");
+			}
+
+			[Fact]
+			public async Task OfTypeWithName_UsingType_ShouldDescribeWithInModifier()
+			{
+				Filtered.Constructors constructors = In.AssemblyContaining<AssemblyFilters>()
+					.Constructors().WithInParameter(typeof(int), "value");
+
+				await That(constructors.GetDescription()).Contains("with in modifier");
+			}
+
+			[Fact]
+			public async Task ExactlyOfType_UsingType_ShouldDescribeWithInModifier()
+			{
+				Filtered.Constructors constructors = In.AssemblyContaining<AssemblyFilters>()
+					.Constructors().WithInParameterExactly(typeof(int));
+
+				await That(constructors.GetDescription()).Contains("with in modifier");
+			}
+
+			[Fact]
+			public async Task ExactlyOfTypeWithName_UsingType_ShouldDescribeWithInModifier()
+			{
+				Filtered.Constructors constructors = In.AssemblyContaining<AssemblyFilters>()
+					.Constructors().WithInParameterExactly(typeof(int), "value");
+
+				await That(constructors.GetDescription()).Contains("with in modifier");
+			}
+#pragma warning restore CA2263
+		}
+
 		private static ConstructorInfo? InParameterConstructor()
 			=> typeof(ClassWithInParameterConstructor).GetConstructors().Single();
 
 		private static ConstructorInfo? PlainConstructor()
 			=> typeof(ClassWithPlainConstructor).GetConstructors().Single();
+
+		private static ConstructorInfo? MixedConstructor()
+			=> typeof(ClassWithMixedConstructor).GetConstructors().Single();
 
 		// ReSharper disable UnusedMember.Local
 		// ReSharper disable UnusedParameter.Local
@@ -77,6 +175,13 @@ public sealed partial class ConstructorFilters
 		private class ClassWithPlainConstructor
 		{
 			public ClassWithPlainConstructor(int value)
+			{
+			}
+		}
+
+		private class ClassWithMixedConstructor
+		{
+			public ClassWithMixedConstructor(in int value, string other)
 			{
 			}
 		}

--- a/Tests/aweXpect.Reflection.Tests/Filters/ConstructorFilters.WithOptionalParameter.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/ConstructorFilters.WithOptionalParameter.Tests.cs
@@ -59,11 +59,109 @@ public sealed partial class ConstructorFilters
 			}
 		}
 
+		public sealed class DescriptionTests
+		{
+			[Fact]
+			public async Task ParameterlessFilter_ShouldMatchConstructorWithOnlySomeOptionalParameters()
+			{
+				Filtered.Constructors constructors = In.AssemblyContaining<AssemblyFilters>()
+					.Constructors().WithOptionalParameter();
+
+				await That(constructors).Contains(MixedConstructor());
+			}
+
+			[Fact]
+			public async Task OfType_ShouldDescribeWithOptionalModifier()
+			{
+				Filtered.Constructors constructors = In.AssemblyContaining<AssemblyFilters>()
+					.Constructors().WithOptionalParameter<int>();
+
+				await That(constructors.GetDescription()).Contains("with optional modifier");
+			}
+
+			[Fact]
+			public async Task OfTypeWithName_ShouldDescribeWithOptionalModifier()
+			{
+				Filtered.Constructors constructors = In.AssemblyContaining<AssemblyFilters>()
+					.Constructors().WithOptionalParameter<int>("value");
+
+				await That(constructors.GetDescription()).Contains("with optional modifier");
+			}
+
+			[Fact]
+			public async Task ByName_ShouldDescribeWithOptionalModifier()
+			{
+				Filtered.Constructors constructors = In.AssemblyContaining<AssemblyFilters>()
+					.Constructors().WithOptionalParameter("value");
+
+				await That(constructors.GetDescription()).Contains("with optional modifier");
+			}
+
+			[Fact]
+			public async Task ExactlyOfType_ShouldDescribeWithOptionalModifier()
+			{
+				Filtered.Constructors constructors = In.AssemblyContaining<AssemblyFilters>()
+					.Constructors().WithOptionalParameterExactly<int>();
+
+				await That(constructors.GetDescription()).Contains("with optional modifier");
+			}
+
+			[Fact]
+			public async Task ExactlyOfTypeWithName_ShouldDescribeWithOptionalModifier()
+			{
+				Filtered.Constructors constructors = In.AssemblyContaining<AssemblyFilters>()
+					.Constructors().WithOptionalParameterExactly<int>("value");
+
+				await That(constructors.GetDescription()).Contains("with optional modifier");
+			}
+
+#pragma warning disable CA2263
+			[Fact]
+			public async Task OfType_UsingType_ShouldDescribeWithOptionalModifier()
+			{
+				Filtered.Constructors constructors = In.AssemblyContaining<AssemblyFilters>()
+					.Constructors().WithOptionalParameter(typeof(int));
+
+				await That(constructors.GetDescription()).Contains("with optional modifier");
+			}
+
+			[Fact]
+			public async Task OfTypeWithName_UsingType_ShouldDescribeWithOptionalModifier()
+			{
+				Filtered.Constructors constructors = In.AssemblyContaining<AssemblyFilters>()
+					.Constructors().WithOptionalParameter(typeof(int), "value");
+
+				await That(constructors.GetDescription()).Contains("with optional modifier");
+			}
+
+			[Fact]
+			public async Task ExactlyOfType_UsingType_ShouldDescribeWithOptionalModifier()
+			{
+				Filtered.Constructors constructors = In.AssemblyContaining<AssemblyFilters>()
+					.Constructors().WithOptionalParameterExactly(typeof(int));
+
+				await That(constructors.GetDescription()).Contains("with optional modifier");
+			}
+
+			[Fact]
+			public async Task ExactlyOfTypeWithName_UsingType_ShouldDescribeWithOptionalModifier()
+			{
+				Filtered.Constructors constructors = In.AssemblyContaining<AssemblyFilters>()
+					.Constructors().WithOptionalParameterExactly(typeof(int), "value");
+
+				await That(constructors.GetDescription()).Contains("with optional modifier");
+			}
+#pragma warning restore CA2263
+		}
+
 		private static ConstructorInfo? OptionalParameterConstructor()
 			=> typeof(ClassWithOptionalParameterConstructor).GetConstructors().Single();
 
 		private static ConstructorInfo? PlainConstructor()
 			=> typeof(ClassWithPlainConstructor).GetConstructors().Single();
+
+		private static ConstructorInfo? MixedConstructor()
+			=> typeof(ClassWithMixedConstructor).GetConstructors().Single();
 
 		// ReSharper disable UnusedMember.Local
 		// ReSharper disable UnusedParameter.Local
@@ -77,6 +175,13 @@ public sealed partial class ConstructorFilters
 		private class ClassWithPlainConstructor
 		{
 			public ClassWithPlainConstructor(int value)
+			{
+			}
+		}
+
+		private class ClassWithMixedConstructor
+		{
+			public ClassWithMixedConstructor(string other, int value = 0)
 			{
 			}
 		}

--- a/Tests/aweXpect.Reflection.Tests/Filters/ConstructorFilters.WithOutParameter.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/ConstructorFilters.WithOutParameter.Tests.cs
@@ -59,11 +59,109 @@ public sealed partial class ConstructorFilters
 			}
 		}
 
+		public sealed class DescriptionTests
+		{
+			[Fact]
+			public async Task ParameterlessFilter_ShouldMatchConstructorWithOnlySomeOutParameters()
+			{
+				Filtered.Constructors constructors = In.AssemblyContaining<AssemblyFilters>()
+					.Constructors().WithOutParameter();
+
+				await That(constructors).Contains(MixedConstructor());
+			}
+
+			[Fact]
+			public async Task OfType_ShouldDescribeWithOutModifier()
+			{
+				Filtered.Constructors constructors = In.AssemblyContaining<AssemblyFilters>()
+					.Constructors().WithOutParameter<int>();
+
+				await That(constructors.GetDescription()).Contains("with out modifier");
+			}
+
+			[Fact]
+			public async Task OfTypeWithName_ShouldDescribeWithOutModifier()
+			{
+				Filtered.Constructors constructors = In.AssemblyContaining<AssemblyFilters>()
+					.Constructors().WithOutParameter<int>("value");
+
+				await That(constructors.GetDescription()).Contains("with out modifier");
+			}
+
+			[Fact]
+			public async Task ByName_ShouldDescribeWithOutModifier()
+			{
+				Filtered.Constructors constructors = In.AssemblyContaining<AssemblyFilters>()
+					.Constructors().WithOutParameter("value");
+
+				await That(constructors.GetDescription()).Contains("with out modifier");
+			}
+
+			[Fact]
+			public async Task ExactlyOfType_ShouldDescribeWithOutModifier()
+			{
+				Filtered.Constructors constructors = In.AssemblyContaining<AssemblyFilters>()
+					.Constructors().WithOutParameterExactly<int>();
+
+				await That(constructors.GetDescription()).Contains("with out modifier");
+			}
+
+			[Fact]
+			public async Task ExactlyOfTypeWithName_ShouldDescribeWithOutModifier()
+			{
+				Filtered.Constructors constructors = In.AssemblyContaining<AssemblyFilters>()
+					.Constructors().WithOutParameterExactly<int>("value");
+
+				await That(constructors.GetDescription()).Contains("with out modifier");
+			}
+
+#pragma warning disable CA2263
+			[Fact]
+			public async Task OfType_UsingType_ShouldDescribeWithOutModifier()
+			{
+				Filtered.Constructors constructors = In.AssemblyContaining<AssemblyFilters>()
+					.Constructors().WithOutParameter(typeof(int));
+
+				await That(constructors.GetDescription()).Contains("with out modifier");
+			}
+
+			[Fact]
+			public async Task OfTypeWithName_UsingType_ShouldDescribeWithOutModifier()
+			{
+				Filtered.Constructors constructors = In.AssemblyContaining<AssemblyFilters>()
+					.Constructors().WithOutParameter(typeof(int), "value");
+
+				await That(constructors.GetDescription()).Contains("with out modifier");
+			}
+
+			[Fact]
+			public async Task ExactlyOfType_UsingType_ShouldDescribeWithOutModifier()
+			{
+				Filtered.Constructors constructors = In.AssemblyContaining<AssemblyFilters>()
+					.Constructors().WithOutParameterExactly(typeof(int));
+
+				await That(constructors.GetDescription()).Contains("with out modifier");
+			}
+
+			[Fact]
+			public async Task ExactlyOfTypeWithName_UsingType_ShouldDescribeWithOutModifier()
+			{
+				Filtered.Constructors constructors = In.AssemblyContaining<AssemblyFilters>()
+					.Constructors().WithOutParameterExactly(typeof(int), "value");
+
+				await That(constructors.GetDescription()).Contains("with out modifier");
+			}
+#pragma warning restore CA2263
+		}
+
 		private static ConstructorInfo? OutParameterConstructor()
 			=> typeof(ClassWithOutParameterConstructor).GetConstructors().Single();
 
 		private static ConstructorInfo? PlainConstructor()
 			=> typeof(ClassWithPlainConstructor).GetConstructors().Single();
+
+		private static ConstructorInfo? MixedConstructor()
+			=> typeof(ClassWithMixedConstructor).GetConstructors().Single();
 
 		// ReSharper disable UnusedMember.Local
 		// ReSharper disable UnusedParameter.Local
@@ -79,6 +177,14 @@ public sealed partial class ConstructorFilters
 		{
 			public ClassWithPlainConstructor(int value)
 			{
+			}
+		}
+
+		private class ClassWithMixedConstructor
+		{
+			public ClassWithMixedConstructor(out int value, string other)
+			{
+				value = 0;
 			}
 		}
 		// ReSharper restore UnusedParameter.Local

--- a/Tests/aweXpect.Reflection.Tests/Filters/ConstructorFilters.WithParameterExactly.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/ConstructorFilters.WithParameterExactly.Tests.cs
@@ -48,7 +48,7 @@ public sealed partial class ConstructorFilters
 					typeof(TestClass).GetConstructor([typeof(DummyBase),])!,
 				]).InAnyOrder();
 				await That(constructors.GetDescription())
-					.IsEqualTo("constructors with parameter of exact type ").AsPrefix();
+					.Contains("and name equal to \"parameter\"");
 			}
 
 			[Fact]
@@ -91,7 +91,7 @@ public sealed partial class ConstructorFilters
 					typeof(TestClass).GetConstructor([typeof(DummyBase),])!,
 				]).InAnyOrder();
 				await That(constructors.GetDescription())
-					.IsEqualTo("constructors with parameter of exact type ").AsPrefix();
+					.Contains("and name equal to \"parameter\"");
 			}
 		}
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/ConstructorFilters.WithParameterModifier.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/ConstructorFilters.WithParameterModifier.Tests.cs
@@ -31,6 +31,9 @@ public sealed partial class ConstructorFilters
 
 				await That(constructors).Contains(OutIntConstructor());
 				await That(constructors).DoesNotContain(PlainIntConstructor());
+				await That(constructors.GetDescription())
+					.IsEqualTo("constructors with parameter of type int and with out modifier in assembly")
+					.AsPrefix();
 			}
 
 			[Fact]
@@ -41,6 +44,9 @@ public sealed partial class ConstructorFilters
 
 				await That(constructors).Contains(InIntConstructor());
 				await That(constructors).DoesNotContain(PlainIntConstructor());
+				await That(constructors.GetDescription())
+					.IsEqualTo("constructors with parameter of type int and with in modifier in assembly")
+					.AsPrefix();
 			}
 
 			[Fact]
@@ -51,6 +57,9 @@ public sealed partial class ConstructorFilters
 
 				await That(constructors).Contains(OptionalIntConstructor());
 				await That(constructors).DoesNotContain(PlainIntConstructor());
+				await That(constructors.GetDescription())
+					.IsEqualTo("constructors with parameter of type int and with optional modifier in assembly")
+					.AsPrefix();
 			}
 
 			[Fact]
@@ -60,6 +69,9 @@ public sealed partial class ConstructorFilters
 					.Constructors().WithParameter<int[]>().WithParamsModifier();
 
 				await That(constructors).Contains(ParamsIntConstructor());
+				await That(constructors.GetDescription())
+					.IsEqualTo("constructors with parameter of type int[] and with params modifier in assembly")
+					.AsPrefix();
 			}
 		}
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/ConstructorFilters.WithParamsParameter.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/ConstructorFilters.WithParamsParameter.Tests.cs
@@ -59,11 +59,109 @@ public sealed partial class ConstructorFilters
 			}
 		}
 
+		public sealed class DescriptionTests
+		{
+			[Fact]
+			public async Task ParameterlessFilter_ShouldMatchConstructorWithOnlySomeParamsParameters()
+			{
+				Filtered.Constructors constructors = In.AssemblyContaining<AssemblyFilters>()
+					.Constructors().WithParamsParameter();
+
+				await That(constructors).Contains(MixedConstructor());
+			}
+
+			[Fact]
+			public async Task OfType_ShouldDescribeWithParamsModifier()
+			{
+				Filtered.Constructors constructors = In.AssemblyContaining<AssemblyFilters>()
+					.Constructors().WithParamsParameter<int[]>();
+
+				await That(constructors.GetDescription()).Contains("with params modifier");
+			}
+
+			[Fact]
+			public async Task OfTypeWithName_ShouldDescribeWithParamsModifier()
+			{
+				Filtered.Constructors constructors = In.AssemblyContaining<AssemblyFilters>()
+					.Constructors().WithParamsParameter<int[]>("values");
+
+				await That(constructors.GetDescription()).Contains("with params modifier");
+			}
+
+			[Fact]
+			public async Task ByName_ShouldDescribeWithParamsModifier()
+			{
+				Filtered.Constructors constructors = In.AssemblyContaining<AssemblyFilters>()
+					.Constructors().WithParamsParameter("values");
+
+				await That(constructors.GetDescription()).Contains("with params modifier");
+			}
+
+			[Fact]
+			public async Task ExactlyOfType_ShouldDescribeWithParamsModifier()
+			{
+				Filtered.Constructors constructors = In.AssemblyContaining<AssemblyFilters>()
+					.Constructors().WithParamsParameterExactly<int[]>();
+
+				await That(constructors.GetDescription()).Contains("with params modifier");
+			}
+
+			[Fact]
+			public async Task ExactlyOfTypeWithName_ShouldDescribeWithParamsModifier()
+			{
+				Filtered.Constructors constructors = In.AssemblyContaining<AssemblyFilters>()
+					.Constructors().WithParamsParameterExactly<int[]>("values");
+
+				await That(constructors.GetDescription()).Contains("with params modifier");
+			}
+
+#pragma warning disable CA2263
+			[Fact]
+			public async Task OfType_UsingType_ShouldDescribeWithParamsModifier()
+			{
+				Filtered.Constructors constructors = In.AssemblyContaining<AssemblyFilters>()
+					.Constructors().WithParamsParameter(typeof(int[]));
+
+				await That(constructors.GetDescription()).Contains("with params modifier");
+			}
+
+			[Fact]
+			public async Task OfTypeWithName_UsingType_ShouldDescribeWithParamsModifier()
+			{
+				Filtered.Constructors constructors = In.AssemblyContaining<AssemblyFilters>()
+					.Constructors().WithParamsParameter(typeof(int[]), "values");
+
+				await That(constructors.GetDescription()).Contains("with params modifier");
+			}
+
+			[Fact]
+			public async Task ExactlyOfType_UsingType_ShouldDescribeWithParamsModifier()
+			{
+				Filtered.Constructors constructors = In.AssemblyContaining<AssemblyFilters>()
+					.Constructors().WithParamsParameterExactly(typeof(int[]));
+
+				await That(constructors.GetDescription()).Contains("with params modifier");
+			}
+
+			[Fact]
+			public async Task ExactlyOfTypeWithName_UsingType_ShouldDescribeWithParamsModifier()
+			{
+				Filtered.Constructors constructors = In.AssemblyContaining<AssemblyFilters>()
+					.Constructors().WithParamsParameterExactly(typeof(int[]), "values");
+
+				await That(constructors.GetDescription()).Contains("with params modifier");
+			}
+#pragma warning restore CA2263
+		}
+
 		private static ConstructorInfo? ParamsParameterConstructor()
 			=> typeof(ClassWithParamsParameterConstructor).GetConstructors().Single();
 
 		private static ConstructorInfo? PlainConstructor()
 			=> typeof(ClassWithPlainConstructor).GetConstructors().Single();
+
+		private static ConstructorInfo? MixedConstructor()
+			=> typeof(ClassWithMixedConstructor).GetConstructors().Single();
 
 		// ReSharper disable UnusedMember.Local
 		// ReSharper disable UnusedParameter.Local
@@ -77,6 +175,13 @@ public sealed partial class ConstructorFilters
 		private class ClassWithPlainConstructor
 		{
 			public ClassWithPlainConstructor(int[] values)
+			{
+			}
+		}
+
+		private class ClassWithMixedConstructor
+		{
+			public ClassWithMixedConstructor(string other, params int[] values)
 			{
 			}
 		}

--- a/Tests/aweXpect.Reflection.Tests/Filters/ConstructorFilters.WithRefParameter.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/ConstructorFilters.WithRefParameter.Tests.cs
@@ -59,11 +59,109 @@ public sealed partial class ConstructorFilters
 			}
 		}
 
+		public sealed class DescriptionTests
+		{
+			[Fact]
+			public async Task ParameterlessFilter_ShouldMatchConstructorWithOnlySomeRefParameters()
+			{
+				Filtered.Constructors constructors = In.AssemblyContaining<AssemblyFilters>()
+					.Constructors().WithRefParameter();
+
+				await That(constructors).Contains(MixedConstructor());
+			}
+
+			[Fact]
+			public async Task OfType_ShouldDescribeWithRefModifier()
+			{
+				Filtered.Constructors constructors = In.AssemblyContaining<AssemblyFilters>()
+					.Constructors().WithRefParameter<int>();
+
+				await That(constructors.GetDescription()).Contains("with ref modifier");
+			}
+
+			[Fact]
+			public async Task OfTypeWithName_ShouldDescribeWithRefModifier()
+			{
+				Filtered.Constructors constructors = In.AssemblyContaining<AssemblyFilters>()
+					.Constructors().WithRefParameter<int>("value");
+
+				await That(constructors.GetDescription()).Contains("with ref modifier");
+			}
+
+			[Fact]
+			public async Task ByName_ShouldDescribeWithRefModifier()
+			{
+				Filtered.Constructors constructors = In.AssemblyContaining<AssemblyFilters>()
+					.Constructors().WithRefParameter("value");
+
+				await That(constructors.GetDescription()).Contains("with ref modifier");
+			}
+
+			[Fact]
+			public async Task ExactlyOfType_ShouldDescribeWithRefModifier()
+			{
+				Filtered.Constructors constructors = In.AssemblyContaining<AssemblyFilters>()
+					.Constructors().WithRefParameterExactly<int>();
+
+				await That(constructors.GetDescription()).Contains("with ref modifier");
+			}
+
+			[Fact]
+			public async Task ExactlyOfTypeWithName_ShouldDescribeWithRefModifier()
+			{
+				Filtered.Constructors constructors = In.AssemblyContaining<AssemblyFilters>()
+					.Constructors().WithRefParameterExactly<int>("value");
+
+				await That(constructors.GetDescription()).Contains("with ref modifier");
+			}
+
+#pragma warning disable CA2263
+			[Fact]
+			public async Task OfType_UsingType_ShouldDescribeWithRefModifier()
+			{
+				Filtered.Constructors constructors = In.AssemblyContaining<AssemblyFilters>()
+					.Constructors().WithRefParameter(typeof(int));
+
+				await That(constructors.GetDescription()).Contains("with ref modifier");
+			}
+
+			[Fact]
+			public async Task OfTypeWithName_UsingType_ShouldDescribeWithRefModifier()
+			{
+				Filtered.Constructors constructors = In.AssemblyContaining<AssemblyFilters>()
+					.Constructors().WithRefParameter(typeof(int), "value");
+
+				await That(constructors.GetDescription()).Contains("with ref modifier");
+			}
+
+			[Fact]
+			public async Task ExactlyOfType_UsingType_ShouldDescribeWithRefModifier()
+			{
+				Filtered.Constructors constructors = In.AssemblyContaining<AssemblyFilters>()
+					.Constructors().WithRefParameterExactly(typeof(int));
+
+				await That(constructors.GetDescription()).Contains("with ref modifier");
+			}
+
+			[Fact]
+			public async Task ExactlyOfTypeWithName_UsingType_ShouldDescribeWithRefModifier()
+			{
+				Filtered.Constructors constructors = In.AssemblyContaining<AssemblyFilters>()
+					.Constructors().WithRefParameterExactly(typeof(int), "value");
+
+				await That(constructors.GetDescription()).Contains("with ref modifier");
+			}
+#pragma warning restore CA2263
+		}
+
 		private static ConstructorInfo? RefParameterConstructor()
 			=> typeof(ClassWithRefParameterConstructor).GetConstructors().Single();
 
 		private static ConstructorInfo? PlainConstructor()
 			=> typeof(ClassWithPlainConstructor).GetConstructors().Single();
+
+		private static ConstructorInfo? MixedConstructor()
+			=> typeof(ClassWithMixedConstructor).GetConstructors().Single();
 
 		// ReSharper disable UnusedMember.Local
 		// ReSharper disable UnusedParameter.Local
@@ -79,6 +177,14 @@ public sealed partial class ConstructorFilters
 		{
 			public ClassWithPlainConstructor(int value)
 			{
+			}
+		}
+
+		private class ClassWithMixedConstructor
+		{
+			public ClassWithMixedConstructor(ref int value, string other)
+			{
+				value = 0;
 			}
 		}
 		// ReSharper restore UnusedParameter.Local


### PR DESCRIPTION
Add description assertions covering the parameter modifier description lambdas ("with in/out/optional/params/ref modifier" and "name ...") across the ConstructorFilters.With{In,Out,Optional,Params,Ref}Parameter, WithParameter and WithParameterExactly overloads, surfaced via GetDescription(). Add mixed-parameter fixtures so the parameterless WithXParameter() filters distinguish Any() from All().