### PR TITLE
coverage: kill mutants for Methods HaveOptionalParameter/HaveParamsParameter

### DIFF
--- a/Tests/aweXpect.Reflection.Tests/ThatMethods.HaveOptionalParameter.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethods.HaveOptionalParameter.Tests.cs
@@ -28,6 +28,22 @@ public sealed partial class ThatMethods
 			}
 
 			[Fact]
+			public async Task WhenMethodHasOneRequiredAndOneOptionalParameter_ShouldSucceed()
+			{
+				IEnumerable<MethodInfo> methods = new[]
+				{
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithRequiredAndOptionalParameter))!,
+				};
+
+				async Task Act()
+				{
+					await That(methods).HaveOptionalParameter();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
 			public async Task WhenNotAllHaveOptionalParameter_ShouldFail()
 			{
 				IEnumerable<MethodInfo> methods = new[]
@@ -45,7 +61,7 @@ public sealed partial class ThatMethods
 					.WithMessage("""
 					             Expected that methods
 					             all have an optional parameter,
-					             but it contained methods without an optional parameter *
+					             but it contained methods without an optional parameter *MethodWithoutModifiers(*
 					             """).AsWildcard();
 			}
 
@@ -79,7 +95,78 @@ public sealed partial class ThatMethods
 					await That(methods).HaveOptionalParameter(typeof(int));
 				}
 
-				await That(Act).Throws<XunitException>();
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methods
+					             all have parameter of type int with optional modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task Generic_WhenNotAllHaveOptionalParameterOfType_ShouldFail()
+			{
+				IEnumerable<MethodInfo> methods = new[]
+				{
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithOptionalParameter))!,
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithoutModifiers))!,
+				};
+
+				async Task Act()
+				{
+					await That(methods).HaveOptionalParameter<int>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methods
+					             all have parameter of type int with optional modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task GenericWithName_WhenNotAllHaveOptionalParameterOfType_ShouldFail()
+			{
+				IEnumerable<MethodInfo> methods = new[]
+				{
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithOptionalParameter))!,
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithoutModifiers))!,
+				};
+
+				async Task Act()
+				{
+					await That(methods).HaveOptionalParameter<int>("value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methods
+					             all have parameter of type int with name "value" with optional modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task WithName_WhenNotAllHaveOptionalParameterWithName_ShouldFail()
+			{
+				IEnumerable<MethodInfo> methods = new[]
+				{
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithOptionalParameter))!,
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithoutModifiers))!,
+				};
+
+				async Task Act()
+				{
+					await That(methods).HaveOptionalParameter("value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methods
+					             all have parameter with name "value" with optional modifier,
+					             but at least one did not
+					             """);
 			}
 
 			[Fact]
@@ -112,7 +199,12 @@ public sealed partial class ThatMethods
 					await That(methods).HaveOptionalParameter(typeof(int), "value");
 				}
 
-				await That(Act).Throws<XunitException>();
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methods
+					             all have parameter of type int with name "value" with optional modifier,
+					             but at least one did not
+					             """);
 			}
 
 			[Fact]
@@ -145,7 +237,78 @@ public sealed partial class ThatMethods
 					await That(methods).HaveOptionalParameterExactly(typeof(int));
 				}
 
