### PR TITLE
coverage: kill mutants in MethodFilters with-parameter family

### DIFF
--- a/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WhichReturnExactly.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WhichReturnExactly.Tests.cs
@@ -89,6 +89,19 @@ public sealed partial class MethodFilters
 		public sealed class OrReturnExactlyGenericTests
 		{
 			[Fact]
+			public async Task ShouldKeepMethodsMatchingTheFirstTypeWhenAddingAnAlternative()
+			{
+				Filtered.Methods methods = In.Type<TestClass>()
+					.Methods().WhichReturnExactly<string>().OrReturnExactly<int>();
+
+				// The first branch (string) must still match after the OR-alternative is added,
+				// and the alternative (int) must also match.
+				await That(methods).Contains(typeof(TestClass).GetMethod(nameof(TestClass.GetString))!);
+				await That(methods).Contains(typeof(TestClass).GetMethod(nameof(TestClass.GetInt))!);
+				await That(methods).DoesNotContain(typeof(TestClass).GetMethod(nameof(TestClass.GetBool))!);
+			}
+
+			[Fact]
 			public async Task ShouldFilterForMethodsWhichReturnExactlyAnyOfMultipleTypes()
 			{
 				Filtered.Methods methods = In.Type<TestClass>()

--- a/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WithInParameter.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WithInParameter.Tests.cs
@@ -29,7 +29,129 @@ public sealed partial class MethodFilters
 
 				await That(methods).DoesNotContain(PlainMethod());
 			}
+
+			[Fact]
+			public async Task ShouldIncludeMethodWhenOnlySomeButNotAllParametersAreInParameters()
+			{
+				Filtered.Methods methods = In.Type<ClassWithInParameterMethod>()
+					.Methods().WithInParameter();
+
+				await That(methods).Contains(MixedParameterMethod());
+				await That(methods).DoesNotContain(PlainMethod());
+			}
+
+			[Fact]
+			public async Task Generic_ShouldIncludeInModifierInDescription()
+			{
+				Filtered.Methods methods = In.AssemblyContaining<AssemblyFilters>()
+					.Methods().WithInParameter<int>();
+
+				await That(methods.GetDescription())
+					.IsEqualTo("methods with parameter of type int and with in modifier in assembly")
+					.AsPrefix();
+			}
+
+			[Fact]
+			public async Task Generic_WithName_ShouldIncludeInModifierInDescription()
+			{
+				Filtered.Methods methods = In.AssemblyContaining<AssemblyFilters>()
+					.Methods().WithInParameter<int>("value");
+
+				await That(methods.GetDescription())
+					.IsEqualTo(
+						"methods with parameter of type int and name equal to \"value\" and with in modifier in assembly")
+					.AsPrefix();
+			}
+
+			[Fact]
+			public async Task ByName_ShouldIncludeInModifierInDescription()
+			{
+				Filtered.Methods methods = In.AssemblyContaining<AssemblyFilters>()
+					.Methods().WithInParameter("value");
+
+				await That(methods.GetDescription())
+					.IsEqualTo(
+						"methods with parameter with name equal to \"value\" and with in modifier in assembly")
+					.AsPrefix();
+			}
+
+#pragma warning disable CA2263
+			[Fact]
+			public async Task UsingType_ShouldIncludeInModifierInDescription()
+			{
+				Filtered.Methods methods = In.AssemblyContaining<AssemblyFilters>()
+					.Methods().WithInParameter(typeof(int));
+
+				await That(methods.GetDescription())
+					.IsEqualTo("methods with parameter of type int and with in modifier in assembly")
+					.AsPrefix();
+			}
+
+			[Fact]
+			public async Task UsingType_WithName_ShouldIncludeInModifierInDescription()
+			{
+				Filtered.Methods methods = In.AssemblyContaining<AssemblyFilters>()
+					.Methods().WithInParameter(typeof(int), "value");
+
+				await That(methods.GetDescription())
+					.IsEqualTo(
+						"methods with parameter of type int and name equal to \"value\" and with in modifier in assembly")
+					.AsPrefix();
+			}
+#pragma warning restore CA2263
+
+			[Fact]
+			public async Task GenericExactly_ShouldIncludeInModifierInDescription()
+			{
+				Filtered.Methods methods = In.AssemblyContaining<AssemblyFilters>()
+					.Methods().WithInParameterExactly<int>();
+
+				await That(methods.GetDescription())
+					.IsEqualTo("methods with parameter of exact type int and with in modifier in assembly")
+					.AsPrefix();
+			}
+
+			[Fact]
+			public async Task GenericExactly_WithName_ShouldIncludeInModifierInDescription()
+			{
+				Filtered.Methods methods = In.AssemblyContaining<AssemblyFilters>()
+					.Methods().WithInParameterExactly<int>("value");
+
+				await That(methods.GetDescription())
+					.IsEqualTo(
+						"methods with parameter of exact type int and name equal to \"value\" and with in modifier in assembly")
+					.AsPrefix();
+			}
+
+#pragma warning disable CA2263
+			[Fact]
+			public async Task UsingTypeExactly_ShouldIncludeInModifierInDescription()
+			{
+				Filtered.Methods methods = In.AssemblyContaining<AssemblyFilters>()
+					.Methods().WithInParameterExactly(typeof(int));
+
+				await That(methods.GetDescription())
+					.IsEqualTo("methods with parameter of exact type int and with in modifier in assembly")
+					.AsPrefix();
+			}
+
+			[Fact]
+			public async Task UsingTypeExactly_WithName_ShouldIncludeInModifierInDescription()
+			{
+				Filtered.Methods methods = In.AssemblyContaining<AssemblyFilters>()
+					.Methods().WithInParameterExactly(typeof(int), "value");
+
+				await That(methods.GetDescription())
+					.IsEqualTo(
+						"methods with parameter of exact type int and name equal to \"value\" and with in modifier in assembly")
+					.AsPrefix();
+			}
+#pragma warning restore CA2263
 		}
