### PR TITLE
feat: add `WhichReturnVoid` filter and `ReturnsVoid`/`ReturnVoid` assertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,7 @@ In addition to [access modifiers](#access-modifiers),
 | static / abstract / sealed / generic | `.WhichAreStatic()` …                               | `.IsStatic()` …                                                 | `.AreStatic()` …             |
 | returns type (or a subtype)          | `.WhichReturn<T>()`                                 | `.Returns<T>()`                                                 | `.Return<T>()`               |
 | returns exactly                      | `.WhichReturnExactly<T>()`                          | `.ReturnsExactly<T>()`                                          | `.ReturnExactly<T>()`        |
+| returns void                         | `.WhichReturnVoid()`                                | `.ReturnsVoid()`                                                | `.ReturnVoid()`              |
 | no parameters                        | `.WithoutParameters()`                              | `.HasNoParameters()`                                            | `.HaveNoParameters()`        |
 | parameter of type (or subtype)       | `.WithParameter<T>()` / `.WithParameter<T>("name")` | `.HasParameter<T>()` / `.HasParameter<T>("name")`               | `.HaveParameter<T>()`        |
 | parameter of exact type              | `.WithParameterExactly<T>()`                        | `.HasParameterExactly<T>()` / `.HasParameterExactly<T>("name")` | `.HaveParameterExactly<T>()` |
@@ -339,7 +340,9 @@ In addition to [access modifiers](#access-modifiers),
 | custom predicate                     | `.Which(m => …)`                                    | `.Satisfies(m => …)`                                            | `.All().Satisfy(m => …)`     |
 
 `WhichReturn<Task>()` and `Returns<Task>()` also match `Task<T>`; the `…Exactly` variants match only the
-exact type. Use `OrReturn<T>()` / `OrReturnExactly<T>()` to allow several return types.
+exact type. Use `OrReturn<T>()` / `OrReturnExactly<T>()` to allow several return types. Since `void` cannot be
+used as a generic type argument, use `WhichReturnVoid()` / `ReturnsVoid()` / `ReturnVoid()` to match
+void-returning methods.
 
 ```csharp
 In.AllLoadedAssemblies().Methods()

--- a/Source/aweXpect.Reflection/Filters/MethodFilters.WhichReturnVoid.cs
+++ b/Source/aweXpect.Reflection/Filters/MethodFilters.WhichReturnVoid.cs
@@ -1,0 +1,12 @@
+using aweXpect.Reflection.Collections;
+
+namespace aweXpect.Reflection;
+
+public static partial class MethodFilters
+{
+	/// <summary>
+	///     Filter for methods which return <see langword="void" />.
+	/// </summary>
+	public static MethodsWhichReturn WhichReturnVoid(this Filtered.Methods @this)
+		=> WhichReturn(@this, typeof(void));
+}

--- a/Source/aweXpect.Reflection/ThatMethod.ReturnsVoid.cs
+++ b/Source/aweXpect.Reflection/ThatMethod.ReturnsVoid.cs
@@ -1,0 +1,14 @@
+using System.Reflection;
+using aweXpect.Core;
+
+namespace aweXpect.Reflection;
+
+public static partial class ThatMethod
+{
+	/// <summary>
+	///     Verifies that the method returns <see langword="void" />.
+	/// </summary>
+	public static MethodReturnResult<MethodInfo?, IThat<MethodInfo?>> ReturnsVoid(
+		this IThat<MethodInfo?> subject)
+		=> Returns(subject, typeof(void));
+}

--- a/Source/aweXpect.Reflection/ThatMethods.ReturnVoid.cs
+++ b/Source/aweXpect.Reflection/ThatMethods.ReturnVoid.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+using System.Reflection;
+using aweXpect.Core;
+
+namespace aweXpect.Reflection;
+
+public static partial class ThatMethods
+{
+	/// <summary>
+	///     Verifies that all methods in the filtered collection return <see langword="void" />.
+	/// </summary>
+	public static MethodsReturnResult<IEnumerable<MethodInfo>, IThat<IEnumerable<MethodInfo>>> ReturnVoid(
+		this IThat<IEnumerable<MethodInfo>> subject)
+		=> Return(subject, typeof(void));
+
+#if NET8_0_OR_GREATER
+	/// <summary>
+	///     Verifies that all methods in the filtered collection return <see langword="void" />.
+	/// </summary>
+	public static MethodsReturnResult<IAsyncEnumerable<MethodInfo>, IThat<IAsyncEnumerable<MethodInfo>>> ReturnVoid(
+		this IThat<IAsyncEnumerable<MethodInfo>> subject)
+		=> Return(subject, typeof(void));
+#endif
+}

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net10.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net10.0.txt
@@ -318,6 +318,7 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.MethodFilters.MethodsWhichReturn WhichReturn<TReturn>(this aweXpect.Reflection.Collections.Filtered.Methods @this) { }
         public static aweXpect.Reflection.MethodFilters.MethodsWhichReturn WhichReturnExactly(this aweXpect.Reflection.Collections.Filtered.Methods @this, System.Type returnType) { }
         public static aweXpect.Reflection.MethodFilters.MethodsWhichReturn WhichReturnExactly<TReturn>(this aweXpect.Reflection.Collections.Filtered.Methods @this) { }
+        public static aweXpect.Reflection.MethodFilters.MethodsWhichReturn WhichReturnVoid(this aweXpect.Reflection.Collections.Filtered.Methods @this) { }
         public static aweXpect.Reflection.MethodFilters.MethodsWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Methods @this, bool inherit = true)
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.MethodFilters.MethodsWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Methods @this, System.Func<TAttribute, bool>? predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
@@ -1045,6 +1046,7 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.ThatMethod.MethodReturnResult<System.Reflection.MethodInfo?, aweXpect.Core.IThat<System.Reflection.MethodInfo?>> Returns<TReturn>(this aweXpect.Core.IThat<System.Reflection.MethodInfo?> subject) { }
         public static aweXpect.Reflection.ThatMethod.MethodReturnResult<System.Reflection.MethodInfo?, aweXpect.Core.IThat<System.Reflection.MethodInfo?>> ReturnsExactly(this aweXpect.Core.IThat<System.Reflection.MethodInfo?> subject, System.Type returnType) { }
         public static aweXpect.Reflection.ThatMethod.MethodReturnResult<System.Reflection.MethodInfo?, aweXpect.Core.IThat<System.Reflection.MethodInfo?>> ReturnsExactly<TReturn>(this aweXpect.Core.IThat<System.Reflection.MethodInfo?> subject) { }
+        public static aweXpect.Reflection.ThatMethod.MethodReturnResult<System.Reflection.MethodInfo?, aweXpect.Core.IThat<System.Reflection.MethodInfo?>> ReturnsVoid(this aweXpect.Core.IThat<System.Reflection.MethodInfo?> subject) { }
         public sealed class MethodReturnResult<TValue, TResult> : aweXpect.Results.AndOrResult<TValue, TResult>, aweXpect.Core.IOptionsProvider<aweXpect.Reflection.Options.TypeFilterOptions>
             where TResult : aweXpect.Core.IThat<TValue>
         {
@@ -1211,6 +1213,8 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.ThatMethods.MethodsReturnResult<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo>>> ReturnExactly(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo>> subject, System.Type returnType) { }
         public static aweXpect.Reflection.ThatMethods.MethodsReturnResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.MethodInfo>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.MethodInfo>>> ReturnExactly<TReturn>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.MethodInfo>> subject) { }
         public static aweXpect.Reflection.ThatMethods.MethodsReturnResult<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo>>> ReturnExactly<TReturn>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo>> subject) { }
+        public static aweXpect.Reflection.ThatMethods.MethodsReturnResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.MethodInfo>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.MethodInfo>>> ReturnVoid(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.MethodInfo>> subject) { }
+        public static aweXpect.Reflection.ThatMethods.MethodsReturnResult<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo>>> ReturnVoid(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo>> subject) { }
         public sealed class MethodsReturnResult<TValue, TResult> : aweXpect.Results.AndOrResult<TValue, TResult>, aweXpect.Core.IOptionsProvider<aweXpect.Reflection.Options.TypeFilterOptions>
             where TResult : aweXpect.Core.IThat<TValue>
         {

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net8.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net8.0.txt
@@ -318,6 +318,7 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.MethodFilters.MethodsWhichReturn WhichReturn<TReturn>(this aweXpect.Reflection.Collections.Filtered.Methods @this) { }
         public static aweXpect.Reflection.MethodFilters.MethodsWhichReturn WhichReturnExactly(this aweXpect.Reflection.Collections.Filtered.Methods @this, System.Type returnType) { }
         public static aweXpect.Reflection.MethodFilters.MethodsWhichReturn WhichReturnExactly<TReturn>(this aweXpect.Reflection.Collections.Filtered.Methods @this) { }
+        public static aweXpect.Reflection.MethodFilters.MethodsWhichReturn WhichReturnVoid(this aweXpect.Reflection.Collections.Filtered.Methods @this) { }
         public static aweXpect.Reflection.MethodFilters.MethodsWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Methods @this, bool inherit = true)
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.MethodFilters.MethodsWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Methods @this, System.Func<TAttribute, bool>? predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
@@ -1045,6 +1046,7 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.ThatMethod.MethodReturnResult<System.Reflection.MethodInfo?, aweXpect.Core.IThat<System.Reflection.MethodInfo?>> Returns<TReturn>(this aweXpect.Core.IThat<System.Reflection.MethodInfo?> subject) { }
         public static aweXpect.Reflection.ThatMethod.MethodReturnResult<System.Reflection.MethodInfo?, aweXpect.Core.IThat<System.Reflection.MethodInfo?>> ReturnsExactly(this aweXpect.Core.IThat<System.Reflection.MethodInfo?> subject, System.Type returnType) { }
         public static aweXpect.Reflection.ThatMethod.MethodReturnResult<System.Reflection.MethodInfo?, aweXpect.Core.IThat<System.Reflection.MethodInfo?>> ReturnsExactly<TReturn>(this aweXpect.Core.IThat<System.Reflection.MethodInfo?> subject) { }
+        public static aweXpect.Reflection.ThatMethod.MethodReturnResult<System.Reflection.MethodInfo?, aweXpect.Core.IThat<System.Reflection.MethodInfo?>> ReturnsVoid(this aweXpect.Core.IThat<System.Reflection.MethodInfo?> subject) { }
         public sealed class MethodReturnResult<TValue, TResult> : aweXpect.Results.AndOrResult<TValue, TResult>, aweXpect.Core.IOptionsProvider<aweXpect.Reflection.Options.TypeFilterOptions>
             where TResult : aweXpect.Core.IThat<TValue>
         {
@@ -1211,6 +1213,8 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.ThatMethods.MethodsReturnResult<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo>>> ReturnExactly(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo>> subject, System.Type returnType) { }
         public static aweXpect.Reflection.ThatMethods.MethodsReturnResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.MethodInfo>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.MethodInfo>>> ReturnExactly<TReturn>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.MethodInfo>> subject) { }
         public static aweXpect.Reflection.ThatMethods.MethodsReturnResult<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo>>> ReturnExactly<TReturn>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo>> subject) { }
+        public static aweXpect.Reflection.ThatMethods.MethodsReturnResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.MethodInfo>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.MethodInfo>>> ReturnVoid(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.MethodInfo>> subject) { }
+        public static aweXpect.Reflection.ThatMethods.MethodsReturnResult<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo>>> ReturnVoid(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo>> subject) { }
         public sealed class MethodsReturnResult<TValue, TResult> : aweXpect.Results.AndOrResult<TValue, TResult>, aweXpect.Core.IOptionsProvider<aweXpect.Reflection.Options.TypeFilterOptions>
             where TResult : aweXpect.Core.IThat<TValue>
         {

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_netstandard2.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_netstandard2.0.txt
@@ -318,6 +318,7 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.MethodFilters.MethodsWhichReturn WhichReturn<TReturn>(this aweXpect.Reflection.Collections.Filtered.Methods @this) { }
         public static aweXpect.Reflection.MethodFilters.MethodsWhichReturn WhichReturnExactly(this aweXpect.Reflection.Collections.Filtered.Methods @this, System.Type returnType) { }
         public static aweXpect.Reflection.MethodFilters.MethodsWhichReturn WhichReturnExactly<TReturn>(this aweXpect.Reflection.Collections.Filtered.Methods @this) { }
+        public static aweXpect.Reflection.MethodFilters.MethodsWhichReturn WhichReturnVoid(this aweXpect.Reflection.Collections.Filtered.Methods @this) { }
         public static aweXpect.Reflection.MethodFilters.MethodsWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Methods @this, bool inherit = true)
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.MethodFilters.MethodsWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Methods @this, System.Func<TAttribute, bool>? predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
@@ -920,6 +921,7 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.ThatMethod.MethodReturnResult<System.Reflection.MethodInfo?, aweXpect.Core.IThat<System.Reflection.MethodInfo?>> Returns<TReturn>(this aweXpect.Core.IThat<System.Reflection.MethodInfo?> subject) { }
         public static aweXpect.Reflection.ThatMethod.MethodReturnResult<System.Reflection.MethodInfo?, aweXpect.Core.IThat<System.Reflection.MethodInfo?>> ReturnsExactly(this aweXpect.Core.IThat<System.Reflection.MethodInfo?> subject, System.Type returnType) { }
         public static aweXpect.Reflection.ThatMethod.MethodReturnResult<System.Reflection.MethodInfo?, aweXpect.Core.IThat<System.Reflection.MethodInfo?>> ReturnsExactly<TReturn>(this aweXpect.Core.IThat<System.Reflection.MethodInfo?> subject) { }
+        public static aweXpect.Reflection.ThatMethod.MethodReturnResult<System.Reflection.MethodInfo?, aweXpect.Core.IThat<System.Reflection.MethodInfo?>> ReturnsVoid(this aweXpect.Core.IThat<System.Reflection.MethodInfo?> subject) { }
         public sealed class MethodReturnResult<TValue, TResult> : aweXpect.Results.AndOrResult<TValue, TResult>, aweXpect.Core.IOptionsProvider<aweXpect.Reflection.Options.TypeFilterOptions>
             where TResult : aweXpect.Core.IThat<TValue>
         {
@@ -1009,6 +1011,7 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.ThatMethods.MethodsReturnResult<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo>>> Return<TReturn>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo>> subject) { }
         public static aweXpect.Reflection.ThatMethods.MethodsReturnResult<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo>>> ReturnExactly(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo>> subject, System.Type returnType) { }
         public static aweXpect.Reflection.ThatMethods.MethodsReturnResult<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo>>> ReturnExactly<TReturn>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo>> subject) { }
+        public static aweXpect.Reflection.ThatMethods.MethodsReturnResult<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo>>> ReturnVoid(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo>> subject) { }
         public sealed class MethodsReturnResult<TValue, TResult> : aweXpect.Results.AndOrResult<TValue, TResult>, aweXpect.Core.IOptionsProvider<aweXpect.Reflection.Options.TypeFilterOptions>
             where TResult : aweXpect.Core.IThat<TValue>
         {

--- a/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WhichReturnVoid.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WhichReturnVoid.Tests.cs
@@ -1,0 +1,50 @@
+using aweXpect.Reflection.Collections;
+
+namespace aweXpect.Reflection.Tests.Filters;
+
+public sealed partial class MethodFilters
+{
+	public sealed class WhichReturnVoid
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task ShouldFilterForMethodsWhichReturnVoid()
+			{
+				Filtered.Methods methods = In.Type<TestClass>()
+					.Methods().WhichReturnVoid();
+
+				await That(methods).IsEqualTo([
+					typeof(TestClass).GetMethod(nameof(TestClass.VoidMethod))!,
+				]).InAnyOrder();
+				await That(methods.GetDescription())
+					.IsEqualTo("methods which return void in")
+					.AsPrefix();
+			}
+
+			[Fact]
+			public async Task ShouldAllowChainingAlternativeReturnType()
+			{
+				Filtered.Methods methods = In.Type<TestClass>()
+					.Methods().WhichReturnVoid().OrReturn<string>();
+
+				await That(methods).IsEqualTo([
+					typeof(TestClass).GetMethod(nameof(TestClass.VoidMethod))!,
+					typeof(TestClass).GetMethod(nameof(TestClass.GetString))!,
+				]).InAnyOrder();
+				await That(methods.GetDescription())
+					.IsEqualTo("methods which return void or return string in")
+					.AsPrefix();
+			}
+		}
+
+#pragma warning disable CA1822 // Mark members as static
+		private class TestClass
+		{
+			public string GetString() => "test";
+			public int GetInt() => 42;
+			public void VoidMethod() { }
+		}
+#pragma warning restore CA1822
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatMethod.ReturnsVoid.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethod.ReturnsVoid.Tests.cs
@@ -1,0 +1,163 @@
+using System.Reflection;
+using Xunit.Sdk;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatMethod
+{
+	public sealed class ReturnsVoid
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenMethodDoesNotReturnVoid_ShouldFail()
+			{
+				MethodInfo subject = GetMethod(nameof(ClassWithMethods.PublicMethod))!;
+
+				async Task Act()
+				{
+					await That(subject).ReturnsVoid();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             returns void,
+					             but it returned int
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenMethodInfoIsNull_ShouldFail()
+			{
+				MethodInfo? subject = null;
+
+				async Task Act()
+				{
+					await That(subject).ReturnsVoid();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             returns void,
+					             but it was <null>
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenMethodReturnsVoid_ShouldSucceed()
+			{
+				MethodInfo subject = GetMethod(nameof(ClassWithMethods.VoidMethod))!;
+
+				async Task Act()
+				{
+					await That(subject).ReturnsVoid();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+		public sealed class OrReturnsTests
+		{
+			[Fact]
+			public async Task WhenMethodReturnsOneOfTheTypes_ShouldSucceed()
+			{
+				MethodInfo subject = GetMethod(nameof(ClassWithMethods.PublicMethod))!;
+
+				async Task Act()
+				{
+					await That(subject).ReturnsVoid().OrReturns<int>();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenMethodReturnsVoid_ShouldSucceed()
+			{
+				MethodInfo subject = GetMethod(nameof(ClassWithMethods.VoidMethod))!;
+
+				async Task Act()
+				{
+					await That(subject).ReturnsVoid().OrReturns<int>();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenMethodReturnsNoneOfTheTypes_ShouldFail()
+			{
+				MethodInfo subject = GetMethod(nameof(ClassWithMethods.PublicMethod))!;
+
+				async Task Act()
+				{
+					await That(subject).ReturnsVoid().OrReturns<bool>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             returns void or bool,
+					             but it returned int
+					             """);
+			}
+		}
+
+		public sealed class NegatedTests
+		{
+			[Fact]
+			public async Task WhenMethodDoesNotReturnVoid_ShouldSucceed()
+			{
+				MethodInfo subject = GetMethod(nameof(ClassWithMethods.PublicMethod))!;
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(it => it.ReturnsVoid());
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenMethodInfoIsNull_ShouldFail()
+			{
+				MethodInfo? subject = null;
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(it => it.ReturnsVoid());
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             does not return void,
+					             but it was <null>
+					             """)
+					.AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenMethodReturnsVoid_ShouldFail()
+			{
+				MethodInfo subject = GetMethod(nameof(ClassWithMethods.VoidMethod))!;
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(it => it.ReturnsVoid());
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             does not return void,
+					             but it did
+					             """)
+					.AsWildcard();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatMethod.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethod.cs
@@ -24,6 +24,7 @@ public sealed partial class ThatMethod
 		public T GenericMethod<T>(T value) => value;
 		public void AnotherGenericMethod<T, U>(T first, U second) { }
 		public int NonGenericMethod() => 1;
+		public void VoidMethod() { }
 
 		public void GenericWithUnrestrictedArgumentMethod<TFoo>()
 		{

--- a/Tests/aweXpect.Reflection.Tests/ThatMethods.ReturnVoid.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethods.ReturnVoid.Tests.cs
@@ -1,0 +1,138 @@
+using System.Collections.Generic;
+using System.Reflection;
+using aweXpect.Reflection.Collections;
+using Xunit.Sdk;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatMethods
+{
+	public sealed class ReturnVoid
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task ShouldFailWhenSomeMethodsDoNotReturnVoid()
+			{
+				IEnumerable<MethodInfo> subject =
+				[
+					typeof(TestClass).GetMethod(nameof(TestClass.VoidMethod))!,
+					typeof(TestClass).GetMethod(nameof(TestClass.GetInt))!,
+				];
+
+				async Task Act()
+				{
+					await That(subject).ReturnVoid();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             all return void,
+					             but it contained not matching methods [
+					               int ThatMethods.TestClass.GetInt()
+					             ]
+					             """);
+			}
+
+			[Fact]
+			public async Task ShouldSucceedWhenAllMethodsReturnVoid()
+			{
+				IEnumerable<MethodInfo> subject =
+				[
+					typeof(TestClass).GetMethod(nameof(TestClass.VoidMethod))!,
+				];
+
+				async Task Act()
+				{
+					await That(subject).ReturnVoid();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+		public sealed class OrReturnTests
+		{
+			[Fact]
+			public async Task WhenAllMethodsReturnOneOfTheTypes_ShouldSucceed()
+			{
+				IEnumerable<MethodInfo> subject =
+				[
+					typeof(TestClass).GetMethod(nameof(TestClass.VoidMethod))!,
+					typeof(TestClass).GetMethod(nameof(TestClass.GetInt))!,
+				];
+
+				async Task Act()
+				{
+					await That(subject).ReturnVoid().OrReturn<int>();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSomeMethodsReturnNoneOfTheTypes_ShouldFail()
+			{
+				IEnumerable<MethodInfo> subject =
+				[
+					typeof(TestClass).GetMethod(nameof(TestClass.VoidMethod))!,
+					typeof(TestClass).GetMethod(nameof(TestClass.GetString))!,
+				];
+
+				async Task Act()
+				{
+					await That(subject).ReturnVoid().OrReturn<int>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             all return void or int,
+					             but it contained not matching methods [
+					               string ThatMethods.TestClass.GetString()
+					             ]
+					             """);
+			}
+		}
+
+		public sealed class NegatedTests
+		{
+			[Fact]
+			public async Task WhenAllMethodsReturnVoid_ShouldFail()
+			{
+				Filtered.Methods methods = In.Type<TestClass>()
+					.Methods().Which(m => m.Name == nameof(TestClass.VoidMethod));
+
+				async Task Act()
+				{
+					await That(methods).DoesNotComplyWith(they => they.ReturnVoid());
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that methods matching m => m.Name == nameof(TestClass.VoidMethod) in type ThatMethods.TestClass
+					             not all return void,
+					             but it only contained matching methods [
+					               void ThatMethods.TestClass.VoidMethod()
+					             ]
+					             """)
+					.AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenSomeMethodsDoNotReturnVoid_ShouldSucceed()
+			{
+				Filtered.Methods methods = In.Type<TestClass>()
+					.Methods().Which(m => m.Name.StartsWith("Get"));
+
+				async Task Act()
+				{
+					await That(methods).DoesNotComplyWith(they => they.ReturnVoid());
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatMethods.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethods.cs
@@ -63,6 +63,7 @@ public sealed partial class ThatMethods
 		public DummyBase GetDummyBase() => new();
 		public Dummy GetDummy() => new();
 		public async Task AsyncMethod() => await Task.CompletedTask;
+		public void VoidMethod() { }
 		public T GenericMethod<T>(T value) => value;
 
 		// ReSharper disable once UnusedTypeParameter


### PR DESCRIPTION
This PR adds a `void` variant to the return-type filter/assertion family.

Because `void` cannot be used as a generic type argument (`.WhichReturn<void>()` doesn't compile), convention tests like *"no public methods in value objects return void"* or *"all event handlers return void"* previously
required raw predicates. This adds first-class support:

| | Filter | Assert (single) | Assert (many) |
|---|---|---|---|
| returns void | `.WhichReturnVoid()` | `.ReturnsVoid()` | `.ReturnVoid()` |

## Implementation

Each new method is a thin delegation to the existing type-based API with `typeof(void)`, reusing all matching logic, descriptions, and `Or…` chaining:

- `MethodFilters.WhichReturnVoid()` → `WhichReturn(@this, typeof(void))`
- `ThatMethod.ReturnsVoid()` → `Returns(subject, typeof(void))`
- `ThatMethods.ReturnVoid()` → `Return(subject, typeof(void))` (with the `IAsyncEnumerable` overload under `NET8_0_OR_GREATER`, matching the existing `Return` family)

No negated methods were added, consistent with `Returns`/`Return`/`WhichReturn`, which have none (negation is via `DoesNotComplyWith`).

## Usage

```csharp
// Filter
In.AllLoadedAssemblies().Methods()
    .WhichArePublic()
    .WhichReturnVoid();

// Assert (single)
await Expect.That(method).ReturnsVoid();

// Assert (many)
await Expect.That(methods).ReturnVoid();
```

---

- *Fixes #236*