### PR TITLE
coverage: kill mutants for ThatMethods Have In/Out/Ref Parameter

### DIFF
--- a/Tests/aweXpect.Reflection.Tests/ThatMethods.HaveInParameter.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethods.HaveInParameter.Tests.cs
@@ -4,6 +4,9 @@ using Xunit.Sdk;
 
 namespace aweXpect.Reflection.Tests;
 
+// The System.Type overloads are deliberately exercised here alongside the generic ones.
+#pragma warning disable CA2263 // Prefer generic overload when type is known
+
 public sealed partial class ThatMethods
 {
 	public sealed class HaveInParameter
@@ -238,6 +241,324 @@ public sealed partial class ThatMethods
 			}
 		}
 
+		public sealed class ModifierMessageTests
+		{
+			[Fact]
+			public async Task Type_WhenNotAllHaveInParameter_ShouldFailWithModifierDescription()
+			{
+				IEnumerable<MethodInfo> methods = new[]
+				{
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithInParameter))!,
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithoutModifiers))!,
+				};
+
+				async Task Act()
+				{
+					await That(methods).HaveInParameter<int>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methods
+					             all have parameter of type int with in modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task SystemType_WhenNotAllHaveInParameter_ShouldFailWithModifierDescription()
+			{
+				IEnumerable<MethodInfo> methods = new[]
+				{
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithInParameter))!,
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithoutModifiers))!,
+				};
+
+				async Task Act()
+				{
+					await That(methods).HaveInParameter(typeof(int));
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methods
+					             all have parameter of type int with in modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task TypeAndName_WhenNotAllHaveInParameter_ShouldFailWithModifierDescription()
+			{
+				IEnumerable<MethodInfo> methods = new[]
+				{
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithInParameter))!,
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithoutModifiers))!,
+				};
+
+				async Task Act()
+				{
+					await That(methods).HaveInParameter<int>("value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methods
+					             all have parameter of type int with name "value" with in modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task SystemTypeAndName_WhenNotAllHaveInParameter_ShouldFailWithModifierDescription()
+			{
+				IEnumerable<MethodInfo> methods = new[]
+				{
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithInParameter))!,
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithoutModifiers))!,
+				};
+
+				async Task Act()
+				{
+					await That(methods).HaveInParameter(typeof(int), "value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methods
+					             all have parameter of type int with name "value" with in modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task Name_WhenNotAllHaveInParameter_ShouldFailWithModifierDescription()
+			{
+				IEnumerable<MethodInfo> methods = new[]
+				{
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithInParameter))!,
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithoutModifiers))!,
+				};
+
+				async Task Act()
+				{
+					await That(methods).HaveInParameter("value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methods
+					             all have parameter with name "value" with in modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task TypeExactly_WhenNotAllHaveInParameter_ShouldFailWithModifierDescription()
+			{
+				IEnumerable<MethodInfo> methods = new[]
+				{
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithInParameter))!,
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithoutModifiers))!,
+				};
+
+				async Task Act()
+				{
+					await That(methods).HaveInParameterExactly<int>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methods
+					             all have parameter of exact type int with in modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task SystemTypeExactly_WhenNotAllHaveInParameter_ShouldFailWithModifierDescription()
+			{
+				IEnumerable<MethodInfo> methods = new[]
+				{
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithInParameter))!,
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithoutModifiers))!,
+				};
+
+				async Task Act()
+				{
+					await That(methods).HaveInParameterExactly(typeof(int));
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methods
+					             all have parameter of exact type int with in modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task TypeExactlyAndName_WhenNotAllHaveInParameter_ShouldFailWithModifierDescription()
+			{
+				IEnumerable<MethodInfo> methods = new[]
+				{
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithInParameter))!,
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithoutModifiers))!,
+				};
+
+				async Task Act()
+				{
+					await That(methods).HaveInParameterExactly<int>("value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methods
+					             all have parameter of exact type int with name "value" with in modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task SystemTypeExactlyAndName_WhenNotAllHaveInParameter_ShouldFailWithModifierDescription()
+			{
+				IEnumerable<MethodInfo> methods = new[]
+				{
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithInParameter))!,
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithoutModifiers))!,
+				};
+
+				async Task Act()
+				{
+					await That(methods).HaveInParameterExactly(typeof(int), "value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methods
+					             all have parameter of exact type int with name "value" with in modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenSomeButNotAllParametersAreIn_ShouldStillSucceed()
+			{
+				// Kills the Any()->All() mutant: this method has an in parameter and a normal one,
+				// so Any(IsInParameter) is true but All(IsInParameter) is false.
+				IEnumerable<MethodInfo> methods = new[]
+				{
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithInAndNormalParameter))!,
+				};
+
+				async Task Act()
+				{
+					await That(methods).HaveInParameter();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenNotAllHaveInParameter_ShouldListOffendingMethod()
+			{
+				// Kills the Formatter.Format(NotMatching) statement mutant: the offending
+				// method must appear in the result message.
+				IEnumerable<MethodInfo> methods = new[]
+				{
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithInParameter))!,
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithoutModifiers))!,
+				};
+
+				async Task Act()
+				{
+					await That(methods).HaveInParameter();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methods
+					             all have an in parameter,
+					             but it contained methods without an in parameter *MethodWithoutModifiers*
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenAllHaveInParameter_NegatedShouldListMatchingMethod()
+			{
+				// Kills the Formatter.Format(Matching) statement mutant in the negated result.
+				IEnumerable<MethodInfo> methods = new[]
+				{
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithInParameter))!,
+				};
+
+				async Task Act()
+				{
+					await That(methods).DoesNotComplyWith(they => they.HaveInParameter());
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methods
+					             not all have an in parameter,
+					             but it only contained methods with an in parameter *MethodWithInParameter*
+					             """).AsWildcard();
+			}
+
+#if NET8_0_OR_GREATER
+			[Fact]
+			public async Task AsyncEnumerable_WhenAllHaveInParameter_ShouldSucceed()
+			{
+				// Kills the async equality (== true -> != true) and boolean (true -> false) mutants.
+				IAsyncEnumerable<MethodInfo> methods = ToAsyncEnumerable(
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithInParameter))!,
+					typeof(TestClass).GetMethod(nameof(TestClass.AnotherMethodWithInParameter))!);
+
+				async Task Act()
+				{
+					await That(methods).HaveInParameter();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task AsyncEnumerable_WhenNotAllHaveInParameter_ShouldFail()
+			{
+				IAsyncEnumerable<MethodInfo> methods = ToAsyncEnumerable(
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithInParameter))!,
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithoutModifiers))!);
+
+				async Task Act()
+				{
+					await That(methods).HaveInParameter();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methods
+					             all have an in parameter,
+					             but it contained methods without an in parameter *MethodWithoutModifiers*
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task AsyncEnumerable_WhenSomeButNotAllParametersAreIn_ShouldStillSucceed()
+			{
+				// Kills the async Any()->All() mutant.
+				IAsyncEnumerable<MethodInfo> methods = ToAsyncEnumerable(
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithInAndNormalParameter))!);
+
+				async Task Act()
+				{
+					await That(methods).HaveInParameter();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+#endif
+		}
+
 #if NET8_0_OR_GREATER
 		private static async IAsyncEnumerable<MethodInfo> ToAsyncEnumerable(params MethodInfo[] items)
 		{
@@ -264,6 +585,10 @@ public sealed partial class ThatMethods
 			}
 
 			public void MethodWithoutModifiers(int value)
+			{
+			}
+
+			public void MethodWithInAndNormalParameter(in int value, string text)
 			{
 			}
 		}

--- a/Tests/aweXpect.Reflection.Tests/ThatMethods.HaveOutParameter.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethods.HaveOutParameter.Tests.cs
@@ -4,6 +4,9 @@ using Xunit.Sdk;
 
 namespace aweXpect.Reflection.Tests;
 
+// The System.Type overloads are deliberately exercised here alongside the generic ones.
+#pragma warning disable CA2263 // Prefer generic overload when type is known
+
 public sealed partial class ThatMethods
 {
 	public sealed class HaveOutParameter
@@ -238,6 +241,324 @@ public sealed partial class ThatMethods
 			}
 		}
 
+		public sealed class ModifierMessageTests
+		{
+			[Fact]
+			public async Task Type_WhenNotAllHaveOutParameter_ShouldFailWithModifierDescription()
+			{
+				IEnumerable<MethodInfo> methods = new[]
+				{
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithOutParameter))!,
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithoutModifiers))!,
+				};
+
+				async Task Act()
+				{
+					await That(methods).HaveOutParameter<int>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methods
+					             all have parameter of type int with out modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task SystemType_WhenNotAllHaveOutParameter_ShouldFailWithModifierDescription()
+			{
+				IEnumerable<MethodInfo> methods = new[]
+				{
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithOutParameter))!,
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithoutModifiers))!,
+				};
+
+				async Task Act()
+				{
+					await That(methods).HaveOutParameter(typeof(int));
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methods
+					             all have parameter of type int with out modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task TypeAndName_WhenNotAllHaveOutParameter_ShouldFailWithModifierDescription()
+			{
+				IEnumerable<MethodInfo> methods = new[]
+				{
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithOutParameter))!,
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithoutModifiers))!,
+				};
+
+				async Task Act()
+				{
+					await That(methods).HaveOutParameter<int>("value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methods
+					             all have parameter of type int with name "value" with out modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task SystemTypeAndName_WhenNotAllHaveOutParameter_ShouldFailWithModifierDescription()
+			{
+				IEnumerable<MethodInfo> methods = new[]
+				{
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithOutParameter))!,
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithoutModifiers))!,
+				};
+
+				async Task Act()
+				{
+					await That(methods).HaveOutParameter(typeof(int), "value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methods
+					             all have parameter of type int with name "value" with out modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task Name_WhenNotAllHaveOutParameter_ShouldFailWithModifierDescription()
+			{
+				IEnumerable<MethodInfo> methods = new[]
+				{
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithOutParameter))!,
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithoutModifiers))!,
+				};
+
+				async Task Act()
+				{
+					await That(methods).HaveOutParameter("value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methods
+					             all have parameter with name "value" with out modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task TypeExactly_WhenNotAllHaveOutParameter_ShouldFailWithModifierDescription()
+			{
+				IEnumerable<MethodInfo> methods = new[]
+				{
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithOutParameter))!,
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithoutModifiers))!,
+				};
+
+				async Task Act()
+				{
+					await That(methods).HaveOutParameterExactly<int>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methods
+					             all have parameter of exact type int with out modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task SystemTypeExactly_WhenNotAllHaveOutParameter_ShouldFailWithModifierDescription()
+			{
+				IEnumerable<MethodInfo> methods = new[]
+				{
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithOutParameter))!,
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithoutModifiers))!,
+				};
+
+				async Task Act()
+				{
+					await That(methods).HaveOutParameterExactly(typeof(int));
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methods
+					             all have parameter of exact type int with out modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task TypeExactlyAndName_WhenNotAllHaveOutParameter_ShouldFailWithModifierDescription()
+			{
+				IEnumerable<MethodInfo> methods = new[]
+				{
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithOutParameter))!,
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithoutModifiers))!,
+				};
+
+				async Task Act()
+				{
+					await That(methods).HaveOutParameterExactly<int>("value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methods
+					             all have parameter of exact type int with name "value" with out modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task SystemTypeExactlyAndName_WhenNotAllHaveOutParameter_ShouldFailWithModifierDescription()
+			{
+				IEnumerable<MethodInfo> methods = new[]
+				{
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithOutParameter))!,
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithoutModifiers))!,
+				};
+
+				async Task Act()
+				{
+					await That(methods).HaveOutParameterExactly(typeof(int), "value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methods
+					             all have parameter of exact type int with name "value" with out modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenSomeButNotAllParametersAreOut_ShouldStillSucceed()
+			{
+				// Kills the Any()->All() mutant: this method has an out parameter and a normal one,
+				// so Any(IsOutParameter) is true but All(IsOutParameter) is false.
+				IEnumerable<MethodInfo> methods = new[]
+				{
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithOutAndNormalParameter))!,
+				};
+
+				async Task Act()
+				{
+					await That(methods).HaveOutParameter();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenNotAllHaveOutParameter_ShouldListOffendingMethod()
+			{
+				// Kills the Formatter.Format(NotMatching) statement mutant: the offending
+				// method must appear in the result message.
+				IEnumerable<MethodInfo> methods = new[]
+				{
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithOutParameter))!,
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithoutModifiers))!,
+				};
+
+				async Task Act()
+				{
+					await That(methods).HaveOutParameter();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methods
+					             all have an out parameter,
+					             but it contained methods without an out parameter *MethodWithoutModifiers*
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenAllHaveOutParameter_NegatedShouldListMatchingMethod()
+			{
+				// Kills the Formatter.Format(Matching) statement mutant in the negated result.
+				IEnumerable<MethodInfo> methods = new[]
+				{
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithOutParameter))!,
+				};
+
+				async Task Act()
+				{
+					await That(methods).DoesNotComplyWith(they => they.HaveOutParameter());
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methods
+					             not all have an out parameter,
+					             but it only contained methods with an out parameter *MethodWithOutParameter*
+					             """).AsWildcard();
+			}
+
+#if NET8_0_OR_GREATER
+			[Fact]
+			public async Task AsyncEnumerable_WhenAllHaveOutParameter_ShouldSucceed()
+			{
+				// Kills the async equality (== true -> != true) and boolean (true -> false) mutants.
+				IAsyncEnumerable<MethodInfo> methods = ToAsyncEnumerable(
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithOutParameter))!,
+					typeof(TestClass).GetMethod(nameof(TestClass.AnotherMethodWithOutParameter))!);
+
+				async Task Act()
+				{
+					await That(methods).HaveOutParameter();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task AsyncEnumerable_WhenNotAllHaveOutParameter_ShouldFail()
+			{
+				IAsyncEnumerable<MethodInfo> methods = ToAsyncEnumerable(
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithOutParameter))!,
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithoutModifiers))!);
+
+				async Task Act()
+				{
+					await That(methods).HaveOutParameter();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methods
+					             all have an out parameter,
+					             but it contained methods without an out parameter *MethodWithoutModifiers*
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task AsyncEnumerable_WhenSomeButNotAllParametersAreOut_ShouldStillSucceed()
+			{
+				// Kills the async Any()->All() mutant.
+				IAsyncEnumerable<MethodInfo> methods = ToAsyncEnumerable(
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithOutAndNormalParameter))!);
+
+				async Task Act()
+				{
+					await That(methods).HaveOutParameter();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+#endif
+		}
+
 #if NET8_0_OR_GREATER
 		private static async IAsyncEnumerable<MethodInfo> ToAsyncEnumerable(params MethodInfo[] items)
 		{
@@ -267,6 +588,11 @@ public sealed partial class ThatMethods
 
 			public void MethodWithoutModifiers(int value)
 			{
+			}
+
+			public void MethodWithOutAndNormalParameter(out int value, string text)
+			{
+				value = 0;
 			}
 		}
 		// ReSharper restore UnusedMember.Local