+
+		private static MethodInfo? MixedParameterMethod()
+			=> typeof(ClassWithInParameterMethod)
+				.GetMethod(nameof(ClassWithInParameterMethod.MethodWithMixedParameters));
 
 		private static MethodInfo? InParameterMethod()
 			=> typeof(ClassWithInParameterMethod)
@@ -45,6 +167,10 @@ public sealed partial class MethodFilters
 		private class ClassWithInParameterMethod
 		{
 			public void MethodWithInParameter(in int value)
+			{
+			}
+
+			public void MethodWithMixedParameters(in int value, int other)
 			{
 			}
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WithOptionalParameter.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WithOptionalParameter.Tests.cs
@@ -29,7 +29,129 @@ public sealed partial class MethodFilters
 
 				await That(methods).DoesNotContain(PlainMethod());
 			}
+
+			[Fact]
+			public async Task ShouldIncludeMethodWhenOnlySomeButNotAllParametersAreOptionalParameters()
+			{
+				Filtered.Methods methods = In.Type<ClassWithOptionalParameterMethod>()
+					.Methods().WithOptionalParameter();
+
+				await That(methods).Contains(MixedParameterMethod());
+				await That(methods).DoesNotContain(PlainMethod());
+			}
+
+			[Fact]
+			public async Task Generic_ShouldIncludeOptionalModifierInDescription()
+			{
+				Filtered.Methods methods = In.AssemblyContaining<AssemblyFilters>()
+					.Methods().WithOptionalParameter<int>();
+
+				await That(methods.GetDescription())
+					.IsEqualTo("methods with parameter of type int and with optional modifier in assembly")
+					.AsPrefix();
+			}
+
+			[Fact]
+			public async Task Generic_WithName_ShouldIncludeOptionalModifierInDescription()
+			{
+				Filtered.Methods methods = In.AssemblyContaining<AssemblyFilters>()
+					.Methods().WithOptionalParameter<int>("value");
+
+				await That(methods.GetDescription())
+					.IsEqualTo(
+						"methods with parameter of type int and name equal to \"value\" and with optional modifier in assembly")
+					.AsPrefix();
+			}
+
+			[Fact]
+			public async Task ByName_ShouldIncludeOptionalModifierInDescription()
+			{
+				Filtered.Methods methods = In.AssemblyContaining<AssemblyFilters>()
+					.Methods().WithOptionalParameter("value");
+
+				await That(methods.GetDescription())
+					.IsEqualTo(
+						"methods with parameter with name equal to \"value\" and with optional modifier in assembly")
+					.AsPrefix();
+			}
+
+#pragma warning disable CA2263
+			[Fact]
+			public async Task UsingType_ShouldIncludeOptionalModifierInDescription()
+			{
+				Filtered.Methods methods = In.AssemblyContaining<AssemblyFilters>()
+					.Methods().WithOptionalParameter(typeof(int));
+
+				await That(methods.GetDescription())
+					.IsEqualTo("methods with parameter of type int and with optional modifier in assembly")
+					.AsPrefix();
+			}
+
+			[Fact]
+			public async Task UsingType_WithName_ShouldIncludeOptionalModifierInDescription()
+			{
+				Filtered.Methods methods = In.AssemblyContaining<AssemblyFilters>()
+					.Methods().WithOptionalParameter(typeof(int), "value");
+
+				await That(methods.GetDescription())
+					.IsEqualTo(
+						"methods with parameter of type int and name equal to \"value\" and with optional modifier in assembly")
+					.AsPrefix();
+			}
+#pragma warning restore CA2263
+
+			[Fact]
+			public async Task GenericExactly_ShouldIncludeOptionalModifierInDescription()
+			{
+				Filtered.Methods methods = In.AssemblyContaining<AssemblyFilters>()
+					.Methods().WithOptionalParameterExactly<int>();
+
+				await That(methods.GetDescription())
+					.IsEqualTo("methods with parameter of exact type int and with optional modifier in assembly")
+					.AsPrefix();
+			}
+
+			[Fact]
+			public async Task GenericExactly_WithName_ShouldIncludeOptionalModifierInDescription()
+			{
+				Filtered.Methods methods = In.AssemblyContaining<AssemblyFilters>()
+					.Methods().WithOptionalParameterExactly<int>("value");
+
+				await That(methods.GetDescription())
+					.IsEqualTo(
+						"methods with parameter of exact type int and name equal to \"value\" and with optional modifier in assembly")
+					.AsPrefix();
+			}
+
+#pragma warning disable CA2263
+			[Fact]
+			public async Task UsingTypeExactly_ShouldIncludeOptionalModifierInDescription()
+			{
+				Filtered.Methods methods = In.AssemblyContaining<AssemblyFilters>()
+					.Methods().WithOptionalParameterExactly(typeof(int));
+
+				await That(methods.GetDescription())
+					.IsEqualTo("methods with parameter of exact type int and with optional modifier in assembly")
+					.AsPrefix();
+			}
+
+			[Fact]
+			public async Task UsingTypeExactly_WithName_ShouldIncludeOptionalModifierInDescription()
+			{
+				Filtered.Methods methods = In.AssemblyContaining<AssemblyFilters>()
+					.Methods().WithOptionalParameterExactly(typeof(int), "value");
+
+				await That(methods.GetDescription())
+					.IsEqualTo(
+						"methods with parameter of exact type int and name equal to \"value\" and with optional modifier in assembly")
+					.AsPrefix();
+			}
+#pragma warning restore CA2263
 		}
