### PR TITLE
feat: add `WithoutName` filter and `DoesNotHaveName`/`DoNotHaveName` negated name assertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,8 +183,20 @@ Shared by all types and members.
 |                                 | Filter                  | Assert (single)           | Assert (many)              |
 |---------------------------------|-------------------------|---------------------------|----------------------------|
 | by name                         | `.WithName("x")`        | `.HasName("x")`           | `.HaveName("x")`           |
+| not by name                     | `.WithoutName("x")`     | `.DoesNotHaveName("x")`   | `.DoNotHaveName("x")`      |
 | by namespace *(types only)*     | `.WithNamespace("x")`   | `.HasNamespace("x")`      | `.HaveNamespace("x")`      |
 | within namespace *(types only)* | `.WithinNamespace("x")` | `.IsWithinNamespace("x")` | `.AreWithinNamespace("x")` |
+
+`WithoutName`/`DoesNotHaveName`/`DoNotHaveName` are the negations of the name filter and assertions:
+`WithoutName` keeps the items whose name does *not* match, `DoesNotHaveName` verifies a single item is
+*not* named the given value, and `DoNotHaveName` verifies that *none* of the items in a collection are.
+They accept the same [string matching options](#string-matching-options) as their positive counterparts:
+
+```csharp
+// Verify that no type in the production assembly is named with a "Test" suffix
+await Expect.That(In.AssemblyContaining<MyClass>().Types())
+    .DoNotHaveName("Test").AsSuffix();
+```
 
 The name/namespace *equality* filters and assertions (`WithName`, `WithNamespace`, and their
 `Has`/`Have` counterparts) accept the
@@ -429,6 +441,7 @@ on them directly:
 |                             | Filter                                 | Assert (single)                  | Assert (many)                     |
 |-----------------------------|----------------------------------------|----------------------------------|-----------------------------------|
 | by name                     | `.WithName("x")`                       | `.HasName("x")`                  | `.HaveName("x")`                  |
+| not by name                 | `.WithoutName("x")`                    | `.DoesNotHaveName("x")`          | `.DoNotHaveName("x")`             |
 | by target framework         | `.WhichTarget("net8.0")`               | `.Targets("net8.0")`             | `.Target("net8.0")`               |
 | has attribute               | `.With<TAttribute>()`                  | `.Has<TAttribute>()`             | `.Have<TAttribute>()`             |
 | depends on assembly         | `.WhichHaveADependencyOn("x")`         | `.HasADependencyOn("x")`         | `.HaveADependencyOn("x")`         |

--- a/Source/aweXpect.Reflection/Filters/AssemblyFilters.WithoutName.cs
+++ b/Source/aweXpect.Reflection/Filters/AssemblyFilters.WithoutName.cs
@@ -1,0 +1,22 @@
+﻿using System.Reflection;
+using aweXpect.Core;
+using aweXpect.Options;
+using aweXpect.Reflection.Collections;
+
+namespace aweXpect.Reflection;
+
+public static partial class AssemblyFilters
+{
+	/// <summary>
+	///     Filter for assemblies without the <paramref name="unexpected" /> name.
+	/// </summary>
+	public static Filtered.Assemblies.StringEqualityResultType WithoutName(this Filtered.Assemblies @this,
+		string unexpected)
+	{
+		StringEqualityOptions options = new();
+		return new Filtered.Assemblies.StringEqualityResultType(@this.Which(Filter.Suffix<Assembly>(
+				async assembly => !await options.AreConsideredEqual(assembly.GetName().Name, unexpected),
+				() => $" without name {options.GetExpectation(unexpected, ExpectationGrammars.None)}")),
+			options);
+	}
+}

--- a/Source/aweXpect.Reflection/Filters/EventFilters.WithoutName.cs
+++ b/Source/aweXpect.Reflection/Filters/EventFilters.WithoutName.cs
@@ -1,0 +1,21 @@
+﻿using System.Reflection;
+using aweXpect.Core;
+using aweXpect.Options;
+using aweXpect.Reflection.Collections;
+
+namespace aweXpect.Reflection;
+
+public static partial class EventFilters
+{
+	/// <summary>
+	///     Filter for events without the <paramref name="unexpected" /> name.
+	/// </summary>
+	public static Filtered.Events.StringEqualityResultType WithoutName(this Filtered.Events @this, string unexpected)
+	{
+		StringEqualityOptions options = new();
+		return new Filtered.Events.StringEqualityResultType(@this.Which(Filter.Suffix<EventInfo>(
+				async eventInfo => !await options.AreConsideredEqual(eventInfo.Name, unexpected),
+				() => $"without name {options.GetExpectation(unexpected, ExpectationGrammars.None)} ")),
+			options);
+	}
+}

--- a/Source/aweXpect.Reflection/Filters/FieldFilters.WithoutName.cs
+++ b/Source/aweXpect.Reflection/Filters/FieldFilters.WithoutName.cs
@@ -1,0 +1,21 @@
+﻿using System.Reflection;
+using aweXpect.Core;
+using aweXpect.Options;
+using aweXpect.Reflection.Collections;
+
+namespace aweXpect.Reflection;
+
+public static partial class FieldFilters
+{
+	/// <summary>
+	///     Filter for fields without the <paramref name="unexpected" /> name.
+	/// </summary>
+	public static Filtered.Fields.StringEqualityResultType WithoutName(this Filtered.Fields @this, string unexpected)
+	{
+		StringEqualityOptions options = new();
+		return new Filtered.Fields.StringEqualityResultType(@this.Which(Filter.Suffix<FieldInfo>(
+				async fieldInfo => !await options.AreConsideredEqual(fieldInfo.Name, unexpected),
+				() => $"without name {options.GetExpectation(unexpected, ExpectationGrammars.None)} ")),
+			options);
+	}
+}

--- a/Source/aweXpect.Reflection/Filters/MethodFilters.WithoutName.cs
+++ b/Source/aweXpect.Reflection/Filters/MethodFilters.WithoutName.cs
@@ -1,0 +1,21 @@
+﻿using System.Reflection;
+using aweXpect.Core;
+using aweXpect.Options;
+using aweXpect.Reflection.Collections;
+
+namespace aweXpect.Reflection;
+
+public static partial class MethodFilters
+{
+	/// <summary>
+	///     Filter for methods without the <paramref name="unexpected" /> name.
+	/// </summary>
+	public static Filtered.Methods.StringEqualityResultType WithoutName(this Filtered.Methods @this, string unexpected)
+	{
+		StringEqualityOptions options = new();
+		return new Filtered.Methods.StringEqualityResultType(@this.Which(Filter.Suffix<MethodInfo>(
+				async methodInfo => !await options.AreConsideredEqual(methodInfo.Name, unexpected),
+				() => $"without name {options.GetExpectation(unexpected, ExpectationGrammars.None)} ")),
+			options);
+	}
+}

--- a/Source/aweXpect.Reflection/Filters/PropertyFilters.WithoutName.cs
+++ b/Source/aweXpect.Reflection/Filters/PropertyFilters.WithoutName.cs
@@ -1,0 +1,22 @@
+﻿using System.Reflection;
+using aweXpect.Core;
+using aweXpect.Options;
+using aweXpect.Reflection.Collections;
+
+namespace aweXpect.Reflection;
+
+public static partial class PropertyFilters
+{
+	/// <summary>
+	///     Filter for properties without the <paramref name="unexpected" /> name.
+	/// </summary>
+	public static Filtered.Properties.StringEqualityResultType WithoutName(this Filtered.Properties @this,
+		string unexpected)
+	{
+		StringEqualityOptions options = new();
+		return new Filtered.Properties.StringEqualityResultType(@this.Which(Filter.Suffix<PropertyInfo>(
+				async propertyInfo => !await options.AreConsideredEqual(propertyInfo.Name, unexpected),
+				() => $"without name {options.GetExpectation(unexpected, ExpectationGrammars.None)} ")),
+			options);
+	}
+}

--- a/Source/aweXpect.Reflection/Filters/TypeFilters.WithoutName.cs
+++ b/Source/aweXpect.Reflection/Filters/TypeFilters.WithoutName.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using aweXpect.Core;
+using aweXpect.Options;
+using aweXpect.Reflection.Collections;
+
+namespace aweXpect.Reflection;
+
+public static partial class TypeFilters
+{
+	/// <summary>
+	///     Filter for types without the <paramref name="unexpected" /> name.
+	/// </summary>
+	public static Filtered.Types.StringEqualityResultType WithoutName(this Filtered.Types @this, string unexpected)
+	{
+		StringEqualityOptions options = new();
+		return new Filtered.Types.StringEqualityResultType(@this.Which(Filter.Suffix<Type>(
+				async type => !await options.AreConsideredEqual(type.Name, unexpected),
+				() => $"without name {options.GetExpectation(unexpected, ExpectationGrammars.None)} ")),
+			options);
+	}
+}

--- a/Source/aweXpect.Reflection/ThatAssemblies.DoNotHaveName.cs
+++ b/Source/aweXpect.Reflection/ThatAssemblies.DoNotHaveName.cs
@@ -1,0 +1,92 @@
+﻿using System.Collections.Generic;
+using System.Reflection;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Options;
+using aweXpect.Reflection.Helpers;
+using aweXpect.Results;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Reflection;
+
+public static partial class ThatAssemblies
+{
+	/// <summary>
+	///     Verifies that none of the items in the filtered collection of <see cref="Assembly" /> have
+	///     the <paramref name="unexpected" /> name.
+	/// </summary>
+	public static StringEqualityTypeResult<IEnumerable<Assembly?>, IThat<IEnumerable<Assembly?>>> DoNotHaveName(
+		this IThat<IEnumerable<Assembly?>> subject, string unexpected)
+	{
+		StringEqualityOptions options = new();
+		return new StringEqualityTypeResult<IEnumerable<Assembly?>, IThat<IEnumerable<Assembly?>>>(subject.Get()
+				.ExpectationBuilder.AddConstraint<IEnumerable<Assembly?>>((it, grammars)
+					=> new DoNotHaveNameConstraint(it, grammars, unexpected, options)),
+			subject,
+			options);
+	}
+
+#if NET8_0_OR_GREATER
+	/// <summary>
+	///     Verifies that none of the items in the filtered collection of <see cref="Assembly" /> have
+	///     the <paramref name="unexpected" /> name.
+	/// </summary>
+	public static StringEqualityTypeResult<IAsyncEnumerable<Assembly?>, IThat<IAsyncEnumerable<Assembly?>>>
+		DoNotHaveName(
+			this IThat<IAsyncEnumerable<Assembly?>> subject, string unexpected)
+	{
+		StringEqualityOptions options = new();
+		return new StringEqualityTypeResult<IAsyncEnumerable<Assembly?>, IThat<IAsyncEnumerable<Assembly?>>>(subject
+				.Get()
+				.ExpectationBuilder.AddConstraint<IAsyncEnumerable<Assembly?>>((it, grammars)
+					=> new DoNotHaveNameConstraint(it, grammars, unexpected, options)),
+			subject,
+			options);
+	}
+#endif
+
+	private sealed class DoNotHaveNameConstraint(
+		string it,
+		ExpectationGrammars grammars,
+		string unexpected,
+		StringEqualityOptions options)
+		: CollectionConstraintResult<Assembly?>(grammars),
+			IAsyncConstraint<IEnumerable<Assembly?>>
+#if NET8_0_OR_GREATER
+			, IAsyncConstraint<IAsyncEnumerable<Assembly?>>
+#endif
+	{
+#if NET8_0_OR_GREATER
+		public async Task<ConstraintResult> IsMetBy(IAsyncEnumerable<Assembly?> actual,
+			CancellationToken cancellationToken)
+			=> await SetAsyncValue(actual,
+				async assembly => !await options.AreConsideredEqual(assembly?.GetName().Name, unexpected));
+#endif
+
+		public async Task<ConstraintResult> IsMetBy(IEnumerable<Assembly?> actual, CancellationToken cancellationToken)
+			=> await SetValue(actual,
+				async assembly => !await options.AreConsideredEqual(assembly?.GetName().Name, unexpected));
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("all have name ").Append(options.GetExpectation(unexpected, Grammars.Negate()));
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(it).Append(" contained not matching types ");
+			Formatter.Format(stringBuilder, NotMatching, FormattingOptions.Indented(indentation));
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("not all have name ").Append(options.GetExpectation(unexpected, Grammars.Negate()));
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(it).Append(" only contained matching types ");
+			Formatter.Format(stringBuilder, Matching, FormattingOptions.Indented(indentation));
+		}
+	}
+}