--- a/Tests/aweXpect.Reflection.Tests/ThatMethods.HaveRefParameter.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethods.HaveRefParameter.Tests.cs
@@ -4,6 +4,9 @@ using Xunit.Sdk;
 
 namespace aweXpect.Reflection.Tests;
 
+// The System.Type overloads are deliberately exercised here alongside the generic ones.
+#pragma warning disable CA2263 // Prefer generic overload when type is known
+
 public sealed partial class ThatMethods
 {
 	public sealed class HaveRefParameter
@@ -238,6 +241,324 @@ public sealed partial class ThatMethods
 			}
 		}
 
+		public sealed class ModifierMessageTests
+		{
+			[Fact]
+			public async Task Type_WhenNotAllHaveRefParameter_ShouldFailWithModifierDescription()
+			{
+				IEnumerable<MethodInfo> methods = new[]
+				{
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithRefParameter))!,
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithoutModifiers))!,
+				};
+
+				async Task Act()
+				{
+					await That(methods).HaveRefParameter<int>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methods
+					             all have parameter of type int with ref modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task SystemType_WhenNotAllHaveRefParameter_ShouldFailWithModifierDescription()
+			{
+				IEnumerable<MethodInfo> methods = new[]
+				{
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithRefParameter))!,
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithoutModifiers))!,
+				};
+
+				async Task Act()
+				{
+					await That(methods).HaveRefParameter(typeof(int));
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methods
+					             all have parameter of type int with ref modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task TypeAndName_WhenNotAllHaveRefParameter_ShouldFailWithModifierDescription()
+			{
+				IEnumerable<MethodInfo> methods = new[]
+				{
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithRefParameter))!,
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithoutModifiers))!,
+				};
+
+				async Task Act()
+				{
+					await That(methods).HaveRefParameter<int>("value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methods
+					             all have parameter of type int with name "value" with ref modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task SystemTypeAndName_WhenNotAllHaveRefParameter_ShouldFailWithModifierDescription()
+			{
+				IEnumerable<MethodInfo> methods = new[]
+				{
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithRefParameter))!,
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithoutModifiers))!,
+				};
+
+				async Task Act()
+				{
+					await That(methods).HaveRefParameter(typeof(int), "value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methods
+					             all have parameter of type int with name "value" with ref modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task Name_WhenNotAllHaveRefParameter_ShouldFailWithModifierDescription()
+			{
+				IEnumerable<MethodInfo> methods = new[]
+				{
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithRefParameter))!,
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithoutModifiers))!,
+				};
+
+				async Task Act()
+				{
+					await That(methods).HaveRefParameter("value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methods
+					             all have parameter with name "value" with ref modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task TypeExactly_WhenNotAllHaveRefParameter_ShouldFailWithModifierDescription()
+			{
+				IEnumerable<MethodInfo> methods = new[]
+				{
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithRefParameter))!,
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithoutModifiers))!,
+				};
+
+				async Task Act()
+				{
+					await That(methods).HaveRefParameterExactly<int>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methods
+					             all have parameter of exact type int with ref modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task SystemTypeExactly_WhenNotAllHaveRefParameter_ShouldFailWithModifierDescription()
+			{
+				IEnumerable<MethodInfo> methods = new[]
+				{
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithRefParameter))!,
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithoutModifiers))!,
+				};
+
+				async Task Act()
+				{
+					await That(methods).HaveRefParameterExactly(typeof(int));
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methods
+					             all have parameter of exact type int with ref modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task TypeExactlyAndName_WhenNotAllHaveRefParameter_ShouldFailWithModifierDescription()
+			{
+				IEnumerable<MethodInfo> methods = new[]
+				{
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithRefParameter))!,
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithoutModifiers))!,
+				};
+
+				async Task Act()
+				{
+					await That(methods).HaveRefParameterExactly<int>("value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methods
+					             all have parameter of exact type int with name "value" with ref modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task SystemTypeExactlyAndName_WhenNotAllHaveRefParameter_ShouldFailWithModifierDescription()
+			{
+				IEnumerable<MethodInfo> methods = new[]
+				{
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithRefParameter))!,
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithoutModifiers))!,
+				};
+
+				async Task Act()
+				{
+					await That(methods).HaveRefParameterExactly(typeof(int), "value");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methods
+					             all have parameter of exact type int with name "value" with ref modifier,
+					             but at least one did not
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenSomeButNotAllParametersAreRef_ShouldStillSucceed()
+			{
+				// Kills the Any()->All() mutant: this method has a ref parameter and a normal one,
+				// so Any(IsRefParameter) is true but All(IsRefParameter) is false.
+				IEnumerable<MethodInfo> methods = new[]
+				{
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithRefAndNormalParameter))!,
+				};
+
+				async Task Act()
+				{
+					await That(methods).HaveRefParameter();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenNotAllHaveRefParameter_ShouldListOffendingMethod()
+			{
+				// Kills the Formatter.Format(NotMatching) statement mutant: the offending
+				// method must appear in the result message.
+				IEnumerable<MethodInfo> methods = new[]
+				{
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithRefParameter))!,
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithoutModifiers))!,
+				};
+
+				async Task Act()
+				{
+					await That(methods).HaveRefParameter();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methods
+					             all have a ref parameter,
+					             but it contained methods without a ref parameter *MethodWithoutModifiers*
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenAllHaveRefParameter_NegatedShouldListMatchingMethod()
+			{
+				// Kills the Formatter.Format(Matching) statement mutant in the negated result.
+				IEnumerable<MethodInfo> methods = new[]
+				{
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithRefParameter))!,
+				};
+
+				async Task Act()
+				{
+					await That(methods).DoesNotComplyWith(they => they.HaveRefParameter());
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methods
+					             not all have a ref parameter,
+					             but it only contained methods with a ref parameter *MethodWithRefParameter*
+					             """).AsWildcard();
+			}
+
+#if NET8_0_OR_GREATER
+			[Fact]
+			public async Task AsyncEnumerable_WhenAllHaveRefParameter_ShouldSucceed()
+			{
+				// Kills the async equality (== true -> != true) and boolean (true -> false) mutants.
+				IAsyncEnumerable<MethodInfo> methods = ToAsyncEnumerable(
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithRefParameter))!,
+					typeof(TestClass).GetMethod(nameof(TestClass.AnotherMethodWithRefParameter))!);
+
+				async Task Act()
+				{
+					await That(methods).HaveRefParameter();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task AsyncEnumerable_WhenNotAllHaveRefParameter_ShouldFail()
+			{
+				IAsyncEnumerable<MethodInfo> methods = ToAsyncEnumerable(
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithRefParameter))!,
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithoutModifiers))!);
+
+				async Task Act()
+				{
+					await That(methods).HaveRefParameter();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methods
+					             all have a ref parameter,
+					             but it contained methods without a ref parameter *MethodWithoutModifiers*
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task AsyncEnumerable_WhenSomeButNotAllParametersAreRef_ShouldStillSucceed()
+			{
+				// Kills the async Any()->All() mutant.
+				IAsyncEnumerable<MethodInfo> methods = ToAsyncEnumerable(
+					typeof(TestClass).GetMethod(nameof(TestClass.MethodWithRefAndNormalParameter))!);
+
+				async Task Act()
+				{
+					await That(methods).HaveRefParameter();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+#endif
+		}
+
 #if NET8_0_OR_GREATER
 		private static async IAsyncEnumerable<MethodInfo> ToAsyncEnumerable(params MethodInfo[] items)
 		{
@@ -267,6 +588,11 @@ public sealed partial class ThatMethods
 
 			public void MethodWithoutModifiers(int value)
 			{
+			}
+
+			public void MethodWithRefAndNormalParameter(ref int value, string text)
+			{
+				value = 0;
 			}
 		}
 		// ReSharper restore UnusedMember.Local


### PR DESCRIPTION
Add modifier-message, quantifier, and result-formatting tests for the HaveInParameter / HaveOutParameter / HaveRefParameter assertions:

- Failure-message tests for every typed/named/exact overload pin the "with in/out/ref modifier" description verbatim, killing the String-mutation mutants on those overloads.
- A method with one in/out/ref parameter plus a normal parameter drives the Any-to-All quantifier mutants on the sync and async constraints.
- Async-enumerable success/failure tests cover the async constraint equality and boolean mutants.
- Result-message tests assert the offending/matching method name appears, killing the Formatter.Format(NotMatching/Matching) statement mutants.