-				await That(Act).Throws<XunitException>();
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methods
+					             all have parameter of exact type int with optional modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task GenericExactly_WhenNotAllHaveOptionalParameterOfType_ShouldFail()
+			{
+				IEnumerable<MethodInfo> methods = new[]
+				{
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithOptionalParameter))!,
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithoutModifiers))!,
+				};
+
+				async Task Act()
+				{
+					await That(methods).HaveOptionalParameterExactly<int>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methods
+					             all have parameter of exact type int with optional modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task GenericExactlyWithName_WhenNotAllHaveOptionalParameterOfType_ShouldFail()
+			{
+				IEnumerable<MethodInfo> methods = new[]
+				{
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithOptionalParameter))!,
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithoutModifiers))!,
+				};
+
+				async Task Act()
+				{
+					await That(methods).HaveOptionalParameterExactly<int>("value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methods
+					             all have parameter of exact type int with name "value" with optional modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task WithTypeExactlyAndName_WhenNotAllHaveOptionalParameterOfType_ShouldFail()
+			{
+				IEnumerable<MethodInfo> methods = new[]
+				{
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithOptionalParameter))!,
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithoutModifiers))!,
+				};
+
+				async Task Act()
+				{
+					await That(methods).HaveOptionalParameterExactly(typeof(int), "value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methods
+					             all have parameter of exact type int with name "value" with optional modifier,
+					             but at least one did not
+					             """);
 			}
 
 			[Fact]
@@ -165,6 +328,55 @@ public sealed partial class ThatMethods
 			}
 
 #if NET8_0_OR_GREATER
+			[Fact]
+			public async Task AsyncEnumerable_WhenAllHaveOptionalParameter_ShouldSucceed()
+			{
+				IAsyncEnumerable<MethodInfo> methods = ToAsyncEnumerable(
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithOptionalParameter))!,
+					typeof(TestClass).GetMethod(nameof(TestClass.AnotherMethodWithOptionalParameter))!);
+
+				async Task Act()
+				{
+					await That(methods).HaveOptionalParameter();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task AsyncEnumerable_WhenMethodHasOneRequiredAndOneOptionalParameter_ShouldSucceed()
+			{
+				IAsyncEnumerable<MethodInfo> methods = ToAsyncEnumerable(
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithRequiredAndOptionalParameter))!);
+
+				async Task Act()
+				{
+					await That(methods).HaveOptionalParameter();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task AsyncEnumerable_WhenNotAllHaveOptionalParameter_ShouldFail()
+			{
+				IAsyncEnumerable<MethodInfo> methods = ToAsyncEnumerable(
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithOptionalParameter))!,
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithoutModifiers))!);
+
+				async Task Act()
+				{
+					await That(methods).HaveOptionalParameter();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methods
+					             all have an optional parameter,
+					             but it contained methods without an optional parameter *MethodWithoutModifiers(*
+					             """).AsWildcard();
+			}
+
 			[Fact]
 			public async Task AsyncEnumerable_WithType_WhenAllHaveOptionalParameterOfType_ShouldSucceed()
 			{
@@ -216,7 +428,7 @@ public sealed partial class ThatMethods
 					.WithMessage("""
 					             Expected that methods
 					             not all have an optional parameter,
-					             but it only contained methods with an optional parameter *
+					             but it only contained methods with an optional parameter *MethodWithOptionalParameter(*
 					             """).AsWildcard();
 			}
 
@@ -260,6 +472,10 @@ public sealed partial class ThatMethods
 			}
 
 			public void AnotherMethodWithOptionalParameter(string text = "")
+			{
+			}
+
+			public void MethodWithRequiredAndOptionalParameter(int required, int value = 0)
 			{
 			}
 

--- a/Tests/aweXpect.Reflection.Tests/ThatMethods.HaveParamsParameter.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethods.HaveParamsParameter.Tests.cs
@@ -28,6 +28,22 @@ public sealed partial class ThatMethods
 			}
 
 			[Fact]
+			public async Task WhenMethodHasOneRequiredAndOneParamsParameter_ShouldSucceed()
+			{
+				IEnumerable<MethodInfo> methods = new[]
+				{
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithRequiredAndParamsParameter))!,
+				};
+
+				async Task Act()
+				{
+					await That(methods).HaveParamsParameter();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
 			public async Task WhenNotAllHaveParamsParameter_ShouldFail()
 			{
 				IEnumerable<MethodInfo> methods = new[]
@@ -45,7 +61,7 @@ public sealed partial class ThatMethods
 					.WithMessage("""
 					             Expected that methods
 					             all have a params parameter,
-					             but it contained methods without a params parameter *
+					             but it contained methods without a params parameter *MethodWithoutModifiers(*
 					             """).AsWildcard();
 			}
 
@@ -79,7 +95,78 @@ public sealed partial class ThatMethods
 					await That(methods).HaveParamsParameter(typeof(int[]));
 				}
 
-				await That(Act).Throws<XunitException>();
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methods
+					             all have parameter of type int[] with params modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task Generic_WhenNotAllHaveParamsParameterOfType_ShouldFail()
+			{
+				IEnumerable<MethodInfo> methods = new[]
+				{
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithParamsParameter))!,
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithoutModifiers))!,
+				};
+
+				async Task Act()
+				{
+					await That(methods).HaveParamsParameter<int[]>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methods
+					             all have parameter of type int[] with params modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task GenericWithName_WhenNotAllHaveParamsParameterOfType_ShouldFail()
+			{
+				IEnumerable<MethodInfo> methods = new[]
+				{
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithParamsParameter))!,
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithoutModifiers))!,
+				};
+
+				async Task Act()
+				{
+					await That(methods).HaveParamsParameter<int[]>("values");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methods
+					             all have parameter of type int[] with name "values" with params modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task WithName_WhenNotAllHaveParamsParameterWithName_ShouldFail()
+			{
+				IEnumerable<MethodInfo> methods = new[]
+				{
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithParamsParameter))!,
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithoutModifiers))!,
+				};
+
+				async Task Act()
+				{
+					await That(methods).HaveParamsParameter("values");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methods
+					             all have parameter with name "values" with params modifier,
+					             but at least one did not
+					             """);
 			}
 
 			[Fact]
@@ -112,7 +199,12 @@ public sealed partial class ThatMethods
 					await That(methods).HaveParamsParameter(typeof(int[]), "values");
 				}
 
-				await That(Act).Throws<XunitException>();
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methods
+					             all have parameter of type int[] with name "values" with params modifier,
+					             but at least one did not
+					             """);
 			}
 
 			[Fact]