+
+		private static MethodInfo? MixedParameterMethod()
+			=> typeof(ClassWithOptionalParameterMethod)
+				.GetMethod(nameof(ClassWithOptionalParameterMethod.MethodWithMixedParameters));
 
 		private static MethodInfo? OptionalParameterMethod()
 			=> typeof(ClassWithOptionalParameterMethod)
@@ -45,6 +167,10 @@ public sealed partial class MethodFilters
 		private class ClassWithOptionalParameterMethod
 		{
 			public void MethodWithOptionalParameter(int value = 0)
+			{
+			}
+
+			public void MethodWithMixedParameters(int other, int value = 0)
 			{
 			}
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WithOutParameter.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WithOutParameter.Tests.cs
@@ -29,7 +29,129 @@ public sealed partial class MethodFilters
 
 				await That(methods).DoesNotContain(PlainMethod());
 			}
+
+			[Fact]
+			public async Task ShouldIncludeMethodWhenOnlySomeButNotAllParametersAreOutParameters()
+			{
+				Filtered.Methods methods = In.Type<ClassWithOutParameterMethod>()
+					.Methods().WithOutParameter();
+
+				await That(methods).Contains(MixedParameterMethod());
+				await That(methods).DoesNotContain(PlainMethod());
+			}
+
+			[Fact]
+			public async Task Generic_ShouldIncludeOutModifierInDescription()
+			{
+				Filtered.Methods methods = In.AssemblyContaining<AssemblyFilters>()
+					.Methods().WithOutParameter<int>();
+
+				await That(methods.GetDescription())
+					.IsEqualTo("methods with parameter of type int and with out modifier in assembly")
+					.AsPrefix();
+			}
+
+			[Fact]
+			public async Task Generic_WithName_ShouldIncludeOutModifierInDescription()
+			{
+				Filtered.Methods methods = In.AssemblyContaining<AssemblyFilters>()
+					.Methods().WithOutParameter<int>("value");
+
+				await That(methods.GetDescription())
+					.IsEqualTo(
+						"methods with parameter of type int and name equal to \"value\" and with out modifier in assembly")
+					.AsPrefix();
+			}
+
+			[Fact]
+			public async Task ByName_ShouldIncludeOutModifierInDescription()
+			{
+				Filtered.Methods methods = In.AssemblyContaining<AssemblyFilters>()
+					.Methods().WithOutParameter("value");
+
+				await That(methods.GetDescription())
+					.IsEqualTo(
+						"methods with parameter with name equal to \"value\" and with out modifier in assembly")
+					.AsPrefix();
+			}
+
+#pragma warning disable CA2263
+			[Fact]
+			public async Task UsingType_ShouldIncludeOutModifierInDescription()
+			{
+				Filtered.Methods methods = In.AssemblyContaining<AssemblyFilters>()
+					.Methods().WithOutParameter(typeof(int));
+
+				await That(methods.GetDescription())
+					.IsEqualTo("methods with parameter of type int and with out modifier in assembly")
+					.AsPrefix();
+			}
+
+			[Fact]
+			public async Task UsingType_WithName_ShouldIncludeOutModifierInDescription()
+			{
+				Filtered.Methods methods = In.AssemblyContaining<AssemblyFilters>()
+					.Methods().WithOutParameter(typeof(int), "value");
+
+				await That(methods.GetDescription())
+					.IsEqualTo(
+						"methods with parameter of type int and name equal to \"value\" and with out modifier in assembly")
+					.AsPrefix();
+			}
+#pragma warning restore CA2263
+
+			[Fact]
+			public async Task GenericExactly_ShouldIncludeOutModifierInDescription()
+			{
+				Filtered.Methods methods = In.AssemblyContaining<AssemblyFilters>()
+					.Methods().WithOutParameterExactly<int>();
+
+				await That(methods.GetDescription())
+					.IsEqualTo("methods with parameter of exact type int and with out modifier in assembly")
+					.AsPrefix();
+			}
+
+			[Fact]
+			public async Task GenericExactly_WithName_ShouldIncludeOutModifierInDescription()
+			{
+				Filtered.Methods methods = In.AssemblyContaining<AssemblyFilters>()
+					.Methods().WithOutParameterExactly<int>("value");
+
+				await That(methods.GetDescription())
+					.IsEqualTo(
+						"methods with parameter of exact type int and name equal to \"value\" and with out modifier in assembly")
+					.AsPrefix();
+			}
+
+#pragma warning disable CA2263
+			[Fact]
+			public async Task UsingTypeExactly_ShouldIncludeOutModifierInDescription()
+			{
+				Filtered.Methods methods = In.AssemblyContaining<AssemblyFilters>()
+					.Methods().WithOutParameterExactly(typeof(int));
+
+				await That(methods.GetDescription())
+					.IsEqualTo("methods with parameter of exact type int and with out modifier in assembly")
+					.AsPrefix();
+			}
+
+			[Fact]
+			public async Task UsingTypeExactly_WithName_ShouldIncludeOutModifierInDescription()
+			{
+				Filtered.Methods methods = In.AssemblyContaining<AssemblyFilters>()
+					.Methods().WithOutParameterExactly(typeof(int), "value");
+
+				await That(methods.GetDescription())
+					.IsEqualTo(
+						"methods with parameter of exact type int and name equal to \"value\" and with out modifier in assembly")
+					.AsPrefix();
+			}
+#pragma warning restore CA2263
 		}