--- a/Source/aweXpect.Reflection/ThatAssembly.DoesNotHaveName.cs
+++ b/Source/aweXpect.Reflection/ThatAssembly.DoesNotHaveName.cs
@@ -1,0 +1,27 @@
+﻿using System.Reflection;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Options;
+using aweXpect.Reflection.Helpers;
+using aweXpect.Results;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Reflection;
+
+public static partial class ThatAssembly
+{
+	/// <summary>
+	///     Verifies that the <see cref="Assembly" /> does not have the <paramref name="unexpected" /> name.
+	/// </summary>
+	public static StringEqualityTypeResult<Assembly?, IThat<Assembly?>> DoesNotHaveName(
+		this IThat<Assembly?> subject, string unexpected)
+	{
+		StringEqualityOptions options = new();
+		return new StringEqualityTypeResult<Assembly?, IThat<Assembly?>>(
+			subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new HasNameConstraint(it, grammars, unexpected, options).Invert()),
+			subject,
+			options);
+	}
+}

--- a/Source/aweXpect.Reflection/ThatMember.DoesNotHaveName.cs
+++ b/Source/aweXpect.Reflection/ThatMember.DoesNotHaveName.cs
@@ -1,0 +1,28 @@
+﻿using System.Reflection;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Options;
+using aweXpect.Reflection.Helpers;
+using aweXpect.Results;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Reflection;
+
+public static partial class ThatMember
+{
+	/// <summary>
+	///     Verifies that the <typeparamref name="TMember" /> does not have the <paramref name="unexpected" /> name.
+	/// </summary>
+	public static StringEqualityTypeResult<TMember, IThat<TMember>> DoesNotHaveName<TMember>(
+		this IThat<TMember> subject, string unexpected)
+		where TMember : MemberInfo?
+	{
+		StringEqualityOptions options = new();
+		return new StringEqualityTypeResult<TMember, IThat<TMember>>(
+			subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new HasNameConstraint<TMember>(it, grammars, unexpected, options).Invert()),
+			subject,
+			options);
+	}
+}

