### PR TITLE
coverage: kill mutants on members/fields/properties/events + non-parameter methods/constructors

### DIFF
--- a/Tests/aweXpect.Reflection.Tests/TestHelpers/AsyncEnumerableExtensions.cs
+++ b/Tests/aweXpect.Reflection.Tests/TestHelpers/AsyncEnumerableExtensions.cs
@@ -1,0 +1,22 @@
+#if NET8_0_OR_GREATER
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace aweXpect.Reflection.Tests.TestHelpers;
+
+internal static class AsyncEnumerableExtensions
+{
+	/// <summary>
+	///     Wraps the <paramref name="items" /> in an <see cref="IAsyncEnumerable{T}" />.
+	/// </summary>
+	public static async IAsyncEnumerable<T> ToTestAsyncEnumerable<T>(this IEnumerable<T> items)
+	{
+		foreach (T item in items)
+		{
+			yield return item;
+		}
+
+		await Task.CompletedTask;
+	}
+}
+#endif

--- a/Tests/aweXpect.Reflection.Tests/ThatConstructors.AreNotStatic.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatConstructors.AreNotStatic.Tests.cs
@@ -1,6 +1,9 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
+#if NET8_0_OR_GREATER
+using aweXpect.Reflection.Tests.TestHelpers;
+#endif
 
 namespace aweXpect.Reflection.Tests;
 
@@ -85,5 +88,48 @@ public sealed partial class ThatConstructors
 					             """).AsWildcard();
 			}
 		}
+
+#if NET8_0_OR_GREATER
+		public sealed class AsyncEnumerableTests
+		{
+			[Fact]
+			public async Task WhenConstructorsContainStaticConstructors_ShouldFail()
+			{
+				IAsyncEnumerable<ConstructorInfo?> subject = typeof(TestClassWithStaticMembers)
+					.GetConstructors(BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance |
+					                 BindingFlags.NonPublic | BindingFlags.DeclaredOnly)
+					.ToTestAsyncEnumerable<ConstructorInfo?>();
+
+				async Task Act()
+				{
+					await That(subject).AreNotStatic();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             are all not static,
+					             but it contained static constructors [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenFilteringOnlyNonStaticConstructors_ShouldSucceed()
+			{
+				IAsyncEnumerable<ConstructorInfo?> subject = typeof(TestClassWithStaticMembers)
+					.GetConstructors(BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly)
+					.ToTestAsyncEnumerable<ConstructorInfo?>();
+
+				async Task Act()
+				{
+					await That(subject).AreNotStatic();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+#endif
 	}
 }

--- a/Tests/aweXpect.Reflection.Tests/ThatConstructors.AreStatic.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatConstructors.AreStatic.Tests.cs
@@ -1,6 +1,9 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
+#if NET8_0_OR_GREATER
+using aweXpect.Reflection.Tests.TestHelpers;
+#endif
 
 namespace aweXpect.Reflection.Tests;
 
@@ -85,5 +88,70 @@ public sealed partial class ThatConstructors
 					             """).AsWildcard();
 			}
 		}