+
+		private static MethodInfo? MixedParameterMethod()
+			=> typeof(ClassWithOutParameterMethod)
+				.GetMethod(nameof(ClassWithOutParameterMethod.MethodWithMixedParameters));
 
 		private static MethodInfo? OutParameterMethod()
 			=> typeof(ClassWithOutParameterMethod)
@@ -45,6 +167,11 @@ public sealed partial class MethodFilters
 		private class ClassWithOutParameterMethod
 		{
 			public void MethodWithOutParameter(out int value)
+			{
+				value = 0;
+			}
+
+			public void MethodWithMixedParameters(out int value, int other)
 			{
 				value = 0;
 			}

--- a/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WithParameterExactly.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WithParameterExactly.Tests.cs
@@ -52,6 +52,28 @@ public sealed partial class MethodFilters
 			}
 
 			[Fact]
+			public async Task WithName_ShouldIncludeNameInDescription()
+			{
+				Filtered.Methods methods = In.Type<TestClassWithIntParameters>()
+					.Methods().WithParameterExactly<int>("value");
+
+				await That(methods.GetDescription())
+					.IsEqualTo("methods with parameter of exact type int and name equal to \"value\" in").AsPrefix();
+			}
+
+#pragma warning disable CA2263
+			[Fact]
+			public async Task UsingType_WithName_ShouldIncludeNameInDescription()
+			{
+				Filtered.Methods methods = In.Type<TestClassWithIntParameters>()
+					.Methods().WithParameterExactly(typeof(int), "value");
+
+				await That(methods.GetDescription())
+					.IsEqualTo("methods with parameter of exact type int and name equal to \"value\" in").AsPrefix();
+			}
+#pragma warning restore CA2263
+
+			[Fact]
 			public async Task UsingType_ShouldFilterForMethodsWithParameterOfExactType()
 			{
 				Filtered.Methods methods = In.Type<TestClass>()
@@ -102,6 +124,11 @@ public sealed partial class MethodFilters
 			public void MethodWithDummyBase(DummyBase parameter) { }
 			public void MethodWithDummy(Dummy parameter) { }
 			public void MethodWithString(string parameter) { }
+		}
+
+		private class TestClassWithIntParameters
+		{
+			public void MethodWithIntValue(int value) { }
 		}
 		// ReSharper restore UnusedParameter.Local
 #pragma warning restore CA1822