@@ -145,7 +237,78 @@ public sealed partial class ThatMethods
 					await That(methods).HaveParamsParameterExactly(typeof(int[]));
 				}
 
-				await That(Act).Throws<XunitException>();
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methods
+					             all have parameter of exact type int[] with params modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task GenericExactly_WhenNotAllHaveParamsParameterOfType_ShouldFail()
+			{
+				IEnumerable<MethodInfo> methods = new[]
+				{
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithParamsParameter))!,
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithoutModifiers))!,
+				};
+
+				async Task Act()
+				{
+					await That(methods).HaveParamsParameterExactly<int[]>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methods
+					             all have parameter of exact type int[] with params modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task GenericExactlyWithName_WhenNotAllHaveParamsParameterOfType_ShouldFail()
+			{
+				IEnumerable<MethodInfo> methods = new[]
+				{
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithParamsParameter))!,
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithoutModifiers))!,
+				};
+
+				async Task Act()
+				{
+					await That(methods).HaveParamsParameterExactly<int[]>("values");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methods
+					             all have parameter of exact type int[] with name "values" with params modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task WithTypeExactlyAndName_WhenNotAllHaveParamsParameterOfType_ShouldFail()
+			{
+				IEnumerable<MethodInfo> methods = new[]
+				{
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithParamsParameter))!,
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithoutModifiers))!,
+				};
+
+				async Task Act()
+				{
+					await That(methods).HaveParamsParameterExactly(typeof(int[]), "values");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methods
+					             all have parameter of exact type int[] with name "values" with params modifier,
+					             but at least one did not
+					             """);
 			}
 
 			[Fact]
@@ -165,6 +328,55 @@ public sealed partial class ThatMethods
 			}
 
 #if NET8_0_OR_GREATER
+			[Fact]
+			public async Task AsyncEnumerable_WhenAllHaveParamsParameter_ShouldSucceed()
+			{
+				IAsyncEnumerable<MethodInfo> methods = ToAsyncEnumerable(
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithParamsParameter))!,
+					typeof(TestClass).GetMethod(nameof(TestClass.AnotherMethodWithParamsParameter))!);
+
+				async Task Act()
+				{
+					await That(methods).HaveParamsParameter();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task AsyncEnumerable_WhenMethodHasOneRequiredAndOneParamsParameter_ShouldSucceed()
+			{
+				IAsyncEnumerable<MethodInfo> methods = ToAsyncEnumerable(
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithRequiredAndParamsParameter))!);
+
+				async Task Act()
+				{
+					await That(methods).HaveParamsParameter();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task AsyncEnumerable_WhenNotAllHaveParamsParameter_ShouldFail()
+			{
+				IAsyncEnumerable<MethodInfo> methods = ToAsyncEnumerable(
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithParamsParameter))!,
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithoutModifiers))!);
+
+				async Task Act()
+				{
+					await That(methods).HaveParamsParameter();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methods
+					             all have a params parameter,
+					             but it contained methods without a params parameter *MethodWithoutModifiers(*
+					             """).AsWildcard();
+			}
+
 			[Fact]
 			public async Task AsyncEnumerable_WithType_WhenAllHaveParamsParameterOfType_ShouldSucceed()
 			{
@@ -216,7 +428,7 @@ public sealed partial class ThatMethods
 					.WithMessage("""
 					             Expected that methods
 					             not all have a params parameter,
-					             but it only contained methods with a params parameter *
+					             but it only contained methods with a params parameter *MethodWithParamsParameter(*
 					             """).AsWildcard();
 			}
 
@@ -260,6 +472,10 @@ public sealed partial class ThatMethods
 			}
 
 			public void AnotherMethodWithParamsParameter(params string[] texts)
+			{
+			}
+
+			public void MethodWithRequiredAndParamsParameter(int required, params int[] values)
 			{
 			}
 


### PR DESCRIPTION
Add exact failure-message tests for every typed/named/exact overload (sync and async) so the 'with optional modifier'/'with params modifier' string fragments are pinned, covering the surviving and uncovered String mutants.

Pin the formatted method signature in the normal/negated result messages to kill the Formatter.Format statement mutants, and add mixed required+optional and required+params cases (plus async constraint coverage) to kill the Any()->All(), equality and boolean mutants on the constraint predicates.