--- a/Source/aweXpect.Reflection/ThatMembers.DoNotHaveName.cs
+++ b/Source/aweXpect.Reflection/ThatMembers.DoNotHaveName.cs
@@ -1,0 +1,92 @@
+﻿using System.Collections.Generic;
+using System.Reflection;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Options;
+using aweXpect.Reflection.Helpers;
+using aweXpect.Results;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Reflection;
+
+public static partial class ThatMembers
+{
+	/// <summary>
+	///     Verifies that none of the items in the filtered collection of <typeparamref name="TMember" /> have
+	///     the <paramref name="unexpected" /> name.
+	/// </summary>
+	public static StringEqualityTypeResult<IEnumerable<TMember>, IThat<IEnumerable<TMember>>> DoNotHaveName<TMember>(
+		this IThat<IEnumerable<TMember>> subject, string unexpected)
+		where TMember : MemberInfo?
+	{
+		StringEqualityOptions options = new();
+		return new StringEqualityTypeResult<IEnumerable<TMember>, IThat<IEnumerable<TMember>>>(subject.Get()
+				.ExpectationBuilder.AddConstraint<IEnumerable<TMember>>((it, grammars)
+					=> new DoNotHaveNameConstraint<TMember>(it, grammars, unexpected, options)),
+			subject,
+			options);
+	}
+
+#if NET8_0_OR_GREATER
+	/// <summary>
+	///     Verifies that none of the items in the filtered collection of <typeparamref name="TMember" /> have
+	///     the <paramref name="unexpected" /> name.
+	/// </summary>
+	public static StringEqualityTypeResult<IAsyncEnumerable<TMember>, IThat<IAsyncEnumerable<TMember>>>
+		DoNotHaveName<TMember>(
+			this IThat<IAsyncEnumerable<TMember>> subject, string unexpected)
+		where TMember : MemberInfo?
+	{
+		StringEqualityOptions options = new();
+		return new StringEqualityTypeResult<IAsyncEnumerable<TMember>, IThat<IAsyncEnumerable<TMember>>>(subject.Get()
+				.ExpectationBuilder.AddConstraint<IAsyncEnumerable<TMember>>((it, grammars)
+					=> new DoNotHaveNameConstraint<TMember>(it, grammars, unexpected, options)),
+			subject,
+			options);
+	}
+#endif
+
+	private sealed class DoNotHaveNameConstraint<TMember>(
+		string it,
+		ExpectationGrammars grammars,
+		string unexpected,
+		StringEqualityOptions options)
+		: CollectionConstraintResult<TMember>(grammars),
+			IAsyncConstraint<IEnumerable<TMember>>
+#if NET8_0_OR_GREATER
+			, IAsyncConstraint<IAsyncEnumerable<TMember>>
+#endif
+		where TMember : MemberInfo?
+	{
+#if NET8_0_OR_GREATER
+		public async Task<ConstraintResult> IsMetBy(IAsyncEnumerable<TMember> actual, CancellationToken cancellationToken)
+			=> await SetAsyncValue(actual,
+				async memberInfo => !await options.AreConsideredEqual(memberInfo?.Name, unexpected));
+#endif
+
+		public async Task<ConstraintResult> IsMetBy(IEnumerable<TMember> actual, CancellationToken cancellationToken)
+			=> await SetValue(actual, async memberInfo => !await options.AreConsideredEqual(memberInfo?.Name, unexpected));
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("all have name ").Append(options.GetExpectation(unexpected, Grammars.Negate()));
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(it).Append(" contained not matching items ");
+			Formatter.Format(stringBuilder, NotMatching, FormattingOptions.Indented(indentation));
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("not all have name ").Append(options.GetExpectation(unexpected, Grammars.Negate()));
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(it).Append(" only contained matching items ");
+			Formatter.Format(stringBuilder, Matching, FormattingOptions.Indented(indentation));
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net10.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net10.0.txt
@@ -45,6 +45,7 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Collections.Filtered.Assemblies.StringEqualityResultType WithName(this aweXpect.Reflection.Collections.Filtered.Assemblies @this, string expected) { }
         public static aweXpect.Reflection.AssemblyFilters.AssembliesWithVersion WithVersion(this aweXpect.Reflection.Collections.Filtered.Assemblies @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Assemblies WithVersion(this aweXpect.Reflection.Collections.Filtered.Assemblies @this, System.Func<System.Version, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
+        public static aweXpect.Reflection.Collections.Filtered.Assemblies.StringEqualityResultType WithoutName(this aweXpect.Reflection.Collections.Filtered.Assemblies @this, string unexpected) { }
         public class AssembliesWith : aweXpect.Reflection.Collections.Filtered.Assemblies
         {
             public AssembliesWith(aweXpect.Reflection.Collections.Filtered.Assemblies inner, aweXpect.Reflection.Collections.IChangeableFilter<System.Reflection.Assembly> filter) { }
@@ -220,6 +221,7 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.EventFilters.EventsWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Events @this, System.Func<TAttribute, bool>? predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Collections.Filtered.Events.StringEqualityResultType WithName(this aweXpect.Reflection.Collections.Filtered.Events @this, string expected) { }
+        public static aweXpect.Reflection.Collections.Filtered.Events.StringEqualityResultType WithoutName(this aweXpect.Reflection.Collections.Filtered.Events @this, string unexpected) { }
         public class EventsWith : aweXpect.Reflection.Collections.Filtered.Events
         {
             public EventsWith(aweXpect.Reflection.Collections.Filtered.Events inner, aweXpect.Reflection.Collections.IChangeableFilter<System.Reflection.EventInfo> filter) { }
@@ -257,6 +259,7 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.FieldFilters.FieldsWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Fields @this, System.Func<TAttribute, bool>? predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Collections.Filtered.Fields.StringEqualityResultType WithName(this aweXpect.Reflection.Collections.Filtered.Fields @this, string expected) { }
+        public static aweXpect.Reflection.Collections.Filtered.Fields.StringEqualityResultType WithoutName(this aweXpect.Reflection.Collections.Filtered.Fields @this, string unexpected) { }
         public class FieldsOfType : aweXpect.Reflection.Collections.Filtered.Fields
         {
             public FieldsOfType(aweXpect.Reflection.Collections.Filtered.Fields inner, aweXpect.Reflection.Collections.IChangeableFilter<System.Reflection.FieldInfo> filter) { }
@@ -384,6 +387,7 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.MethodFilters.MethodsWithNamedParameter<object?> WithRefParameterExactly(this aweXpect.Reflection.Collections.Filtered.Methods @this, System.Type parameterType, string expected) { }
         public static aweXpect.Reflection.MethodFilters.MethodsWithParameter<T> WithRefParameterExactly<T>(this aweXpect.Reflection.Collections.Filtered.Methods @this) { }
         public static aweXpect.Reflection.MethodFilters.MethodsWithNamedParameter<T> WithRefParameterExactly<T>(this aweXpect.Reflection.Collections.Filtered.Methods @this, string expected) { }
+        public static aweXpect.Reflection.Collections.Filtered.Methods.StringEqualityResultType WithoutName(this aweXpect.Reflection.Collections.Filtered.Methods @this, string unexpected) { }
         public static aweXpect.Reflection.Collections.Filtered.Methods WithoutParameters(this aweXpect.Reflection.Collections.Filtered.Methods @this) { }
         public class GenericMethods : aweXpect.Reflection.Collections.Filtered.Methods
         {
@@ -496,6 +500,7 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.PropertyFilters.PropertiesWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Properties @this, System.Func<TAttribute, bool>? predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Collections.Filtered.Properties.StringEqualityResultType WithName(this aweXpect.Reflection.Collections.Filtered.Properties @this, string expected) { }
+        public static aweXpect.Reflection.Collections.Filtered.Properties.StringEqualityResultType WithoutName(this aweXpect.Reflection.Collections.Filtered.Properties @this, string unexpected) { }
         public class PropertiesOfType : aweXpect.Reflection.Collections.Filtered.Properties
         {
             public PropertiesOfType(aweXpect.Reflection.Collections.Filtered.Properties inner, aweXpect.Reflection.Collections.IChangeableFilter<System.Reflection.PropertyInfo> filter) { }
@@ -515,6 +520,8 @@ namespace aweXpect.Reflection
     }
     public static class ThatAssemblies
     {
+        public static aweXpect.Results.StringEqualityTypeResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.Assembly?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.Assembly?>>> DoNotHaveName(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.Assembly?>> subject, string unexpected) { }
+        public static aweXpect.Results.StringEqualityTypeResult<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>>> DoNotHaveName(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>> subject, string unexpected) { }
         public static aweXpect.Reflection.Results.HaveAttributeResult<System.Reflection.Assembly?, System.Collections.Generic.IAsyncEnumerable<System.Reflection.Assembly?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.Assembly?>> subject, bool inherit = true)
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Results.HaveAttributeResult<System.Reflection.Assembly?, System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>> subject, bool inherit = true)
@@ -559,6 +566,7 @@ namespace aweXpect.Reflection
     }
     public static class ThatAssembly
     {
+        public static aweXpect.Results.StringEqualityTypeResult<System.Reflection.Assembly?, aweXpect.Core.IThat<System.Reflection.Assembly?>> DoesNotHaveName(this aweXpect.Core.IThat<System.Reflection.Assembly?> subject, string unexpected) { }
         public static aweXpect.Reflection.Results.HasAttributeResult<System.Reflection.Assembly?> Has<TAttribute>(this aweXpect.Core.IThat<System.Reflection.Assembly?> subject, bool inherit = true)
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Results.HasAttributeResult<System.Reflection.Assembly?> Has<TAttribute>(this aweXpect.Core.IThat<System.Reflection.Assembly?> subject, System.Func<TAttribute, bool> predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
@@ -929,6 +937,8 @@ namespace aweXpect.Reflection
             where TMember : System.Reflection.MemberInfo? { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TMember>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>>> ArePublic<TMember>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>> subject)
             where TMember : System.Reflection.MemberInfo? { }
+        public static aweXpect.Results.StringEqualityTypeResult<TMember, aweXpect.Core.IThat<TMember>> DoesNotHaveName<TMember>(this aweXpect.Core.IThat<TMember> subject, string unexpected)
+            where TMember : System.Reflection.MemberInfo? { }
         public static aweXpect.Results.StringEqualityTypeResult<TMember, aweXpect.Core.IThat<TMember>> HasName<TMember>(this aweXpect.Core.IThat<TMember> subject, string expected)
             where TMember : System.Reflection.MemberInfo? { }
         public static aweXpect.Results.AndOrResult<TMember, aweXpect.Core.IThat<TMember>> IsInternal<TMember>(this aweXpect.Core.IThat<TMember> subject)
@@ -958,6 +968,10 @@ namespace aweXpect.Reflection
     }
     public static class ThatMembers
     {
+        public static aweXpect.Results.StringEqualityTypeResult<System.Collections.Generic.IAsyncEnumerable<TMember>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TMember>>> DoNotHaveName<TMember>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TMember>> subject, string unexpected)
+            where TMember : System.Reflection.MemberInfo? { }
+        public static aweXpect.Results.StringEqualityTypeResult<System.Collections.Generic.IEnumerable<TMember>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>>> DoNotHaveName<TMember>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>> subject, string unexpected)
+            where TMember : System.Reflection.MemberInfo? { }
         public static aweXpect.Results.StringEqualityTypeResult<System.Collections.Generic.IAsyncEnumerable<TMember>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TMember>>> HaveName<TMember>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TMember>> subject, string expected)
             where TMember : System.Reflection.MemberInfo? { }
         public static aweXpect.Results.StringEqualityTypeResult<System.Collections.Generic.IEnumerable<TMember>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>>> HaveName<TMember>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>> subject, string expected)
@@ -1496,6 +1510,7 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Collections.Filtered.Types.StringEqualityResultType WithName(this aweXpect.Reflection.Collections.Filtered.Types @this, string expected) { }
         public static aweXpect.Reflection.Collections.Filtered.Types.StringEqualityResultType WithNamespace(this aweXpect.Reflection.Collections.Filtered.Types @this, string expected) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WithinNamespace(this aweXpect.Reflection.Collections.Filtered.Types @this, string expected) { }
+        public static aweXpect.Reflection.Collections.Filtered.Types.StringEqualityResultType WithoutName(this aweXpect.Reflection.Collections.Filtered.Types @this, string unexpected) { }
         public class GenericTypes : aweXpect.Reflection.Collections.Filtered.Types
         {
             public GenericTypes(aweXpect.Reflection.Collections.Filtered.Types inner) { }

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net8.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net8.0.txt
@@ -45,6 +45,7 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Collections.Filtered.Assemblies.StringEqualityResultType WithName(this aweXpect.Reflection.Collections.Filtered.Assemblies @this, string expected) { }
         public static aweXpect.Reflection.AssemblyFilters.AssembliesWithVersion WithVersion(this aweXpect.Reflection.Collections.Filtered.Assemblies @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Assemblies WithVersion(this aweXpect.Reflection.Collections.Filtered.Assemblies @this, System.Func<System.Version, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
+        public static aweXpect.Reflection.Collections.Filtered.Assemblies.StringEqualityResultType WithoutName(this aweXpect.Reflection.Collections.Filtered.Assemblies @this, string unexpected) { }
         public class AssembliesWith : aweXpect.Reflection.Collections.Filtered.Assemblies
         {
             public AssembliesWith(aweXpect.Reflection.Collections.Filtered.Assemblies inner, aweXpect.Reflection.Collections.IChangeableFilter<System.Reflection.Assembly> filter) { }
@@ -220,6 +221,7 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.EventFilters.EventsWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Events @this, System.Func<TAttribute, bool>? predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Collections.Filtered.Events.StringEqualityResultType WithName(this aweXpect.Reflection.Collections.Filtered.Events @this, string expected) { }
+        public static aweXpect.Reflection.Collections.Filtered.Events.StringEqualityResultType WithoutName(this aweXpect.Reflection.Collections.Filtered.Events @this, string unexpected) { }
         public class EventsWith : aweXpect.Reflection.Collections.Filtered.Events
         {
             public EventsWith(aweXpect.Reflection.Collections.Filtered.Events inner, aweXpect.Reflection.Collections.IChangeableFilter<System.Reflection.EventInfo> filter) { }
@@ -257,6 +259,7 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.FieldFilters.FieldsWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Fields @this, System.Func<TAttribute, bool>? predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Collections.Filtered.Fields.StringEqualityResultType WithName(this aweXpect.Reflection.Collections.Filtered.Fields @this, string expected) { }
+        public static aweXpect.Reflection.Collections.Filtered.Fields.StringEqualityResultType WithoutName(this aweXpect.Reflection.Collections.Filtered.Fields @this, string unexpected) { }
         public class FieldsOfType : aweXpect.Reflection.Collections.Filtered.Fields
         {
             public FieldsOfType(aweXpect.Reflection.Collections.Filtered.Fields inner, aweXpect.Reflection.Collections.IChangeableFilter<System.Reflection.FieldInfo> filter) { }
@@ -384,6 +387,7 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.MethodFilters.MethodsWithNamedParameter<object?> WithRefParameterExactly(this aweXpect.Reflection.Collections.Filtered.Methods @this, System.Type parameterType, string expected) { }
         public static aweXpect.Reflection.MethodFilters.MethodsWithParameter<T> WithRefParameterExactly<T>(this aweXpect.Reflection.Collections.Filtered.Methods @this) { }
         public static aweXpect.Reflection.MethodFilters.MethodsWithNamedParameter<T> WithRefParameterExactly<T>(this aweXpect.Reflection.Collections.Filtered.Methods @this, string expected) { }
+        public static aweXpect.Reflection.Collections.Filtered.Methods.StringEqualityResultType WithoutName(this aweXpect.Reflection.Collections.Filtered.Methods @this, string unexpected) { }
         public static aweXpect.Reflection.Collections.Filtered.Methods WithoutParameters(this aweXpect.Reflection.Collections.Filtered.Methods @this) { }
         public class GenericMethods : aweXpect.Reflection.Collections.Filtered.Methods
         {
@@ -496,6 +500,7 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.PropertyFilters.PropertiesWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Properties @this, System.Func<TAttribute, bool>? predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Collections.Filtered.Properties.StringEqualityResultType WithName(this aweXpect.Reflection.Collections.Filtered.Properties @this, string expected) { }
+        public static aweXpect.Reflection.Collections.Filtered.Properties.StringEqualityResultType WithoutName(this aweXpect.Reflection.Collections.Filtered.Properties @this, string unexpected) { }
         public class PropertiesOfType : aweXpect.Reflection.Collections.Filtered.Properties
         {
             public PropertiesOfType(aweXpect.Reflection.Collections.Filtered.Properties inner, aweXpect.Reflection.Collections.IChangeableFilter<System.Reflection.PropertyInfo> filter) { }
@@ -515,6 +520,8 @@ namespace aweXpect.Reflection
     }
     public static class ThatAssemblies
     {
+        public static aweXpect.Results.StringEqualityTypeResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.Assembly?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.Assembly?>>> DoNotHaveName(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.Assembly?>> subject, string unexpected) { }
+        public static aweXpect.Results.StringEqualityTypeResult<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>>> DoNotHaveName(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>> subject, string unexpected) { }
         public static aweXpect.Reflection.Results.HaveAttributeResult<System.Reflection.Assembly?, System.Collections.Generic.IAsyncEnumerable<System.Reflection.Assembly?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.Assembly?>> subject, bool inherit = true)
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Results.HaveAttributeResult<System.Reflection.Assembly?, System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>> subject, bool inherit = true)
@@ -559,6 +566,7 @@ namespace aweXpect.Reflection
     }
     public static class ThatAssembly
     {
+        public static aweXpect.Results.StringEqualityTypeResult<System.Reflection.Assembly?, aweXpect.Core.IThat<System.Reflection.Assembly?>> DoesNotHaveName(this aweXpect.Core.IThat<System.Reflection.Assembly?> subject, string unexpected) { }
         public static aweXpect.Reflection.Results.HasAttributeResult<System.Reflection.Assembly?> Has<TAttribute>(this aweXpect.Core.IThat<System.Reflection.Assembly?> subject, bool inherit = true)
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Results.HasAttributeResult<System.Reflection.Assembly?> Has<TAttribute>(this aweXpect.Core.IThat<System.Reflection.Assembly?> subject, System.Func<TAttribute, bool> predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
@@ -929,6 +937,8 @@ namespace aweXpect.Reflection
             where TMember : System.Reflection.MemberInfo? { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TMember>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>>> ArePublic<TMember>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>> subject)
             where TMember : System.Reflection.MemberInfo? { }
+        public static aweXpect.Results.StringEqualityTypeResult<TMember, aweXpect.Core.IThat<TMember>> DoesNotHaveName<TMember>(this aweXpect.Core.IThat<TMember> subject, string unexpected)
+            where TMember : System.Reflection.MemberInfo? { }
         public static aweXpect.Results.StringEqualityTypeResult<TMember, aweXpect.Core.IThat<TMember>> HasName<TMember>(this aweXpect.Core.IThat<TMember> subject, string expected)
             where TMember : System.Reflection.MemberInfo? { }
         public static aweXpect.Results.AndOrResult<TMember, aweXpect.Core.IThat<TMember>> IsInternal<TMember>(this aweXpect.Core.IThat<TMember> subject)
@@ -958,6 +968,10 @@ namespace aweXpect.Reflection
     }
     public static class ThatMembers
     {
+        public static aweXpect.Results.StringEqualityTypeResult<System.Collections.Generic.IAsyncEnumerable<TMember>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TMember>>> DoNotHaveName<TMember>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TMember>> subject, string unexpected)
+            where TMember : System.Reflection.MemberInfo? { }
+        public static aweXpect.Results.StringEqualityTypeResult<System.Collections.Generic.IEnumerable<TMember>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>>> DoNotHaveName<TMember>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>> subject, string unexpected)
+            where TMember : System.Reflection.MemberInfo? { }
         public static aweXpect.Results.StringEqualityTypeResult<System.Collections.Generic.IAsyncEnumerable<TMember>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TMember>>> HaveName<TMember>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TMember>> subject, string expected)
             where TMember : System.Reflection.MemberInfo? { }
         public static aweXpect.Results.StringEqualityTypeResult<System.Collections.Generic.IEnumerable<TMember>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>>> HaveName<TMember>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>> subject, string expected)
@@ -1496,6 +1510,7 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Collections.Filtered.Types.StringEqualityResultType WithName(this aweXpect.Reflection.Collections.Filtered.Types @this, string expected) { }
         public static aweXpect.Reflection.Collections.Filtered.Types.StringEqualityResultType WithNamespace(this aweXpect.Reflection.Collections.Filtered.Types @this, string expected) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WithinNamespace(this aweXpect.Reflection.Collections.Filtered.Types @this, string expected) { }
+        public static aweXpect.Reflection.Collections.Filtered.Types.StringEqualityResultType WithoutName(this aweXpect.Reflection.Collections.Filtered.Types @this, string unexpected) { }
         public class GenericTypes : aweXpect.Reflection.Collections.Filtered.Types
         {
             public GenericTypes(aweXpect.Reflection.Collections.Filtered.Types inner) { }

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_netstandard2.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_netstandard2.0.txt
@@ -45,6 +45,7 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Collections.Filtered.Assemblies.StringEqualityResultType WithName(this aweXpect.Reflection.Collections.Filtered.Assemblies @this, string expected) { }
         public static aweXpect.Reflection.AssemblyFilters.AssembliesWithVersion WithVersion(this aweXpect.Reflection.Collections.Filtered.Assemblies @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Assemblies WithVersion(this aweXpect.Reflection.Collections.Filtered.Assemblies @this, System.Func<System.Version, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
+        public static aweXpect.Reflection.Collections.Filtered.Assemblies.StringEqualityResultType WithoutName(this aweXpect.Reflection.Collections.Filtered.Assemblies @this, string unexpected) { }
         public class AssembliesWith : aweXpect.Reflection.Collections.Filtered.Assemblies
         {
             public AssembliesWith(aweXpect.Reflection.Collections.Filtered.Assemblies inner, aweXpect.Reflection.Collections.IChangeableFilter<System.Reflection.Assembly> filter) { }
@@ -220,6 +221,7 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.EventFilters.EventsWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Events @this, System.Func<TAttribute, bool>? predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Collections.Filtered.Events.StringEqualityResultType WithName(this aweXpect.Reflection.Collections.Filtered.Events @this, string expected) { }
+        public static aweXpect.Reflection.Collections.Filtered.Events.StringEqualityResultType WithoutName(this aweXpect.Reflection.Collections.Filtered.Events @this, string unexpected) { }
         public class EventsWith : aweXpect.Reflection.Collections.Filtered.Events
         {
             public EventsWith(aweXpect.Reflection.Collections.Filtered.Events inner, aweXpect.Reflection.Collections.IChangeableFilter<System.Reflection.EventInfo> filter) { }
@@ -257,6 +259,7 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.FieldFilters.FieldsWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Fields @this, System.Func<TAttribute, bool>? predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Collections.Filtered.Fields.StringEqualityResultType WithName(this aweXpect.Reflection.Collections.Filtered.Fields @this, string expected) { }
+        public static aweXpect.Reflection.Collections.Filtered.Fields.StringEqualityResultType WithoutName(this aweXpect.Reflection.Collections.Filtered.Fields @this, string unexpected) { }
         public class FieldsOfType : aweXpect.Reflection.Collections.Filtered.Fields
         {
             public FieldsOfType(aweXpect.Reflection.Collections.Filtered.Fields inner, aweXpect.Reflection.Collections.IChangeableFilter<System.Reflection.FieldInfo> filter) { }
@@ -384,6 +387,7 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.MethodFilters.MethodsWithNamedParameter<object?> WithRefParameterExactly(this aweXpect.Reflection.Collections.Filtered.Methods @this, System.Type parameterType, string expected) { }
         public static aweXpect.Reflection.MethodFilters.MethodsWithParameter<T> WithRefParameterExactly<T>(this aweXpect.Reflection.Collections.Filtered.Methods @this) { }
         public static aweXpect.Reflection.MethodFilters.MethodsWithNamedParameter<T> WithRefParameterExactly<T>(this aweXpect.Reflection.Collections.Filtered.Methods @this, string expected) { }
+        public static aweXpect.Reflection.Collections.Filtered.Methods.StringEqualityResultType WithoutName(this aweXpect.Reflection.Collections.Filtered.Methods @this, string unexpected) { }
         public static aweXpect.Reflection.Collections.Filtered.Methods WithoutParameters(this aweXpect.Reflection.Collections.Filtered.Methods @this) { }
         public class GenericMethods : aweXpect.Reflection.Collections.Filtered.Methods
         {
@@ -496,6 +500,7 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.PropertyFilters.PropertiesWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Properties @this, System.Func<TAttribute, bool>? predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Collections.Filtered.Properties.StringEqualityResultType WithName(this aweXpect.Reflection.Collections.Filtered.Properties @this, string expected) { }
+        public static aweXpect.Reflection.Collections.Filtered.Properties.StringEqualityResultType WithoutName(this aweXpect.Reflection.Collections.Filtered.Properties @this, string unexpected) { }
         public class PropertiesOfType : aweXpect.Reflection.Collections.Filtered.Properties
         {
             public PropertiesOfType(aweXpect.Reflection.Collections.Filtered.Properties inner, aweXpect.Reflection.Collections.IChangeableFilter<System.Reflection.PropertyInfo> filter) { }
@@ -515,6 +520,7 @@ namespace aweXpect.Reflection
     }
     public static class ThatAssemblies
     {
+        public static aweXpect.Results.StringEqualityTypeResult<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>>> DoNotHaveName(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>> subject, string unexpected) { }
         public static aweXpect.Reflection.Results.HaveAttributeResult<System.Reflection.Assembly?, System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>> subject, bool inherit = true)
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Results.HaveAttributeResult<System.Reflection.Assembly?, System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>> subject, System.Func<TAttribute, bool> predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
@@ -547,6 +553,7 @@ namespace aweXpect.Reflection
     }
     public static class ThatAssembly
     {
+        public static aweXpect.Results.StringEqualityTypeResult<System.Reflection.Assembly?, aweXpect.Core.IThat<System.Reflection.Assembly?>> DoesNotHaveName(this aweXpect.Core.IThat<System.Reflection.Assembly?> subject, string unexpected) { }
         public static aweXpect.Reflection.Results.HasAttributeResult<System.Reflection.Assembly?> Has<TAttribute>(this aweXpect.Core.IThat<System.Reflection.Assembly?> subject, bool inherit = true)
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Results.HasAttributeResult<System.Reflection.Assembly?> Has<TAttribute>(this aweXpect.Core.IThat<System.Reflection.Assembly?> subject, System.Func<TAttribute, bool> predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
@@ -808,6 +815,8 @@ namespace aweXpect.Reflection
             where TMember : System.Reflection.MemberInfo? { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TMember>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>>> ArePublic<TMember>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>> subject)
             where TMember : System.Reflection.MemberInfo? { }
+        public static aweXpect.Results.StringEqualityTypeResult<TMember, aweXpect.Core.IThat<TMember>> DoesNotHaveName<TMember>(this aweXpect.Core.IThat<TMember> subject, string unexpected)
+            where TMember : System.Reflection.MemberInfo? { }
         public static aweXpect.Results.StringEqualityTypeResult<TMember, aweXpect.Core.IThat<TMember>> HasName<TMember>(this aweXpect.Core.IThat<TMember> subject, string expected)
             where TMember : System.Reflection.MemberInfo? { }
         public static aweXpect.Results.AndOrResult<TMember, aweXpect.Core.IThat<TMember>> IsInternal<TMember>(this aweXpect.Core.IThat<TMember> subject)
@@ -837,6 +846,8 @@ namespace aweXpect.Reflection
     }
     public static class ThatMembers
     {
+        public static aweXpect.Results.StringEqualityTypeResult<System.Collections.Generic.IEnumerable<TMember>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>>> DoNotHaveName<TMember>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>> subject, string unexpected)
+            where TMember : System.Reflection.MemberInfo? { }
         public static aweXpect.Results.StringEqualityTypeResult<System.Collections.Generic.IEnumerable<TMember>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>>> HaveName<TMember>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>> subject, string expected)
             where TMember : System.Reflection.MemberInfo? { }
         public static aweXpect.Results.StringEqualityTypeResult<System.Collections.Generic.IEnumerable<TMember>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>>> HaveName<TMember>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>> subject, System.Func<TMember, string> expectedNameSelector, [System.Runtime.CompilerServices.CallerArgumentExpression("expectedNameSelector")] string doNotPopulateThisValue = "")
@@ -1232,6 +1243,7 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Collections.Filtered.Types.StringEqualityResultType WithName(this aweXpect.Reflection.Collections.Filtered.Types @this, string expected) { }
         public static aweXpect.Reflection.Collections.Filtered.Types.StringEqualityResultType WithNamespace(this aweXpect.Reflection.Collections.Filtered.Types @this, string expected) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WithinNamespace(this aweXpect.Reflection.Collections.Filtered.Types @this, string expected) { }
+        public static aweXpect.Reflection.Collections.Filtered.Types.StringEqualityResultType WithoutName(this aweXpect.Reflection.Collections.Filtered.Types @this, string unexpected) { }
         public class GenericTypes : aweXpect.Reflection.Collections.Filtered.Types
         {
             public GenericTypes(aweXpect.Reflection.Collections.Filtered.Types inner) { }

--- a/Tests/aweXpect.Reflection.Tests/Filters/AssemblyFilters.WithoutName.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/AssemblyFilters.WithoutName.Tests.cs
@@ -1,0 +1,51 @@
+﻿using aweXpect.Reflection.Collections;
+
+namespace aweXpect.Reflection.Tests.Filters;
+
+public sealed partial class AssemblyFilters
+{
+	public sealed class WithoutName
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task ShouldFilterOutAssembliesWithName()
+			{
+				Filtered.Assemblies assemblies = In.AllLoadedAssemblies()
+					.WithoutName("aweXpect.Reflection.Tests");
+
+				await That(assemblies).All().Satisfy(a => a!.GetName().Name != "aweXpect.Reflection.Tests")
+					.And.IsNotEmpty();
+				await That(assemblies.GetDescription())
+					.IsEqualTo("in all loaded assemblies without name equal to \"aweXpect.Reflection.Tests\"");
+			}
+
+			[Fact]
+			public async Task ShouldSupportAsSuffix()
+			{
+				Filtered.Assemblies assemblies = In.AllLoadedAssemblies()
+					.WithoutName(".Tests").AsSuffix();
+
+				await That(assemblies).All().Satisfy(a => !a!.GetName().Name!.EndsWith(".Tests"))
+					.And.IsNotEmpty();
+				await That(assemblies.GetDescription())
+					.IsEqualTo("in all loaded assemblies without name ending with \".Tests\"");
+			}
+
+			[Fact]
+			public async Task ShouldSupportIgnoringCase()
+			{
+				Filtered.Assemblies assemblies = In.AllLoadedAssemblies()
+					.WithoutName("awexpect.reflection.tests").IgnoringCase();
+
+				await That(assemblies).All()
+					.Satisfy(a => !string.Equals(a!.GetName().Name, "aweXpect.Reflection.Tests",
+						System.StringComparison.OrdinalIgnoreCase))
+					.And.IsNotEmpty();
+				await That(assemblies.GetDescription())
+					.IsEqualTo(
+						"in all loaded assemblies without name equal to \"awexpect.reflection.tests\" ignoring case");
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/Filters/EventFilters.WithoutName.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/EventFilters.WithoutName.Tests.cs
@@ -1,0 +1,34 @@
+﻿using aweXpect.Reflection.Collections;
+
+namespace aweXpect.Reflection.Tests.Filters;
+
+public sealed partial class EventFilters
+{
+	public sealed class WithoutName
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task ShouldFilterOutEventsWithName()
+			{
+				Filtered.Events events = In.Type<ConcreteEventClass>()
+					.Events().WithoutName("ConcreteEvent");
+
+				await That(events).All().Satisfy(e => e!.Name != "ConcreteEvent").And.IsNotEmpty();
+				await That(events.GetDescription())
+					.IsEqualTo("events without name equal to \"ConcreteEvent\" in").AsPrefix();
+			}
+
+			[Fact]
+			public async Task ShouldSupportAsSuffix()
+			{
+				Filtered.Events events = In.Type<ConcreteEventClass>()
+					.Events().WithoutName("ConcreteEvent").AsSuffix();
+
+				await That(events).All().Satisfy(e => !e!.Name.EndsWith("ConcreteEvent")).And.IsNotEmpty();
+				await That(events.GetDescription())
+					.IsEqualTo("events without name ending with \"ConcreteEvent\" in").AsPrefix();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/Filters/FieldFilters.WithoutName.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/FieldFilters.WithoutName.Tests.cs
@@ -1,0 +1,42 @@
+﻿using aweXpect.Reflection.Collections;
+
+namespace aweXpect.Reflection.Tests.Filters;
+
+public sealed partial class FieldFilters
+{
+	public sealed class WithoutName
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task ShouldFilterOutFieldsWithName()
+			{
+				Filtered.Fields fields = In.Type<ClassWithTwoFields>()
+					.Fields().WithoutName("ExcludedField");
+
+				await That(fields).All().Satisfy(f => f!.Name != "ExcludedField").And.IsNotEmpty();
+				await That(fields.GetDescription())
+					.IsEqualTo("fields without name equal to \"ExcludedField\" in").AsPrefix();
+			}
+
+			[Fact]
+			public async Task ShouldSupportAsSuffix()
+			{
+				Filtered.Fields fields = In.Type<ClassWithTwoFields>()
+					.Fields().WithoutName("ExcludedField").AsSuffix();
+
+				await That(fields).All().Satisfy(f => !f!.Name.EndsWith("ExcludedField")).And.IsNotEmpty();
+				await That(fields.GetDescription())
+					.IsEqualTo("fields without name ending with \"ExcludedField\" in").AsPrefix();
+			}
+
+#pragma warning disable CS0649 // Field is never assigned to, and will always have its default value
+			private class ClassWithTwoFields
+			{
+				public int? ExcludedField;
+				public int? KeptField;
+			}
+#pragma warning restore CS0649
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WithoutName.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WithoutName.Tests.cs
@@ -1,0 +1,34 @@
+﻿using aweXpect.Reflection.Collections;
+
+namespace aweXpect.Reflection.Tests.Filters;
+
+public sealed partial class MethodFilters
+{
+	public sealed class WithoutName
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task ShouldFilterOutMethodsWithName()
+			{
+				Filtered.Methods methods = In.Type<ConcreteMethodClass>()
+					.Methods().WithoutName("ConcreteMethod");
+
+				await That(methods).All().Satisfy(m => m!.Name != "ConcreteMethod").And.IsNotEmpty();
+				await That(methods.GetDescription())
+					.IsEqualTo("methods without name equal to \"ConcreteMethod\" in").AsPrefix();
+			}
+
+			[Fact]
+			public async Task ShouldSupportAsSuffix()
+			{
+				Filtered.Methods methods = In.Type<ConcreteMethodClass>()
+					.Methods().WithoutName("ConcreteMethod").AsSuffix();
+
+				await That(methods).All().Satisfy(m => !m!.Name.EndsWith("ConcreteMethod")).And.IsNotEmpty();
+				await That(methods.GetDescription())
+					.IsEqualTo("methods without name ending with \"ConcreteMethod\" in").AsPrefix();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/Filters/PropertyFilters.WithoutName.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/PropertyFilters.WithoutName.Tests.cs
@@ -1,0 +1,34 @@
+﻿using aweXpect.Reflection.Collections;
+
+namespace aweXpect.Reflection.Tests.Filters;
+
+public sealed partial class PropertyFilters
+{
+	public sealed class WithoutName
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task ShouldFilterOutPropertiesWithName()
+			{
+				Filtered.Properties properties = In.Type<ConcretePropertyClass>()
+					.Properties().WithoutName("ConcreteProperty");
+
+				await That(properties).All().Satisfy(p => p!.Name != "ConcreteProperty").And.IsNotEmpty();
+				await That(properties.GetDescription())
+					.IsEqualTo("properties without name equal to \"ConcreteProperty\" in").AsPrefix();
+			}
+
+			[Fact]
+			public async Task ShouldSupportAsSuffix()
+			{
+				Filtered.Properties properties = In.Type<ConcretePropertyClass>()
+					.Properties().WithoutName("ConcreteProperty").AsSuffix();
+
+				await That(properties).All().Satisfy(p => !p!.Name.EndsWith("ConcreteProperty")).And.IsNotEmpty();
+				await That(properties.GetDescription())
+					.IsEqualTo("properties without name ending with \"ConcreteProperty\" in").AsPrefix();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WithoutName.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WithoutName.Tests.cs
@@ -1,0 +1,40 @@
+﻿using aweXpect.Reflection.Collections;
+
+namespace aweXpect.Reflection.Tests.Filters;
+
+public sealed partial class TypeFilters
+{
+	public sealed class WithoutName
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task ShouldFilterOutTypesWithName()
+			{
+				Filtered.Types types = In.AssemblyContaining<AssemblyFilters>()
+					.Types().WithoutName(nameof(TypeToExcludeByName));
+
+				await That(types).All().Satisfy(t => t!.Name != nameof(TypeToExcludeByName))
+					.And.IsNotEmpty();
+				await That(types.GetDescription())
+					.IsEqualTo("types without name equal to \"TypeToExcludeByName\" in assembly")
+					.AsPrefix();
+			}
+
+			[Fact]
+			public async Task ShouldSupportAsSuffix()
+			{
+				Filtered.Types types = In.AssemblyContaining<AssemblyFilters>()
+					.Types().WithoutName("ToExcludeByName").AsSuffix();
+
+				await That(types).All().Satisfy(t => !t!.Name.EndsWith("ToExcludeByName"))
+					.And.IsNotEmpty();
+				await That(types.GetDescription())
+					.IsEqualTo("types without name ending with \"ToExcludeByName\" in assembly")
+					.AsPrefix();
+			}
+
+			private class TypeToExcludeByName;
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatAssemblies.DoNotHaveName.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatAssemblies.DoNotHaveName.Tests.cs
@@ -1,0 +1,181 @@
+﻿using System.Collections.Generic;
+using System.Reflection;
+using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Tests.TestHelpers;
+using aweXpect.Reflection.Tests.TestHelpers.Types;
+using Xunit.Sdk;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatAssemblies
+{
+	public sealed class DoNotHaveName
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenNoAssemblyHasName_ShouldSucceed()
+			{
+				Filtered.Assemblies subject = In.AssemblyContaining<PublicAbstractClass>();
+
+				async Task Act()
+				{
+					await That(subject).DoNotHaveName("NonExistentAssembly");
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenAssemblyHasName_ShouldFail()
+			{
+				Filtered.Assemblies subject = In.AssemblyContaining<PublicAbstractClass>();
+
+				async Task Act()
+				{
+					await That(subject).DoNotHaveName("aweXpect.Reflection.Tests");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that in assembly containing type PublicAbstractClass
+					             all have name not equal to "aweXpect.Reflection.Tests",
+					             but it contained not matching types [
+					               aweXpect.Reflection.Tests, Version=*, Culture=neutral, PublicKeyToken=null
+					             ]
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenAssemblyHasMatchingSuffix_ShouldFail()
+			{
+				Filtered.Assemblies subject = In.AssemblyContaining<PublicAbstractClass>();
+
+				async Task Act()
+				{
+					await That(subject).DoNotHaveName(".Tests").AsSuffix();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that in assembly containing type PublicAbstractClass
+					             all have name not ending with ".Tests",
+					             but it contained not matching types [
+					               aweXpect.Reflection.Tests, Version=*, Culture=neutral, PublicKeyToken=null
+					             ]
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenAssemblyMatchesIgnoringCase_ShouldFail()
+			{
+				Filtered.Assemblies subject = In.AssemblyContaining<PublicAbstractClass>();
+
+				async Task Act()
+				{
+					await That(subject).DoNotHaveName("AWExPECT.rEFLECTION.tESTS").IgnoringCase();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that in assembly containing type PublicAbstractClass
+					             all have name not equal to "AWExPECT.rEFLECTION.tESTS" ignoring case,
+					             but it contained not matching types [
+					               aweXpect.Reflection.Tests, Version=*, Culture=neutral, PublicKeyToken=null
+					             ]
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task Enumerable_WhenNoAssemblyHasName_ShouldSucceed()
+			{
+				IEnumerable<Assembly?> subject = new Assembly?[]
+				{
+					typeof(PublicAbstractClass).Assembly, null,
+				};
+
+				async Task Act()
+				{
+					await That(subject).DoNotHaveName("NonExistentAssembly");
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+#if NET8_0_OR_GREATER
+			[Fact]
+			public async Task AsyncEnumerable_WhenNoAssemblyHasName_ShouldSucceed()
+			{
+				IAsyncEnumerable<Assembly?> subject = new Assembly?[]
+				{
+					typeof(PublicAbstractClass).Assembly, null,
+				}.ToTestAsyncEnumerable<Assembly?>();
+
+				async Task Act()
+				{
+					await That(subject).DoNotHaveName("NonExistentAssembly");
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task AsyncEnumerable_WhenAssemblyHasName_ShouldFail()
+			{
+				IAsyncEnumerable<Assembly?> subject = new[]
+				{
+					typeof(PublicAbstractClass).Assembly,
+				}.ToTestAsyncEnumerable<Assembly?>();
+
+				async Task Act()
+				{
+					await That(subject).DoNotHaveName("aweXpect.Reflection.Tests");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             all have name not equal to "aweXpect.Reflection.Tests",
+					             but it contained not matching types [
+					               aweXpect.Reflection.Tests, Version=*, Culture=neutral, PublicKeyToken=null
+					             ]
+					             """).AsWildcard();
+			}
+#endif
+		}
+
+		public sealed class NegatedTests
+		{
+			[Fact]
+			public async Task WhenAssemblyHasName_ShouldSucceed()
+			{
+				Filtered.Assemblies subject = In.AssemblyContaining<PublicAbstractClass>();
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(they => they.DoNotHaveName("aweXpect.Reflection.Tests"));
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenNoAssemblyHasName_ShouldFail()
+			{
+				Filtered.Assemblies subject = In.AssemblyContaining<PublicAbstractClass>();
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(they => they.DoNotHaveName("NonExistentAssembly"));
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that in assembly containing type PublicAbstractClass
+					             not all have name not equal to "NonExistentAssembly",
+					             but it only contained matching types *
+					             """).AsWildcard();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatAssembly.DoesNotHaveName.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatAssembly.DoesNotHaveName.Tests.cs
@@ -1,0 +1,150 @@
+﻿using System.Reflection;
+using aweXpect.Reflection.Tests.TestHelpers.Types;
+using Xunit.Sdk;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatAssembly
+{
+	public sealed class DoesNotHaveName
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenAssemblyHasDifferentName_ShouldSucceed()
+			{
+				Assembly subject = typeof(PublicAbstractClass).Assembly;
+
+				async Task Act()
+				{
+					await That(subject).DoesNotHaveName("NonExistentAssembly");
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenExpectedValueIsOnlySubstring_ShouldSucceed()
+			{
+				Assembly subject = typeof(PublicAbstractClass).Assembly;
+
+				async Task Act()
+				{
+					await That(subject).DoesNotHaveName("Reflection");
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenAssemblyHasMatchingName_ShouldFail()
+			{
+				Assembly subject = typeof(PublicAbstractClass).Assembly;
+
+				async Task Act()
+				{
+					await That(subject).DoesNotHaveName("aweXpect.Reflection.Tests");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has name not equal to "aweXpect.Reflection.Tests",
+					             but it was "aweXpect.Reflection.Tests"
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenAssemblyHasMatchingSuffix_ShouldFail()
+			{
+				Assembly subject = typeof(PublicAbstractClass).Assembly;
+
+				async Task Act()
+				{
+					await That(subject).DoesNotHaveName(".Tests").AsSuffix();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has name not ending with ".Tests",
+					             but it was "aweXpect.Reflection.Tests"
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenAssemblyMatchesIgnoringCase_ShouldFail()
+			{
+				Assembly subject = typeof(PublicAbstractClass).Assembly;
+
+				async Task Act()
+				{
+					await That(subject).DoesNotHaveName("AWExPECT.rEFLECTION.tESTS").IgnoringCase();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has name not equal to "AWExPECT.rEFLECTION.tESTS" ignoring case,
+					             but it was "aweXpect.Reflection.Tests"
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenAssemblyIsNull_ShouldFail()
+			{
+				Assembly? subject = null;
+
+				async Task Act()
+				{
+					await That(subject).DoesNotHaveName("foo");
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             has name not equal to "foo",
+					             but it was <null>
+					             """);
+			}
+		}
+
+		public sealed class NegatedTests
+		{
+			[Fact]
+			public async Task WhenAssemblyHasName_ShouldSucceed()
+			{
+				Assembly subject = typeof(PublicAbstractClass).Assembly;
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(it => it.DoesNotHaveName("aweXpect.Reflection.Tests"));
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenAssemblyHasDifferentName_ShouldFail()
+			{
+				Assembly subject = typeof(PublicAbstractClass).Assembly;
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(it => it.DoesNotHaveName("NonExistentAssembly"));
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has name equal to "NonExistentAssembly",
+					             but it was "aweXpect.Reflection.Tests" which differs at index 0:
+					                ↓ (actual)
+					               "aweXpect.Reflection.Tests"
+					               "NonExistentAssembly"
+					                ↑ (expected)
+					             """);
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatType.DoesNotHaveName.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatType.DoesNotHaveName.Tests.cs
@@ -1,0 +1,149 @@
+﻿using aweXpect.Reflection.Tests.TestHelpers.Types;
+using Xunit.Sdk;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatType
+{
+	public sealed class DoesNotHaveName
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenTypeHasDifferentName_ShouldSucceed()
+			{
+				Type subject = typeof(PublicAbstractClass);
+
+				async Task Act()
+				{
+					await That(subject).DoesNotHaveName("NonExistentClass");
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenExpectedValueIsOnlySubstring_ShouldSucceed()
+			{
+				Type subject = typeof(PublicAbstractClass);
+
+				async Task Act()
+				{
+					await That(subject).DoesNotHaveName("Abstract");
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenTypeHasMatchingName_ShouldFail()
+			{
+				Type subject = typeof(PublicAbstractClass);
+
+				async Task Act()
+				{
+					await That(subject).DoesNotHaveName("PublicAbstractClass");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has name not equal to "PublicAbstractClass",
+					             but it was "PublicAbstractClass"
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenTypeHasMatchingSuffix_ShouldFail()
+			{
+				Type subject = typeof(PublicAbstractClass);
+
+				async Task Act()
+				{
+					await That(subject).DoesNotHaveName("AbstractClass").AsSuffix();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has name not ending with "AbstractClass",
+					             but it was "PublicAbstractClass"
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenTypeMatchesIgnoringCase_ShouldFail()
+			{
+				Type subject = typeof(PublicAbstractClass);
+
+				async Task Act()
+				{
+					await That(subject).DoesNotHaveName("pUBLICaBSTRACTcLASS").IgnoringCase();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has name not equal to "pUBLICaBSTRACTcLASS" ignoring case,
+					             but it was "PublicAbstractClass"
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenTypeIsNull_ShouldFail()
+			{
+				Type? subject = null;
+
+				async Task Act()
+				{
+					await That(subject).DoesNotHaveName("foo");
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             has name not equal to "foo",
+					             but it was <null>
+					             """);
+			}
+		}
+
+		public sealed class NegatedTests
+		{
+			[Fact]
+			public async Task WhenTypeHasName_ShouldSucceed()
+			{
+				Type subject = typeof(PublicAbstractClass);
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(it => it.DoesNotHaveName("PublicAbstractClass"));
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenTypeHasDifferentName_ShouldFail()
+			{
+				Type subject = typeof(PublicAbstractClass);
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(it => it.DoesNotHaveName("NonExistentClass"));
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has name equal to "NonExistentClass",
+					             but it was "PublicAbstractClass" which differs at index 0:
+					                ↓ (actual)
+					               "PublicAbstractClass"
+					               "NonExistentClass"
+					                ↑ (expected)
+					             """);
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.DoNotHaveName.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.DoNotHaveName.Tests.cs
@@ -1,0 +1,171 @@
+﻿using System;
+using System.Collections.Generic;
+using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Tests.TestHelpers;
+using Xunit.Sdk;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatTypes
+{
+	public sealed class DoNotHaveName
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenNoTypeHasName_ShouldSucceed()
+			{
+				Filtered.Types subject = In.AssemblyContaining<Tests>()
+					.Types().WithName(nameof(DoNotHaveNameType));
+
+				async Task Act()
+				{
+					await That(subject).DoNotHaveName("SomeOtherClassName");
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenTypeHasName_ShouldFail()
+			{
+				Filtered.Types subject = In.AssemblyContaining<Tests>()
+					.Types().WithName(nameof(DoNotHaveNameType));
+
+				async Task Act()
+				{
+					await That(subject).DoNotHaveName(nameof(DoNotHaveNameType));
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that types with name equal to "DoNotHaveNameType" in assembly containing type ThatTypes.DoNotHaveName.Tests
+					             all have name not equal to "DoNotHaveNameType",
+					             but it contained not matching items [
+					               *DoNotHaveNameType*
+					             ]
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenTypeMatchesSuffix_ShouldFail()
+			{
+				Filtered.Types subject = In.AssemblyContaining<Tests>()
+					.Types().WithName(nameof(DoNotHaveNameType));
+
+				async Task Act()
+				{
+					await That(subject).DoNotHaveName("HaveNameType").AsSuffix();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that types with name equal to "DoNotHaveNameType" in assembly containing type ThatTypes.DoNotHaveName.Tests
+					             all have name not ending with "HaveNameType",
+					             but it contained not matching items [
+					               *DoNotHaveNameType*
+					             ]
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task Enumerable_WhenNoTypeHasName_ShouldSucceed()
+			{
+				IEnumerable<Type?> subject = new[]
+				{
+					typeof(DoNotHaveNameType), null,
+				};
+
+				async Task Act()
+				{
+					await That(subject).DoNotHaveName("SomeOtherClassName");
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+#if NET8_0_OR_GREATER
+			[Fact]
+			public async Task AsyncEnumerable_WhenNoTypeHasName_ShouldSucceed()
+			{
+				IAsyncEnumerable<Type?> subject = new[]
+				{
+					typeof(DoNotHaveNameType), null,
+				}.ToTestAsyncEnumerable<Type?>();
+
+				async Task Act()
+				{
+					await That(subject).DoNotHaveName("SomeOtherClassName");
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task AsyncEnumerable_WhenTypeHasName_ShouldFail()
+			{
+				IAsyncEnumerable<Type?> subject = new[]
+				{
+					typeof(DoNotHaveNameType),
+				}.ToTestAsyncEnumerable<Type?>();
+
+				async Task Act()
+				{
+					await That(subject).DoNotHaveName(nameof(DoNotHaveNameType));
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             all have name not equal to "DoNotHaveNameType",
+					             but it contained not matching items [
+					               *DoNotHaveNameType*
+					             ]
+					             """).AsWildcard();
+			}
+#endif
+
+			private class DoNotHaveNameType;
+		}
+
+		public sealed class NegatedTests
+		{
+			[Fact]
+			public async Task WhenTypeHasName_ShouldSucceed()
+			{
+				Filtered.Types subject = In.AssemblyContaining<Tests>()
+					.Types().WithName(nameof(DoNotHaveNameTypeNeg));
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(they => they.DoNotHaveName(nameof(DoNotHaveNameTypeNeg)));
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenNoTypeHasName_ShouldFail()
+			{
+				Filtered.Types subject = In.AssemblyContaining<Tests>()
+					.Types().WithName(nameof(DoNotHaveNameTypeNeg));
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(they => they.DoNotHaveName("SomeOtherClassName"));
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that types with name equal to "DoNotHaveNameTypeNeg" in assembly containing type ThatTypes.DoNotHaveName.Tests
+					             not all have name not equal to "SomeOtherClassName",
+					             but it only contained matching items [
+					               *DoNotHaveNameTypeNeg*
+					             ]
+					             """).AsWildcard();
+			}
+
+			private class DoNotHaveNameTypeNeg;
+		}
+	}
+}


### PR DESCRIPTION
Add the negations of the name filter and assertions across assemblies and all member kinds:

- WithoutName: keeps items whose name does not match (Assembly, Type, Method, Property, Field, Event)
- DoesNotHaveName: verifies a single subject is not named the given value (ThatMember<TMember> generic + ThatAssembly)
- DoNotHaveName: verifies none of the items in a collection are named the given value (ThatMembers<TMember> generic + ThatAssemblies, IEnumerable and IAsyncEnumerable)

All variants accept the existing string matching options (AsPrefix, AsSuffix, AsWildcard, AsRegex, IgnoringCase). Single-subject assertions reuse the positive constraint via .Invert(); collection assertions use an inverted per-item predicate so the result reads "none have" rather than "not all have".

Includes tests with 100% line and branch coverage, regenerated public API approval files, and updated README.