--- a/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WithParameterModifier.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WithParameterModifier.Tests.cs
@@ -30,6 +30,9 @@ public sealed partial class MethodFilters
 
 				await That(methods).Contains(OutIntMethod());
 				await That(methods).DoesNotContain(PlainIntMethod());
+				await That(methods.GetDescription())
+					.IsEqualTo("methods with parameter of type int and with out modifier in assembly")
+					.AsPrefix();
 			}
 
 			[Fact]
@@ -40,6 +43,9 @@ public sealed partial class MethodFilters
 
 				await That(methods).Contains(InIntMethod());
 				await That(methods).DoesNotContain(PlainIntMethod());
+				await That(methods.GetDescription())
+					.IsEqualTo("methods with parameter of type int and with in modifier in assembly")
+					.AsPrefix();
 			}
 
 			[Fact]
@@ -50,6 +56,9 @@ public sealed partial class MethodFilters
 
 				await That(methods).Contains(OptionalIntMethod());
 				await That(methods).DoesNotContain(PlainIntMethod());
+				await That(methods.GetDescription())
+					.IsEqualTo("methods with parameter of type int and with optional modifier in assembly")
+					.AsPrefix();
 			}
 
 			[Fact]
@@ -59,6 +68,9 @@ public sealed partial class MethodFilters
 					.Methods().WithParameter<int[]>().WithParamsModifier();
 
 				await That(methods).Contains(ParamsIntMethod());