+
+#if NET8_0_OR_GREATER
+		public sealed class AsyncEnumerableTests
+		{
+			[Fact]
+			public async Task WhenConstructorsContainNonStaticConstructors_ShouldFail()
+			{
+				IAsyncEnumerable<ConstructorInfo?> subject = typeof(TestClassWithStaticMembers)
+					.GetConstructors(BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance |
+					                 BindingFlags.NonPublic | BindingFlags.DeclaredOnly)
+					.ToTestAsyncEnumerable<ConstructorInfo?>();
+
+				async Task Act()
+				{
+					await That(subject).AreStatic();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             are all static,
+					             but it contained non-static constructors [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenFilteringOnlyStaticConstructors_ShouldSucceed()
+			{
+				IAsyncEnumerable<ConstructorInfo?> subject = typeof(TestClassWithStaticMembers)
+					.GetConstructors(BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.DeclaredOnly)
+					.ToTestAsyncEnumerable<ConstructorInfo?>();
+
+				async Task Act()
+				{
+					await That(subject).AreStatic();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenFilteringOnlyStaticConstructors_Negated_ShouldFail()
+			{
+				IAsyncEnumerable<ConstructorInfo?> subject = typeof(TestClassWithStaticMembers)
+					.GetConstructors(BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.DeclaredOnly)
+					.ToTestAsyncEnumerable<ConstructorInfo?>();
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(they => they.AreStatic());
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             are not all static,
+					             but it only contained static constructors [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+		}
+#endif
 	}
 }

--- a/Tests/aweXpect.Reflection.Tests/ThatConstructors.Have.AttributeTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatConstructors.Have.AttributeTests.cs
@@ -1,6 +1,9 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Reflection;
 using Xunit.Sdk;
+#if NET8_0_OR_GREATER
+using aweXpect.Reflection.Tests.TestHelpers;
+#endif
 
 namespace aweXpect.Reflection.Tests;
 
@@ -88,6 +91,94 @@ public sealed partial class ThatConstructors
 					             ]
 					             """);
 			}
+
+#if NET8_0_OR_GREATER
+			public sealed class AsyncEnumerableTests
+			{
+				[Fact]
+				public async Task WhenAllConstructorsHaveAttribute_ShouldSucceed()
+				{
+					IAsyncEnumerable<ConstructorInfo?> subject = new[]
+					{
+						typeof(TestClass).GetConstructor([typeof(string),])!,
+						typeof(TestClass).GetConstructor([typeof(int),])!,
+					}.ToTestAsyncEnumerable<ConstructorInfo?>();
+
+					async Task Act()
+					{
+						await That(subject).Have<TestAttribute>();
+					}
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenNotAllConstructorsHaveAttribute_ShouldFail()
+				{
+					IAsyncEnumerable<ConstructorInfo?> subject = new[]
+					{
+						typeof(TestClass).GetConstructor([typeof(string),])!,
+						typeof(TestClass).GetConstructor(Type.EmptyTypes)!,
+					}.ToTestAsyncEnumerable<ConstructorInfo?>();
+
+					async Task Act()
+					{
+						await That(subject).Have<TestAttribute>();
+					}
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             all have ThatConstructors.Have.AttributeTests.TestAttribute,
+						             but it contained not matching constructors [
+						               ThatConstructors.Have.AttributeTests.TestClass()
+						             ]
+						             """);
+				}
+
+				[Fact]
+				public async Task WhenAllConstructorsHaveMatchingAttribute_ShouldSucceed()
+				{
+					IAsyncEnumerable<ConstructorInfo?> subject = new[]
+					{
+						typeof(TestClass).GetConstructor([typeof(string),])!,
+						typeof(TestClass).GetConstructor([typeof(int),])!,
+					}.ToTestAsyncEnumerable<ConstructorInfo?>();
+
+					async Task Act()
+					{
+						await That(subject).Have<TestAttribute>(attr => attr.Value.StartsWith("Constructor"));
+					}
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenNotAllConstructorsHaveMatchingAttribute_ShouldFail()
+				{
+					IAsyncEnumerable<ConstructorInfo?> subject = new[]
+					{
+						typeof(TestClass).GetConstructor([typeof(string),])!,
+						typeof(TestClass).GetConstructor([typeof(int),])!,
+					}.ToTestAsyncEnumerable<ConstructorInfo?>();
+
+					async Task Act()
+					{
+						await That(subject).Have<TestAttribute>(attr => attr.Value == "WrongValue");
+					}
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             all have ThatConstructors.Have.AttributeTests.TestAttribute matching attr => attr.Value == "WrongValue",
+						             but it contained not matching constructors [
+						               ThatConstructors.Have.AttributeTests.TestClass(string value),
+						               ThatConstructors.Have.AttributeTests.TestClass(int value)
+						             ]
+						             """);
+				}
+			}
+#endif
 
 			[AttributeUsage(AttributeTargets.Constructor)]
 			private class TestAttribute : Attribute

--- a/Tests/aweXpect.Reflection.Tests/ThatEvents.AreNotAbstract.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatEvents.AreNotAbstract.Tests.cs
@@ -1,7 +1,10 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
+#if NET8_0_OR_GREATER
+using aweXpect.Reflection.Tests.TestHelpers;
+#endif
 
 namespace aweXpect.Reflection.Tests;
 
@@ -86,5 +89,48 @@ public sealed partial class ThatEvents
 					             """).AsWildcard();
 			}
 		}
+
+#if NET8_0_OR_GREATER
+		public sealed class AsyncEnumerableTests
+		{
+			[Fact]
+			public async Task WhenFilteringOnlyNonAbstractEvents_ShouldSucceed()
+			{
+				IAsyncEnumerable<EventInfo?> subject = typeof(AbstractClassWithMembers)
+					.GetEvents(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+					.Where(e => e.Name == nameof(AbstractClassWithMembers.VirtualEvent))
+					.ToTestAsyncEnumerable<EventInfo?>();
+
+				async Task Act()
+				{
+					await That(subject).AreNotAbstract();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenEventsContainAbstractEvents_ShouldFail()
+			{
+				IAsyncEnumerable<EventInfo?> subject = typeof(AbstractClassWithMembers)
+					.GetEvents(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+					.ToTestAsyncEnumerable<EventInfo?>();
+
+				async Task Act()
+				{
+					await That(subject).AreNotAbstract();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             are all not abstract,
+					             but it contained abstract events [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+		}
+#endif
 	}
 }

--- a/Tests/aweXpect.Reflection.Tests/ThatEvents.AreNotSealed.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatEvents.AreNotSealed.Tests.cs
@@ -1,6 +1,9 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
+#if NET8_0_OR_GREATER
+using aweXpect.Reflection.Tests.TestHelpers;
+#endif
 
 namespace aweXpect.Reflection.Tests;
 
@@ -83,5 +86,47 @@ public sealed partial class ThatEvents
 					             """).AsWildcard();
 			}
 		}
+
+#if NET8_0_OR_GREATER
+		public sealed class AsyncEnumerableTests
+		{
+			[Fact]
+			public async Task WhenFilteringOnlyNonSealedEvents_ShouldSucceed()
+			{
+				IAsyncEnumerable<EventInfo?> subject = typeof(AbstractClassWithMembers)
+					.GetEvents(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+					.ToTestAsyncEnumerable<EventInfo?>();
+
+				async Task Act()
+				{
+					await That(subject).AreNotSealed();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenEventsContainSealedEvents_ShouldFail()
+			{
+				IAsyncEnumerable<EventInfo?> subject = typeof(ClassWithSealedMembers)
+					.GetEvents(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+					.ToTestAsyncEnumerable<EventInfo?>();
+
+				async Task Act()
+				{
+					await That(subject).AreNotSealed();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             are all not sealed,
+					             but it contained sealed events [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+		}
+#endif
 	}
 }

--- a/Tests/aweXpect.Reflection.Tests/ThatEvents.Have.AttributeTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatEvents.Have.AttributeTests.cs
@@ -1,6 +1,9 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Reflection;
 using Xunit.Sdk;
+#if NET8_0_OR_GREATER
+using aweXpect.Reflection.Tests.TestHelpers;
+#endif
 
 namespace aweXpect.Reflection.Tests;
 
@@ -88,6 +91,90 @@ public sealed partial class ThatEvents
 					             ]
 					             """);
 			}
+
+#if NET8_0_OR_GREATER
+			public sealed class AsyncEnumerableTests
+			{
+				[Fact]
+				public async Task WhenAllEventsHaveAttribute_ShouldSucceed()
+				{
+					IAsyncEnumerable<EventInfo?> subject = new[]
+					{
+						typeof(TestClass).GetEvent("TestEvent1")!, typeof(TestClass).GetEvent("TestEvent2")!,
+					}.ToTestAsyncEnumerable<EventInfo?>();
+
+					async Task Act()
+					{
+						await That(subject).Have<TestAttribute>();
+					}
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenNotAllEventsHaveAttribute_ShouldFail()
+				{
+					IAsyncEnumerable<EventInfo?> subject = new[]
+					{
+						typeof(TestClass).GetEvent("TestEvent1")!, typeof(TestClass).GetEvent("NoAttributeEvent")!,
+					}.ToTestAsyncEnumerable<EventInfo?>();
+
+					async Task Act()
+					{
+						await That(subject).Have<TestAttribute>();
+					}
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             all have ThatEvents.Have.AttributeTests.TestAttribute,
+						             but it contained not matching events [
+						               event Action ThatEvents.Have.AttributeTests.TestClass.NoAttributeEvent
+						             ]
+						             """);
+				}
+
+				[Fact]
+				public async Task WhenAllEventsHaveMatchingAttribute_ShouldSucceed()
+				{
+					IAsyncEnumerable<EventInfo?> subject = new[]
+					{
+						typeof(TestClass).GetEvent("TestEvent1")!, typeof(TestClass).GetEvent("TestEvent2")!,
+					}.ToTestAsyncEnumerable<EventInfo?>();
+
+					async Task Act()
+					{
+						await That(subject).Have<TestAttribute>(attr => attr.Value.StartsWith("Event"));
+					}
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenNotAllEventsHaveMatchingAttribute_ShouldFail()
+				{
+					IAsyncEnumerable<EventInfo?> subject = new[]
+					{
+						typeof(TestClass).GetEvent("TestEvent1")!, typeof(TestClass).GetEvent("TestEvent2")!,
+					}.ToTestAsyncEnumerable<EventInfo?>();
+
+					async Task Act()
+					{
+						await That(subject).Have<TestAttribute>(attr => attr.Value == "WrongValue");
+					}
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             all have ThatEvents.Have.AttributeTests.TestAttribute matching attr => attr.Value == "WrongValue",
+						             but it contained not matching events [
+						               event Action ThatEvents.Have.AttributeTests.TestClass.TestEvent1,
+						               event Action ThatEvents.Have.AttributeTests.TestClass.TestEvent2
+						             ]
+						             """);
+				}
+			}
+#endif
 
 			[AttributeUsage(AttributeTargets.Event)]
 			private class TestAttribute : Attribute

--- a/Tests/aweXpect.Reflection.Tests/ThatField.IsOfExactType.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatField.IsOfExactType.Tests.cs
@@ -142,6 +142,24 @@ public sealed partial class ThatField
 
 				await That(Act).DoesNotThrow();
 			}
+
+			[Fact]
+			public async Task WhenFieldStrictlyInheritsFromOrOfExactType_ShouldFail()
+			{
+				FieldInfo subject = typeof(TestClass).GetField(nameof(TestClass.DummyField))!;
+
+				async Task Act()
+				{
+					await That(subject).IsOfExactType<int>().OrOfExactType<DummyBase>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is of exact type int or of exact type *DummyBase,
+					             but it was of type *Dummy
+					             """).AsWildcard();
+			}
 		}
 #pragma warning restore CA2263
 	}

--- a/Tests/aweXpect.Reflection.Tests/ThatFields.AreNotStatic.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatFields.AreNotStatic.Tests.cs
@@ -1,6 +1,9 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
+#if NET8_0_OR_GREATER
+using aweXpect.Reflection.Tests.TestHelpers;
+#endif
 
 namespace aweXpect.Reflection.Tests;
 
@@ -85,5 +88,48 @@ public sealed partial class ThatFields
 					             """).AsWildcard();
 			}
 		}
+
+#if NET8_0_OR_GREATER
+		public sealed class AsyncEnumerableTests
+		{
+			[Fact]
+			public async Task WhenFieldsContainStaticFields_ShouldFail()
+			{
+				IAsyncEnumerable<FieldInfo?> subject = typeof(TestClassWithStaticMembers)
+					.GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance |
+					           BindingFlags.DeclaredOnly)
+					.ToTestAsyncEnumerable<FieldInfo?>();
+
+				async Task Act()
+				{
+					await That(subject).AreNotStatic();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             are all not static,
+					             but it contained static fields [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenFilteringOnlyNonStaticFields_ShouldSucceed()
+			{
+				IAsyncEnumerable<FieldInfo?> subject = typeof(TestClassWithStaticMembers)
+					.GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly)
+					.ToTestAsyncEnumerable<FieldInfo?>();
+
+				async Task Act()
+				{
+					await That(subject).AreNotStatic();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+#endif
 	}
 }

--- a/Tests/aweXpect.Reflection.Tests/ThatFields.AreOfExactType.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatFields.AreOfExactType.Tests.cs
@@ -1,6 +1,9 @@
 ﻿using System.Collections.Generic;
 using System.Reflection;
 using Xunit.Sdk;
+#if NET8_0_OR_GREATER
+using aweXpect.Reflection.Tests.TestHelpers;
+#endif
 
 namespace aweXpect.Reflection.Tests;
 
@@ -68,7 +71,74 @@ public sealed partial class ThatFields
 
 				await That(Act).DoesNotThrow();
 			}
+
+			[Fact]
+			public async Task WhenFieldStrictlyInheritsFromOrOfExactType_ShouldFail()
+			{
+				IEnumerable<FieldInfo> subject =
+				[
+					typeof(TestClass).GetField(nameof(TestClass.DummyField))!,
+				];
+
+				async Task Act()
+				{
+					await That(subject).AreOfExactType<int>().OrOfExactType<DummyBase>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             all are of exact type int or of exact type *DummyBase,
+					             but it contained not matching fields [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
 		}
+
+#if NET8_0_OR_GREATER
+		public sealed class AsyncEnumerableTests
+		{
+			[Fact]
+			public async Task ShouldSucceedWhenAllFieldsAreOfExactType()
+			{
+				IAsyncEnumerable<FieldInfo?> subject = new[]
+				{
+					typeof(TestClass).GetField(nameof(TestClass.DummyBaseField))!,
+				}.ToTestAsyncEnumerable<FieldInfo?>();
+
+				async Task Act()
+				{
+					await That(subject).AreOfExactType<DummyBase>();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task ShouldFailWhenFieldsInheritFromType()
+			{
+				IAsyncEnumerable<FieldInfo?> subject = new[]
+				{
+					typeof(TestClass).GetField(nameof(TestClass.DummyField))!,
+				}.ToTestAsyncEnumerable<FieldInfo?>();
+
+				async Task Act()
+				{
+					await That(subject).AreOfExactType<DummyBase>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             all are of exact type *DummyBase,
+					             but it contained not matching fields [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+		}
+#endif
 
 		private class TestClass
 		{

--- a/Tests/aweXpect.Reflection.Tests/ThatFields.AreOfType.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatFields.AreOfType.Tests.cs
@@ -1,6 +1,9 @@
 ﻿using System.Collections.Generic;
 using System.Reflection;
 using Xunit.Sdk;
+#if NET8_0_OR_GREATER
+using aweXpect.Reflection.Tests.TestHelpers;
+#endif
 
 namespace aweXpect.Reflection.Tests;
 
@@ -111,6 +114,68 @@ public sealed partial class ThatFields
 				await That(Act).DoesNotThrow();
 			}
 		}
+
+#if NET8_0_OR_GREATER
+		public sealed class AsyncEnumerableTests
+		{
+			[Fact]
+			public async Task ShouldSucceedWhenAllFieldsAreOfType()
+			{
+				IAsyncEnumerable<FieldInfo?> subject = new[]
+				{
+					typeof(TestClass).GetField(nameof(TestClass.IntField))!,
+					typeof(TestClass).GetField(nameof(TestClass.OtherIntField))!,
+				}.ToTestAsyncEnumerable<FieldInfo?>();
+
+				async Task Act()
+				{
+					await That(subject).AreOfType<int>();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task ShouldSucceedWithInheritance()
+			{
+				IAsyncEnumerable<FieldInfo?> subject = new[]
+				{
+					typeof(TestClass).GetField(nameof(TestClass.DummyField))!,
+				}.ToTestAsyncEnumerable<FieldInfo?>();
+
+				async Task Act()
+				{
+					await That(subject).AreOfType<DummyBase>();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task ShouldFailWhenSomeFieldsAreNotOfType()
+			{
+				IAsyncEnumerable<FieldInfo?> subject = new[]
+				{
+					typeof(TestClass).GetField(nameof(TestClass.IntField))!,
+					typeof(TestClass).GetField(nameof(TestClass.StringField))!,
+				}.ToTestAsyncEnumerable<FieldInfo?>();
+
+				async Task Act()
+				{
+					await That(subject).AreOfType<int>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             all are of type int,
+					             but it contained not matching fields [
+					               string ThatFields.AreOfType.TestClass.StringField
+					             ]
+					             """);
+			}
+		}
+#endif
 
 		private class TestClass
 		{

--- a/Tests/aweXpect.Reflection.Tests/ThatFields.AreStatic.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatFields.AreStatic.Tests.cs
@@ -1,6 +1,9 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
+#if NET8_0_OR_GREATER
+using aweXpect.Reflection.Tests.TestHelpers;
+#endif
 
 namespace aweXpect.Reflection.Tests;
 
@@ -85,5 +88,70 @@ public sealed partial class ThatFields
 					             """).AsWildcard();
 			}
 		}
+
+#if NET8_0_OR_GREATER
+		public sealed class AsyncEnumerableTests
+		{
+			[Fact]
+			public async Task WhenFieldsContainNonStaticFields_ShouldFail()
+			{
+				IAsyncEnumerable<FieldInfo?> subject = typeof(TestClassWithStaticMembers)
+					.GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance |
+					           BindingFlags.DeclaredOnly)
+					.ToTestAsyncEnumerable<FieldInfo?>();
+
+				async Task Act()
+				{
+					await That(subject).AreStatic();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             are all static,
+					             but it contained non-static fields [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenFilteringOnlyStaticFields_ShouldSucceed()
+			{
+				IAsyncEnumerable<FieldInfo?> subject = typeof(TestClassWithStaticMembers)
+					.GetFields(BindingFlags.Static | BindingFlags.Public | BindingFlags.DeclaredOnly)
+					.ToTestAsyncEnumerable<FieldInfo?>();
+
+				async Task Act()
+				{
+					await That(subject).AreStatic();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenFilteringOnlyStaticFields_Negated_ShouldFail()
+			{
+				IAsyncEnumerable<FieldInfo?> subject = typeof(TestClassWithStaticMembers)
+					.GetFields(BindingFlags.Static | BindingFlags.Public | BindingFlags.DeclaredOnly)
+					.ToTestAsyncEnumerable<FieldInfo?>();
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(they => they.AreStatic());
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             are not all static,
+					             but it only contained static fields [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+		}
+#endif
 	}
 }

--- a/Tests/aweXpect.Reflection.Tests/ThatFields.Have.AttributeTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatFields.Have.AttributeTests.cs
@@ -1,6 +1,9 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Reflection;
 using Xunit.Sdk;
+#if NET8_0_OR_GREATER
+using aweXpect.Reflection.Tests.TestHelpers;
+#endif
 
 namespace aweXpect.Reflection.Tests;
 
@@ -88,6 +91,90 @@ public sealed partial class ThatFields
 					             ]
 					             """);
 			}
+
+#if NET8_0_OR_GREATER
+			public sealed class AsyncEnumerableTests
+			{
+				[Fact]
+				public async Task WhenAllFieldsHaveAttribute_ShouldSucceed()
+				{
+					IAsyncEnumerable<FieldInfo?> subject = new[]
+					{
+						typeof(TestClass).GetField("TestField1")!, typeof(TestClass).GetField("TestField2")!,
+					}.ToTestAsyncEnumerable<FieldInfo?>();
+
+					async Task Act()
+					{
+						await That(subject).Have<TestAttribute>();
+					}
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenNotAllFieldsHaveAttribute_ShouldFail()
+				{
+					IAsyncEnumerable<FieldInfo?> subject = new[]
+					{
+						typeof(TestClass).GetField("TestField1")!, typeof(TestClass).GetField("NoAttributeField")!,
+					}.ToTestAsyncEnumerable<FieldInfo?>();
+
+					async Task Act()
+					{
+						await That(subject).Have<TestAttribute>();
+					}
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             all have ThatFields.Have.AttributeTests.TestAttribute,
+						             but it contained not matching fields [
+						               string ThatFields.Have.AttributeTests.TestClass.NoAttributeField
+						             ]
+						             """);
+				}
+
+				[Fact]
+				public async Task WhenAllFieldsHaveMatchingAttribute_ShouldSucceed()
+				{
+					IAsyncEnumerable<FieldInfo?> subject = new[]
+					{
+						typeof(TestClass).GetField("TestField1")!, typeof(TestClass).GetField("TestField2")!,
+					}.ToTestAsyncEnumerable<FieldInfo?>();
+
+					async Task Act()
+					{
+						await That(subject).Have<TestAttribute>(attr => attr.Value.StartsWith("Field"));
+					}
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenNotAllFieldsHaveMatchingAttribute_ShouldFail()
+				{
+					IAsyncEnumerable<FieldInfo?> subject = new[]
+					{
+						typeof(TestClass).GetField("TestField1")!, typeof(TestClass).GetField("TestField2")!,
+					}.ToTestAsyncEnumerable<FieldInfo?>();
+
+					async Task Act()
+					{
+						await That(subject).Have<TestAttribute>(attr => attr.Value == "WrongValue");
+					}
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             all have ThatFields.Have.AttributeTests.TestAttribute matching attr => attr.Value == "WrongValue",
+						             but it contained not matching fields [
+						               string ThatFields.Have.AttributeTests.TestClass.TestField1,
+						               string ThatFields.Have.AttributeTests.TestClass.TestField2
+						             ]
+						             """);
+				}
+			}
+#endif
 
 			[AttributeUsage(AttributeTargets.Field)]
 			private class TestAttribute : Attribute

--- a/Tests/aweXpect.Reflection.Tests/ThatMethods.AreGeneric.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethods.AreGeneric.Tests.cs
@@ -1,4 +1,7 @@
+using System.Collections.Generic;
+using System.Reflection;
 using aweXpect.Reflection.Collections;
+using Xunit.Sdk;
 
 namespace aweXpect.Reflection.Tests;
 
@@ -6,6 +9,48 @@ public sealed partial class ThatMethods
 {
 	public sealed partial class AreGeneric
 	{
+		public sealed class EnumerableTests
+		{
+			[Fact]
+			public async Task WhenAllMethodsAreGeneric_ShouldSucceed()
+			{
+				IEnumerable<MethodInfo> subject =
+				[
+					typeof(ClassWithMethods).GetMethod(nameof(ClassWithMethods.GenericMethod1))!,
+				];
+
+				async Task Act()
+				{
+					await That(subject).AreGeneric();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenMethodIsNotGeneric_ShouldFail()
+			{
+				IEnumerable<MethodInfo> subject =
+				[
+					typeof(ClassWithMethods).GetMethod(nameof(ClassWithMethods.NonGenericMethod1))!,
+				];
+
+				async Task Act()
+				{
+					await That(subject).AreGeneric();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             are all generic,
+					             but it contained not matching methods [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+		}
+
 		public sealed class Tests
 		{
 			[Fact]

--- a/Tests/aweXpect.Reflection.Tests/ThatMethods.AreNotGeneric.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethods.AreNotGeneric.Tests.cs
@@ -1,4 +1,7 @@
+using System.Collections.Generic;
+using System.Reflection;
 using aweXpect.Reflection.Collections;
+using Xunit.Sdk;
 
 namespace aweXpect.Reflection.Tests;
 
@@ -6,6 +9,48 @@ public sealed partial class ThatMethods
 {
 	public sealed class AreNotGeneric
 	{
+		public sealed class EnumerableTests
+		{
+			[Fact]
+			public async Task WhenAllMethodsAreNotGeneric_ShouldSucceed()
+			{
+				IEnumerable<MethodInfo> subject =
+				[
+					typeof(ClassWithMethods).GetMethod(nameof(ClassWithMethods.NonGenericMethod1))!,
+				];
+
+				async Task Act()
+				{
+					await That(subject).AreNotGeneric();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenMethodIsGeneric_ShouldFail()
+			{
+				IEnumerable<MethodInfo> subject =
+				[
+					typeof(ClassWithMethods).GetMethod(nameof(ClassWithMethods.GenericMethod1))!,
+				];
+
+				async Task Act()
+				{
+					await That(subject).AreNotGeneric();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             are all not generic,
+					             but it contained generic methods [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+		}
+
 		public sealed class Tests
 		{
 			[Fact]

--- a/Tests/aweXpect.Reflection.Tests/ThatMethods.AreNotInternal.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethods.AreNotInternal.Tests.cs
@@ -1,4 +1,6 @@
-﻿using aweXpect.Reflection.Collections;
+﻿using System.Collections.Generic;
+using System.Reflection;
+using aweXpect.Reflection.Collections;
 using Xunit.Sdk;
 
 namespace aweXpect.Reflection.Tests;
@@ -7,6 +9,50 @@ public sealed partial class ThatMethods
 {
 	public sealed class AreNotInternal
 	{
+		public sealed class EnumerableTests
+		{
+			[Fact]
+			public async Task WhenAllMethodsAreNotInternal_ShouldSucceed()
+			{
+				IEnumerable<MethodInfo> subject =
+				[
+					typeof(ClassWithMethods).GetMethod("PublicMethod1",
+						BindingFlags.Public | BindingFlags.Instance)!,
+				];
+
+				async Task Act()
+				{
+					await That(subject).AreNotInternal();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenMethodIsInternal_ShouldFail()
+			{
+				IEnumerable<MethodInfo> subject =
+				[
+					typeof(ClassWithMethods).GetMethod("InternalMethod1",
+						BindingFlags.NonPublic | BindingFlags.Instance)!,
+				];
+
+				async Task Act()
+				{
+					await That(subject).AreNotInternal();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             all are not internal,
+					             but it contained internal items [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+		}
+
 		public sealed class Tests
 		{
 			[Fact]

--- a/Tests/aweXpect.Reflection.Tests/ThatMethods.AreNotPrivate.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethods.AreNotPrivate.Tests.cs
@@ -1,4 +1,6 @@
-﻿using aweXpect.Reflection.Collections;
+﻿using System.Collections.Generic;
+using System.Reflection;
+using aweXpect.Reflection.Collections;
 using Xunit.Sdk;
 
 namespace aweXpect.Reflection.Tests;
@@ -7,6 +9,50 @@ public sealed partial class ThatMethods
 {
 	public sealed class AreNotPrivate
 	{
+		public sealed class EnumerableTests
+		{
+			[Fact]
+			public async Task WhenAllMethodsAreNotPrivate_ShouldSucceed()
+			{
+				IEnumerable<MethodInfo> subject =
+				[
+					typeof(ClassWithMethods).GetMethod("PublicMethod1",
+						BindingFlags.Public | BindingFlags.Instance)!,
+				];
+
+				async Task Act()
+				{
+					await That(subject).AreNotPrivate();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenMethodIsPrivate_ShouldFail()
+			{
+				IEnumerable<MethodInfo> subject =
+				[
+					typeof(ClassWithMethods).GetMethod("PrivateMethod1",
+						BindingFlags.NonPublic | BindingFlags.Instance)!,
+				];
+
+				async Task Act()
+				{
+					await That(subject).AreNotPrivate();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             all are not private,
+					             but it contained private items [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+		}
+
 		public sealed class Tests
 		{
 			[Theory]

--- a/Tests/aweXpect.Reflection.Tests/ThatMethods.AreNotPrivateProtected.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethods.AreNotPrivateProtected.Tests.cs
@@ -1,4 +1,6 @@
-﻿using aweXpect.Reflection.Collections;
+﻿using System.Collections.Generic;
+using System.Reflection;
+using aweXpect.Reflection.Collections;
 using Xunit.Sdk;
 
 namespace aweXpect.Reflection.Tests;
@@ -7,6 +9,50 @@ public sealed partial class ThatMethods
 {
 	public sealed class AreNotPrivateProtected
 	{
+		public sealed class EnumerableTests
+		{
+			[Fact]
+			public async Task WhenAllMethodsAreNotPrivateProtected_ShouldSucceed()
+			{
+				IEnumerable<MethodInfo> subject =
+				[
+					typeof(ClassWithMethods).GetMethod("PublicMethod1",
+						BindingFlags.Public | BindingFlags.Instance)!,
+				];
+
+				async Task Act()
+				{
+					await That(subject).AreNotPrivateProtected();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenMethodIsPrivateProtected_ShouldFail()
+			{
+				IEnumerable<MethodInfo> subject =
+				[
+					typeof(ClassWithMethods).GetMethod("PrivateProtectedMethod1",
+						BindingFlags.NonPublic | BindingFlags.Instance)!,
+				];
+
+				async Task Act()
+				{
+					await That(subject).AreNotPrivateProtected();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             all are not private protected,
+					             but it contained private protected items [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+		}
+
 		public sealed class Tests
 		{
 			[Theory]

--- a/Tests/aweXpect.Reflection.Tests/ThatMethods.AreNotProtected.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethods.AreNotProtected.Tests.cs
@@ -1,4 +1,6 @@
-﻿using aweXpect.Reflection.Collections;
+﻿using System.Collections.Generic;
+using System.Reflection;
+using aweXpect.Reflection.Collections;
 using Xunit.Sdk;
 
 namespace aweXpect.Reflection.Tests;
@@ -7,6 +9,50 @@ public sealed partial class ThatMethods
 {
 	public sealed class AreNotProtected
 	{
+		public sealed class EnumerableTests
+		{
+			[Fact]
+			public async Task WhenAllMethodsAreNotProtected_ShouldSucceed()
+			{
+				IEnumerable<MethodInfo> subject =
+				[
+					typeof(ClassWithMethods).GetMethod("PublicMethod1",
+						BindingFlags.Public | BindingFlags.Instance)!,
+				];
+
+				async Task Act()
+				{
+					await That(subject).AreNotProtected();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenMethodIsProtected_ShouldFail()
+			{
+				IEnumerable<MethodInfo> subject =
+				[
+					typeof(ClassWithMethods).GetMethod("ProtectedMethod1",
+						BindingFlags.NonPublic | BindingFlags.Instance)!,
+				];
+
+				async Task Act()
+				{
+					await That(subject).AreNotProtected();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             all are not protected,
+					             but it contained protected items [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+		}
+
 		public sealed class Tests
 		{
 			[Theory]

--- a/Tests/aweXpect.Reflection.Tests/ThatMethods.AreNotProtectedInternal.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethods.AreNotProtectedInternal.Tests.cs
@@ -1,4 +1,6 @@
-﻿using aweXpect.Reflection.Collections;
+﻿using System.Collections.Generic;
+using System.Reflection;
+using aweXpect.Reflection.Collections;
 using Xunit.Sdk;
 
 namespace aweXpect.Reflection.Tests;
@@ -7,6 +9,50 @@ public sealed partial class ThatMethods
 {
 	public sealed class AreNotProtectedInternal
 	{
+		public sealed class EnumerableTests
+		{
+			[Fact]
+			public async Task WhenAllMethodsAreNotProtectedInternal_ShouldSucceed()
+			{
+				IEnumerable<MethodInfo> subject =
+				[
+					typeof(ClassWithMethods).GetMethod("PublicMethod1",
+						BindingFlags.Public | BindingFlags.Instance)!,
+				];
+
+				async Task Act()
+				{
+					await That(subject).AreNotProtectedInternal();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenMethodIsProtectedInternal_ShouldFail()
+			{
+				IEnumerable<MethodInfo> subject =
+				[
+					typeof(ClassWithMethods).GetMethod("ProtectedInternalMethod1",
+						BindingFlags.NonPublic | BindingFlags.Instance)!,
+				];
+
+				async Task Act()
+				{
+					await That(subject).AreNotProtectedInternal();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             all are not protected internal,
+					             but it contained protected internal items [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+		}
+
 		public sealed class Tests
 		{
 			[Theory]

--- a/Tests/aweXpect.Reflection.Tests/ThatMethods.AreNotPublic.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethods.AreNotPublic.Tests.cs
@@ -1,4 +1,6 @@
-﻿using aweXpect.Reflection.Collections;
+﻿using System.Collections.Generic;
+using System.Reflection;
+using aweXpect.Reflection.Collections;
 using Xunit.Sdk;
 
 namespace aweXpect.Reflection.Tests;
@@ -7,6 +9,50 @@ public sealed partial class ThatMethods
 {
 	public sealed class AreNotPublic
 	{
+		public sealed class EnumerableTests
+		{
+			[Fact]
+			public async Task WhenAllMethodsAreNotPublic_ShouldSucceed()
+			{
+				IEnumerable<MethodInfo> subject =
+				[
+					typeof(ClassWithMethods).GetMethod("InternalMethod1",
+						BindingFlags.NonPublic | BindingFlags.Instance)!,
+				];
+
+				async Task Act()
+				{
+					await That(subject).AreNotPublic();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenMethodIsPublic_ShouldFail()
+			{
+				IEnumerable<MethodInfo> subject =
+				[
+					typeof(ClassWithMethods).GetMethod("PublicMethod1",
+						BindingFlags.Public | BindingFlags.Instance)!,
+				];
+
+				async Task Act()
+				{
+					await That(subject).AreNotPublic();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             all are not public,
+					             but it contained public items [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+		}
+
 		public sealed class Tests
 		{
 			[Theory]

--- a/Tests/aweXpect.Reflection.Tests/ThatMethods.AreNotSealed.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethods.AreNotSealed.Tests.cs
@@ -1,6 +1,9 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
+#if NET8_0_OR_GREATER
+using aweXpect.Reflection.Tests.TestHelpers;
+#endif
 
 namespace aweXpect.Reflection.Tests;
 
@@ -83,5 +86,47 @@ public sealed partial class ThatMethods
 				await That(Act).DoesNotThrow();
 			}
 		}
+
+#if NET8_0_OR_GREATER
+		public sealed class AsyncEnumerableTests
+		{
+			[Fact]
+			public async Task WhenFilteringOnlyNonSealedMethods_ShouldSucceed()
+			{
+				IAsyncEnumerable<MethodInfo?> subject = typeof(AbstractClassWithMembers)
+					.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+					.ToTestAsyncEnumerable<MethodInfo?>();
+
+				async Task Act()
+				{
+					await That(subject).AreNotSealed();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenMethodsContainSealedMethods_ShouldFail()
+			{
+				IAsyncEnumerable<MethodInfo?> subject = typeof(ClassWithSealedMembers)
+					.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+					.ToTestAsyncEnumerable<MethodInfo?>();
+
+				async Task Act()
+				{
+					await That(subject).AreNotSealed();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             are all not sealed,
+					             but it contained sealed methods [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+		}
+#endif
 	}
 }

--- a/Tests/aweXpect.Reflection.Tests/ThatMethods.AreNotStatic.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethods.AreNotStatic.Tests.cs
@@ -1,6 +1,9 @@
 ﻿using System.Collections.Generic;
 using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
+#if NET8_0_OR_GREATER
+using aweXpect.Reflection.Tests.TestHelpers;
+#endif
 
 namespace aweXpect.Reflection.Tests;
 
@@ -85,5 +88,48 @@ public sealed partial class ThatMethods
 				await That(Act).DoesNotThrow();
 			}
 		}
+
+#if NET8_0_OR_GREATER
+		public sealed class AsyncEnumerableTests
+		{
+			[Fact]
+			public async Task WhenFilteringOnlyNonStaticMethods_ShouldSucceed()
+			{
+				IAsyncEnumerable<MethodInfo?> subject = typeof(TestClassWithStaticMembers)
+					.GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly)
+					.ToTestAsyncEnumerable<MethodInfo?>();
+
+				async Task Act()
+				{
+					await That(subject).AreNotStatic();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenMethodsContainStaticMethods_ShouldFail()
+			{
+				IAsyncEnumerable<MethodInfo?> subject = typeof(TestClassWithStaticMembers)
+					.GetMethods(BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance |
+					            BindingFlags.DeclaredOnly)
+					.ToTestAsyncEnumerable<MethodInfo?>();
+
+				async Task Act()
+				{
+					await That(subject).AreNotStatic();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             are all not static,
+					             but it contained static methods [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+		}
+#endif
 	}
 }

--- a/Tests/aweXpect.Reflection.Tests/ThatMethods.AreStatic.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethods.AreStatic.Tests.cs
@@ -1,6 +1,9 @@
 ﻿using System.Collections.Generic;
 using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
+#if NET8_0_OR_GREATER
+using aweXpect.Reflection.Tests.TestHelpers;
+#endif
 
 namespace aweXpect.Reflection.Tests;
 
@@ -85,5 +88,70 @@ public sealed partial class ThatMethods
 				await That(Act).DoesNotThrow();
 			}
 		}
+
+#if NET8_0_OR_GREATER
+		public sealed class AsyncEnumerableTests
+		{
+			[Fact]
+			public async Task WhenFilteringOnlyStaticMethods_ShouldSucceed()
+			{
+				IAsyncEnumerable<MethodInfo?> subject = typeof(TestClassWithStaticMembers)
+					.GetMethods(BindingFlags.Static | BindingFlags.Public | BindingFlags.DeclaredOnly)
+					.ToTestAsyncEnumerable<MethodInfo?>();
+
+				async Task Act()
+				{
+					await That(subject).AreStatic();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenMethodsContainNonStaticMethods_ShouldFail()
+			{
+				IAsyncEnumerable<MethodInfo?> subject = typeof(TestClassWithStaticMembers)
+					.GetMethods(BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance |
+					            BindingFlags.DeclaredOnly)
+					.ToTestAsyncEnumerable<MethodInfo?>();
+
+				async Task Act()
+				{
+					await That(subject).AreStatic();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             are all static,
+					             but it contained non-static methods [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenFilteringOnlyStaticMethods_Negated_ShouldFail()
+			{
+				IAsyncEnumerable<MethodInfo?> subject = typeof(TestClassWithStaticMembers)
+					.GetMethods(BindingFlags.Static | BindingFlags.Public | BindingFlags.DeclaredOnly)
+					.ToTestAsyncEnumerable<MethodInfo?>();
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(they => they.AreStatic());
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             are not all static,
+					             but it only contained static methods [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+		}
+#endif
 	}
 }

--- a/Tests/aweXpect.Reflection.Tests/ThatMethods.Have.AttributeTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethods.Have.AttributeTests.cs
@@ -1,6 +1,9 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Reflection;
 using Xunit.Sdk;
+#if NET8_0_OR_GREATER
+using aweXpect.Reflection.Tests.TestHelpers;
+#endif
 
 namespace aweXpect.Reflection.Tests;
 
@@ -88,6 +91,90 @@ public sealed partial class ThatMethods
 					             ]
 					             """);
 			}
+
+#if NET8_0_OR_GREATER
+			public sealed class AsyncEnumerableTests
+			{
+				[Fact]
+				public async Task WhenAllMethodsHaveAttribute_ShouldSucceed()
+				{
+					IAsyncEnumerable<MethodInfo?> subject = new[]
+					{
+						typeof(TestClass).GetMethod("TestMethod1")!, typeof(TestClass).GetMethod("TestMethod2")!,
+					}.ToTestAsyncEnumerable<MethodInfo?>();
+
+					async Task Act()
+					{
+						await That(subject).Have<TestAttribute>();
+					}
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenNotAllMethodsHaveAttribute_ShouldFail()
+				{
+					IAsyncEnumerable<MethodInfo?> subject = new[]
+					{
+						typeof(TestClass).GetMethod("TestMethod1")!, typeof(TestClass).GetMethod("NoAttributeMethod")!,
+					}.ToTestAsyncEnumerable<MethodInfo?>();
+
+					async Task Act()
+					{
+						await That(subject).Have<TestAttribute>();
+					}
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             all have ThatMethods.Have.AttributeTests.TestAttribute,
+						             but it contained not matching methods [
+						               void ThatMethods.Have.AttributeTests.TestClass.NoAttributeMethod()
+						             ]
+						             """);
+				}
+
+				[Fact]
+				public async Task WhenAllMethodsHaveMatchingAttribute_ShouldSucceed()
+				{
+					IAsyncEnumerable<MethodInfo?> subject = new[]
+					{
+						typeof(TestClass).GetMethod("TestMethod1")!, typeof(TestClass).GetMethod("TestMethod2")!,
+					}.ToTestAsyncEnumerable<MethodInfo?>();
+
+					async Task Act()
+					{
+						await That(subject).Have<TestAttribute>(attr => attr.Value.StartsWith("Method"));
+					}
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenNotAllMethodsHaveMatchingAttribute_ShouldFail()
+				{
+					IAsyncEnumerable<MethodInfo?> subject = new[]
+					{
+						typeof(TestClass).GetMethod("TestMethod1")!, typeof(TestClass).GetMethod("TestMethod2")!,
+					}.ToTestAsyncEnumerable<MethodInfo?>();
+
+					async Task Act()
+					{
+						await That(subject).Have<TestAttribute>(attr => attr.Value == "WrongValue");
+					}
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             all have ThatMethods.Have.AttributeTests.TestAttribute matching attr => attr.Value == "WrongValue",
+						             but it contained not matching methods [
+						               void ThatMethods.Have.AttributeTests.TestClass.TestMethod1(),
+						               void ThatMethods.Have.AttributeTests.TestClass.TestMethod2()
+						             ]
+						             """);
+				}
+			}
+#endif
 
 			[AttributeUsage(AttributeTargets.Method)]
 			private class TestAttribute : Attribute

--- a/Tests/aweXpect.Reflection.Tests/ThatMethods.HaveName.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethods.HaveName.Tests.cs
@@ -1,4 +1,6 @@
-﻿using aweXpect.Reflection.Collections;
+﻿using System.Collections.Generic;
+using System.Reflection;
+using aweXpect.Reflection.Collections;
 using Xunit.Sdk;
 
 namespace aweXpect.Reflection.Tests;
@@ -7,6 +9,90 @@ public sealed partial class ThatMethods
 {
 	public sealed class HaveName
 	{
+		public sealed class EnumerableTests
+		{
+			[Fact]
+			public async Task WhenAllMethodsHaveName_ShouldSucceed()
+			{
+				IEnumerable<MethodInfo> subject =
+				[
+					typeof(ClassWithMethods).GetMethod(nameof(ClassWithMethods.PublicMethod1))!,
+				];
+
+				async Task Act()
+				{
+					await That(subject).HaveName("PublicMethod1");
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSelectorMatchesEachName_ShouldSucceed()
+			{
+				IEnumerable<MethodInfo> subject =
+				[
+					typeof(ClassWithMethods).GetMethod(nameof(ClassWithMethods.PublicMethod1))!,
+					typeof(ClassWithMethods).GetMethod(nameof(ClassWithMethods.PublicMethod2))!,
+				];
+
+				async Task Act()
+				{
+					await That(subject).HaveName(method => method.Name);
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenMultipleMethodsDoNotMatchSelector_ShouldListAllSeparatedByComma()
+			{
+				IEnumerable<MethodInfo> subject =
+				[
+					typeof(ClassWithMethods).GetMethod(nameof(ClassWithMethods.PublicMethod1))!,
+					typeof(ClassWithMethods).GetMethod(nameof(ClassWithMethods.PublicMethod2))!,
+				];
+
+				async Task Act()
+				{
+					await That(subject).HaveName(method => method.Name + "X");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             all have name matching method => method.Name + "X",
+					             but it contained not matching items [
+					               int ThatMethods.ClassWithMethods.PublicMethod1() with name "PublicMethod1" instead of "PublicMethod1X",
+					               int ThatMethods.ClassWithMethods.PublicMethod2() with name "PublicMethod2" instead of "PublicMethod2X"
+					             ]
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenSelectorMatchesEachName_Negated_ShouldFail()
+			{
+				IEnumerable<MethodInfo> subject =
+				[
+					typeof(ClassWithMethods).GetMethod(nameof(ClassWithMethods.PublicMethod1))!,
+				];
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(they => they.HaveName(method => method.Name));
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             not all have name matching method => method.Name,
+					             but it only contained matching items [
+					               int ThatMethods.ClassWithMethods.PublicMethod1()
+					             ]
+					             """);
+			}
+		}
+
 		public sealed class Tests
 		{
 			[Fact]

--- a/Tests/aweXpect.Reflection.Tests/ThatMethods.Return.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethods.Return.Tests.cs
@@ -1,4 +1,6 @@
-﻿using aweXpect.Reflection.Collections;
+﻿using System.Collections.Generic;
+using System.Reflection;
+using aweXpect.Reflection.Collections;
 using Xunit.Sdk;
 
 namespace aweXpect.Reflection.Tests;
@@ -9,6 +11,65 @@ public sealed partial class ThatMethods
 {
 	public sealed class Return
 	{
+		public sealed class EnumerableTests
+		{
+			[Fact]
+			public async Task ShouldSucceedWhenAllMethodsReturnSpecifiedType()
+			{
+				IEnumerable<MethodInfo> subject =
+				[
+					typeof(TestClass).GetMethod(nameof(TestClass.GetString))!,
+				];
+
+				async Task Act()
+				{
+					await That(subject).Return<string>();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task ShouldSucceedWithInheritance()
+			{
+				IEnumerable<MethodInfo> subject =
+				[
+					typeof(TestClass).GetMethod(nameof(TestClass.GetDummy))!,
+				];
+
+				async Task Act()
+				{
+					await That(subject).Return<DummyBase>();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task ShouldFailWhenSomeMethodsDoNotReturnSpecifiedType()
+			{
+				IEnumerable<MethodInfo> subject =
+				[
+					typeof(TestClass).GetMethod(nameof(TestClass.GetString))!,
+					typeof(TestClass).GetMethod(nameof(TestClass.GetInt))!,
+				];
+
+				async Task Act()
+				{
+					await That(subject).Return<string>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             all return string,
+					             but it contained not matching methods [
+					               int ThatMethods.TestClass.GetInt()
+					             ]
+					             """);
+			}
+		}
+
 		public sealed class GenericTests
 		{
 			[Fact]

--- a/Tests/aweXpect.Reflection.Tests/ThatMethods.ReturnExactly.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethods.ReturnExactly.Tests.cs
@@ -1,4 +1,6 @@
-﻿using aweXpect.Reflection.Collections;
+﻿using System.Collections.Generic;
+using System.Reflection;
+using aweXpect.Reflection.Collections;
 using Xunit.Sdk;
 
 namespace aweXpect.Reflection.Tests;
@@ -9,6 +11,48 @@ public sealed partial class ThatMethods
 {
 	public sealed class ReturnExactly
 	{
+		public sealed class EnumerableTests
+		{
+			[Fact]
+			public async Task ShouldSucceedWhenAllMethodsReturnExactType()
+			{
+				IEnumerable<MethodInfo> subject =
+				[
+					typeof(TestClass).GetMethod(nameof(TestClass.GetString))!,
+				];
+
+				async Task Act()
+				{
+					await That(subject).ReturnExactly<string>();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task ShouldFailWhenMethodsReturnInheritedType()
+			{
+				IEnumerable<MethodInfo> subject =
+				[
+					typeof(TestClass).GetMethod(nameof(TestClass.GetDummy))!,
+				];
+
+				async Task Act()
+				{
+					await That(subject).ReturnExactly<DummyBase>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             all return exactly *DummyBase,
+					             but it contained not matching methods [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+		}
+
 		public sealed class GenericTests
 		{
 			[Fact]

--- a/Tests/aweXpect.Reflection.Tests/ThatProperties.AreNotAbstract.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatProperties.AreNotAbstract.Tests.cs
@@ -1,7 +1,10 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
+#if NET8_0_OR_GREATER
+using aweXpect.Reflection.Tests.TestHelpers;
+#endif
 
 namespace aweXpect.Reflection.Tests;
 
@@ -86,5 +89,48 @@ public sealed partial class ThatProperties
 				await That(Act).DoesNotThrow();
 			}
 		}
+
+#if NET8_0_OR_GREATER
+		public sealed class AsyncEnumerableTests
+		{
+			[Fact]
+			public async Task WhenFilteringOnlyNonAbstractProperties_ShouldSucceed()
+			{
+				IAsyncEnumerable<PropertyInfo?> subject = typeof(AbstractClassWithMembers)
+					.GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+					.Where(p => p.GetGetMethod()?.IsAbstract != true && p.GetSetMethod()?.IsAbstract != true)
+					.ToTestAsyncEnumerable<PropertyInfo?>();
+
+				async Task Act()
+				{
+					await That(subject).AreNotAbstract();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenPropertiesContainAbstractProperties_ShouldFail()
+			{
+				IAsyncEnumerable<PropertyInfo?> subject = typeof(AbstractClassWithMembers)
+					.GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+					.ToTestAsyncEnumerable<PropertyInfo?>();
+
+				async Task Act()
+				{
+					await That(subject).AreNotAbstract();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             are all not abstract,
+					             but it contained abstract properties [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+		}
+#endif
 	}
 }

--- a/Tests/aweXpect.Reflection.Tests/ThatProperties.AreNotSealed.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatProperties.AreNotSealed.Tests.cs
@@ -1,6 +1,9 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
+#if NET8_0_OR_GREATER
+using aweXpect.Reflection.Tests.TestHelpers;
+#endif
 
 namespace aweXpect.Reflection.Tests;
 
@@ -83,5 +86,47 @@ public sealed partial class ThatProperties
 				await That(Act).DoesNotThrow();
 			}
 		}
+
+#if NET8_0_OR_GREATER
+		public sealed class AsyncEnumerableTests
+		{
+			[Fact]
+			public async Task WhenFilteringOnlyNonSealedProperties_ShouldSucceed()
+			{
+				IAsyncEnumerable<PropertyInfo?> subject = typeof(AbstractClassWithMembers)
+					.GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+					.ToTestAsyncEnumerable<PropertyInfo?>();
+
+				async Task Act()
+				{
+					await That(subject).AreNotSealed();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenPropertiesContainSealedProperties_ShouldFail()
+			{
+				IAsyncEnumerable<PropertyInfo?> subject = typeof(ClassWithSealedMembers)
+					.GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+					.ToTestAsyncEnumerable<PropertyInfo?>();
+
+				async Task Act()
+				{
+					await That(subject).AreNotSealed();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             are all not sealed,
+					             but it contained sealed properties [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+		}
+#endif
 	}
 }

--- a/Tests/aweXpect.Reflection.Tests/ThatProperties.AreNotStatic.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatProperties.AreNotStatic.Tests.cs
@@ -1,6 +1,9 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
+#if NET8_0_OR_GREATER
+using aweXpect.Reflection.Tests.TestHelpers;
+#endif
 
 namespace aweXpect.Reflection.Tests;
 
@@ -85,5 +88,48 @@ public sealed partial class ThatProperties
 				await That(Act).DoesNotThrow();
 			}
 		}
+
+#if NET8_0_OR_GREATER
+		public sealed class AsyncEnumerableTests
+		{
+			[Fact]
+			public async Task WhenFilteringOnlyNonStaticProperties_ShouldSucceed()
+			{
+				IAsyncEnumerable<PropertyInfo?> subject = typeof(TestClassWithStaticMembers)
+					.GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly)
+					.ToTestAsyncEnumerable<PropertyInfo?>();
+
+				async Task Act()
+				{
+					await That(subject).AreNotStatic();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenPropertiesContainStaticProperties_ShouldFail()
+			{
+				IAsyncEnumerable<PropertyInfo?> subject = typeof(TestClassWithStaticMembers)
+					.GetProperties(BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance |
+					               BindingFlags.DeclaredOnly)
+					.ToTestAsyncEnumerable<PropertyInfo?>();
+
+				async Task Act()
+				{
+					await That(subject).AreNotStatic();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             are all not static,
+					             but it contained static properties [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+		}
+#endif
 	}
 }

--- a/Tests/aweXpect.Reflection.Tests/ThatProperties.AreOfExactType.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatProperties.AreOfExactType.Tests.cs
@@ -1,6 +1,9 @@
 ﻿using System.Collections.Generic;
 using System.Reflection;
 using Xunit.Sdk;
+#if NET8_0_OR_GREATER
+using aweXpect.Reflection.Tests.TestHelpers;
+#endif
 
 namespace aweXpect.Reflection.Tests;
 
@@ -68,7 +71,74 @@ public sealed partial class ThatProperties
 
 				await That(Act).DoesNotThrow();
 			}
+
+			[Fact]
+			public async Task WhenPropertyStrictlyInheritsFromOrOfExactType_ShouldFail()
+			{
+				IEnumerable<PropertyInfo> subject =
+				[
+					typeof(TestClass).GetProperty(nameof(TestClass.DummyProperty))!,
+				];
+
+				async Task Act()
+				{
+					await That(subject).AreOfExactType<int>().OrOfExactType<DummyBase>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             all are of exact type int or of exact type *DummyBase,
+					             but it contained not matching properties [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
 		}
+
+#if NET8_0_OR_GREATER
+		public sealed class AsyncEnumerableTests
+		{
+			[Fact]
+			public async Task ShouldSucceedWhenAllPropertiesAreOfExactType()
+			{
+				IAsyncEnumerable<PropertyInfo?> subject = new[]
+				{
+					typeof(TestClass).GetProperty(nameof(TestClass.DummyBaseProperty))!,
+				}.ToTestAsyncEnumerable<PropertyInfo?>();
+
+				async Task Act()
+				{
+					await That(subject).AreOfExactType<DummyBase>();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task ShouldFailWhenPropertiesInheritFromType()
+			{
+				IAsyncEnumerable<PropertyInfo?> subject = new[]
+				{
+					typeof(TestClass).GetProperty(nameof(TestClass.DummyProperty))!,
+				}.ToTestAsyncEnumerable<PropertyInfo?>();
+
+				async Task Act()
+				{
+					await That(subject).AreOfExactType<DummyBase>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             all are of exact type *DummyBase,
+					             but it contained not matching properties [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+		}
+#endif
 
 		private class TestClass
 		{

--- a/Tests/aweXpect.Reflection.Tests/ThatProperties.AreOfType.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatProperties.AreOfType.Tests.cs
@@ -1,6 +1,9 @@
 ﻿using System.Collections.Generic;
 using System.Reflection;
 using Xunit.Sdk;
+#if NET8_0_OR_GREATER
+using aweXpect.Reflection.Tests.TestHelpers;
+#endif
 
 namespace aweXpect.Reflection.Tests;
 
@@ -111,6 +114,68 @@ public sealed partial class ThatProperties
 				await That(Act).DoesNotThrow();
 			}
 		}
+
+#if NET8_0_OR_GREATER
+		public sealed class AsyncEnumerableTests
+		{
+			[Fact]
+			public async Task ShouldSucceedWhenAllPropertiesAreOfType()
+			{
+				IAsyncEnumerable<PropertyInfo?> subject = new[]
+				{
+					typeof(TestClass).GetProperty(nameof(TestClass.IntProperty))!,
+					typeof(TestClass).GetProperty(nameof(TestClass.OtherIntProperty))!,
+				}.ToTestAsyncEnumerable<PropertyInfo?>();
+
+				async Task Act()
+				{
+					await That(subject).AreOfType<int>();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task ShouldSucceedWithInheritance()
+			{
+				IAsyncEnumerable<PropertyInfo?> subject = new[]
+				{
+					typeof(TestClass).GetProperty(nameof(TestClass.DummyProperty))!,
+				}.ToTestAsyncEnumerable<PropertyInfo?>();
+
+				async Task Act()
+				{
+					await That(subject).AreOfType<DummyBase>();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task ShouldFailWhenSomePropertiesAreNotOfType()
+			{
+				IAsyncEnumerable<PropertyInfo?> subject = new[]
+				{
+					typeof(TestClass).GetProperty(nameof(TestClass.IntProperty))!,
+					typeof(TestClass).GetProperty(nameof(TestClass.StringProperty))!,
+				}.ToTestAsyncEnumerable<PropertyInfo?>();
+
+				async Task Act()
+				{
+					await That(subject).AreOfType<int>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             all are of type int,
+					             but it contained not matching properties [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+		}
+#endif
 
 		private class TestClass
 		{

--- a/Tests/aweXpect.Reflection.Tests/ThatProperties.Have.AttributeTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatProperties.Have.AttributeTests.cs
@@ -1,6 +1,9 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Reflection;
 using Xunit.Sdk;
+#if NET8_0_OR_GREATER
+using aweXpect.Reflection.Tests.TestHelpers;
+#endif
 
 namespace aweXpect.Reflection.Tests;
 
@@ -88,6 +91,91 @@ public sealed partial class ThatProperties
 					             ]
 					             """);
 			}
+
+#if NET8_0_OR_GREATER
+			public sealed class AsyncEnumerableTests
+			{
+				[Fact]
+				public async Task WhenAllPropertiesHaveAttribute_ShouldSucceed()
+				{
+					IAsyncEnumerable<PropertyInfo?> subject = new[]
+					{
+						typeof(TestClass).GetProperty("TestProperty1")!, typeof(TestClass).GetProperty("TestProperty2")!,
+					}.ToTestAsyncEnumerable<PropertyInfo?>();
+
+					async Task Act()
+					{
+						await That(subject).Have<TestAttribute>();
+					}
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenNotAllPropertiesHaveAttribute_ShouldFail()
+				{
+					IAsyncEnumerable<PropertyInfo?> subject = new[]
+					{
+						typeof(TestClass).GetProperty("TestProperty1")!,
+						typeof(TestClass).GetProperty("NoAttributeProperty")!,
+					}.ToTestAsyncEnumerable<PropertyInfo?>();
+
+					async Task Act()
+					{
+						await That(subject).Have<TestAttribute>();
+					}
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             all have ThatProperties.Have.AttributeTests.TestAttribute,
+						             but it contained not matching properties [
+						               public string ThatProperties.Have.AttributeTests.TestClass.NoAttributeProperty { get; set; }
+						             ]
+						             """);
+				}
+
+				[Fact]
+				public async Task WhenAllPropertiesHaveMatchingAttribute_ShouldSucceed()
+				{
+					IAsyncEnumerable<PropertyInfo?> subject = new[]
+					{
+						typeof(TestClass).GetProperty("TestProperty1")!, typeof(TestClass).GetProperty("TestProperty2")!,
+					}.ToTestAsyncEnumerable<PropertyInfo?>();
+
+					async Task Act()
+					{
+						await That(subject).Have<TestAttribute>(attr => attr.Value.StartsWith("Property"));
+					}
+
+					await That(Act).DoesNotThrow();
+				}
+
+				[Fact]
+				public async Task WhenNotAllPropertiesHaveMatchingAttribute_ShouldFail()
+				{
+					IAsyncEnumerable<PropertyInfo?> subject = new[]
+					{
+						typeof(TestClass).GetProperty("TestProperty1")!, typeof(TestClass).GetProperty("TestProperty2")!,
+					}.ToTestAsyncEnumerable<PropertyInfo?>();
+
+					async Task Act()
+					{
+						await That(subject).Have<TestAttribute>(attr => attr.Value == "WrongValue");
+					}
+
+					await That(Act).Throws<XunitException>()
+						.WithMessage("""
+						             Expected that subject
+						             all have ThatProperties.Have.AttributeTests.TestAttribute matching attr => attr.Value == "WrongValue",
+						             but it contained not matching properties [
+						               public string ThatProperties.Have.AttributeTests.TestClass.TestProperty1 { get; set; },
+						               public string ThatProperties.Have.AttributeTests.TestClass.TestProperty2 { get; set; }
+						             ]
+						             """);
+				}
+			}
+#endif
 
 			[AttributeUsage(AttributeTargets.Property)]
 			private class TestAttribute : Attribute


### PR DESCRIPTION
Add tests targeting Stryker.NET survived/no-coverage mutants for the MISC chunk (ThatFields/ThatProperties/ThatEvents/ThatMembers + non-parameter ThatMethods/ThatConstructors):

- Cover NET8+ IAsyncEnumerable overloads (AreStatic/AreNotStatic, Have attribute, AreNot{Abstract,Sealed,Static}, AreOfType/AreOfExactType) with success + exact-message failure tests via a new ToTestAsyncEnumerable test helper.
- Cover sync IEnumerable overloads that the Filtered-based tests bypass on NET8 (Return/ReturnExactly, AreGeneric/AreNotGeneric, ThatMember AreNot{Internal,Private,PrivateProtected,Protected,ProtectedInternal,Public}, HaveName name-selector list rendering + block bodies).
- Add OrOfExactType strict-subtype failure tests to kill RegisterType exact-flag mutants (ThatField/ThatFields/ThatProperties).