### PR TITLE
coverage: kill mutants on ThatConstructors.HaveOptional/ParamsParameter

### DIFF
--- a/Tests/aweXpect.Reflection.Tests/ThatConstructors.HaveOptionalParameter.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatConstructors.HaveOptionalParameter.Tests.cs
@@ -46,8 +46,194 @@ public sealed partial class ThatConstructors
 					.WithMessage("""
 					             Expected that constructors
 					             all have an optional parameter,
-					             but it contained constructors without an optional parameter *
-					             """).AsWildcard();
+					             but it contained constructors without an optional parameter [
+					               ThatConstructors.HaveOptionalParameter.ClassWithoutModifiers(int value)
+					             ]
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenSomeButNotAllParametersAreOptional_ShouldSucceed()
+			{
+				IEnumerable<ConstructorInfo> constructors = new[]
+				{
+					typeof(ClassWithMixedOptionalParameter).GetConstructors().Single(),
+				};
+
+				async Task Act()
+				{
+					await That(constructors).HaveOptionalParameter();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task ByGenericType_WhenNotAllHaveOptionalParameter_ShouldFail()
+			{
+				IEnumerable<ConstructorInfo> constructors = new[]
+				{
+					typeof(ClassWithoutModifiers).GetConstructors().Single(),
+				};
+
+				async Task Act()
+				{
+					await That(constructors).HaveOptionalParameter<int>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter of type int with optional modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task ByGenericTypeAndName_WhenNotAllHaveOptionalParameter_ShouldFail()
+			{
+				IEnumerable<ConstructorInfo> constructors = new[]
+				{
+					typeof(ClassWithoutModifiers).GetConstructors().Single(),
+				};
+
+				async Task Act()
+				{
+					await That(constructors).HaveOptionalParameter<int>("value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter of type int with name "value" with optional modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task ByName_WhenNotAllHaveOptionalParameter_ShouldFail()
+			{
+				IEnumerable<ConstructorInfo> constructors = new[]
+				{
+					typeof(ClassWithoutModifiers).GetConstructors().Single(),
+				};
+
+				async Task Act()
+				{
+					await That(constructors).HaveOptionalParameter("value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter with name "value" with optional modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task ByTypeAndName_WhenNotAllHaveOptionalParameter_ShouldFail()
+			{
+				IEnumerable<ConstructorInfo> constructors = new[]
+				{
+					typeof(ClassWithoutModifiers).GetConstructors().Single(),
+				};
+
+				async Task Act()
+				{
+					await That(constructors).HaveOptionalParameter(typeof(int), "value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter of type int with name "value" with optional modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task ByGenericTypeExactly_WhenNotAllHaveOptionalParameter_ShouldFail()
+			{
+				IEnumerable<ConstructorInfo> constructors = new[]
+				{
+					typeof(ClassWithoutModifiers).GetConstructors().Single(),
+				};
+
+				async Task Act()
+				{
+					await That(constructors).HaveOptionalParameterExactly<int>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter of exact type int with optional modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task ByTypeExactly_WhenNotAllHaveOptionalParameter_ShouldFail()
+			{
+				IEnumerable<ConstructorInfo> constructors = new[]
+				{
+					typeof(ClassWithoutModifiers).GetConstructors().Single(),
+				};
+
+				async Task Act()
+				{
+					await That(constructors).HaveOptionalParameterExactly(typeof(int));
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter of exact type int with optional modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task ByGenericTypeExactlyAndName_WhenNotAllHaveOptionalParameter_ShouldFail()
+			{
+				IEnumerable<ConstructorInfo> constructors = new[]
+				{
+					typeof(ClassWithoutModifiers).GetConstructors().Single(),
+				};
+
+				async Task Act()
+				{
+					await That(constructors).HaveOptionalParameterExactly<int>("value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter of exact type int with name "value" with optional modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task ByTypeExactlyAndName_WhenNotAllHaveOptionalParameter_ShouldFail()
+			{
+				IEnumerable<ConstructorInfo> constructors = new[]
+				{
+					typeof(ClassWithoutModifiers).GetConstructors().Single(),
+				};
+
+				async Task Act()
+				{
+					await That(constructors).HaveOptionalParameterExactly(typeof(int), "value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter of exact type int with name "value" with optional modifier,
+					             but at least one did not
+					             """);
 			}
 
 			[Fact]
@@ -247,6 +433,209 @@ public sealed partial class ThatConstructors
 
 				await That(Act).Throws<XunitException>();
 			}
+
+			[Fact]
+			public async Task AsyncEnumerable_WhenAllHaveOptionalParameter_ShouldSucceed()
+			{
+				IAsyncEnumerable<ConstructorInfo> constructors = ToAsyncEnumerable(
+					typeof(ClassWithOptionalParameter).GetConstructors().Single(),
+					typeof(AnotherClassWithOptionalParameter).GetConstructors().Single());
+
+				async Task Act()
+				{
+					await That(constructors).HaveOptionalParameter();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task AsyncEnumerable_WhenSomeButNotAllParametersAreOptional_ShouldSucceed()
+			{
+				IAsyncEnumerable<ConstructorInfo> constructors = ToAsyncEnumerable(
+					typeof(ClassWithMixedOptionalParameter).GetConstructors().Single());
+
+				async Task Act()
+				{
+					await That(constructors).HaveOptionalParameter();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task AsyncEnumerable_WhenNotAllHaveOptionalParameter_ShouldFail()
+			{
+				IAsyncEnumerable<ConstructorInfo> constructors = ToAsyncEnumerable(
+					typeof(ClassWithOptionalParameter).GetConstructors().Single(),
+					typeof(ClassWithoutModifiers).GetConstructors().Single());
+
+				async Task Act()
+				{
+					await That(constructors).HaveOptionalParameter();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have an optional parameter,
+					             but it contained constructors without an optional parameter [
+					               ThatConstructors.HaveOptionalParameter.ClassWithoutModifiers(int value)
+					             ]
+					             """);
+			}
+
+			[Fact]
+			public async Task AsyncEnumerable_ByGenericType_WhenNotAllHaveOptionalParameter_ShouldFail()
+			{
+				IAsyncEnumerable<ConstructorInfo> constructors = ToAsyncEnumerable(
+					typeof(ClassWithoutModifiers).GetConstructors().Single());
+
+				async Task Act()
+				{
+					await That(constructors).HaveOptionalParameter<int>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter of type int with optional modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task AsyncEnumerable_ByGenericTypeAndName_WhenNotAllHaveOptionalParameter_ShouldFail()
+			{
+				IAsyncEnumerable<ConstructorInfo> constructors = ToAsyncEnumerable(
+					typeof(ClassWithoutModifiers).GetConstructors().Single());
+
+				async Task Act()
+				{
+					await That(constructors).HaveOptionalParameter<int>("value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter of type int with name "value" with optional modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task AsyncEnumerable_ByName_WhenNotAllHaveOptionalParameter_ShouldFail()
+			{
+				IAsyncEnumerable<ConstructorInfo> constructors = ToAsyncEnumerable(
+					typeof(ClassWithoutModifiers).GetConstructors().Single());
+
+				async Task Act()
+				{
+					await That(constructors).HaveOptionalParameter("value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter with name "value" with optional modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task AsyncEnumerable_ByTypeAndName_WhenNotAllHaveOptionalParameter_ShouldFail()
+			{
+				IAsyncEnumerable<ConstructorInfo> constructors = ToAsyncEnumerable(
+					typeof(ClassWithoutModifiers).GetConstructors().Single());
+
+				async Task Act()
+				{
+					await That(constructors).HaveOptionalParameter(typeof(int), "value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter of type int with name "value" with optional modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task AsyncEnumerable_ByGenericTypeExactly_WhenNotAllHaveOptionalParameter_ShouldFail()
+			{
+				IAsyncEnumerable<ConstructorInfo> constructors = ToAsyncEnumerable(
+					typeof(ClassWithoutModifiers).GetConstructors().Single());
+
+				async Task Act()
+				{
+					await That(constructors).HaveOptionalParameterExactly<int>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter of exact type int with optional modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task AsyncEnumerable_ByTypeExactly_WhenNotAllHaveOptionalParameter_ShouldFail()
+			{
+				IAsyncEnumerable<ConstructorInfo> constructors = ToAsyncEnumerable(
+					typeof(ClassWithoutModifiers).GetConstructors().Single());
+
+				async Task Act()
+				{
+					await That(constructors).HaveOptionalParameterExactly(typeof(int));
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter of exact type int with optional modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task AsyncEnumerable_ByGenericTypeExactlyAndName_WhenNotAllHaveOptionalParameter_ShouldFail()
+			{
+				IAsyncEnumerable<ConstructorInfo> constructors = ToAsyncEnumerable(
+					typeof(ClassWithoutModifiers).GetConstructors().Single());
+
+				async Task Act()
+				{
+					await That(constructors).HaveOptionalParameterExactly<int>("value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter of exact type int with name "value" with optional modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task AsyncEnumerable_ByTypeExactlyAndName_WhenNotAllHaveOptionalParameter_ShouldFail()
+			{
+				IAsyncEnumerable<ConstructorInfo> constructors = ToAsyncEnumerable(
+					typeof(ClassWithoutModifiers).GetConstructors().Single());
+
+				async Task Act()
+				{
+					await That(constructors).HaveOptionalParameterExactly(typeof(int), "value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter of exact type int with name "value" with optional modifier,
+					             but at least one did not
+					             """);
+			}
 #endif
 		}
 
@@ -270,8 +659,11 @@ public sealed partial class ThatConstructors
 					.WithMessage("""
 					             Expected that constructors
 					             not all have an optional parameter,
-					             but it only contained constructors with an optional parameter *
-					             """).AsWildcard();
+					             but it only contained constructors with an optional parameter [
+					               ThatConstructors.HaveOptionalParameter.ClassWithOptionalParameter(int value = 0),
+					               ThatConstructors.HaveOptionalParameter.AnotherClassWithOptionalParameter(string text = "")
+					             ]
+					             """);
 			}
 
 			[Fact]
@@ -316,6 +708,13 @@ public sealed partial class ThatConstructors
 		private class AnotherClassWithOptionalParameter
 		{
 			public AnotherClassWithOptionalParameter(string text = "")
+			{
+			}
+		}
+
+		private class ClassWithMixedOptionalParameter
+		{
+			public ClassWithMixedOptionalParameter(int required, int value = 0)
 			{
 			}
 		}

--- a/Tests/aweXpect.Reflection.Tests/ThatConstructors.HaveParamsParameter.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatConstructors.HaveParamsParameter.Tests.cs
@@ -46,8 +46,194 @@ public sealed partial class ThatConstructors
 					.WithMessage("""
 					             Expected that constructors
 					             all have a params parameter,
-					             but it contained constructors without a params parameter *
-					             """).AsWildcard();
+					             but it contained constructors without a params parameter [
+					               ThatConstructors.HaveParamsParameter.ClassWithoutModifiers(int[] values)
+					             ]
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenSomeButNotAllParametersAreParams_ShouldSucceed()
+			{
+				IEnumerable<ConstructorInfo> constructors = new[]
+				{
+					typeof(ClassWithMixedParamsParameter).GetConstructors().Single(),
+				};
+
+				async Task Act()
+				{
+					await That(constructors).HaveParamsParameter();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task ByGenericType_WhenNotAllHaveParamsParameter_ShouldFail()
+			{
+				IEnumerable<ConstructorInfo> constructors = new[]
+				{
+					typeof(ClassWithoutModifiers).GetConstructors().Single(),
+				};
+
+				async Task Act()
+				{
+					await That(constructors).HaveParamsParameter<int[]>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter of type int[] with params modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task ByGenericTypeAndName_WhenNotAllHaveParamsParameter_ShouldFail()
+			{
+				IEnumerable<ConstructorInfo> constructors = new[]
+				{
+					typeof(ClassWithoutModifiers).GetConstructors().Single(),
+				};
+
+				async Task Act()
+				{
+					await That(constructors).HaveParamsParameter<int[]>("values");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter of type int[] with name "values" with params modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task ByName_WhenNotAllHaveParamsParameter_ShouldFail()
+			{
+				IEnumerable<ConstructorInfo> constructors = new[]
+				{
+					typeof(ClassWithoutModifiers).GetConstructors().Single(),
+				};
+
+				async Task Act()
+				{
+					await That(constructors).HaveParamsParameter("values");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter with name "values" with params modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task ByTypeAndName_WhenNotAllHaveParamsParameter_ShouldFail()
+			{
+				IEnumerable<ConstructorInfo> constructors = new[]
+				{
+					typeof(ClassWithoutModifiers).GetConstructors().Single(),
+				};
+
+				async Task Act()
+				{
+					await That(constructors).HaveParamsParameter(typeof(int[]), "values");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter of type int[] with name "values" with params modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task ByGenericTypeExactly_WhenNotAllHaveParamsParameter_ShouldFail()
+			{
+				IEnumerable<ConstructorInfo> constructors = new[]
+				{
+					typeof(ClassWithoutModifiers).GetConstructors().Single(),
+				};
+
+				async Task Act()
+				{
+					await That(constructors).HaveParamsParameterExactly<int[]>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter of exact type int[] with params modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task ByTypeExactly_WhenNotAllHaveParamsParameter_ShouldFail()
+			{
+				IEnumerable<ConstructorInfo> constructors = new[]
+				{
+					typeof(ClassWithoutModifiers).GetConstructors().Single(),
+				};
+
+				async Task Act()
+				{
+					await That(constructors).HaveParamsParameterExactly(typeof(int[]));
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter of exact type int[] with params modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task ByGenericTypeExactlyAndName_WhenNotAllHaveParamsParameter_ShouldFail()
+			{
+				IEnumerable<ConstructorInfo> constructors = new[]
+				{
+					typeof(ClassWithoutModifiers).GetConstructors().Single(),
+				};
+
+				async Task Act()
+				{
+					await That(constructors).HaveParamsParameterExactly<int[]>("values");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter of exact type int[] with name "values" with params modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task ByTypeExactlyAndName_WhenNotAllHaveParamsParameter_ShouldFail()
+			{
+				IEnumerable<ConstructorInfo> constructors = new[]
+				{
+					typeof(ClassWithoutModifiers).GetConstructors().Single(),
+				};
+
+				async Task Act()
+				{
+					await That(constructors).HaveParamsParameterExactly(typeof(int[]), "values");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter of exact type int[] with name "values" with params modifier,
+					             but at least one did not
+					             """);
 			}
 
 			[Fact]
@@ -247,6 +433,209 @@ public sealed partial class ThatConstructors
 
 				await That(Act).Throws<XunitException>();
 			}
+
+			[Fact]
+			public async Task AsyncEnumerable_WhenAllHaveParamsParameter_ShouldSucceed()
+			{
+				IAsyncEnumerable<ConstructorInfo> constructors = ToAsyncEnumerable(
+					typeof(ClassWithParamsParameter).GetConstructors().Single(),
+					typeof(AnotherClassWithParamsParameter).GetConstructors().Single());
+
+				async Task Act()
+				{
+					await That(constructors).HaveParamsParameter();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task AsyncEnumerable_WhenSomeButNotAllParametersAreParams_ShouldSucceed()
+			{
+				IAsyncEnumerable<ConstructorInfo> constructors = ToAsyncEnumerable(
+					typeof(ClassWithMixedParamsParameter).GetConstructors().Single());
+
+				async Task Act()
+				{
+					await That(constructors).HaveParamsParameter();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task AsyncEnumerable_WhenNotAllHaveParamsParameter_ShouldFail()
+			{
+				IAsyncEnumerable<ConstructorInfo> constructors = ToAsyncEnumerable(
+					typeof(ClassWithParamsParameter).GetConstructors().Single(),
+					typeof(ClassWithoutModifiers).GetConstructors().Single());
+
+				async Task Act()
+				{
+					await That(constructors).HaveParamsParameter();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have a params parameter,
+					             but it contained constructors without a params parameter [
+					               ThatConstructors.HaveParamsParameter.ClassWithoutModifiers(int[] values)
+					             ]
+					             """);
+			}
+
+			[Fact]
+			public async Task AsyncEnumerable_ByGenericType_WhenNotAllHaveParamsParameter_ShouldFail()
+			{
+				IAsyncEnumerable<ConstructorInfo> constructors = ToAsyncEnumerable(
+					typeof(ClassWithoutModifiers).GetConstructors().Single());
+
+				async Task Act()
+				{
+					await That(constructors).HaveParamsParameter<int[]>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter of type int[] with params modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task AsyncEnumerable_ByGenericTypeAndName_WhenNotAllHaveParamsParameter_ShouldFail()
+			{
+				IAsyncEnumerable<ConstructorInfo> constructors = ToAsyncEnumerable(
+					typeof(ClassWithoutModifiers).GetConstructors().Single());
+
+				async Task Act()
+				{
+					await That(constructors).HaveParamsParameter<int[]>("values");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter of type int[] with name "values" with params modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task AsyncEnumerable_ByName_WhenNotAllHaveParamsParameter_ShouldFail()
+			{
+				IAsyncEnumerable<ConstructorInfo> constructors = ToAsyncEnumerable(
+					typeof(ClassWithoutModifiers).GetConstructors().Single());
+
+				async Task Act()
+				{
+					await That(constructors).HaveParamsParameter("values");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter with name "values" with params modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task AsyncEnumerable_ByTypeAndName_WhenNotAllHaveParamsParameter_ShouldFail()
+			{
+				IAsyncEnumerable<ConstructorInfo> constructors = ToAsyncEnumerable(
+					typeof(ClassWithoutModifiers).GetConstructors().Single());
+
+				async Task Act()
+				{
+					await That(constructors).HaveParamsParameter(typeof(int[]), "values");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter of type int[] with name "values" with params modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task AsyncEnumerable_ByGenericTypeExactly_WhenNotAllHaveParamsParameter_ShouldFail()
+			{
+				IAsyncEnumerable<ConstructorInfo> constructors = ToAsyncEnumerable(
+					typeof(ClassWithoutModifiers).GetConstructors().Single());
+
+				async Task Act()
+				{
+					await That(constructors).HaveParamsParameterExactly<int[]>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter of exact type int[] with params modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task AsyncEnumerable_ByTypeExactly_WhenNotAllHaveParamsParameter_ShouldFail()
+			{
+				IAsyncEnumerable<ConstructorInfo> constructors = ToAsyncEnumerable(
+					typeof(ClassWithoutModifiers).GetConstructors().Single());
+
+				async Task Act()
+				{
+					await That(constructors).HaveParamsParameterExactly(typeof(int[]));
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter of exact type int[] with params modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task AsyncEnumerable_ByGenericTypeExactlyAndName_WhenNotAllHaveParamsParameter_ShouldFail()
+			{
+				IAsyncEnumerable<ConstructorInfo> constructors = ToAsyncEnumerable(
+					typeof(ClassWithoutModifiers).GetConstructors().Single());
+
+				async Task Act()
+				{
+					await That(constructors).HaveParamsParameterExactly<int[]>("values");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter of exact type int[] with name "values" with params modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task AsyncEnumerable_ByTypeExactlyAndName_WhenNotAllHaveParamsParameter_ShouldFail()
+			{
+				IAsyncEnumerable<ConstructorInfo> constructors = ToAsyncEnumerable(
+					typeof(ClassWithoutModifiers).GetConstructors().Single());
+
+				async Task Act()
+				{
+					await That(constructors).HaveParamsParameterExactly(typeof(int[]), "values");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that constructors
+					             all have parameter of exact type int[] with name "values" with params modifier,
+					             but at least one did not
+					             """);
+			}
 #endif
 		}
 
@@ -270,8 +659,11 @@ public sealed partial class ThatConstructors
 					.WithMessage("""
 					             Expected that constructors
 					             not all have a params parameter,
-					             but it only contained constructors with a params parameter *
-					             """).AsWildcard();
+					             but it only contained constructors with a params parameter [
+					               ThatConstructors.HaveParamsParameter.ClassWithParamsParameter(int[] values),
+					               ThatConstructors.HaveParamsParameter.AnotherClassWithParamsParameter(string[] texts)
+					             ]
+					             """);
 			}
 
 			[Fact]
@@ -316,6 +708,13 @@ public sealed partial class ThatConstructors
 		private class AnotherClassWithParamsParameter
 		{
 			public AnotherClassWithParamsParameter(params string[] texts)
+			{
+			}
+		}
+
+		private class ClassWithMixedParamsParameter
+		{
+			public ClassWithMixedParamsParameter(int first, params int[] values)
 			{
 			}
 		}


### PR DESCRIPTION
Add exact-message failure tests for every HaveOptionalParameter and HaveParamsParameter overload (generic, type, name, type+name, and the Exactly variants, both sync and async) so the 'with optional modifier' / 'with params modifier' description strings are pinned verbatim.

Pin the full formatted constructor list in the parameterless normal and negated failure messages (previously matched with a trailing wildcard), covering the Formatter.Format statement mutations.

Add async parameterless success/fail tests and 'some but not all parameters' success cases to cover the async Any()-based constraint, the Any()->All() quantifier mutation, the boolean/equality mutations, and the previously-uncovered IsMetBy code path.