+				await That(methods.GetDescription())
+					.IsEqualTo("methods with parameter of type int[] and with params modifier in assembly")
+					.AsPrefix();
 			}
 		}
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WithParamsParameter.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WithParamsParameter.Tests.cs
@@ -38,7 +38,129 @@ public sealed partial class MethodFilters
 
 				await That(methods).DoesNotContain(PlainMethod());
 			}
+
+			[Fact]
+			public async Task ShouldIncludeMethodWhenOnlySomeButNotAllParametersAreParamsParameters()
+			{
+				Filtered.Methods methods = In.Type<ClassWithParamsParameterMethod>()
+					.Methods().WithParamsParameter();
+
+				await That(methods).Contains(MixedParameterMethod());
+				await That(methods).DoesNotContain(PlainMethod());
+			}
+
+			[Fact]
+			public async Task Generic_ShouldIncludeParamsModifierInDescription()
+			{
+				Filtered.Methods methods = In.AssemblyContaining<AssemblyFilters>()
+					.Methods().WithParamsParameter<int[]>();
+
+				await That(methods.GetDescription())
+					.IsEqualTo("methods with parameter of type int[] and with params modifier in assembly")
+					.AsPrefix();
+			}
+
+			[Fact]
+			public async Task Generic_WithName_ShouldIncludeParamsModifierInDescription()
+			{
+				Filtered.Methods methods = In.AssemblyContaining<AssemblyFilters>()
+					.Methods().WithParamsParameter<int[]>("values");
+
+				await That(methods.GetDescription())
+					.IsEqualTo(
+						"methods with parameter of type int[] and name equal to \"values\" and with params modifier in assembly")
+					.AsPrefix();
+			}
+
+			[Fact]
+			public async Task ByName_ShouldIncludeParamsModifierInDescription()
+			{
+				Filtered.Methods methods = In.AssemblyContaining<AssemblyFilters>()
+					.Methods().WithParamsParameter("values");
+
+				await That(methods.GetDescription())
+					.IsEqualTo(
+						"methods with parameter with name equal to \"values\" and with params modifier in assembly")
+					.AsPrefix();
+			}
+
+#pragma warning disable CA2263
+			[Fact]
+			public async Task UsingType_ShouldIncludeParamsModifierInDescription()
+			{
+				Filtered.Methods methods = In.AssemblyContaining<AssemblyFilters>()
+					.Methods().WithParamsParameter(typeof(int[]));
+
+				await That(methods.GetDescription())
+					.IsEqualTo("methods with parameter of type int[] and with params modifier in assembly")
+					.AsPrefix();
+			}
+
+			[Fact]
+			public async Task UsingType_WithName_ShouldIncludeParamsModifierInDescription()
+			{
+				Filtered.Methods methods = In.AssemblyContaining<AssemblyFilters>()
+					.Methods().WithParamsParameter(typeof(int[]), "values");
+
+				await That(methods.GetDescription())
+					.IsEqualTo(
+						"methods with parameter of type int[] and name equal to \"values\" and with params modifier in assembly")
+					.AsPrefix();
+			}
+#pragma warning restore CA2263
+
+			[Fact]
+			public async Task GenericExactly_ShouldIncludeParamsModifierInDescription()
+			{
+				Filtered.Methods methods = In.AssemblyContaining<AssemblyFilters>()
+					.Methods().WithParamsParameterExactly<int[]>();
+
+				await That(methods.GetDescription())
+					.IsEqualTo("methods with parameter of exact type int[] and with params modifier in assembly")
+					.AsPrefix();
+			}
+
+			[Fact]
+			public async Task GenericExactly_WithName_ShouldIncludeParamsModifierInDescription()
+			{
+				Filtered.Methods methods = In.AssemblyContaining<AssemblyFilters>()
+					.Methods().WithParamsParameterExactly<int[]>("values");
+
+				await That(methods.GetDescription())
+					.IsEqualTo(
+						"methods with parameter of exact type int[] and name equal to \"values\" and with params modifier in assembly")
+					.AsPrefix();
+			}
+
+#pragma warning disable CA2263
+			[Fact]
+			public async Task UsingTypeExactly_ShouldIncludeParamsModifierInDescription()
+			{
+				Filtered.Methods methods = In.AssemblyContaining<AssemblyFilters>()
+					.Methods().WithParamsParameterExactly(typeof(int[]));
+
+				await That(methods.GetDescription())
+					.IsEqualTo("methods with parameter of exact type int[] and with params modifier in assembly")
+					.AsPrefix();
+			}
+
+			[Fact]
+			public async Task UsingTypeExactly_WithName_ShouldIncludeParamsModifierInDescription()
+			{
+				Filtered.Methods methods = In.AssemblyContaining<AssemblyFilters>()
+					.Methods().WithParamsParameterExactly(typeof(int[]), "values");
+
+				await That(methods.GetDescription())
+					.IsEqualTo(
+						"methods with parameter of exact type int[] and name equal to \"values\" and with params modifier in assembly")
+					.AsPrefix();
+			}
+#pragma warning restore CA2263
 		}
