### PR TITLE
coverage: kill mutants in ThatConstructor Has*Parameter* family

### DIFF
--- a/Tests/aweXpect.Reflection.Tests/ThatConstructor.HasInParameter.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatConstructor.HasInParameter.Tests.cs
@@ -60,7 +60,7 @@ public sealed partial class ThatConstructor
 			}
 		}
 
-		public sealed class TypedOverloads
+		public sealed class TypedOverloadsTests
 		{
 			[Fact]
 			public async Task GenericType_WhenParameterIsNotIn_ShouldFail()

--- a/Tests/aweXpect.Reflection.Tests/ThatConstructor.HasInParameter.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatConstructor.HasInParameter.Tests.cs
@@ -60,6 +60,186 @@ public sealed partial class ThatConstructor
 			}
 		}
 
+		public sealed class TypedOverloads
+		{
+			[Fact]
+			public async Task GenericType_WhenParameterIsNotIn_ShouldFail()
+			{
+				ConstructorInfo constructorInfo = typeof(ClassWithoutModifiers).GetConstructors().Single();
+
+				async Task Act()
+				{
+					await That(constructorInfo).HasInParameter<int>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructorInfo
+					             has parameter of type int with in modifier,
+					             but it did not
+					             """);
+			}
+
+			[Fact]
+			public async Task GenericTypeAndName_WhenParameterIsNotIn_ShouldFail()
+			{
+				ConstructorInfo constructorInfo = typeof(ClassWithoutModifiers).GetConstructors().Single();
+
+				async Task Act()
+				{
+					await That(constructorInfo).HasInParameter<int>("value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructorInfo
+					             has parameter of type int with name "value" with in modifier,
+					             but it did not
+					             """);
+			}
+
+			[Fact]
+			public async Task Name_WhenParameterIsNotIn_ShouldFail()
+			{
+				ConstructorInfo constructorInfo = typeof(ClassWithoutModifiers).GetConstructors().Single();
+
+				async Task Act()
+				{
+					await That(constructorInfo).HasInParameter("value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructorInfo
+					             has parameter with name "value" with in modifier,
+					             but it did not
+					             """);
+			}
+
+			[Fact]
+			public async Task GenericExactType_WhenParameterIsNotIn_ShouldFail()
+			{
+				ConstructorInfo constructorInfo = typeof(ClassWithoutModifiers).GetConstructors().Single();
+
+				async Task Act()
+				{
+					await That(constructorInfo).HasInParameterExactly<int>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructorInfo
+					             has parameter of exact type int with in modifier,
+					             but it did not
+					             """);
+			}
+
+			[Fact]
+			public async Task GenericExactTypeAndName_WhenParameterIsNotIn_ShouldFail()
+			{
+				ConstructorInfo constructorInfo = typeof(ClassWithoutModifiers).GetConstructors().Single();
+
+				async Task Act()
+				{
+					await That(constructorInfo).HasInParameterExactly<int>("value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructorInfo
+					             has parameter of exact type int with name "value" with in modifier,
+					             but it did not
+					             """);
+			}
+
+#pragma warning disable CA2263
+			[Fact]
+			public async Task Type_WhenParameterIsNotIn_ShouldFail()
+			{
+				ConstructorInfo constructorInfo = typeof(ClassWithoutModifiers).GetConstructors().Single();
+
+				async Task Act()
+				{
+					await That(constructorInfo).HasInParameter(typeof(int));
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructorInfo
+					             has parameter of type int with in modifier,
+					             but it did not
+					             """);
+			}
+
+			[Fact]
+			public async Task TypeAndName_WhenParameterIsNotIn_ShouldFail()
+			{
+				ConstructorInfo constructorInfo = typeof(ClassWithoutModifiers).GetConstructors().Single();
+
+				async Task Act()
+				{
+					await That(constructorInfo).HasInParameter(typeof(int), "value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructorInfo
+					             has parameter of type int with name "value" with in modifier,
+					             but it did not
+					             """);
+			}
+
+			[Fact]
+			public async Task ExactType_WhenParameterIsNotIn_ShouldFail()
+			{
+				ConstructorInfo constructorInfo = typeof(ClassWithoutModifiers).GetConstructors().Single();
+
+				async Task Act()
+				{
+					await That(constructorInfo).HasInParameterExactly(typeof(int));
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructorInfo
+					             has parameter of exact type int with in modifier,
+					             but it did not
+					             """);
+			}
+
+			[Fact]
+			public async Task ExactTypeAndName_WhenParameterIsNotIn_ShouldFail()
+			{
+				ConstructorInfo constructorInfo = typeof(ClassWithoutModifiers).GetConstructors().Single();
+
+				async Task Act()
+				{
+					await That(constructorInfo).HasInParameterExactly(typeof(int), "value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructorInfo
+					             has parameter of exact type int with name "value" with in modifier,
+					             but it did not
+					             """);
+			}
+#pragma warning restore CA2263
+
+			[Fact]
+			public async Task WhenOnlySomeParametersAreIn_ShouldSucceed()
+			{
+				ConstructorInfo constructorInfo = typeof(ClassWithMixedParameters).GetConstructors().Single();
+
+				async Task Act()
+				{
+					await That(constructorInfo).HasInParameter();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
 		public sealed class NegatedTests
 		{
 			[Fact]
@@ -92,6 +272,24 @@ public sealed partial class ThatConstructor
 
 				await That(Act).DoesNotThrow();
 			}
+
+			[Fact]
+			public async Task GenericType_WhenParameterIsIn_ShouldFail()
+			{
+				ConstructorInfo constructorInfo = typeof(ClassWithInParameter).GetConstructors().Single();
+
+				async Task Act()
+				{
+					await That(constructorInfo).DoesNotComplyWith(it => it.HasInParameter<int>());
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructorInfo
+					             does not have parameter of type int with in modifier,
+					             but it did
+					             """);
+			}
 		}
 
 		// ReSharper disable UnusedParameter.Local
@@ -106,6 +304,13 @@ public sealed partial class ThatConstructor
 		private class ClassWithoutModifiers
 		{
 			public ClassWithoutModifiers(int value)
+			{
+			}
+		}
+
+		private class ClassWithMixedParameters
+		{
+			public ClassWithMixedParameters(in int value, int other)
 			{
 			}
 		}

--- a/Tests/aweXpect.Reflection.Tests/ThatConstructor.HasOptionalParameter.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatConstructor.HasOptionalParameter.Tests.cs
@@ -60,6 +60,186 @@ public sealed partial class ThatConstructor
 			}
 		}
 
+		public sealed class TypedOverloads
+		{
+			[Fact]
+			public async Task GenericType_WhenParameterIsNotOptional_ShouldFail()
+			{
+				ConstructorInfo constructorInfo = typeof(ClassWithoutModifiers).GetConstructors().Single();
+
+				async Task Act()
+				{
+					await That(constructorInfo).HasOptionalParameter<int>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructorInfo
+					             has parameter of type int with optional modifier,
+					             but it did not
+					             """);
+			}
+
+			[Fact]
+			public async Task GenericTypeAndName_WhenParameterIsNotOptional_ShouldFail()
+			{
+				ConstructorInfo constructorInfo = typeof(ClassWithoutModifiers).GetConstructors().Single();
+
+				async Task Act()
+				{
+					await That(constructorInfo).HasOptionalParameter<int>("value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructorInfo
+					             has parameter of type int with name "value" with optional modifier,
+					             but it did not
+					             """);
+			}
+
+			[Fact]
+			public async Task Name_WhenParameterIsNotOptional_ShouldFail()
+			{
+				ConstructorInfo constructorInfo = typeof(ClassWithoutModifiers).GetConstructors().Single();
+
+				async Task Act()
+				{
+					await That(constructorInfo).HasOptionalParameter("value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructorInfo
+					             has parameter with name "value" with optional modifier,
+					             but it did not
+					             """);
+			}
+
+			[Fact]
+			public async Task GenericExactType_WhenParameterIsNotOptional_ShouldFail()
+			{
+				ConstructorInfo constructorInfo = typeof(ClassWithoutModifiers).GetConstructors().Single();
+
+				async Task Act()
+				{
+					await That(constructorInfo).HasOptionalParameterExactly<int>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructorInfo
+					             has parameter of exact type int with optional modifier,
+					             but it did not
+					             """);
+			}
+
+			[Fact]
+			public async Task GenericExactTypeAndName_WhenParameterIsNotOptional_ShouldFail()
+			{
+				ConstructorInfo constructorInfo = typeof(ClassWithoutModifiers).GetConstructors().Single();
+
+				async Task Act()
+				{
+					await That(constructorInfo).HasOptionalParameterExactly<int>("value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructorInfo
+					             has parameter of exact type int with name "value" with optional modifier,
+					             but it did not
+					             """);
+			}
+
+#pragma warning disable CA2263
+			[Fact]
+			public async Task Type_WhenParameterIsNotOptional_ShouldFail()
+			{
+				ConstructorInfo constructorInfo = typeof(ClassWithoutModifiers).GetConstructors().Single();
+
+				async Task Act()
+				{
+					await That(constructorInfo).HasOptionalParameter(typeof(int));
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructorInfo
+					             has parameter of type int with optional modifier,
+					             but it did not
+					             """);
+			}
+
+			[Fact]
+			public async Task TypeAndName_WhenParameterIsNotOptional_ShouldFail()
+			{
+				ConstructorInfo constructorInfo = typeof(ClassWithoutModifiers).GetConstructors().Single();
+
+				async Task Act()
+				{
+					await That(constructorInfo).HasOptionalParameter(typeof(int), "value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructorInfo
+					             has parameter of type int with name "value" with optional modifier,
+					             but it did not
+					             """);
+			}
+
+			[Fact]
+			public async Task ExactType_WhenParameterIsNotOptional_ShouldFail()
+			{
+				ConstructorInfo constructorInfo = typeof(ClassWithoutModifiers).GetConstructors().Single();
+
+				async Task Act()
+				{
+					await That(constructorInfo).HasOptionalParameterExactly(typeof(int));
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructorInfo
+					             has parameter of exact type int with optional modifier,
+					             but it did not
+					             """);
+			}
+
+			[Fact]
+			public async Task ExactTypeAndName_WhenParameterIsNotOptional_ShouldFail()
+			{
+				ConstructorInfo constructorInfo = typeof(ClassWithoutModifiers).GetConstructors().Single();
+
+				async Task Act()
+				{
+					await That(constructorInfo).HasOptionalParameterExactly(typeof(int), "value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructorInfo
+					             has parameter of exact type int with name "value" with optional modifier,
+					             but it did not
+					             """);
+			}
+#pragma warning restore CA2263
+
+			[Fact]
+			public async Task WhenOnlySomeParametersAreOptional_ShouldSucceed()
+			{
+				ConstructorInfo constructorInfo = typeof(ClassWithMixedParameters).GetConstructors().Single();
+
+				async Task Act()
+				{
+					await That(constructorInfo).HasOptionalParameter();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
 		public sealed class NegatedTests
 		{
 			[Fact]
@@ -106,6 +286,13 @@ public sealed partial class ThatConstructor
 		private class ClassWithoutModifiers
 		{
 			public ClassWithoutModifiers(int value)
+			{
+			}
+		}
+
+		private class ClassWithMixedParameters
+		{
+			public ClassWithMixedParameters(int value, int other = 0)
 			{
 			}
 		}

--- a/Tests/aweXpect.Reflection.Tests/ThatConstructor.HasOptionalParameter.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatConstructor.HasOptionalParameter.Tests.cs
@@ -60,7 +60,7 @@ public sealed partial class ThatConstructor
 			}
 		}
 
-		public sealed class TypedOverloads
+		public sealed class TypedOverloadsTests
 		{
 			[Fact]
 			public async Task GenericType_WhenParameterIsNotOptional_ShouldFail()

--- a/Tests/aweXpect.Reflection.Tests/ThatConstructor.HasOutParameter.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatConstructor.HasOutParameter.Tests.cs
@@ -60,6 +60,186 @@ public sealed partial class ThatConstructor
 			}
 		}
 
+		public sealed class TypedOverloads
+		{
+			[Fact]
+			public async Task GenericType_WhenParameterIsNotOut_ShouldFail()
+			{
+				ConstructorInfo constructorInfo = typeof(ClassWithoutModifiers).GetConstructors().Single();
+
+				async Task Act()
+				{
+					await That(constructorInfo).HasOutParameter<int>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructorInfo
+					             has parameter of type int with out modifier,
+					             but it did not
+					             """);
+			}
+
+			[Fact]
+			public async Task GenericTypeAndName_WhenParameterIsNotOut_ShouldFail()
+			{
+				ConstructorInfo constructorInfo = typeof(ClassWithoutModifiers).GetConstructors().Single();
+
+				async Task Act()
+				{
+					await That(constructorInfo).HasOutParameter<int>("value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructorInfo
+					             has parameter of type int with name "value" with out modifier,
+					             but it did not
+					             """);
+			}
+
+			[Fact]
+			public async Task Name_WhenParameterIsNotOut_ShouldFail()
+			{
+				ConstructorInfo constructorInfo = typeof(ClassWithoutModifiers).GetConstructors().Single();
+
+				async Task Act()
+				{
+					await That(constructorInfo).HasOutParameter("value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructorInfo
+					             has parameter with name "value" with out modifier,
+					             but it did not
+					             """);
+			}
+
+			[Fact]
+			public async Task GenericExactType_WhenParameterIsNotOut_ShouldFail()
+			{
+				ConstructorInfo constructorInfo = typeof(ClassWithoutModifiers).GetConstructors().Single();
+
+				async Task Act()
+				{
+					await That(constructorInfo).HasOutParameterExactly<int>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructorInfo
+					             has parameter of exact type int with out modifier,
+					             but it did not
+					             """);
+			}
+
+			[Fact]
+			public async Task GenericExactTypeAndName_WhenParameterIsNotOut_ShouldFail()
+			{
+				ConstructorInfo constructorInfo = typeof(ClassWithoutModifiers).GetConstructors().Single();
+
+				async Task Act()
+				{
+					await That(constructorInfo).HasOutParameterExactly<int>("value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructorInfo
+					             has parameter of exact type int with name "value" with out modifier,
+					             but it did not
+					             """);
+			}
+
+#pragma warning disable CA2263
+			[Fact]
+			public async Task Type_WhenParameterIsNotOut_ShouldFail()
+			{
+				ConstructorInfo constructorInfo = typeof(ClassWithoutModifiers).GetConstructors().Single();
+
+				async Task Act()
+				{
+					await That(constructorInfo).HasOutParameter(typeof(int));
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructorInfo
+					             has parameter of type int with out modifier,
+					             but it did not
+					             """);
+			}
+
+			[Fact]
+			public async Task TypeAndName_WhenParameterIsNotOut_ShouldFail()
+			{
+				ConstructorInfo constructorInfo = typeof(ClassWithoutModifiers).GetConstructors().Single();
+
+				async Task Act()
+				{
+					await That(constructorInfo).HasOutParameter(typeof(int), "value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructorInfo
+					             has parameter of type int with name "value" with out modifier,
+					             but it did not
+					             """);
+			}
+
+			[Fact]
+			public async Task ExactType_WhenParameterIsNotOut_ShouldFail()
+			{
+				ConstructorInfo constructorInfo = typeof(ClassWithoutModifiers).GetConstructors().Single();
+
+				async Task Act()
+				{
+					await That(constructorInfo).HasOutParameterExactly(typeof(int));
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructorInfo
+					             has parameter of exact type int with out modifier,
+					             but it did not
+					             """);
+			}
+
+			[Fact]
+			public async Task ExactTypeAndName_WhenParameterIsNotOut_ShouldFail()
+			{
+				ConstructorInfo constructorInfo = typeof(ClassWithoutModifiers).GetConstructors().Single();
+
+				async Task Act()
+				{
+					await That(constructorInfo).HasOutParameterExactly(typeof(int), "value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructorInfo
+					             has parameter of exact type int with name "value" with out modifier,
+					             but it did not
+					             """);
+			}
+#pragma warning restore CA2263
+
+			[Fact]
+			public async Task WhenOnlySomeParametersAreOut_ShouldSucceed()
+			{
+				ConstructorInfo constructorInfo = typeof(ClassWithMixedParameters).GetConstructors().Single();
+
+				async Task Act()
+				{
+					await That(constructorInfo).HasOutParameter();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
 		public sealed class NegatedTests
 		{
 			[Fact]
@@ -108,6 +288,14 @@ public sealed partial class ThatConstructor
 		{
 			public ClassWithoutModifiers(int value)
 			{
+			}
+		}
+
+		private class ClassWithMixedParameters
+		{
+			public ClassWithMixedParameters(out int value, int other)
+			{
+				value = 0;
 			}
 		}
 		// ReSharper restore UnusedMember.Local

--- a/Tests/aweXpect.Reflection.Tests/ThatConstructor.HasOutParameter.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatConstructor.HasOutParameter.Tests.cs
@@ -60,7 +60,7 @@ public sealed partial class ThatConstructor
 			}
 		}
 
-		public sealed class TypedOverloads
+		public sealed class TypedOverloadsTests
 		{
 			[Fact]
 			public async Task GenericType_WhenParameterIsNotOut_ShouldFail()

--- a/Tests/aweXpect.Reflection.Tests/ThatConstructor.HasParameter.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatConstructor.HasParameter.Tests.cs
@@ -649,6 +649,24 @@ public sealed partial class ThatConstructor
 					             """);
 			}
 
+			[Fact]
+			public async Task AtIndex_WhenParameterExistsAtSpecificIndex_ShouldFail()
+			{
+				ConstructorInfo constructorInfo = typeof(TestClass).GetConstructor([typeof(int), typeof(string),])!;
+
+				async Task Act()
+				{
+					await That(constructorInfo).DoesNotComplyWith(it => it.HasParameter<int>().AtIndex(0));
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructorInfo
+					             does not have parameter of type int at index 0,
+					             but it did
+					             """);
+			}
+
 			// ReSharper disable UnusedParameter.Local
 			// ReSharper disable UnusedMember.Local
 			private class TestClass

--- a/Tests/aweXpect.Reflection.Tests/ThatConstructor.HasParameterExactly.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatConstructor.HasParameterExactly.Tests.cs
@@ -76,6 +76,42 @@ public sealed partial class ThatConstructor
 			}
 
 			[Fact]
+			public async Task WhenParameterIsSubtypeWithMatchingName_ShouldFail()
+			{
+				ConstructorInfo constructorInfo = typeof(TestClass).GetConstructor([typeof(Stream),])!;
+
+				async Task Act()
+				{
+					await That(constructorInfo).HasParameterExactly<IDisposable>("stream");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructorInfo
+					             has parameter of exact type IDisposable with name "stream",
+					             but it did not
+					             """);
+			}
+
+			[Fact]
+			public async Task WithType_WhenParameterIsSubtypeWithMatchingName_ShouldFail()
+			{
+				ConstructorInfo constructorInfo = typeof(TestClass).GetConstructor([typeof(Stream),])!;
+
+				async Task Act()
+				{
+					await That(constructorInfo).HasParameterExactly(typeof(IDisposable), "stream");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructorInfo
+					             has parameter of exact type IDisposable with name "stream",
+					             but it did not
+					             """);
+			}
+
+			[Fact]
 			public async Task WhenParameterNameDoesNotMatch_ShouldFail()
 			{
 				ConstructorInfo constructorInfo = typeof(TestClass).GetConstructor([typeof(Stream),])!;

--- a/Tests/aweXpect.Reflection.Tests/ThatConstructor.HasParamsParameter.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatConstructor.HasParamsParameter.Tests.cs
@@ -60,6 +60,186 @@ public sealed partial class ThatConstructor
 			}
 		}
 
+		public sealed class TypedOverloads
+		{
+			[Fact]
+			public async Task GenericType_WhenParameterIsNotParams_ShouldFail()
+			{
+				ConstructorInfo constructorInfo = typeof(ClassWithoutModifiers).GetConstructors().Single();
+
+				async Task Act()
+				{
+					await That(constructorInfo).HasParamsParameter<int[]>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructorInfo
+					             has parameter of type int[] with params modifier,
+					             but it did not
+					             """);
+			}
+
+			[Fact]
+			public async Task GenericTypeAndName_WhenParameterIsNotParams_ShouldFail()
+			{
+				ConstructorInfo constructorInfo = typeof(ClassWithoutModifiers).GetConstructors().Single();
+
+				async Task Act()
+				{
+					await That(constructorInfo).HasParamsParameter<int[]>("values");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructorInfo
+					             has parameter of type int[] with name "values" with params modifier,
+					             but it did not
+					             """);
+			}
+
+			[Fact]
+			public async Task Name_WhenParameterIsNotParams_ShouldFail()
+			{
+				ConstructorInfo constructorInfo = typeof(ClassWithoutModifiers).GetConstructors().Single();
+
+				async Task Act()
+				{
+					await That(constructorInfo).HasParamsParameter("values");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructorInfo
+					             has parameter with name "values" with params modifier,
+					             but it did not
+					             """);
+			}
+
+			[Fact]
+			public async Task GenericExactType_WhenParameterIsNotParams_ShouldFail()
+			{
+				ConstructorInfo constructorInfo = typeof(ClassWithoutModifiers).GetConstructors().Single();
+
+				async Task Act()
+				{
+					await That(constructorInfo).HasParamsParameterExactly<int[]>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructorInfo
+					             has parameter of exact type int[] with params modifier,
+					             but it did not
+					             """);
+			}
+
+			[Fact]
+			public async Task GenericExactTypeAndName_WhenParameterIsNotParams_ShouldFail()
+			{
+				ConstructorInfo constructorInfo = typeof(ClassWithoutModifiers).GetConstructors().Single();
+
+				async Task Act()
+				{
+					await That(constructorInfo).HasParamsParameterExactly<int[]>("values");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructorInfo
+					             has parameter of exact type int[] with name "values" with params modifier,
+					             but it did not
+					             """);
+			}
+
+#pragma warning disable CA2263
+			[Fact]
+			public async Task Type_WhenParameterIsNotParams_ShouldFail()
+			{
+				ConstructorInfo constructorInfo = typeof(ClassWithoutModifiers).GetConstructors().Single();
+
+				async Task Act()
+				{
+					await That(constructorInfo).HasParamsParameter(typeof(int[]));
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructorInfo
+					             has parameter of type int[] with params modifier,
+					             but it did not
+					             """);
+			}
+
+			[Fact]
+			public async Task TypeAndName_WhenParameterIsNotParams_ShouldFail()
+			{
+				ConstructorInfo constructorInfo = typeof(ClassWithoutModifiers).GetConstructors().Single();
+
+				async Task Act()
+				{
+					await That(constructorInfo).HasParamsParameter(typeof(int[]), "values");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructorInfo
+					             has parameter of type int[] with name "values" with params modifier,
+					             but it did not
+					             """);
+			}
+
+			[Fact]
+			public async Task ExactType_WhenParameterIsNotParams_ShouldFail()
+			{
+				ConstructorInfo constructorInfo = typeof(ClassWithoutModifiers).GetConstructors().Single();
+
+				async Task Act()
+				{
+					await That(constructorInfo).HasParamsParameterExactly(typeof(int[]));
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructorInfo
+					             has parameter of exact type int[] with params modifier,
+					             but it did not
+					             """);
+			}
+
+			[Fact]
+			public async Task ExactTypeAndName_WhenParameterIsNotParams_ShouldFail()
+			{
+				ConstructorInfo constructorInfo = typeof(ClassWithoutModifiers).GetConstructors().Single();
+
+				async Task Act()
+				{
+					await That(constructorInfo).HasParamsParameterExactly(typeof(int[]), "values");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructorInfo
+					             has parameter of exact type int[] with name "values" with params modifier,
+					             but it did not
+					             """);
+			}
+#pragma warning restore CA2263
+
+			[Fact]
+			public async Task WhenOnlySomeParametersAreParams_ShouldSucceed()
+			{
+				ConstructorInfo constructorInfo = typeof(ClassWithMixedParameters).GetConstructors().Single();
+
+				async Task Act()
+				{
+					await That(constructorInfo).HasParamsParameter();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
 		public sealed class NegatedTests
 		{
 			[Fact]
@@ -106,6 +286,13 @@ public sealed partial class ThatConstructor
 		private class ClassWithoutModifiers
 		{
 			public ClassWithoutModifiers(int[] values)
+			{
+			}
+		}
+
+		private class ClassWithMixedParameters
+		{
+			public ClassWithMixedParameters(int value, params int[] values)
 			{
 			}
 		}

--- a/Tests/aweXpect.Reflection.Tests/ThatConstructor.HasParamsParameter.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatConstructor.HasParamsParameter.Tests.cs
@@ -60,7 +60,7 @@ public sealed partial class ThatConstructor
 			}
 		}
 
-		public sealed class TypedOverloads
+		public sealed class TypedOverloadsTests
 		{
 			[Fact]
 			public async Task GenericType_WhenParameterIsNotParams_ShouldFail()

--- a/Tests/aweXpect.Reflection.Tests/ThatConstructor.HasRefParameter.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatConstructor.HasRefParameter.Tests.cs
@@ -60,7 +60,7 @@ public sealed partial class ThatConstructor
 			}
 		}
 
-		public sealed class TypedOverloads
+		public sealed class TypedOverloadsTests
 		{
 			[Fact]
 			public async Task GenericType_WhenParameterIsNotRef_ShouldFail()

--- a/Tests/aweXpect.Reflection.Tests/ThatConstructor.HasRefParameter.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatConstructor.HasRefParameter.Tests.cs
@@ -60,6 +60,186 @@ public sealed partial class ThatConstructor
 			}
 		}
 
+		public sealed class TypedOverloads
+		{
+			[Fact]
+			public async Task GenericType_WhenParameterIsNotRef_ShouldFail()
+			{
+				ConstructorInfo constructorInfo = typeof(ClassWithoutModifiers).GetConstructors().Single();
+
+				async Task Act()
+				{
+					await That(constructorInfo).HasRefParameter<int>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructorInfo
+					             has parameter of type int with ref modifier,
+					             but it did not
+					             """);
+			}
+
+			[Fact]
+			public async Task GenericTypeAndName_WhenParameterIsNotRef_ShouldFail()
+			{
+				ConstructorInfo constructorInfo = typeof(ClassWithoutModifiers).GetConstructors().Single();
+
+				async Task Act()
+				{
+					await That(constructorInfo).HasRefParameter<int>("value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructorInfo
+					             has parameter of type int with name "value" with ref modifier,
+					             but it did not
+					             """);
+			}
+
+			[Fact]
+			public async Task Name_WhenParameterIsNotRef_ShouldFail()
+			{
+				ConstructorInfo constructorInfo = typeof(ClassWithoutModifiers).GetConstructors().Single();
+
+				async Task Act()
+				{
+					await That(constructorInfo).HasRefParameter("value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructorInfo
+					             has parameter with name "value" with ref modifier,
+					             but it did not
+					             """);
+			}
+
+			[Fact]
+			public async Task GenericExactType_WhenParameterIsNotRef_ShouldFail()
+			{
+				ConstructorInfo constructorInfo = typeof(ClassWithoutModifiers).GetConstructors().Single();
+
+				async Task Act()
+				{
+					await That(constructorInfo).HasRefParameterExactly<int>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructorInfo
+					             has parameter of exact type int with ref modifier,
+					             but it did not
+					             """);
+			}
+
+			[Fact]
+			public async Task GenericExactTypeAndName_WhenParameterIsNotRef_ShouldFail()
+			{
+				ConstructorInfo constructorInfo = typeof(ClassWithoutModifiers).GetConstructors().Single();
+
+				async Task Act()
+				{
+					await That(constructorInfo).HasRefParameterExactly<int>("value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructorInfo
+					             has parameter of exact type int with name "value" with ref modifier,
+					             but it did not
+					             """);
+			}
+
+#pragma warning disable CA2263
+			[Fact]
+			public async Task Type_WhenParameterIsNotRef_ShouldFail()
+			{
+				ConstructorInfo constructorInfo = typeof(ClassWithoutModifiers).GetConstructors().Single();
+
+				async Task Act()
+				{
+					await That(constructorInfo).HasRefParameter(typeof(int));
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructorInfo
+					             has parameter of type int with ref modifier,
+					             but it did not
+					             """);
+			}
+
+			[Fact]
+			public async Task TypeAndName_WhenParameterIsNotRef_ShouldFail()
+			{
+				ConstructorInfo constructorInfo = typeof(ClassWithoutModifiers).GetConstructors().Single();
+
+				async Task Act()
+				{
+					await That(constructorInfo).HasRefParameter(typeof(int), "value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructorInfo
+					             has parameter of type int with name "value" with ref modifier,
+					             but it did not
+					             """);
+			}
+
+			[Fact]
+			public async Task ExactType_WhenParameterIsNotRef_ShouldFail()
+			{
+				ConstructorInfo constructorInfo = typeof(ClassWithoutModifiers).GetConstructors().Single();
+
+				async Task Act()
+				{
+					await That(constructorInfo).HasRefParameterExactly(typeof(int));
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructorInfo
+					             has parameter of exact type int with ref modifier,
+					             but it did not
+					             """);
+			}
+
+			[Fact]
+			public async Task ExactTypeAndName_WhenParameterIsNotRef_ShouldFail()
+			{
+				ConstructorInfo constructorInfo = typeof(ClassWithoutModifiers).GetConstructors().Single();
+
+				async Task Act()
+				{
+					await That(constructorInfo).HasRefParameterExactly(typeof(int), "value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructorInfo
+					             has parameter of exact type int with name "value" with ref modifier,
+					             but it did not
+					             """);
+			}
+#pragma warning restore CA2263
+
+			[Fact]
+			public async Task WhenOnlySomeParametersAreRef_ShouldSucceed()
+			{
+				ConstructorInfo constructorInfo = typeof(ClassWithMixedParameters).GetConstructors().Single();
+
+				async Task Act()
+				{
+					await That(constructorInfo).HasRefParameter();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
 		public sealed class NegatedTests
 		{
 			[Fact]
@@ -108,6 +288,14 @@ public sealed partial class ThatConstructor
 		{
 			public ClassWithoutModifiers(int value)
 			{
+			}
+		}
+
+		private class ClassWithMixedParameters
+		{
+			public ClassWithMixedParameters(ref int value, int other)
+			{
+				value = 0;
 			}
 		}
 		// ReSharper restore UnusedMember.Local


### PR DESCRIPTION
Add failure-message and quantifier tests covering the typed/exact parameter-modifier overloads and the constraint description branches for the singular ConstructorInfo Has*Parameter assertions.

- For each modifier (in/out/ref/optional/params): add failing-case tests for all generic/Type/name/exact overloads that pin the modifier text in the expectation message, plus a mixed-parameter success test to kill the Any()->All() quantifier mutant.
- HasParameter: add a negated AtIndex test (negated index-description branch) and a negated typed-modifier test (negated modifier description).
- HasParameterExactly: add subtype-with-matching-name failure tests to kill the exact-type boolean flag mutants on the name overloads.