### PR TITLE
coverage: kill mutants in ThatMethod Has-Parameter family

### DIFF
--- a/Tests/aweXpect.Reflection.Tests/ThatMethod.HasInParameter.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethod.HasInParameter.Tests.cs
@@ -59,6 +59,163 @@ public sealed partial class ThatMethod
 			}
 
 			[Fact]
+			public async Task WhenSomeButNotAllParametersAreInParameters_ShouldSucceed()
+			{
+				MethodInfo methodInfo = typeof(TestClass).GetMethod(nameof(TestClass.MethodWithMixedParameters))!;
+
+				async Task Act()
+				{
+					await That(methodInfo).HasInParameter();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task Generic_WhenMethodHasNoInParameter_ShouldFail()
+			{
+				MethodInfo methodInfo = typeof(TestClass).GetMethod(nameof(TestClass.MethodWithoutModifiers))!;
+
+				async Task Act()
+				{
+					await That(methodInfo).HasInParameter<int>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methodInfo
+					             has parameter of type int with in modifier,
+					             but it did not
+					             """);
+			}
+
+			[Fact]
+			public async Task GenericWithName_WhenMethodHasNoInParameter_ShouldFail()
+			{
+				MethodInfo methodInfo = typeof(TestClass).GetMethod(nameof(TestClass.MethodWithoutModifiers))!;
+
+				async Task Act()
+				{
+					await That(methodInfo).HasInParameter<int>("value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methodInfo
+					             has parameter of type int with name "value" with in modifier,
+					             but it did not
+					             """);
+			}
+
+			[Fact]
+			public async Task TypeWithName_WhenMethodHasNoInParameter_ShouldFail()
+			{
+				MethodInfo methodInfo = typeof(TestClass).GetMethod(nameof(TestClass.MethodWithoutModifiers))!;
+
+				async Task Act()
+				{
+					await That(methodInfo).HasInParameter(typeof(int), "value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methodInfo
+					             has parameter of type int with name "value" with in modifier,
+					             but it did not
+					             """);
+			}
+
+			[Fact]
+			public async Task Name_WhenMethodHasNoInParameter_ShouldFail()
+			{
+				MethodInfo methodInfo = typeof(TestClass).GetMethod(nameof(TestClass.MethodWithoutModifiers))!;
+
+				async Task Act()
+				{
+					await That(methodInfo).HasInParameter("value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methodInfo
+					             has parameter with name "value" with in modifier,
+					             but it did not
+					             """);
+			}
+
+			[Fact]
+			public async Task GenericExactly_WhenMethodHasNoInParameter_ShouldFail()
+			{
+				MethodInfo methodInfo = typeof(TestClass).GetMethod(nameof(TestClass.MethodWithoutModifiers))!;
+
+				async Task Act()
+				{
+					await That(methodInfo).HasInParameterExactly<int>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methodInfo
+					             has parameter of exact type int with in modifier,
+					             but it did not
+					             """);
+			}
+
+			[Fact]
+			public async Task TypeExactly_WhenMethodHasNoInParameter_ShouldFail()
+			{
+				MethodInfo methodInfo = typeof(TestClass).GetMethod(nameof(TestClass.MethodWithoutModifiers))!;
+
+				async Task Act()
+				{
+					await That(methodInfo).HasInParameterExactly(typeof(int));
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methodInfo
+					             has parameter of exact type int with in modifier,
+					             but it did not
+					             """);
+			}
+
+			[Fact]
+			public async Task GenericExactlyWithName_WhenMethodHasNoInParameter_ShouldFail()
+			{
+				MethodInfo methodInfo = typeof(TestClass).GetMethod(nameof(TestClass.MethodWithoutModifiers))!;
+
+				async Task Act()
+				{
+					await That(methodInfo).HasInParameterExactly<int>("value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methodInfo
+					             has parameter of exact type int with name "value" with in modifier,
+					             but it did not
+					             """);
+			}
+
+			[Fact]
+			public async Task TypeExactlyWithName_WhenMethodHasNoInParameter_ShouldFail()
+			{
+				MethodInfo methodInfo = typeof(TestClass).GetMethod(nameof(TestClass.MethodWithoutModifiers))!;
+
+				async Task Act()
+				{
+					await That(methodInfo).HasInParameterExactly(typeof(int), "value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methodInfo
+					             has parameter of exact type int with name "value" with in modifier,
+					             but it did not
+					             """);
+			}
+
+			[Fact]
 			public async Task Type_WhenMethodHasInParameterOfType_ShouldSucceed()
 			{
 				MethodInfo methodInfo = typeof(TestClass).GetMethod(nameof(TestClass.MethodWithInParameter))!;
@@ -161,6 +318,24 @@ public sealed partial class ThatMethod
 
 				await That(Act).DoesNotThrow();
 			}
+
+			[Fact]
+			public async Task Generic_WhenMethodHasInParameter_ShouldFail()
+			{
+				MethodInfo methodInfo = typeof(TestClass).GetMethod(nameof(TestClass.MethodWithInParameter))!;
+
+				async Task Act()
+				{
+					await That(methodInfo).DoesNotComplyWith(it => it.HasInParameter<int>());
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methodInfo
+					             does not have parameter of type int with in modifier,
+					             but it did
+					             """);
+			}
 		}
 
 #pragma warning disable CA1822
@@ -169,6 +344,10 @@ public sealed partial class ThatMethod
 		private class TestClass
 		{
 			public void MethodWithInParameter(in int value)
+			{
+			}
+
+			public void MethodWithMixedParameters(in int value, string other)
 			{
 			}
 

--- a/Tests/aweXpect.Reflection.Tests/ThatMethod.HasOptionalParameter.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethod.HasOptionalParameter.Tests.cs
@@ -59,6 +59,163 @@ public sealed partial class ThatMethod
 			}
 
 			[Fact]
+			public async Task WhenSomeButNotAllParametersAreOptionalParameters_ShouldSucceed()
+			{
+				MethodInfo methodInfo = typeof(TestClass).GetMethod(nameof(TestClass.MethodWithMixedParameters))!;
+
+				async Task Act()
+				{
+					await That(methodInfo).HasOptionalParameter();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task Generic_WhenMethodHasNoOptionalParameter_ShouldFail()
+			{
+				MethodInfo methodInfo = typeof(TestClass).GetMethod(nameof(TestClass.MethodWithoutModifiers))!;
+
+				async Task Act()
+				{
+					await That(methodInfo).HasOptionalParameter<int>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methodInfo
+					             has parameter of type int with optional modifier,
+					             but it did not
+					             """);
+			}
+
+			[Fact]
+			public async Task GenericWithName_WhenMethodHasNoOptionalParameter_ShouldFail()
+			{
+				MethodInfo methodInfo = typeof(TestClass).GetMethod(nameof(TestClass.MethodWithoutModifiers))!;
+
+				async Task Act()
+				{
+					await That(methodInfo).HasOptionalParameter<int>("value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methodInfo
+					             has parameter of type int with name "value" with optional modifier,
+					             but it did not
+					             """);
+			}
+
+			[Fact]
+			public async Task TypeWithName_WhenMethodHasNoOptionalParameter_ShouldFail()
+			{
+				MethodInfo methodInfo = typeof(TestClass).GetMethod(nameof(TestClass.MethodWithoutModifiers))!;
+
+				async Task Act()
+				{
+					await That(methodInfo).HasOptionalParameter(typeof(int), "value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methodInfo
+					             has parameter of type int with name "value" with optional modifier,
+					             but it did not
+					             """);
+			}
+
+			[Fact]
+			public async Task Name_WhenMethodHasNoOptionalParameter_ShouldFail()
+			{
+				MethodInfo methodInfo = typeof(TestClass).GetMethod(nameof(TestClass.MethodWithoutModifiers))!;
+
+				async Task Act()
+				{
+					await That(methodInfo).HasOptionalParameter("value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methodInfo
+					             has parameter with name "value" with optional modifier,
+					             but it did not
+					             """);
+			}
+
+			[Fact]
+			public async Task GenericExactly_WhenMethodHasNoOptionalParameter_ShouldFail()
+			{
+				MethodInfo methodInfo = typeof(TestClass).GetMethod(nameof(TestClass.MethodWithoutModifiers))!;
+
+				async Task Act()
+				{
+					await That(methodInfo).HasOptionalParameterExactly<int>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methodInfo
+					             has parameter of exact type int with optional modifier,
+					             but it did not
+					             """);
+			}
+
+			[Fact]
+			public async Task TypeExactly_WhenMethodHasNoOptionalParameter_ShouldFail()
+			{
+				MethodInfo methodInfo = typeof(TestClass).GetMethod(nameof(TestClass.MethodWithoutModifiers))!;
+
+				async Task Act()
+				{
+					await That(methodInfo).HasOptionalParameterExactly(typeof(int));
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methodInfo
+					             has parameter of exact type int with optional modifier,
+					             but it did not
+					             """);
+			}
+
+			[Fact]
+			public async Task GenericExactlyWithName_WhenMethodHasNoOptionalParameter_ShouldFail()
+			{
+				MethodInfo methodInfo = typeof(TestClass).GetMethod(nameof(TestClass.MethodWithoutModifiers))!;
+
+				async Task Act()
+				{
+					await That(methodInfo).HasOptionalParameterExactly<int>("value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methodInfo
+					             has parameter of exact type int with name "value" with optional modifier,
+					             but it did not
+					             """);
+			}
+
+			[Fact]
+			public async Task TypeExactlyWithName_WhenMethodHasNoOptionalParameter_ShouldFail()
+			{
+				MethodInfo methodInfo = typeof(TestClass).GetMethod(nameof(TestClass.MethodWithoutModifiers))!;
+
+				async Task Act()
+				{
+					await That(methodInfo).HasOptionalParameterExactly(typeof(int), "value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methodInfo
+					             has parameter of exact type int with name "value" with optional modifier,
+					             but it did not
+					             """);
+			}
+
+			[Fact]
 			public async Task Type_WhenMethodHasOptionalParameterOfType_ShouldSucceed()
 			{
 				MethodInfo methodInfo = typeof(TestClass).GetMethod(nameof(TestClass.MethodWithOptionalParameter))!;
@@ -169,6 +326,10 @@ public sealed partial class ThatMethod
 		private class TestClass
 		{
 			public void MethodWithOptionalParameter(int value = 0)
+			{
+			}
+
+			public void MethodWithMixedParameters(int required, int value = 0)
 			{
 			}
 

--- a/Tests/aweXpect.Reflection.Tests/ThatMethod.HasOutParameter.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethod.HasOutParameter.Tests.cs
@@ -59,6 +59,163 @@ public sealed partial class ThatMethod
 			}
 
 			[Fact]
+			public async Task WhenSomeButNotAllParametersAreOutParameters_ShouldSucceed()
+			{
+				MethodInfo methodInfo = typeof(TestClass).GetMethod(nameof(TestClass.MethodWithMixedParameters))!;
+
+				async Task Act()
+				{
+					await That(methodInfo).HasOutParameter();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task Generic_WhenMethodHasNoOutParameter_ShouldFail()
+			{
+				MethodInfo methodInfo = typeof(TestClass).GetMethod(nameof(TestClass.MethodWithoutModifiers))!;
+
+				async Task Act()
+				{
+					await That(methodInfo).HasOutParameter<int>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methodInfo
+					             has parameter of type int with out modifier,
+					             but it did not
+					             """);
+			}
+
+			[Fact]
+			public async Task GenericWithName_WhenMethodHasNoOutParameter_ShouldFail()
+			{
+				MethodInfo methodInfo = typeof(TestClass).GetMethod(nameof(TestClass.MethodWithoutModifiers))!;
+
+				async Task Act()
+				{
+					await That(methodInfo).HasOutParameter<int>("value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methodInfo
+					             has parameter of type int with name "value" with out modifier,
+					             but it did not
+					             """);
+			}
+
+			[Fact]
+			public async Task TypeWithName_WhenMethodHasNoOutParameter_ShouldFail()
+			{
+				MethodInfo methodInfo = typeof(TestClass).GetMethod(nameof(TestClass.MethodWithoutModifiers))!;
+
+				async Task Act()
+				{
+					await That(methodInfo).HasOutParameter(typeof(int), "value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methodInfo
+					             has parameter of type int with name "value" with out modifier,
+					             but it did not
+					             """);
+			}
+
+			[Fact]
+			public async Task Name_WhenMethodHasNoOutParameter_ShouldFail()
+			{
+				MethodInfo methodInfo = typeof(TestClass).GetMethod(nameof(TestClass.MethodWithoutModifiers))!;
+
+				async Task Act()
+				{
+					await That(methodInfo).HasOutParameter("value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methodInfo
+					             has parameter with name "value" with out modifier,
+					             but it did not
+					             """);
+			}
+
+			[Fact]
+			public async Task GenericExactly_WhenMethodHasNoOutParameter_ShouldFail()
+			{
+				MethodInfo methodInfo = typeof(TestClass).GetMethod(nameof(TestClass.MethodWithoutModifiers))!;
+
+				async Task Act()
+				{
+					await That(methodInfo).HasOutParameterExactly<int>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methodInfo
+					             has parameter of exact type int with out modifier,
+					             but it did not
+					             """);
+			}
+
+			[Fact]
+			public async Task TypeExactly_WhenMethodHasNoOutParameter_ShouldFail()
+			{
+				MethodInfo methodInfo = typeof(TestClass).GetMethod(nameof(TestClass.MethodWithoutModifiers))!;
+
+				async Task Act()
+				{
+					await That(methodInfo).HasOutParameterExactly(typeof(int));
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methodInfo
+					             has parameter of exact type int with out modifier,
+					             but it did not
+					             """);
+			}
+
+			[Fact]
+			public async Task GenericExactlyWithName_WhenMethodHasNoOutParameter_ShouldFail()
+			{
+				MethodInfo methodInfo = typeof(TestClass).GetMethod(nameof(TestClass.MethodWithoutModifiers))!;
+
+				async Task Act()
+				{
+					await That(methodInfo).HasOutParameterExactly<int>("value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methodInfo
+					             has parameter of exact type int with name "value" with out modifier,
+					             but it did not
+					             """);
+			}
+
+			[Fact]
+			public async Task TypeExactlyWithName_WhenMethodHasNoOutParameter_ShouldFail()
+			{
+				MethodInfo methodInfo = typeof(TestClass).GetMethod(nameof(TestClass.MethodWithoutModifiers))!;
+
+				async Task Act()
+				{
+					await That(methodInfo).HasOutParameterExactly(typeof(int), "value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methodInfo
+					             has parameter of exact type int with name "value" with out modifier,
+					             but it did not
+					             """);
+			}
+
+			[Fact]
 			public async Task Type_WhenMethodHasOutParameterOfType_ShouldSucceed()
 			{
 				MethodInfo methodInfo = typeof(TestClass).GetMethod(nameof(TestClass.MethodWithOutParameter))!;
@@ -169,6 +326,11 @@ public sealed partial class ThatMethod
 		private class TestClass
 		{
 			public void MethodWithOutParameter(out int value)
+			{
+				value = 0;
+			}
+
+			public void MethodWithMixedParameters(out int value, string other)
 			{
 				value = 0;
 			}

--- a/Tests/aweXpect.Reflection.Tests/ThatMethod.HasParameter.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethod.HasParameter.Tests.cs
@@ -495,6 +495,24 @@ public sealed partial class ThatMethod
 		public sealed class NegatedTests
 		{
 			[Fact]
+			public async Task AtIndex_WhenParameterExistsAtSpecificIndex_ShouldFail()
+			{
+				MethodInfo methodInfo = typeof(TestClass).GetMethod(nameof(TestClass.MethodWithIntAndString))!;
+
+				async Task Act()
+				{
+					await That(methodInfo).DoesNotComplyWith(it => it.HasParameter<int>().AtIndex(0));
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methodInfo
+					             does not have parameter of type int at index 0,
+					             but it did
+					             """);
+			}
+
+			[Fact]
 			public async Task HasParameterByName_WhenParameterDoesNotExist_ShouldSucceed()
 			{
 				MethodInfo methodInfo = typeof(TestClass).GetMethod(nameof(TestClass.MethodWithoutParameters))!;

--- a/Tests/aweXpect.Reflection.Tests/ThatMethod.HasParameterExactly.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethod.HasParameterExactly.Tests.cs
@@ -94,6 +94,24 @@ public sealed partial class ThatMethod
 			}
 
 			[Fact]
+			public async Task WithName_WhenParameterIsSubtype_ShouldFail()
+			{
+				MethodInfo methodInfo = typeof(TestClass).GetMethod(nameof(TestClass.MethodWithStream))!;
+
+				async Task Act()
+				{
+					await That(methodInfo).HasParameterExactly<IDisposable>("stream");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methodInfo
+					             has parameter of exact type IDisposable with name "stream",
+					             but it did not
+					             """);
+			}
+
+			[Fact]
 			public async Task Type_WhenMethodIsNull_ShouldFail()
 			{
 				MethodInfo? methodInfo = null;

--- a/Tests/aweXpect.Reflection.Tests/ThatMethod.HasParamsParameter.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethod.HasParamsParameter.Tests.cs
@@ -59,6 +59,163 @@ public sealed partial class ThatMethod
 			}
 
 			[Fact]
+			public async Task WhenSomeButNotAllParametersAreParamsParameters_ShouldSucceed()
+			{
+				MethodInfo methodInfo = typeof(TestClass).GetMethod(nameof(TestClass.MethodWithMixedParameters))!;
+
+				async Task Act()
+				{
+					await That(methodInfo).HasParamsParameter();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task Generic_WhenMethodHasNoParamsParameter_ShouldFail()
+			{
+				MethodInfo methodInfo = typeof(TestClass).GetMethod(nameof(TestClass.MethodWithoutModifiers))!;
+
+				async Task Act()
+				{
+					await That(methodInfo).HasParamsParameter<int[]>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methodInfo
+					             has parameter of type int[] with params modifier,
+					             but it did not
+					             """);
+			}
+
+			[Fact]
+			public async Task GenericWithName_WhenMethodHasNoParamsParameter_ShouldFail()
+			{
+				MethodInfo methodInfo = typeof(TestClass).GetMethod(nameof(TestClass.MethodWithoutModifiers))!;
+
+				async Task Act()
+				{
+					await That(methodInfo).HasParamsParameter<int[]>("values");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methodInfo
+					             has parameter of type int[] with name "values" with params modifier,
+					             but it did not
+					             """);
+			}
+
+			[Fact]
+			public async Task TypeWithName_WhenMethodHasNoParamsParameter_ShouldFail()
+			{
+				MethodInfo methodInfo = typeof(TestClass).GetMethod(nameof(TestClass.MethodWithoutModifiers))!;
+
+				async Task Act()
+				{
+					await That(methodInfo).HasParamsParameter(typeof(int[]), "values");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methodInfo
+					             has parameter of type int[] with name "values" with params modifier,
+					             but it did not
+					             """);
+			}
+
+			[Fact]
+			public async Task Name_WhenMethodHasNoParamsParameter_ShouldFail()
+			{
+				MethodInfo methodInfo = typeof(TestClass).GetMethod(nameof(TestClass.MethodWithoutModifiers))!;
+
+				async Task Act()
+				{
+					await That(methodInfo).HasParamsParameter("values");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methodInfo
+					             has parameter with name "values" with params modifier,
+					             but it did not
+					             """);
+			}
+
+			[Fact]
+			public async Task GenericExactly_WhenMethodHasNoParamsParameter_ShouldFail()
+			{
+				MethodInfo methodInfo = typeof(TestClass).GetMethod(nameof(TestClass.MethodWithoutModifiers))!;
+
+				async Task Act()
+				{
+					await That(methodInfo).HasParamsParameterExactly<int[]>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methodInfo
+					             has parameter of exact type int[] with params modifier,
+					             but it did not
+					             """);
+			}
+
+			[Fact]
+			public async Task TypeExactly_WhenMethodHasNoParamsParameter_ShouldFail()
+			{
+				MethodInfo methodInfo = typeof(TestClass).GetMethod(nameof(TestClass.MethodWithoutModifiers))!;
+
+				async Task Act()
+				{
+					await That(methodInfo).HasParamsParameterExactly(typeof(int[]));
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methodInfo
+					             has parameter of exact type int[] with params modifier,
+					             but it did not
+					             """);
+			}
+
+			[Fact]
+			public async Task GenericExactlyWithName_WhenMethodHasNoParamsParameter_ShouldFail()
+			{
+				MethodInfo methodInfo = typeof(TestClass).GetMethod(nameof(TestClass.MethodWithoutModifiers))!;
+
+				async Task Act()
+				{
+					await That(methodInfo).HasParamsParameterExactly<int[]>("values");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methodInfo
+					             has parameter of exact type int[] with name "values" with params modifier,
+					             but it did not
+					             """);
+			}
+
+			[Fact]
+			public async Task TypeExactlyWithName_WhenMethodHasNoParamsParameter_ShouldFail()
+			{
+				MethodInfo methodInfo = typeof(TestClass).GetMethod(nameof(TestClass.MethodWithoutModifiers))!;
+
+				async Task Act()
+				{
+					await That(methodInfo).HasParamsParameterExactly(typeof(int[]), "values");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methodInfo
+					             has parameter of exact type int[] with name "values" with params modifier,
+					             but it did not
+					             """);
+			}
+
+			[Fact]
 			public async Task Type_WhenMethodHasParamsParameterOfType_ShouldSucceed()
 			{
 				MethodInfo methodInfo = typeof(TestClass).GetMethod(nameof(TestClass.MethodWithParamsParameter))!;
@@ -169,6 +326,10 @@ public sealed partial class ThatMethod
 		private class TestClass
 		{
 			public void MethodWithParamsParameter(params int[] values)
+			{
+			}
+
+			public void MethodWithMixedParameters(int first, params int[] values)
 			{
 			}
 

--- a/Tests/aweXpect.Reflection.Tests/ThatMethod.HasRefParameter.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethod.HasRefParameter.Tests.cs
@@ -59,6 +59,91 @@ public sealed partial class ThatMethod
 			}
 
 			[Fact]
+			public async Task WhenSomeButNotAllParametersAreRefParameters_ShouldSucceed()
+			{
+				MethodInfo methodInfo = typeof(TestClass).GetMethod(nameof(TestClass.MethodWithMixedParameters))!;
+
+				async Task Act()
+				{
+					await That(methodInfo).HasRefParameter();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task TypeWithName_WhenMethodHasNoRefParameter_ShouldFail()
+			{
+				MethodInfo methodInfo = typeof(TestClass).GetMethod(nameof(TestClass.MethodWithoutModifiers))!;
+
+				async Task Act()
+				{
+					await That(methodInfo).HasRefParameter(typeof(int), "value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methodInfo
+					             has parameter of type int with name "value" with ref modifier,
+					             but it did not
+					             """);
+			}
+
+			[Fact]
+			public async Task Name_WhenMethodHasNoRefParameter_ShouldFail()
+			{
+				MethodInfo methodInfo = typeof(TestClass).GetMethod(nameof(TestClass.MethodWithoutModifiers))!;
+
+				async Task Act()
+				{
+					await That(methodInfo).HasRefParameter("value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methodInfo
+					             has parameter with name "value" with ref modifier,
+					             but it did not
+					             """);
+			}
+
+			[Fact]
+			public async Task TypeExactly_WhenMethodHasNoRefParameter_ShouldFail()
+			{
+				MethodInfo methodInfo = typeof(TestClass).GetMethod(nameof(TestClass.MethodWithoutModifiers))!;
+
+				async Task Act()
+				{
+					await That(methodInfo).HasRefParameterExactly(typeof(int));
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methodInfo
+					             has parameter of exact type int with ref modifier,
+					             but it did not
+					             """);
+			}
+
+			[Fact]
+			public async Task TypeExactlyWithName_WhenMethodHasNoRefParameter_ShouldFail()
+			{
+				MethodInfo methodInfo = typeof(TestClass).GetMethod(nameof(TestClass.MethodWithoutModifiers))!;
+
+				async Task Act()
+				{
+					await That(methodInfo).HasRefParameterExactly(typeof(int), "value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methodInfo
+					             has parameter of exact type int with name "value" with ref modifier,
+					             but it did not
+					             """);
+			}
+
+			[Fact]
 			public async Task Type_WhenMethodHasRefParameterOfType_ShouldSucceed()
 			{
 				MethodInfo methodInfo = typeof(TestClass).GetMethod(nameof(TestClass.MethodWithRefParameter))!;
@@ -169,6 +254,11 @@ public sealed partial class ThatMethod
 		private class TestClass
 		{
 			public void MethodWithRefParameter(ref int value)
+			{
+				value = 0;
+			}
+
+			public void MethodWithMixedParameters(ref int value, string other)
 			{
 				value = 0;
 			}


### PR DESCRIPTION
Add failure-message and quantifier tests for the singular ThatMethod Has-Parameter modifier overloads (in/out/optional/params/ref), plus the exact-type-with-name boolean filter and the negated index/modifier description branches of HasParameter.

- Modifier description strings ("with in/out/optional/params/ref modifier"): add failing-case tests per overload asserting the verbatim message fragment.
- Linq quantifier Any to All: add success tests on methods where only some parameters carry the modifier.
- HasParameterExactly with-name boolean: add subtype failure tests so the exact-type flag is pinned.
- HasParameter negated path: add negated index and typed-modifier failure tests so the negated index/modifier description appends are pinned.