+
+		private static MethodInfo? MixedParameterMethod()
+			=> typeof(ClassWithParamsParameterMethod)
+				.GetMethod(nameof(ClassWithParamsParameterMethod.MethodWithMixedParameters));
 
 		private static MethodInfo? ParamsParameterMethod()
 			=> typeof(ClassWithParamsParameterMethod)
@@ -62,6 +184,10 @@ public sealed partial class MethodFilters
 			}
 
 			public void MethodWithParamsCollectionParameter(params System.Collections.Generic.List<int> values)
+			{
+			}
+
+			public void MethodWithMixedParameters(int other, params int[] values)
 			{
 			}
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WithRefParameter.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WithRefParameter.Tests.cs
@@ -29,7 +29,129 @@ public sealed partial class MethodFilters
 
 				await That(methods).DoesNotContain(PlainMethod());
 			}
+
+			[Fact]
+			public async Task ShouldIncludeMethodWhenOnlySomeButNotAllParametersAreRefParameters()
+			{
+				Filtered.Methods methods = In.Type<ClassWithRefParameterMethod>()
+					.Methods().WithRefParameter();
+
+				await That(methods).Contains(MixedParameterMethod());
+				await That(methods).DoesNotContain(PlainMethod());
+			}
+
+			[Fact]
+			public async Task Generic_ShouldIncludeRefModifierInDescription()
+			{
+				Filtered.Methods methods = In.AssemblyContaining<AssemblyFilters>()
+					.Methods().WithRefParameter<int>();
+
+				await That(methods.GetDescription())
+					.IsEqualTo("methods with parameter of type int and with ref modifier in assembly")
+					.AsPrefix();
+			}
+
+			[Fact]
+			public async Task Generic_WithName_ShouldIncludeRefModifierInDescription()
+			{
+				Filtered.Methods methods = In.AssemblyContaining<AssemblyFilters>()
+					.Methods().WithRefParameter<int>("value");
+
+				await That(methods.GetDescription())
+					.IsEqualTo(
+						"methods with parameter of type int and name equal to \"value\" and with ref modifier in assembly")
+					.AsPrefix();
+			}
+
+			[Fact]
+			public async Task ByName_ShouldIncludeRefModifierInDescription()
+			{
+				Filtered.Methods methods = In.AssemblyContaining<AssemblyFilters>()
+					.Methods().WithRefParameter("value");
+
+				await That(methods.GetDescription())
+					.IsEqualTo(
+						"methods with parameter with name equal to \"value\" and with ref modifier in assembly")
+					.AsPrefix();
+			}
+
+#pragma warning disable CA2263
+			[Fact]
+			public async Task UsingType_ShouldIncludeRefModifierInDescription()
+			{
+				Filtered.Methods methods = In.AssemblyContaining<AssemblyFilters>()
+					.Methods().WithRefParameter(typeof(int));
+
+				await That(methods.GetDescription())
+					.IsEqualTo("methods with parameter of type int and with ref modifier in assembly")
+					.AsPrefix();
+			}
+
+			[Fact]
+			public async Task UsingType_WithName_ShouldIncludeRefModifierInDescription()
+			{
+				Filtered.Methods methods = In.AssemblyContaining<AssemblyFilters>()
+					.Methods().WithRefParameter(typeof(int), "value");
+
+				await That(methods.GetDescription())
+					.IsEqualTo(
+						"methods with parameter of type int and name equal to \"value\" and with ref modifier in assembly")
+					.AsPrefix();
+			}
+#pragma warning restore CA2263
+
+			[Fact]
+			public async Task GenericExactly_ShouldIncludeRefModifierInDescription()
+			{
+				Filtered.Methods methods = In.AssemblyContaining<AssemblyFilters>()
+					.Methods().WithRefParameterExactly<int>();
+
+				await That(methods.GetDescription())
+					.IsEqualTo("methods with parameter of exact type int and with ref modifier in assembly")
+					.AsPrefix();
+			}
+
+			[Fact]
+			public async Task GenericExactly_WithName_ShouldIncludeRefModifierInDescription()
+			{
+				Filtered.Methods methods = In.AssemblyContaining<AssemblyFilters>()
+					.Methods().WithRefParameterExactly<int>("value");
+
+				await That(methods.GetDescription())
+					.IsEqualTo(
+						"methods with parameter of exact type int and name equal to \"value\" and with ref modifier in assembly")
+					.AsPrefix();
+			}
+
+#pragma warning disable CA2263
+			[Fact]
+			public async Task UsingTypeExactly_ShouldIncludeRefModifierInDescription()
+			{
+				Filtered.Methods methods = In.AssemblyContaining<AssemblyFilters>()
+					.Methods().WithRefParameterExactly(typeof(int));
+
+				await That(methods.GetDescription())
+					.IsEqualTo("methods with parameter of exact type int and with ref modifier in assembly")
+					.AsPrefix();
+			}
+
+			[Fact]
+			public async Task UsingTypeExactly_WithName_ShouldIncludeRefModifierInDescription()
+			{
+				Filtered.Methods methods = In.AssemblyContaining<AssemblyFilters>()
+					.Methods().WithRefParameterExactly(typeof(int), "value");
+
+				await That(methods.GetDescription())
+					.IsEqualTo(
+						"methods with parameter of exact type int and name equal to \"value\" and with ref modifier in assembly")
+					.AsPrefix();
+			}
+#pragma warning restore CA2263
 		}
+
+		private static MethodInfo? MixedParameterMethod()
+			=> typeof(ClassWithRefParameterMethod)
+				.GetMethod(nameof(ClassWithRefParameterMethod.MethodWithMixedParameters));
 
 		private static MethodInfo? RefParameterMethod()
 			=> typeof(ClassWithRefParameterMethod)
@@ -45,6 +167,11 @@ public sealed partial class MethodFilters
 		private class ClassWithRefParameterMethod
 		{
 			public void MethodWithRefParameter(ref int value)
+			{
+				value = 0;
+			}
+
+			public void MethodWithMixedParameters(ref int value, int other)
 			{
 				value = 0;
 			}


### PR DESCRIPTION
Strengthen tests for the MethodFilters With(In/Out/Optional/Params/Ref)Parameter, WithParameter, WithParameterExactly and WhichReturnExactly filters so that the surviving/no-coverage mutants from the Stryker report are killed:

- Add GetDescription assertions for every typed/named modifier overload so the emptied 'with <modifier> modifier' and 'name ...' description strings are pinned.
- Add mixed-parameter fixtures (some-but-not-all params carry the modifier) so the Any()->All() Linq mutants on the no-arg modifier filters are killed.
- Pin the modifier descriptions of WithOut/In/Optional/Params modifier chained on WithParameter, and the exact named-parameter descriptions of WithParameterExactly.
- Add a focused OrReturnExactly test that keeps methods matching the first type so the 'result ||' -> 'false' mutant is killed.