### PR TITLE
feat: add `Without` filter and `DoesNotHave`/`DoNotHave` negated attribute assertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,15 +161,17 @@ await Expect.That(methods).ArePublic();
 
 Shared by all types, members, and assemblies.
 
-|                                    | Filter                      | Assert (single)            | Assert (many)               |
-|------------------------------------|-----------------------------|----------------------------|-----------------------------|
-| has attribute                      | `.With<TAttribute>()`       | `.Has<TAttribute>()`       | `.Have<TAttribute>()`       |
-| has attribute matching a predicate | `.With<TAttribute>(a => …)` | `.Has<TAttribute>(a => …)` | `.Have<TAttribute>(a => …)` |
-| any of several attributes          | `.With<T1>().OrWith<T2>()`  | -                          | -                           |
+|                                    | Filter                      | Assert (single)              | Assert (many)               |
+|------------------------------------|-----------------------------|------------------------------|-----------------------------|
+| has attribute                      | `.With<TAttribute>()`       | `.Has<TAttribute>()`         | `.Have<TAttribute>()`       |
+| has attribute matching a predicate | `.With<TAttribute>(a => …)` | `.Has<TAttribute>(a => …)`   | `.Have<TAttribute>(a => …)` |
+| any of several attributes          | `.With<T1>().OrWith<T2>()`  | -                            | -                           |
+| does not have attribute            | `.Without<TAttribute>()`    | `.DoesNotHave<TAttribute>()` | `.DoNotHave<TAttribute>()`  |
 
-All attribute filters and assertions (`With`, `OrWith`, `Has`, `Have`, `OrHas`, `OrHave`) take an optional
-`inherit` parameter (default `true`) that controls whether attributes inherited from base types are
-considered: `.With<TAttribute>(inherit: false)`.
+All attribute filters and assertions (`With`, `OrWith`, `Without`, `Has`, `Have`, `DoesNotHave`, `DoNotHave`,
+`OrHas`, `OrHave`) take an optional `inherit` parameter (default `true`) that controls whether attributes
+inherited from base types are considered: `.With<TAttribute>(inherit: false)`. Chain multiple
+`.Without<TAttribute>()` calls to exclude several attributes (an item must have none of them).
 
 ```csharp
 await Expect.That(type).Has<ObsoleteAttribute>(a => a.Message == "Use NewClass instead");
@@ -444,6 +446,7 @@ on them directly:
 | not by name                 | `.WithoutName("x")`                    | `.DoesNotHaveName("x")`          | `.DoNotHaveName("x")`             |
 | by target framework         | `.WhichTarget("net8.0")`               | `.Targets("net8.0")`             | `.Target("net8.0")`               |
 | has attribute               | `.With<TAttribute>()`                  | `.Has<TAttribute>()`             | `.Have<TAttribute>()`             |
+| does not have attribute     | `.Without<TAttribute>()`               | `.DoesNotHave<TAttribute>()`     | `.DoNotHave<TAttribute>()`        |
 | depends on assembly         | `.WhichHaveADependencyOn("x")`         | `.HasADependencyOn("x")`         | `.HaveADependencyOn("x")`         |
 | does not depend on assembly | `.WhichHaveNoDependencyOn("x")`        | `.HasNoDependencyOn("x")`        | `.HaveNoDependencyOn("x")`        |
 | depends only on set         | `.WhichHaveDependenciesOnlyOn("x", …)` | `.HasDependenciesOnlyOn("x", …)` | `.HaveDependenciesOnlyOn("x", …)` |

--- a/Source/aweXpect.Reflection/Filters/AssemblyFilters.Without.cs
+++ b/Source/aweXpect.Reflection/Filters/AssemblyFilters.Without.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Reflection;
+using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Helpers;
+
+namespace aweXpect.Reflection;
+
+public static partial class AssemblyFilters
+{
+	/// <summary>
+	///     Filter for assemblies without attribute of type <typeparamref name="TAttribute" />.
+	/// </summary>
+	/// <remarks>
+	///     The optional parameter <paramref name="inherit" /> (default value <see langword="true" /> specifies, if
+	///     the attribute can be inherited from a base type.
+	/// </remarks>
+	public static Filtered.Assemblies Without<TAttribute>(this Filtered.Assemblies @this, bool inherit = true)
+		where TAttribute : Attribute
+		=> @this.Which(Filter.Suffix<Assembly>(
+			assembly => !assembly.HasAttribute<TAttribute>(inherit: inherit),
+			$" without {(inherit ? "" : DirectText)}{Formatter.Format(typeof(TAttribute))}"));
+}

--- a/Source/aweXpect.Reflection/Filters/ConstructorFilters.Without.cs
+++ b/Source/aweXpect.Reflection/Filters/ConstructorFilters.Without.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Reflection;
+using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Helpers;
+
+namespace aweXpect.Reflection;
+
+public static partial class ConstructorFilters
+{
+	/// <summary>
+	///     Filter for constructors without attribute of type <typeparamref name="TAttribute" />.
+	/// </summary>
+	public static Filtered.Constructors Without<TAttribute>(this Filtered.Constructors @this)
+		where TAttribute : Attribute
+		=> @this.Which(Filter.Suffix<ConstructorInfo>(
+			constructorInfo => !constructorInfo.HasAttribute<TAttribute>(),
+			$"without {Formatter.Format(typeof(TAttribute))} "));
+}

--- a/Source/aweXpect.Reflection/Filters/EventFilters.Without.cs
+++ b/Source/aweXpect.Reflection/Filters/EventFilters.Without.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Reflection;
+using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Helpers;
+
+namespace aweXpect.Reflection;
+
+public static partial class EventFilters
+{
+	/// <summary>
+	///     Filter for events without attribute of type <typeparamref name="TAttribute" />.
+	/// </summary>
+	/// <remarks>
+	///     The optional parameter <paramref name="inherit" /> (default value <see langword="true" /> specifies, if
+	///     the attribute can be inherited from a base type.
+	/// </remarks>
+	public static Filtered.Events Without<TAttribute>(this Filtered.Events @this, bool inherit = true)
+		where TAttribute : Attribute
+		=> @this.Which(Filter.Suffix<EventInfo>(
+			eventInfo => !eventInfo.HasAttribute<TAttribute>(inherit: inherit),
+			$"without {(inherit ? "" : DirectText)}{Formatter.Format(typeof(TAttribute))} "));
+}

--- a/Source/aweXpect.Reflection/Filters/FieldFilters.Without.cs
+++ b/Source/aweXpect.Reflection/Filters/FieldFilters.Without.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Reflection;
+using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Helpers;
+
+namespace aweXpect.Reflection;
+
+public static partial class FieldFilters
+{
+	/// <summary>
+	///     Filter for fields without attribute of type <typeparamref name="TAttribute" />.
+	/// </summary>
+	public static Filtered.Fields Without<TAttribute>(this Filtered.Fields @this)
+		where TAttribute : Attribute
+		=> @this.Which(Filter.Suffix<FieldInfo>(
+			fieldInfo => !fieldInfo.HasAttribute<TAttribute>(),
+			$"without {Formatter.Format(typeof(TAttribute))} "));
+}

--- a/Source/aweXpect.Reflection/Filters/MethodFilters.Without.cs
+++ b/Source/aweXpect.Reflection/Filters/MethodFilters.Without.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Reflection;
+using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Helpers;
+
+namespace aweXpect.Reflection;
+
+public static partial class MethodFilters
+{
+	/// <summary>
+	///     Filter for methods without attribute of type <typeparamref name="TAttribute" />.
+	/// </summary>
+	/// <remarks>
+	///     The optional parameter <paramref name="inherit" /> (default value <see langword="true" /> specifies, if
+	///     the attribute can be inherited from a base type.
+	/// </remarks>
+	public static Filtered.Methods Without<TAttribute>(this Filtered.Methods @this, bool inherit = true)
+		where TAttribute : Attribute
+		=> @this.Which(Filter.Suffix<MethodInfo>(
+			methodInfo => !methodInfo.HasAttribute<TAttribute>(inherit: inherit),
+			$"without {(inherit ? "" : DirectText)}{Formatter.Format(typeof(TAttribute))} "));
+}

--- a/Source/aweXpect.Reflection/Filters/PropertyFilters.Without.cs
+++ b/Source/aweXpect.Reflection/Filters/PropertyFilters.Without.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Reflection;
+using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Helpers;
+
+namespace aweXpect.Reflection;
+
+public static partial class PropertyFilters
+{
+	/// <summary>
+	///     Filter for properties without attribute of type <typeparamref name="TAttribute" />.
+	/// </summary>
+	/// <remarks>
+	///     The optional parameter <paramref name="inherit" /> (default value <see langword="true" /> specifies, if
+	///     the attribute can be inherited from a base type.
+	/// </remarks>
+	public static Filtered.Properties Without<TAttribute>(this Filtered.Properties @this, bool inherit = true)
+		where TAttribute : Attribute
+		=> @this.Which(Filter.Suffix<PropertyInfo>(
+			propertyInfo => !propertyInfo.HasAttribute<TAttribute>(inherit: inherit),
+			$"without {(inherit ? "" : DirectText)}{Formatter.Format(typeof(TAttribute))} "));
+}

--- a/Source/aweXpect.Reflection/Filters/TypeFilters.Without.cs
+++ b/Source/aweXpect.Reflection/Filters/TypeFilters.Without.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Helpers;
+
+namespace aweXpect.Reflection;
+
+public static partial class TypeFilters
+{
+	/// <summary>
+	///     Filter for types without attribute of type <typeparamref name="TAttribute" />.
+	/// </summary>
+	/// <remarks>
+	///     The optional parameter <paramref name="inherit" /> (default value <see langword="true" /> specifies, if
+	///     the attribute can be inherited from a base type.
+	/// </remarks>
+	public static Filtered.Types Without<TAttribute>(this Filtered.Types @this, bool inherit = true)
+		where TAttribute : Attribute
+		=> @this.Which(Filter.Suffix<Type>(
+			type => !type.HasAttribute<TAttribute>(inherit: inherit),
+			$"without {(inherit ? "" : DirectText)}{Formatter.Format(typeof(TAttribute))} "));
+}

--- a/Source/aweXpect.Reflection/ThatAssemblies.DoNotHave.cs
+++ b/Source/aweXpect.Reflection/ThatAssemblies.DoNotHave.cs
@@ -1,0 +1,108 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text;
+#if NET8_0_OR_GREATER
+using System.Threading;
+using System.Threading.Tasks;
+#endif
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Reflection.Helpers;
+using aweXpect.Reflection.Options;
+using aweXpect.Results;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Reflection;
+
+public static partial class ThatAssemblies
+{
+	/// <summary>
+	///     Verifies that none of the items in the filtered collection of <see cref="Assembly" /> have
+	///     attribute of type <typeparamref name="TAttribute" />.
+	/// </summary>
+	/// <remarks>
+	///     The optional parameter <paramref name="inherit" /> (default value <see langword="true" /> specifies, if
+	///     the attribute can be inherited from a base type.
+	/// </remarks>
+	public static AndOrResult<IEnumerable<Assembly?>, IThat<IEnumerable<Assembly?>>> DoNotHave<TAttribute>(
+		this IThat<IEnumerable<Assembly?>> subject, bool inherit = true)
+		where TAttribute : Attribute
+	{
+		AttributeFilterOptions<Assembly?> attributeFilterOptions =
+			new((a, attributeType, p, i) => a.HasAttribute(attributeType, p, i));
+		attributeFilterOptions.RegisterAttribute<TAttribute>(inherit);
+		return new AndOrResult<IEnumerable<Assembly?>, IThat<IEnumerable<Assembly?>>>(
+			subject.Get().ExpectationBuilder.AddConstraint<IEnumerable<Assembly?>>((it, grammars)
+				=> new DoNotHaveAttributeConstraint(it, grammars | ExpectationGrammars.Plural, attributeFilterOptions)),
+			subject);
+	}
+
+#if NET8_0_OR_GREATER
+	/// <summary>
+	///     Verifies that none of the items in the filtered collection of <see cref="Assembly" /> have
+	///     attribute of type <typeparamref name="TAttribute" />.
+	/// </summary>
+	/// <remarks>
+	///     The optional parameter <paramref name="inherit" /> (default value <see langword="true" /> specifies, if
+	///     the attribute can be inherited from a base type.
+	/// </remarks>
+	public static AndOrResult<IAsyncEnumerable<Assembly?>, IThat<IAsyncEnumerable<Assembly?>>> DoNotHave<TAttribute>(
+		this IThat<IAsyncEnumerable<Assembly?>> subject, bool inherit = true)
+		where TAttribute : Attribute
+	{
+		AttributeFilterOptions<Assembly?> attributeFilterOptions =
+			new((a, attributeType, p, i) => a.HasAttribute(attributeType, p, i));
+		attributeFilterOptions.RegisterAttribute<TAttribute>(inherit);
+		return new AndOrResult<IAsyncEnumerable<Assembly?>, IThat<IAsyncEnumerable<Assembly?>>>(
+			subject.Get().ExpectationBuilder.AddConstraint<IAsyncEnumerable<Assembly?>>((it, grammars)
+				=> new DoNotHaveAttributeConstraint(it, grammars | ExpectationGrammars.Plural, attributeFilterOptions)),
+			subject);
+	}
+#endif
+
+	private sealed class DoNotHaveAttributeConstraint(
+		string it,
+		ExpectationGrammars grammars,
+		AttributeFilterOptions<Assembly?> attributeFilterOptions)
+		: CollectionConstraintResult<Assembly?>(grammars),
+			IValueConstraint<IEnumerable<Assembly?>>
+#if NET8_0_OR_GREATER
+			, IAsyncConstraint<IAsyncEnumerable<Assembly?>>
+#endif
+	{
+#if NET8_0_OR_GREATER
+		public async Task<ConstraintResult> IsMetBy(IAsyncEnumerable<Assembly?> actual,
+			CancellationToken cancellationToken)
+			=> await SetAsyncValue(actual, member => !attributeFilterOptions.Matches(member));
+#endif
+
+		public ConstraintResult IsMetBy(IEnumerable<Assembly?> actual)
+			=> SetValue(actual, member => !attributeFilterOptions.Matches(member));
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("all ");
+			attributeFilterOptions.AppendDescription(stringBuilder, Grammars.Negate());
+		}
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(it).Append(" contained not matching assemblies ");
+			Formatter.Format(stringBuilder, NotMatching, FormattingOptions.Indented(indentation));
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("not all ");
+			attributeFilterOptions.AppendDescription(stringBuilder, Grammars.Negate());
+		}
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(it).Append(" only contained matching assemblies ");
+			Formatter.Format(stringBuilder, Matching, FormattingOptions.Indented(indentation));
+		}
+	}
+}

--- a/Source/aweXpect.Reflection/ThatAssembly.DoesNotHave.cs
+++ b/Source/aweXpect.Reflection/ThatAssembly.DoesNotHave.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Reflection;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Reflection.Helpers;
+using aweXpect.Reflection.Options;
+using aweXpect.Results;
+
+namespace aweXpect.Reflection;
+
+public static partial class ThatAssembly
+{
+	/// <summary>
+	///     Verifies that the <see cref="Assembly" /> does not have attribute of type <typeparamref name="TAttribute" />.
+	/// </summary>
+	/// <remarks>
+	///     The optional parameter <paramref name="inherit" /> (default value <see langword="true" />) specifies, if
+	///     the attribute can be inherited from a base type.
+	/// </remarks>
+	public static AndOrResult<Assembly?, IThat<Assembly?>> DoesNotHave<TAttribute>(
+		this IThat<Assembly?> subject, bool inherit = true)
+		where TAttribute : Attribute
+	{
+		AttributeFilterOptions<Assembly?> attributeFilterOptions =
+			new((a, attributeType, p, i) => a.HasAttribute(attributeType, p, i));
+		attributeFilterOptions.RegisterAttribute<TAttribute>(inherit);
+		return new AndOrResult<Assembly?, IThat<Assembly?>>(subject.Get().ExpectationBuilder.AddConstraint(
+				(it, grammars)
+					=> new HasAttributeConstraint(it, grammars, attributeFilterOptions).Invert()),
+			subject);
+	}
+}

--- a/Source/aweXpect.Reflection/ThatConstructor.DoesNotHave.cs
+++ b/Source/aweXpect.Reflection/ThatConstructor.DoesNotHave.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Reflection;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Reflection.Helpers;
+using aweXpect.Reflection.Options;
+using aweXpect.Results;
+
+namespace aweXpect.Reflection;
+
+public static partial class ThatConstructor
+{
+	/// <summary>
+	///     Verifies that the <see cref="ConstructorInfo" /> does not have attribute of type
+	///     <typeparamref name="TAttribute" />.
+	/// </summary>
+	/// <remarks>
+	///     The optional parameter <paramref name="inherit" /> (default value <see langword="true" />) specifies, if
+	///     the attribute can be inherited from a base type.
+	/// </remarks>
+	public static AndOrResult<ConstructorInfo?, IThat<ConstructorInfo?>> DoesNotHave<TAttribute>(
+		this IThat<ConstructorInfo?> subject, bool inherit = true)
+		where TAttribute : Attribute
+	{
+		AttributeFilterOptions<ConstructorInfo?> attributeFilterOptions =
+			new((a, attributeType, p, i) => a.HasAttribute(attributeType, p, i));
+		attributeFilterOptions.RegisterAttribute<TAttribute>(inherit);
+		return new AndOrResult<ConstructorInfo?, IThat<ConstructorInfo?>>(subject.Get().ExpectationBuilder.AddConstraint(
+				(it, grammars)
+					=> new HasAttributeConstraint(it, grammars, attributeFilterOptions).Invert()),
+			subject);
+	}
+}

--- a/Source/aweXpect.Reflection/ThatConstructors.DoNotHave.cs
+++ b/Source/aweXpect.Reflection/ThatConstructors.DoNotHave.cs
@@ -1,0 +1,109 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text;
+#if NET8_0_OR_GREATER
+using System.Threading;
+using System.Threading.Tasks;
+#endif
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Reflection.Helpers;
+using aweXpect.Reflection.Options;
+using aweXpect.Results;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Reflection;
+
+public static partial class ThatConstructors
+{
+	/// <summary>
+	///     Verifies that none of the items in the filtered collection of <see cref="ConstructorInfo" /> have
+	///     attribute of type <typeparamref name="TAttribute" />.
+	/// </summary>
+	/// <remarks>
+	///     The optional parameter <paramref name="inherit" /> (default value <see langword="true" /> specifies, if
+	///     the attribute can be inherited from a base type.
+	/// </remarks>
+	public static AndOrResult<IEnumerable<ConstructorInfo?>, IThat<IEnumerable<ConstructorInfo?>>> DoNotHave<TAttribute>(
+		this IThat<IEnumerable<ConstructorInfo?>> subject, bool inherit = true)
+		where TAttribute : Attribute
+	{
+		AttributeFilterOptions<ConstructorInfo?> attributeFilterOptions =
+			new((a, attributeType, p, i) => a.HasAttribute(attributeType, p, i));
+		attributeFilterOptions.RegisterAttribute<TAttribute>(inherit);
+		return new AndOrResult<IEnumerable<ConstructorInfo?>, IThat<IEnumerable<ConstructorInfo?>>>(
+			subject.Get().ExpectationBuilder.AddConstraint<IEnumerable<ConstructorInfo?>>((it, grammars)
+				=> new DoNotHaveAttributeConstraint(it, grammars | ExpectationGrammars.Plural, attributeFilterOptions)),
+			subject);
+	}
+
+#if NET8_0_OR_GREATER
+	/// <summary>
+	///     Verifies that none of the items in the filtered collection of <see cref="ConstructorInfo" /> have
+	///     attribute of type <typeparamref name="TAttribute" />.
+	/// </summary>
+	/// <remarks>
+	///     The optional parameter <paramref name="inherit" /> (default value <see langword="true" /> specifies, if
+	///     the attribute can be inherited from a base type.
+	/// </remarks>
+	public static AndOrResult<IAsyncEnumerable<ConstructorInfo?>, IThat<IAsyncEnumerable<ConstructorInfo?>>>
+		DoNotHave<TAttribute>(
+			this IThat<IAsyncEnumerable<ConstructorInfo?>> subject, bool inherit = true)
+		where TAttribute : Attribute
+	{
+		AttributeFilterOptions<ConstructorInfo?> attributeFilterOptions =
+			new((a, attributeType, p, i) => a.HasAttribute(attributeType, p, i));
+		attributeFilterOptions.RegisterAttribute<TAttribute>(inherit);
+		return new AndOrResult<IAsyncEnumerable<ConstructorInfo?>, IThat<IAsyncEnumerable<ConstructorInfo?>>>(
+			subject.Get().ExpectationBuilder.AddConstraint<IAsyncEnumerable<ConstructorInfo?>>((it, grammars)
+				=> new DoNotHaveAttributeConstraint(it, grammars | ExpectationGrammars.Plural, attributeFilterOptions)),
+			subject);
+	}
+#endif
+
+	private sealed class DoNotHaveAttributeConstraint(
+		string it,
+		ExpectationGrammars grammars,
+		AttributeFilterOptions<ConstructorInfo?> attributeFilterOptions)
+		: CollectionConstraintResult<ConstructorInfo?>(grammars),
+			IValueConstraint<IEnumerable<ConstructorInfo?>>
+#if NET8_0_OR_GREATER
+			, IAsyncConstraint<IAsyncEnumerable<ConstructorInfo?>>
+#endif
+	{
+#if NET8_0_OR_GREATER
+		public async Task<ConstraintResult> IsMetBy(IAsyncEnumerable<ConstructorInfo?> actual,
+			CancellationToken cancellationToken)
+			=> await SetAsyncValue(actual, member => !attributeFilterOptions.Matches(member));
+#endif
+
+		public ConstraintResult IsMetBy(IEnumerable<ConstructorInfo?> actual)
+			=> SetValue(actual, member => !attributeFilterOptions.Matches(member));
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("all ");
+			attributeFilterOptions.AppendDescription(stringBuilder, Grammars.Negate());
+		}
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(it).Append(" contained not matching constructors ");
+			Formatter.Format(stringBuilder, NotMatching, FormattingOptions.Indented(indentation));
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("not all ");
+			attributeFilterOptions.AppendDescription(stringBuilder, Grammars.Negate());
+		}
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(it).Append(" only contained matching constructors ");
+			Formatter.Format(stringBuilder, Matching, FormattingOptions.Indented(indentation));
+		}
+	}
+}

--- a/Source/aweXpect.Reflection/ThatEvent.DoesNotHave.cs
+++ b/Source/aweXpect.Reflection/ThatEvent.DoesNotHave.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Reflection;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Reflection.Helpers;
+using aweXpect.Reflection.Options;
+using aweXpect.Results;
+
+namespace aweXpect.Reflection;
+
+public static partial class ThatEvent
+{
+	/// <summary>
+	///     Verifies that the <see cref="EventInfo" /> does not have attribute of type <typeparamref name="TAttribute" />.
+	/// </summary>
+	/// <remarks>
+	///     The optional parameter <paramref name="inherit" /> (default value <see langword="true" />) specifies, if
+	///     the attribute can be inherited from a base type.
+	/// </remarks>
+	public static AndOrResult<EventInfo?, IThat<EventInfo?>> DoesNotHave<TAttribute>(
+		this IThat<EventInfo?> subject, bool inherit = true)
+		where TAttribute : Attribute
+	{
+		AttributeFilterOptions<EventInfo?> attributeFilterOptions =
+			new((a, attributeType, p, i) => a.HasAttribute(attributeType, p, i));
+		attributeFilterOptions.RegisterAttribute<TAttribute>(inherit);
+		return new AndOrResult<EventInfo?, IThat<EventInfo?>>(subject.Get().ExpectationBuilder.AddConstraint(
+				(it, grammars)
+					=> new HasAttributeConstraint(it, grammars, attributeFilterOptions).Invert()),
+			subject);
+	}
+}

--- a/Source/aweXpect.Reflection/ThatEvents.DoNotHave.cs
+++ b/Source/aweXpect.Reflection/ThatEvents.DoNotHave.cs
@@ -1,0 +1,108 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text;
+#if NET8_0_OR_GREATER
+using System.Threading;
+using System.Threading.Tasks;
+#endif
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Reflection.Helpers;
+using aweXpect.Reflection.Options;
+using aweXpect.Results;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Reflection;
+
+public static partial class ThatEvents
+{
+	/// <summary>
+	///     Verifies that none of the items in the filtered collection of <see cref="EventInfo" /> have
+	///     attribute of type <typeparamref name="TAttribute" />.
+	/// </summary>
+	/// <remarks>
+	///     The optional parameter <paramref name="inherit" /> (default value <see langword="true" /> specifies, if
+	///     the attribute can be inherited from a base type.
+	/// </remarks>
+	public static AndOrResult<IEnumerable<EventInfo?>, IThat<IEnumerable<EventInfo?>>> DoNotHave<TAttribute>(
+		this IThat<IEnumerable<EventInfo?>> subject, bool inherit = true)
+		where TAttribute : Attribute
+	{
+		AttributeFilterOptions<EventInfo?> attributeFilterOptions =
+			new((a, attributeType, p, i) => a.HasAttribute(attributeType, p, i));
+		attributeFilterOptions.RegisterAttribute<TAttribute>(inherit);
+		return new AndOrResult<IEnumerable<EventInfo?>, IThat<IEnumerable<EventInfo?>>>(
+			subject.Get().ExpectationBuilder.AddConstraint<IEnumerable<EventInfo?>>((it, grammars)
+				=> new DoNotHaveAttributeConstraint(it, grammars | ExpectationGrammars.Plural, attributeFilterOptions)),
+			subject);
+	}
+
+#if NET8_0_OR_GREATER
+	/// <summary>
+	///     Verifies that none of the items in the filtered collection of <see cref="EventInfo" /> have
+	///     attribute of type <typeparamref name="TAttribute" />.
+	/// </summary>
+	/// <remarks>
+	///     The optional parameter <paramref name="inherit" /> (default value <see langword="true" /> specifies, if
+	///     the attribute can be inherited from a base type.
+	/// </remarks>
+	public static AndOrResult<IAsyncEnumerable<EventInfo?>, IThat<IAsyncEnumerable<EventInfo?>>> DoNotHave<TAttribute>(
+		this IThat<IAsyncEnumerable<EventInfo?>> subject, bool inherit = true)
+		where TAttribute : Attribute
+	{
+		AttributeFilterOptions<EventInfo?> attributeFilterOptions =
+			new((a, attributeType, p, i) => a.HasAttribute(attributeType, p, i));
+		attributeFilterOptions.RegisterAttribute<TAttribute>(inherit);
+		return new AndOrResult<IAsyncEnumerable<EventInfo?>, IThat<IAsyncEnumerable<EventInfo?>>>(
+			subject.Get().ExpectationBuilder.AddConstraint<IAsyncEnumerable<EventInfo?>>((it, grammars)
+				=> new DoNotHaveAttributeConstraint(it, grammars | ExpectationGrammars.Plural, attributeFilterOptions)),
+			subject);
+	}
+#endif
+
+	private sealed class DoNotHaveAttributeConstraint(
+		string it,
+		ExpectationGrammars grammars,
+		AttributeFilterOptions<EventInfo?> attributeFilterOptions)
+		: CollectionConstraintResult<EventInfo?>(grammars),
+			IValueConstraint<IEnumerable<EventInfo?>>
+#if NET8_0_OR_GREATER
+			, IAsyncConstraint<IAsyncEnumerable<EventInfo?>>
+#endif
+	{
+#if NET8_0_OR_GREATER
+		public async Task<ConstraintResult> IsMetBy(IAsyncEnumerable<EventInfo?> actual,
+			CancellationToken cancellationToken)
+			=> await SetAsyncValue(actual, member => !attributeFilterOptions.Matches(member));
+#endif
+
+		public ConstraintResult IsMetBy(IEnumerable<EventInfo?> actual)
+			=> SetValue(actual, member => !attributeFilterOptions.Matches(member));
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("all ");
+			attributeFilterOptions.AppendDescription(stringBuilder, Grammars.Negate());
+		}
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(it).Append(" contained not matching events ");
+			Formatter.Format(stringBuilder, NotMatching, FormattingOptions.Indented(indentation));
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("not all ");
+			attributeFilterOptions.AppendDescription(stringBuilder, Grammars.Negate());
+		}
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(it).Append(" only contained matching events ");
+			Formatter.Format(stringBuilder, Matching, FormattingOptions.Indented(indentation));
+		}
+	}
+}

--- a/Source/aweXpect.Reflection/ThatField.DoesNotHave.cs
+++ b/Source/aweXpect.Reflection/ThatField.DoesNotHave.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Reflection;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Reflection.Helpers;
+using aweXpect.Reflection.Options;
+using aweXpect.Results;
+
+namespace aweXpect.Reflection;
+
+public static partial class ThatField
+{
+	/// <summary>
+	///     Verifies that the <see cref="FieldInfo" /> does not have attribute of type <typeparamref name="TAttribute" />.
+	/// </summary>
+	/// <remarks>
+	///     The optional parameter <paramref name="inherit" /> (default value <see langword="true" />) specifies, if
+	///     the attribute can be inherited from a base type.
+	/// </remarks>
+	public static AndOrResult<FieldInfo?, IThat<FieldInfo?>> DoesNotHave<TAttribute>(
+		this IThat<FieldInfo?> subject, bool inherit = true)
+		where TAttribute : Attribute
+	{
+		AttributeFilterOptions<FieldInfo?> attributeFilterOptions =
+			new((a, attributeType, p, i) => a.HasAttribute(attributeType, p, i));
+		attributeFilterOptions.RegisterAttribute<TAttribute>(inherit);
+		return new AndOrResult<FieldInfo?, IThat<FieldInfo?>>(subject.Get().ExpectationBuilder.AddConstraint(
+				(it, grammars)
+					=> new HasAttributeConstraint(it, grammars, attributeFilterOptions).Invert()),
+			subject);
+	}
+}

--- a/Source/aweXpect.Reflection/ThatFields.DoNotHave.cs
+++ b/Source/aweXpect.Reflection/ThatFields.DoNotHave.cs
@@ -1,0 +1,108 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text;
+#if NET8_0_OR_GREATER
+using System.Threading;
+using System.Threading.Tasks;
+#endif
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Reflection.Helpers;
+using aweXpect.Reflection.Options;
+using aweXpect.Results;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Reflection;
+
+public static partial class ThatFields
+{
+	/// <summary>
+	///     Verifies that none of the items in the filtered collection of <see cref="FieldInfo" /> have
+	///     attribute of type <typeparamref name="TAttribute" />.
+	/// </summary>
+	/// <remarks>
+	///     The optional parameter <paramref name="inherit" /> (default value <see langword="true" /> specifies, if
+	///     the attribute can be inherited from a base type.
+	/// </remarks>
+	public static AndOrResult<IEnumerable<FieldInfo?>, IThat<IEnumerable<FieldInfo?>>> DoNotHave<TAttribute>(
+		this IThat<IEnumerable<FieldInfo?>> subject, bool inherit = true)
+		where TAttribute : Attribute
+	{
+		AttributeFilterOptions<FieldInfo?> attributeFilterOptions =
+			new((a, attributeType, p, i) => a.HasAttribute(attributeType, p, i));
+		attributeFilterOptions.RegisterAttribute<TAttribute>(inherit);
+		return new AndOrResult<IEnumerable<FieldInfo?>, IThat<IEnumerable<FieldInfo?>>>(
+			subject.Get().ExpectationBuilder.AddConstraint<IEnumerable<FieldInfo?>>((it, grammars)
+				=> new DoNotHaveAttributeConstraint(it, grammars | ExpectationGrammars.Plural, attributeFilterOptions)),
+			subject);
+	}
+
+#if NET8_0_OR_GREATER
+	/// <summary>
+	///     Verifies that none of the items in the filtered collection of <see cref="FieldInfo" /> have
+	///     attribute of type <typeparamref name="TAttribute" />.
+	/// </summary>
+	/// <remarks>
+	///     The optional parameter <paramref name="inherit" /> (default value <see langword="true" /> specifies, if
+	///     the attribute can be inherited from a base type.
+	/// </remarks>
+	public static AndOrResult<IAsyncEnumerable<FieldInfo?>, IThat<IAsyncEnumerable<FieldInfo?>>> DoNotHave<TAttribute>(
+		this IThat<IAsyncEnumerable<FieldInfo?>> subject, bool inherit = true)
+		where TAttribute : Attribute
+	{
+		AttributeFilterOptions<FieldInfo?> attributeFilterOptions =
+			new((a, attributeType, p, i) => a.HasAttribute(attributeType, p, i));
+		attributeFilterOptions.RegisterAttribute<TAttribute>(inherit);
+		return new AndOrResult<IAsyncEnumerable<FieldInfo?>, IThat<IAsyncEnumerable<FieldInfo?>>>(
+			subject.Get().ExpectationBuilder.AddConstraint<IAsyncEnumerable<FieldInfo?>>((it, grammars)
+				=> new DoNotHaveAttributeConstraint(it, grammars | ExpectationGrammars.Plural, attributeFilterOptions)),
+			subject);
+	}
+#endif
+
+	private sealed class DoNotHaveAttributeConstraint(
+		string it,
+		ExpectationGrammars grammars,
+		AttributeFilterOptions<FieldInfo?> attributeFilterOptions)
+		: CollectionConstraintResult<FieldInfo?>(grammars),
+			IValueConstraint<IEnumerable<FieldInfo?>>
+#if NET8_0_OR_GREATER
+			, IAsyncConstraint<IAsyncEnumerable<FieldInfo?>>
+#endif
+	{
+#if NET8_0_OR_GREATER
+		public async Task<ConstraintResult> IsMetBy(IAsyncEnumerable<FieldInfo?> actual,
+			CancellationToken cancellationToken)
+			=> await SetAsyncValue(actual, member => !attributeFilterOptions.Matches(member));
+#endif
+
+		public ConstraintResult IsMetBy(IEnumerable<FieldInfo?> actual)
+			=> SetValue(actual, member => !attributeFilterOptions.Matches(member));
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("all ");
+			attributeFilterOptions.AppendDescription(stringBuilder, Grammars.Negate());
+		}
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(it).Append(" contained not matching fields ");
+			Formatter.Format(stringBuilder, NotMatching, FormattingOptions.Indented(indentation));
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("not all ");
+			attributeFilterOptions.AppendDescription(stringBuilder, Grammars.Negate());
+		}
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(it).Append(" only contained matching fields ");
+			Formatter.Format(stringBuilder, Matching, FormattingOptions.Indented(indentation));
+		}
+	}
+}

--- a/Source/aweXpect.Reflection/ThatMethod.DoesNotHave.cs
+++ b/Source/aweXpect.Reflection/ThatMethod.DoesNotHave.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Reflection;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Reflection.Helpers;
+using aweXpect.Reflection.Options;
+using aweXpect.Results;
+
+namespace aweXpect.Reflection;
+
+public static partial class ThatMethod
+{
+	/// <summary>
+	///     Verifies that the <see cref="MethodInfo" /> does not have attribute of type <typeparamref name="TAttribute" />.
+	/// </summary>
+	/// <remarks>
+	///     The optional parameter <paramref name="inherit" /> (default value <see langword="true" />) specifies, if
+	///     the attribute can be inherited from a base type.
+	/// </remarks>
+	public static AndOrResult<MethodInfo?, IThat<MethodInfo?>> DoesNotHave<TAttribute>(
+		this IThat<MethodInfo?> subject, bool inherit = true)
+		where TAttribute : Attribute
+	{
+		AttributeFilterOptions<MethodInfo?> attributeFilterOptions =
+			new((a, attributeType, p, i) => a.HasAttribute(attributeType, p, i));
+		attributeFilterOptions.RegisterAttribute<TAttribute>(inherit);
+		return new AndOrResult<MethodInfo?, IThat<MethodInfo?>>(subject.Get().ExpectationBuilder.AddConstraint(
+				(it, grammars)
+					=> new HasAttributeConstraint(it, grammars, attributeFilterOptions).Invert()),
+			subject);
+	}
+}

--- a/Source/aweXpect.Reflection/ThatMethods.DoNotHave.cs
+++ b/Source/aweXpect.Reflection/ThatMethods.DoNotHave.cs
@@ -1,0 +1,108 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text;
+#if NET8_0_OR_GREATER
+using System.Threading;
+using System.Threading.Tasks;
+#endif
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Reflection.Helpers;
+using aweXpect.Reflection.Options;
+using aweXpect.Results;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Reflection;
+
+public static partial class ThatMethods
+{
+	/// <summary>
+	///     Verifies that none of the items in the filtered collection of <see cref="MethodInfo" /> have
+	///     attribute of type <typeparamref name="TAttribute" />.
+	/// </summary>
+	/// <remarks>
+	///     The optional parameter <paramref name="inherit" /> (default value <see langword="true" /> specifies, if
+	///     the attribute can be inherited from a base type.
+	/// </remarks>
+	public static AndOrResult<IEnumerable<MethodInfo?>, IThat<IEnumerable<MethodInfo?>>> DoNotHave<TAttribute>(
+		this IThat<IEnumerable<MethodInfo?>> subject, bool inherit = true)
+		where TAttribute : Attribute
+	{
+		AttributeFilterOptions<MethodInfo?> attributeFilterOptions =
+			new((a, attributeType, p, i) => a.HasAttribute(attributeType, p, i));
+		attributeFilterOptions.RegisterAttribute<TAttribute>(inherit);
+		return new AndOrResult<IEnumerable<MethodInfo?>, IThat<IEnumerable<MethodInfo?>>>(
+			subject.Get().ExpectationBuilder.AddConstraint<IEnumerable<MethodInfo?>>((it, grammars)
+				=> new DoNotHaveAttributeConstraint(it, grammars | ExpectationGrammars.Plural, attributeFilterOptions)),
+			subject);
+	}
+
+#if NET8_0_OR_GREATER
+	/// <summary>
+	///     Verifies that none of the items in the filtered collection of <see cref="MethodInfo" /> have
+	///     attribute of type <typeparamref name="TAttribute" />.
+	/// </summary>
+	/// <remarks>
+	///     The optional parameter <paramref name="inherit" /> (default value <see langword="true" /> specifies, if
+	///     the attribute can be inherited from a base type.
+	/// </remarks>
+	public static AndOrResult<IAsyncEnumerable<MethodInfo?>, IThat<IAsyncEnumerable<MethodInfo?>>> DoNotHave<TAttribute>(
+		this IThat<IAsyncEnumerable<MethodInfo?>> subject, bool inherit = true)
+		where TAttribute : Attribute
+	{
+		AttributeFilterOptions<MethodInfo?> attributeFilterOptions =
+			new((a, attributeType, p, i) => a.HasAttribute(attributeType, p, i));
+		attributeFilterOptions.RegisterAttribute<TAttribute>(inherit);
+		return new AndOrResult<IAsyncEnumerable<MethodInfo?>, IThat<IAsyncEnumerable<MethodInfo?>>>(
+			subject.Get().ExpectationBuilder.AddConstraint<IAsyncEnumerable<MethodInfo?>>((it, grammars)
+				=> new DoNotHaveAttributeConstraint(it, grammars | ExpectationGrammars.Plural, attributeFilterOptions)),
+			subject);
+	}
+#endif
+
+	private sealed class DoNotHaveAttributeConstraint(
+		string it,
+		ExpectationGrammars grammars,
+		AttributeFilterOptions<MethodInfo?> attributeFilterOptions)
+		: CollectionConstraintResult<MethodInfo?>(grammars),
+			IValueConstraint<IEnumerable<MethodInfo?>>
+#if NET8_0_OR_GREATER
+			, IAsyncConstraint<IAsyncEnumerable<MethodInfo?>>
+#endif
+	{
+#if NET8_0_OR_GREATER
+		public async Task<ConstraintResult> IsMetBy(IAsyncEnumerable<MethodInfo?> actual,
+			CancellationToken cancellationToken)
+			=> await SetAsyncValue(actual, member => !attributeFilterOptions.Matches(member));
+#endif
+
+		public ConstraintResult IsMetBy(IEnumerable<MethodInfo?> actual)
+			=> SetValue(actual, member => !attributeFilterOptions.Matches(member));
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("all ");
+			attributeFilterOptions.AppendDescription(stringBuilder, Grammars.Negate());
+		}
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(it).Append(" contained not matching methods ");
+			Formatter.Format(stringBuilder, NotMatching, FormattingOptions.Indented(indentation));
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("not all ");
+			attributeFilterOptions.AppendDescription(stringBuilder, Grammars.Negate());
+		}
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(it).Append(" only contained matching methods ");
+			Formatter.Format(stringBuilder, Matching, FormattingOptions.Indented(indentation));
+		}
+	}
+}

--- a/Source/aweXpect.Reflection/ThatProperties.DoNotHave.cs
+++ b/Source/aweXpect.Reflection/ThatProperties.DoNotHave.cs
@@ -1,0 +1,109 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text;
+#if NET8_0_OR_GREATER
+using System.Threading;
+using System.Threading.Tasks;
+#endif
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Reflection.Helpers;
+using aweXpect.Reflection.Options;
+using aweXpect.Results;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Reflection;
+
+public static partial class ThatProperties
+{
+	/// <summary>
+	///     Verifies that none of the items in the filtered collection of <see cref="PropertyInfo" /> have
+	///     attribute of type <typeparamref name="TAttribute" />.
+	/// </summary>
+	/// <remarks>
+	///     The optional parameter <paramref name="inherit" /> (default value <see langword="true" /> specifies, if
+	///     the attribute can be inherited from a base type.
+	/// </remarks>
+	public static AndOrResult<IEnumerable<PropertyInfo?>, IThat<IEnumerable<PropertyInfo?>>> DoNotHave<TAttribute>(
+		this IThat<IEnumerable<PropertyInfo?>> subject, bool inherit = true)
+		where TAttribute : Attribute
+	{
+		AttributeFilterOptions<PropertyInfo?> attributeFilterOptions =
+			new((a, attributeType, p, i) => a.HasAttribute(attributeType, p, i));
+		attributeFilterOptions.RegisterAttribute<TAttribute>(inherit);
+		return new AndOrResult<IEnumerable<PropertyInfo?>, IThat<IEnumerable<PropertyInfo?>>>(
+			subject.Get().ExpectationBuilder.AddConstraint<IEnumerable<PropertyInfo?>>((it, grammars)
+				=> new DoNotHaveAttributeConstraint(it, grammars | ExpectationGrammars.Plural, attributeFilterOptions)),
+			subject);
+	}
+
+#if NET8_0_OR_GREATER
+	/// <summary>
+	///     Verifies that none of the items in the filtered collection of <see cref="PropertyInfo" /> have
+	///     attribute of type <typeparamref name="TAttribute" />.
+	/// </summary>
+	/// <remarks>
+	///     The optional parameter <paramref name="inherit" /> (default value <see langword="true" /> specifies, if
+	///     the attribute can be inherited from a base type.
+	/// </remarks>
+	public static AndOrResult<IAsyncEnumerable<PropertyInfo?>, IThat<IAsyncEnumerable<PropertyInfo?>>>
+		DoNotHave<TAttribute>(
+			this IThat<IAsyncEnumerable<PropertyInfo?>> subject, bool inherit = true)
+		where TAttribute : Attribute
+	{
+		AttributeFilterOptions<PropertyInfo?> attributeFilterOptions =
+			new((a, attributeType, p, i) => a.HasAttribute(attributeType, p, i));
+		attributeFilterOptions.RegisterAttribute<TAttribute>(inherit);
+		return new AndOrResult<IAsyncEnumerable<PropertyInfo?>, IThat<IAsyncEnumerable<PropertyInfo?>>>(
+			subject.Get().ExpectationBuilder.AddConstraint<IAsyncEnumerable<PropertyInfo?>>((it, grammars)
+				=> new DoNotHaveAttributeConstraint(it, grammars | ExpectationGrammars.Plural, attributeFilterOptions)),
+			subject);
+	}
+#endif
+
+	private sealed class DoNotHaveAttributeConstraint(
+		string it,
+		ExpectationGrammars grammars,
+		AttributeFilterOptions<PropertyInfo?> attributeFilterOptions)
+		: CollectionConstraintResult<PropertyInfo?>(grammars),
+			IValueConstraint<IEnumerable<PropertyInfo?>>
+#if NET8_0_OR_GREATER
+			, IAsyncConstraint<IAsyncEnumerable<PropertyInfo?>>
+#endif
+	{
+#if NET8_0_OR_GREATER
+		public async Task<ConstraintResult> IsMetBy(IAsyncEnumerable<PropertyInfo?> actual,
+			CancellationToken cancellationToken)
+			=> await SetAsyncValue(actual, member => !attributeFilterOptions.Matches(member));
+#endif
+
+		public ConstraintResult IsMetBy(IEnumerable<PropertyInfo?> actual)
+			=> SetValue(actual, member => !attributeFilterOptions.Matches(member));
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("all ");
+			attributeFilterOptions.AppendDescription(stringBuilder, Grammars.Negate());
+		}
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(it).Append(" contained not matching properties ");
+			Formatter.Format(stringBuilder, NotMatching, FormattingOptions.Indented(indentation));
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("not all ");
+			attributeFilterOptions.AppendDescription(stringBuilder, Grammars.Negate());
+		}
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(it).Append(" only contained matching properties ");
+			Formatter.Format(stringBuilder, Matching, FormattingOptions.Indented(indentation));
+		}
+	}
+}

--- a/Source/aweXpect.Reflection/ThatProperty.DoesNotHave.cs
+++ b/Source/aweXpect.Reflection/ThatProperty.DoesNotHave.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Reflection;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Reflection.Helpers;
+using aweXpect.Reflection.Options;
+using aweXpect.Results;
+
+namespace aweXpect.Reflection;
+
+public static partial class ThatProperty
+{
+	/// <summary>
+	///     Verifies that the <see cref="PropertyInfo" /> does not have attribute of type
+	///     <typeparamref name="TAttribute" />.
+	/// </summary>
+	/// <remarks>
+	///     The optional parameter <paramref name="inherit" /> (default value <see langword="true" />) specifies, if
+	///     the attribute can be inherited from a base type.
+	/// </remarks>
+	public static AndOrResult<PropertyInfo?, IThat<PropertyInfo?>> DoesNotHave<TAttribute>(
+		this IThat<PropertyInfo?> subject, bool inherit = true)
+		where TAttribute : Attribute
+	{
+		AttributeFilterOptions<PropertyInfo?> attributeFilterOptions =
+			new((a, attributeType, p, i) => a.HasAttribute(attributeType, p, i));
+		attributeFilterOptions.RegisterAttribute<TAttribute>(inherit);
+		return new AndOrResult<PropertyInfo?, IThat<PropertyInfo?>>(subject.Get().ExpectationBuilder.AddConstraint(
+				(it, grammars)
+					=> new HasAttributeConstraint(it, grammars, attributeFilterOptions).Invert()),
+			subject);
+	}
+}

--- a/Source/aweXpect.Reflection/ThatType.DoesNotHave.cs
+++ b/Source/aweXpect.Reflection/ThatType.DoesNotHave.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Reflection.Helpers;
+using aweXpect.Reflection.Options;
+using aweXpect.Results;
+
+namespace aweXpect.Reflection;
+
+public static partial class ThatType
+{
+	/// <summary>
+	///     Verifies that the <see cref="Type" /> does not have attribute of type <typeparamref name="TAttribute" />.
+	/// </summary>
+	/// <remarks>
+	///     The optional parameter <paramref name="inherit" /> (default value <see langword="true" />) specifies, if
+	///     the attribute can be inherited from a base type.
+	/// </remarks>
+	public static AndOrResult<Type?, IThat<Type?>> DoesNotHave<TAttribute>(this IThat<Type?> subject, bool inherit = true)
+		where TAttribute : Attribute
+	{
+		AttributeFilterOptions<Type?> attributeFilterOptions =
+			new((a, attributeType, p, i) => a.HasAttribute(attributeType, p, i));
+		attributeFilterOptions.RegisterAttribute<TAttribute>(inherit);
+		return new AndOrResult<Type?, IThat<Type?>>(subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new HasAttributeConstraint(it, grammars, attributeFilterOptions).Invert()),
+			subject);
+	}
+}

--- a/Source/aweXpect.Reflection/ThatTypes.DoNotHave.cs
+++ b/Source/aweXpect.Reflection/ThatTypes.DoNotHave.cs
@@ -1,0 +1,106 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+#if NET8_0_OR_GREATER
+using System.Threading;
+using System.Threading.Tasks;
+#endif
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Reflection.Helpers;
+using aweXpect.Reflection.Options;
+using aweXpect.Results;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Reflection;
+
+public static partial class ThatTypes
+{
+	/// <summary>
+	///     Verifies that none of the items in the filtered collection of <see cref="Type" /> have
+	///     attribute of type <typeparamref name="TAttribute" />.
+	/// </summary>
+	/// <remarks>
+	///     The optional parameter <paramref name="inherit" /> (default value <see langword="true" /> specifies, if
+	///     the attribute can be inherited from a base type.
+	/// </remarks>
+	public static AndOrResult<IEnumerable<Type?>, IThat<IEnumerable<Type?>>> DoNotHave<TAttribute>(
+		this IThat<IEnumerable<Type?>> subject, bool inherit = true)
+		where TAttribute : Attribute
+	{
+		AttributeFilterOptions<Type?> attributeFilterOptions =
+			new((a, attributeType, p, i) => a.HasAttribute(attributeType, p, i));
+		attributeFilterOptions.RegisterAttribute<TAttribute>(inherit);
+		return new AndOrResult<IEnumerable<Type?>, IThat<IEnumerable<Type?>>>(
+			subject.Get().ExpectationBuilder.AddConstraint<IEnumerable<Type?>>((it, grammars)
+				=> new DoNotHaveAttributeConstraint(it, grammars | ExpectationGrammars.Plural, attributeFilterOptions)),
+			subject);
+	}
+
+#if NET8_0_OR_GREATER
+	/// <summary>
+	///     Verifies that none of the items in the filtered collection of <see cref="Type" /> have
+	///     attribute of type <typeparamref name="TAttribute" />.
+	/// </summary>
+	/// <remarks>
+	///     The optional parameter <paramref name="inherit" /> (default value <see langword="true" /> specifies, if
+	///     the attribute can be inherited from a base type.
+	/// </remarks>
+	public static AndOrResult<IAsyncEnumerable<Type?>, IThat<IAsyncEnumerable<Type?>>> DoNotHave<TAttribute>(
+		this IThat<IAsyncEnumerable<Type?>> subject, bool inherit = true)
+		where TAttribute : Attribute
+	{
+		AttributeFilterOptions<Type?> attributeFilterOptions =
+			new((a, attributeType, p, i) => a.HasAttribute(attributeType, p, i));
+		attributeFilterOptions.RegisterAttribute<TAttribute>(inherit);
+		return new AndOrResult<IAsyncEnumerable<Type?>, IThat<IAsyncEnumerable<Type?>>>(
+			subject.Get().ExpectationBuilder.AddConstraint<IAsyncEnumerable<Type?>>((it, grammars)
+				=> new DoNotHaveAttributeConstraint(it, grammars | ExpectationGrammars.Plural, attributeFilterOptions)),
+			subject);
+	}
+#endif
+
+	private sealed class DoNotHaveAttributeConstraint(
+		string it,
+		ExpectationGrammars grammars,
+		AttributeFilterOptions<Type?> attributeFilterOptions)
+		: CollectionConstraintResult<Type?>(grammars),
+			IValueConstraint<IEnumerable<Type?>>
+#if NET8_0_OR_GREATER
+			, IAsyncConstraint<IAsyncEnumerable<Type?>>
+#endif
+	{
+#if NET8_0_OR_GREATER
+		public async Task<ConstraintResult> IsMetBy(IAsyncEnumerable<Type?> actual, CancellationToken cancellationToken)
+			=> await SetAsyncValue(actual, member => !attributeFilterOptions.Matches(member));
+#endif
+
+		public ConstraintResult IsMetBy(IEnumerable<Type?> actual)
+			=> SetValue(actual, member => !attributeFilterOptions.Matches(member));
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("all ");
+			attributeFilterOptions.AppendDescription(stringBuilder, Grammars.Negate());
+		}
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(it).Append(" contained not matching types ");
+			Formatter.Format(stringBuilder, NotMatching, FormattingOptions.Indented(indentation));
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("not all ");
+			attributeFilterOptions.AppendDescription(stringBuilder, Grammars.Negate());
+		}
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(it).Append(" only contained matching types ");
+			Formatter.Format(stringBuilder, Matching, FormattingOptions.Indented(indentation));
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net10.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net10.0.txt
@@ -45,6 +45,8 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Collections.Filtered.Assemblies.StringEqualityResultType WithName(this aweXpect.Reflection.Collections.Filtered.Assemblies @this, string expected) { }
         public static aweXpect.Reflection.AssemblyFilters.AssembliesWithVersion WithVersion(this aweXpect.Reflection.Collections.Filtered.Assemblies @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Assemblies WithVersion(this aweXpect.Reflection.Collections.Filtered.Assemblies @this, System.Func<System.Version, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
+        public static aweXpect.Reflection.Collections.Filtered.Assemblies Without<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Assemblies @this, bool inherit = true)
+            where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Collections.Filtered.Assemblies.StringEqualityResultType WithoutName(this aweXpect.Reflection.Collections.Filtered.Assemblies @this, string unexpected) { }
         public class AssembliesWith : aweXpect.Reflection.Collections.Filtered.Assemblies
         {
@@ -156,6 +158,8 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.ConstructorFilters.ConstructorsWithNamedParameter<object?> WithRefParameterExactly(this aweXpect.Reflection.Collections.Filtered.Constructors @this, System.Type parameterType, string expected) { }
         public static aweXpect.Reflection.ConstructorFilters.ConstructorsWithParameter<T> WithRefParameterExactly<T>(this aweXpect.Reflection.Collections.Filtered.Constructors @this) { }
         public static aweXpect.Reflection.ConstructorFilters.ConstructorsWithNamedParameter<T> WithRefParameterExactly<T>(this aweXpect.Reflection.Collections.Filtered.Constructors @this, string expected) { }
+        public static aweXpect.Reflection.Collections.Filtered.Constructors Without<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Constructors @this)
+            where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Collections.Filtered.Constructors WithoutParameters(this aweXpect.Reflection.Collections.Filtered.Constructors @this) { }
         public class ConstructorsWith : aweXpect.Reflection.Collections.Filtered.Constructors
         {
@@ -221,6 +225,8 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.EventFilters.EventsWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Events @this, System.Func<TAttribute, bool>? predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Collections.Filtered.Events.StringEqualityResultType WithName(this aweXpect.Reflection.Collections.Filtered.Events @this, string expected) { }
+        public static aweXpect.Reflection.Collections.Filtered.Events Without<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Events @this, bool inherit = true)
+            where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Collections.Filtered.Events.StringEqualityResultType WithoutName(this aweXpect.Reflection.Collections.Filtered.Events @this, string unexpected) { }
         public class EventsWith : aweXpect.Reflection.Collections.Filtered.Events
         {
@@ -259,6 +265,8 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.FieldFilters.FieldsWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Fields @this, System.Func<TAttribute, bool>? predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Collections.Filtered.Fields.StringEqualityResultType WithName(this aweXpect.Reflection.Collections.Filtered.Fields @this, string expected) { }
+        public static aweXpect.Reflection.Collections.Filtered.Fields Without<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Fields @this)
+            where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Collections.Filtered.Fields.StringEqualityResultType WithoutName(this aweXpect.Reflection.Collections.Filtered.Fields @this, string unexpected) { }
         public class FieldsOfType : aweXpect.Reflection.Collections.Filtered.Fields
         {
@@ -387,6 +395,8 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.MethodFilters.MethodsWithNamedParameter<object?> WithRefParameterExactly(this aweXpect.Reflection.Collections.Filtered.Methods @this, System.Type parameterType, string expected) { }
         public static aweXpect.Reflection.MethodFilters.MethodsWithParameter<T> WithRefParameterExactly<T>(this aweXpect.Reflection.Collections.Filtered.Methods @this) { }
         public static aweXpect.Reflection.MethodFilters.MethodsWithNamedParameter<T> WithRefParameterExactly<T>(this aweXpect.Reflection.Collections.Filtered.Methods @this, string expected) { }
+        public static aweXpect.Reflection.Collections.Filtered.Methods Without<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Methods @this, bool inherit = true)
+            where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Collections.Filtered.Methods.StringEqualityResultType WithoutName(this aweXpect.Reflection.Collections.Filtered.Methods @this, string unexpected) { }
         public static aweXpect.Reflection.Collections.Filtered.Methods WithoutParameters(this aweXpect.Reflection.Collections.Filtered.Methods @this) { }
         public class GenericMethods : aweXpect.Reflection.Collections.Filtered.Methods
@@ -500,6 +510,8 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.PropertyFilters.PropertiesWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Properties @this, System.Func<TAttribute, bool>? predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Collections.Filtered.Properties.StringEqualityResultType WithName(this aweXpect.Reflection.Collections.Filtered.Properties @this, string expected) { }
+        public static aweXpect.Reflection.Collections.Filtered.Properties Without<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Properties @this, bool inherit = true)
+            where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Collections.Filtered.Properties.StringEqualityResultType WithoutName(this aweXpect.Reflection.Collections.Filtered.Properties @this, string unexpected) { }
         public class PropertiesOfType : aweXpect.Reflection.Collections.Filtered.Properties
         {
@@ -520,6 +532,10 @@ namespace aweXpect.Reflection
     }
     public static class ThatAssemblies
     {
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.Assembly?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.Assembly?>>> DoNotHave<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.Assembly?>> subject, bool inherit = true)
+            where TAttribute : System.Attribute { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>>> DoNotHave<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>> subject, bool inherit = true)
+            where TAttribute : System.Attribute { }
         public static aweXpect.Results.StringEqualityTypeResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.Assembly?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.Assembly?>>> DoNotHaveName(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.Assembly?>> subject, string unexpected) { }
         public static aweXpect.Results.StringEqualityTypeResult<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>>> DoNotHaveName(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>> subject, string unexpected) { }
         public static aweXpect.Reflection.Results.HaveAttributeResult<System.Reflection.Assembly?, System.Collections.Generic.IAsyncEnumerable<System.Reflection.Assembly?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.Assembly?>> subject, bool inherit = true)
@@ -566,6 +582,8 @@ namespace aweXpect.Reflection
     }
     public static class ThatAssembly
     {
+        public static aweXpect.Results.AndOrResult<System.Reflection.Assembly?, aweXpect.Core.IThat<System.Reflection.Assembly?>> DoesNotHave<TAttribute>(this aweXpect.Core.IThat<System.Reflection.Assembly?> subject, bool inherit = true)
+            where TAttribute : System.Attribute { }
         public static aweXpect.Results.StringEqualityTypeResult<System.Reflection.Assembly?, aweXpect.Core.IThat<System.Reflection.Assembly?>> DoesNotHaveName(this aweXpect.Core.IThat<System.Reflection.Assembly?> subject, string unexpected) { }
         public static aweXpect.Reflection.Results.HasAttributeResult<System.Reflection.Assembly?> Has<TAttribute>(this aweXpect.Core.IThat<System.Reflection.Assembly?> subject, bool inherit = true)
             where TAttribute : System.Attribute { }
@@ -598,6 +616,8 @@ namespace aweXpect.Reflection
     }
     public static class ThatConstructor
     {
+        public static aweXpect.Results.AndOrResult<System.Reflection.ConstructorInfo?, aweXpect.Core.IThat<System.Reflection.ConstructorInfo?>> DoesNotHave<TAttribute>(this aweXpect.Core.IThat<System.Reflection.ConstructorInfo?> subject, bool inherit = true)
+            where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Results.HasAttributeResult<System.Reflection.ConstructorInfo?> Has<TAttribute>(this aweXpect.Core.IThat<System.Reflection.ConstructorInfo?> subject, bool inherit = true)
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Results.HasAttributeResult<System.Reflection.ConstructorInfo?> Has<TAttribute>(this aweXpect.Core.IThat<System.Reflection.ConstructorInfo?> subject, System.Func<TAttribute, bool> predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
@@ -672,6 +692,10 @@ namespace aweXpect.Reflection
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>>> AreNotStatic(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.ConstructorInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.ConstructorInfo?>>> AreStatic(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.ConstructorInfo?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>>> AreStatic(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.ConstructorInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.ConstructorInfo?>>> DoNotHave<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.ConstructorInfo?>> subject, bool inherit = true)
+            where TAttribute : System.Attribute { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>>> DoNotHave<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>> subject, bool inherit = true)
+            where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Results.HaveAttributeResult<System.Reflection.ConstructorInfo?, System.Collections.Generic.IAsyncEnumerable<System.Reflection.ConstructorInfo?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.ConstructorInfo?>> subject, bool inherit = true)
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Results.HaveAttributeResult<System.Reflection.ConstructorInfo?, System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>> subject, bool inherit = true)
@@ -805,6 +829,8 @@ namespace aweXpect.Reflection
     }
     public static class ThatEvent
     {
+        public static aweXpect.Results.AndOrResult<System.Reflection.EventInfo?, aweXpect.Core.IThat<System.Reflection.EventInfo?>> DoesNotHave<TAttribute>(this aweXpect.Core.IThat<System.Reflection.EventInfo?> subject, bool inherit = true)
+            where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Results.HasAttributeResult<System.Reflection.EventInfo?> Has<TAttribute>(this aweXpect.Core.IThat<System.Reflection.EventInfo?> subject, bool inherit = true)
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Results.HasAttributeResult<System.Reflection.EventInfo?> Has<TAttribute>(this aweXpect.Core.IThat<System.Reflection.EventInfo?> subject, System.Func<TAttribute, bool> predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
@@ -824,6 +850,10 @@ namespace aweXpect.Reflection
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>>> AreNotSealed(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.EventInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.EventInfo?>>> AreSealed(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.EventInfo?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>>> AreSealed(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.EventInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.EventInfo?>>> DoNotHave<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.EventInfo?>> subject, bool inherit = true)
+            where TAttribute : System.Attribute { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>>> DoNotHave<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>> subject, bool inherit = true)
+            where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Results.HaveAttributeResult<System.Reflection.EventInfo?, System.Collections.Generic.IAsyncEnumerable<System.Reflection.EventInfo?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.EventInfo?>> subject, bool inherit = true)
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Results.HaveAttributeResult<System.Reflection.EventInfo?, System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>> subject, bool inherit = true)
@@ -835,6 +865,8 @@ namespace aweXpect.Reflection
     }
     public static class ThatField
     {
+        public static aweXpect.Results.AndOrResult<System.Reflection.FieldInfo?, aweXpect.Core.IThat<System.Reflection.FieldInfo?>> DoesNotHave<TAttribute>(this aweXpect.Core.IThat<System.Reflection.FieldInfo?> subject, bool inherit = true)
+            where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Results.HasAttributeResult<System.Reflection.FieldInfo?> Has<TAttribute>(this aweXpect.Core.IThat<System.Reflection.FieldInfo?> subject, bool inherit = true)
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Results.HasAttributeResult<System.Reflection.FieldInfo?> Has<TAttribute>(this aweXpect.Core.IThat<System.Reflection.FieldInfo?> subject, System.Func<TAttribute, bool> predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
@@ -869,6 +901,10 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.ThatFields.FieldsOfTypeResult<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>>> AreOfType<TField>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.FieldInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.FieldInfo?>>> AreStatic(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.FieldInfo?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>>> AreStatic(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.FieldInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.FieldInfo?>>> DoNotHave<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.FieldInfo?>> subject, bool inherit = true)
+            where TAttribute : System.Attribute { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>>> DoNotHave<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>> subject, bool inherit = true)
+            where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Results.HaveAttributeResult<System.Reflection.FieldInfo?, System.Collections.Generic.IAsyncEnumerable<System.Reflection.FieldInfo?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.FieldInfo?>> subject, bool inherit = true)
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Results.HaveAttributeResult<System.Reflection.FieldInfo?, System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>> subject, bool inherit = true)
@@ -983,6 +1019,8 @@ namespace aweXpect.Reflection
     }
     public static class ThatMethod
     {
+        public static aweXpect.Results.AndOrResult<System.Reflection.MethodInfo?, aweXpect.Core.IThat<System.Reflection.MethodInfo?>> DoesNotHave<TAttribute>(this aweXpect.Core.IThat<System.Reflection.MethodInfo?> subject, bool inherit = true)
+            where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Results.HasAttributeResult<System.Reflection.MethodInfo?> Has<TAttribute>(this aweXpect.Core.IThat<System.Reflection.MethodInfo?> subject, bool inherit = true)
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Results.HasAttributeResult<System.Reflection.MethodInfo?> Has<TAttribute>(this aweXpect.Core.IThat<System.Reflection.MethodInfo?> subject, System.Func<TAttribute, bool> predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
@@ -1089,6 +1127,10 @@ namespace aweXpect.Reflection
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo?>>> AreSealed(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.MethodInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.MethodInfo?>>> AreStatic(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.MethodInfo?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo?>>> AreStatic(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo?>> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.MethodInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.MethodInfo?>>> DoNotHave<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.MethodInfo?>> subject, bool inherit = true)
+            where TAttribute : System.Attribute { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo?>>> DoNotHave<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo?>> subject, bool inherit = true)
+            where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Results.HaveAttributeResult<System.Reflection.MethodInfo?, System.Collections.Generic.IAsyncEnumerable<System.Reflection.MethodInfo?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.MethodInfo?>> subject, bool inherit = true)
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Results.HaveAttributeResult<System.Reflection.MethodInfo?, System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo?>> subject, bool inherit = true)
@@ -1271,6 +1313,10 @@ namespace aweXpect.Reflection
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>>> AreWritable(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.PropertyInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.PropertyInfo?>>> AreWriteOnly(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.PropertyInfo?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>>> AreWriteOnly(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.PropertyInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.PropertyInfo?>>> DoNotHave<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.PropertyInfo?>> subject, bool inherit = true)
+            where TAttribute : System.Attribute { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>>> DoNotHave<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>> subject, bool inherit = true)
+            where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Results.HaveAttributeResult<System.Reflection.PropertyInfo?, System.Collections.Generic.IAsyncEnumerable<System.Reflection.PropertyInfo?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.PropertyInfo?>> subject, bool inherit = true)
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Results.HaveAttributeResult<System.Reflection.PropertyInfo?, System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>> subject, bool inherit = true)
@@ -1291,6 +1337,8 @@ namespace aweXpect.Reflection
     }
     public static class ThatProperty
     {
+        public static aweXpect.Results.AndOrResult<System.Reflection.PropertyInfo?, aweXpect.Core.IThat<System.Reflection.PropertyInfo?>> DoesNotHave<TAttribute>(this aweXpect.Core.IThat<System.Reflection.PropertyInfo?> subject, bool inherit = true)
+            where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Results.HasAttributeResult<System.Reflection.PropertyInfo?> Has<TAttribute>(this aweXpect.Core.IThat<System.Reflection.PropertyInfo?> subject, bool inherit = true)
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Results.HasAttributeResult<System.Reflection.PropertyInfo?> Has<TAttribute>(this aweXpect.Core.IThat<System.Reflection.PropertyInfo?> subject, System.Func<TAttribute, bool> predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
@@ -1327,6 +1375,8 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Results.TypeContainingMembersResult<System.Type?> ContainsFields(this aweXpect.Core.IThat<System.Type?> subject, System.Func<aweXpect.Reflection.Collections.Filtered.Fields, aweXpect.Reflection.Collections.Filtered.Fields> filter) { }
         public static aweXpect.Reflection.Results.TypeContainingMembersResult<System.Type?> ContainsMethods(this aweXpect.Core.IThat<System.Type?> subject, System.Func<aweXpect.Reflection.Collections.Filtered.Methods, aweXpect.Reflection.Collections.Filtered.Methods> filter) { }
         public static aweXpect.Reflection.Results.TypeContainingMembersResult<System.Type?> ContainsProperties(this aweXpect.Core.IThat<System.Type?> subject, System.Func<aweXpect.Reflection.Collections.Filtered.Properties, aweXpect.Reflection.Collections.Filtered.Properties> filter) { }
+        public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> DoesNotHave<TAttribute>(this aweXpect.Core.IThat<System.Type?> subject, bool inherit = true)
+            where TAttribute : System.Attribute { }
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> DoesNotInheritFrom(this aweXpect.Core.IThat<System.Type?> subject, System.Type baseType, bool forceDirect = false) { }
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> DoesNotInheritFrom<TBaseType>(this aweXpect.Core.IThat<System.Type?> subject, bool forceDirect = false) { }
         public static aweXpect.Reflection.Results.HasAttributeResult<System.Type?> Has<TAttribute>(this aweXpect.Core.IThat<System.Type?> subject, bool inherit = true)
@@ -1433,6 +1483,10 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Results.TypeContainingMembersResult<System.Collections.Generic.IEnumerable<System.Type?>> ContainMethods(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject, System.Func<aweXpect.Reflection.Collections.Filtered.Methods, aweXpect.Reflection.Collections.Filtered.Methods> filter) { }
         public static aweXpect.Reflection.Results.TypeContainingMembersResult<System.Collections.Generic.IAsyncEnumerable<System.Type?>> ContainProperties(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>> subject, System.Func<aweXpect.Reflection.Collections.Filtered.Properties, aweXpect.Reflection.Collections.Filtered.Properties> filter) { }
         public static aweXpect.Reflection.Results.TypeContainingMembersResult<System.Collections.Generic.IEnumerable<System.Type?>> ContainProperties(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject, System.Func<aweXpect.Reflection.Collections.Filtered.Properties, aweXpect.Reflection.Collections.Filtered.Properties> filter) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>>> DoNotHave<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>> subject, bool inherit = true)
+            where TAttribute : System.Attribute { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> DoNotHave<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject, bool inherit = true)
+            where TAttribute : System.Attribute { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>>> DoNotInheritFrom(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>> subject, System.Type baseType, bool forceDirect = false) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> DoNotInheritFrom(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject, System.Type baseType, bool forceDirect = false) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>>> DoNotInheritFrom<TBaseType>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>> subject, bool forceDirect = false) { }
@@ -1510,6 +1564,8 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Collections.Filtered.Types.StringEqualityResultType WithName(this aweXpect.Reflection.Collections.Filtered.Types @this, string expected) { }
         public static aweXpect.Reflection.Collections.Filtered.Types.StringEqualityResultType WithNamespace(this aweXpect.Reflection.Collections.Filtered.Types @this, string expected) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WithinNamespace(this aweXpect.Reflection.Collections.Filtered.Types @this, string expected) { }
+        public static aweXpect.Reflection.Collections.Filtered.Types Without<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Types @this, bool inherit = true)
+            where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Collections.Filtered.Types.StringEqualityResultType WithoutName(this aweXpect.Reflection.Collections.Filtered.Types @this, string unexpected) { }
         public class GenericTypes : aweXpect.Reflection.Collections.Filtered.Types
         {

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net8.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net8.0.txt
@@ -45,6 +45,8 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Collections.Filtered.Assemblies.StringEqualityResultType WithName(this aweXpect.Reflection.Collections.Filtered.Assemblies @this, string expected) { }
         public static aweXpect.Reflection.AssemblyFilters.AssembliesWithVersion WithVersion(this aweXpect.Reflection.Collections.Filtered.Assemblies @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Assemblies WithVersion(this aweXpect.Reflection.Collections.Filtered.Assemblies @this, System.Func<System.Version, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
+        public static aweXpect.Reflection.Collections.Filtered.Assemblies Without<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Assemblies @this, bool inherit = true)
+            where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Collections.Filtered.Assemblies.StringEqualityResultType WithoutName(this aweXpect.Reflection.Collections.Filtered.Assemblies @this, string unexpected) { }
         public class AssembliesWith : aweXpect.Reflection.Collections.Filtered.Assemblies
         {
@@ -156,6 +158,8 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.ConstructorFilters.ConstructorsWithNamedParameter<object?> WithRefParameterExactly(this aweXpect.Reflection.Collections.Filtered.Constructors @this, System.Type parameterType, string expected) { }
         public static aweXpect.Reflection.ConstructorFilters.ConstructorsWithParameter<T> WithRefParameterExactly<T>(this aweXpect.Reflection.Collections.Filtered.Constructors @this) { }
         public static aweXpect.Reflection.ConstructorFilters.ConstructorsWithNamedParameter<T> WithRefParameterExactly<T>(this aweXpect.Reflection.Collections.Filtered.Constructors @this, string expected) { }
+        public static aweXpect.Reflection.Collections.Filtered.Constructors Without<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Constructors @this)
+            where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Collections.Filtered.Constructors WithoutParameters(this aweXpect.Reflection.Collections.Filtered.Constructors @this) { }
         public class ConstructorsWith : aweXpect.Reflection.Collections.Filtered.Constructors
         {
@@ -221,6 +225,8 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.EventFilters.EventsWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Events @this, System.Func<TAttribute, bool>? predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Collections.Filtered.Events.StringEqualityResultType WithName(this aweXpect.Reflection.Collections.Filtered.Events @this, string expected) { }
+        public static aweXpect.Reflection.Collections.Filtered.Events Without<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Events @this, bool inherit = true)
+            where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Collections.Filtered.Events.StringEqualityResultType WithoutName(this aweXpect.Reflection.Collections.Filtered.Events @this, string unexpected) { }
         public class EventsWith : aweXpect.Reflection.Collections.Filtered.Events
         {
@@ -259,6 +265,8 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.FieldFilters.FieldsWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Fields @this, System.Func<TAttribute, bool>? predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Collections.Filtered.Fields.StringEqualityResultType WithName(this aweXpect.Reflection.Collections.Filtered.Fields @this, string expected) { }
+        public static aweXpect.Reflection.Collections.Filtered.Fields Without<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Fields @this)
+            where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Collections.Filtered.Fields.StringEqualityResultType WithoutName(this aweXpect.Reflection.Collections.Filtered.Fields @this, string unexpected) { }
         public class FieldsOfType : aweXpect.Reflection.Collections.Filtered.Fields
         {
@@ -387,6 +395,8 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.MethodFilters.MethodsWithNamedParameter<object?> WithRefParameterExactly(this aweXpect.Reflection.Collections.Filtered.Methods @this, System.Type parameterType, string expected) { }
         public static aweXpect.Reflection.MethodFilters.MethodsWithParameter<T> WithRefParameterExactly<T>(this aweXpect.Reflection.Collections.Filtered.Methods @this) { }
         public static aweXpect.Reflection.MethodFilters.MethodsWithNamedParameter<T> WithRefParameterExactly<T>(this aweXpect.Reflection.Collections.Filtered.Methods @this, string expected) { }
+        public static aweXpect.Reflection.Collections.Filtered.Methods Without<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Methods @this, bool inherit = true)
+            where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Collections.Filtered.Methods.StringEqualityResultType WithoutName(this aweXpect.Reflection.Collections.Filtered.Methods @this, string unexpected) { }
         public static aweXpect.Reflection.Collections.Filtered.Methods WithoutParameters(this aweXpect.Reflection.Collections.Filtered.Methods @this) { }
         public class GenericMethods : aweXpect.Reflection.Collections.Filtered.Methods
@@ -500,6 +510,8 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.PropertyFilters.PropertiesWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Properties @this, System.Func<TAttribute, bool>? predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Collections.Filtered.Properties.StringEqualityResultType WithName(this aweXpect.Reflection.Collections.Filtered.Properties @this, string expected) { }
+        public static aweXpect.Reflection.Collections.Filtered.Properties Without<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Properties @this, bool inherit = true)
+            where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Collections.Filtered.Properties.StringEqualityResultType WithoutName(this aweXpect.Reflection.Collections.Filtered.Properties @this, string unexpected) { }
         public class PropertiesOfType : aweXpect.Reflection.Collections.Filtered.Properties
         {
@@ -520,6 +532,10 @@ namespace aweXpect.Reflection
     }
     public static class ThatAssemblies
     {
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.Assembly?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.Assembly?>>> DoNotHave<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.Assembly?>> subject, bool inherit = true)
+            where TAttribute : System.Attribute { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>>> DoNotHave<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>> subject, bool inherit = true)
+            where TAttribute : System.Attribute { }
         public static aweXpect.Results.StringEqualityTypeResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.Assembly?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.Assembly?>>> DoNotHaveName(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.Assembly?>> subject, string unexpected) { }
         public static aweXpect.Results.StringEqualityTypeResult<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>>> DoNotHaveName(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>> subject, string unexpected) { }
         public static aweXpect.Reflection.Results.HaveAttributeResult<System.Reflection.Assembly?, System.Collections.Generic.IAsyncEnumerable<System.Reflection.Assembly?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.Assembly?>> subject, bool inherit = true)
@@ -566,6 +582,8 @@ namespace aweXpect.Reflection
     }
     public static class ThatAssembly
     {
+        public static aweXpect.Results.AndOrResult<System.Reflection.Assembly?, aweXpect.Core.IThat<System.Reflection.Assembly?>> DoesNotHave<TAttribute>(this aweXpect.Core.IThat<System.Reflection.Assembly?> subject, bool inherit = true)
+            where TAttribute : System.Attribute { }
         public static aweXpect.Results.StringEqualityTypeResult<System.Reflection.Assembly?, aweXpect.Core.IThat<System.Reflection.Assembly?>> DoesNotHaveName(this aweXpect.Core.IThat<System.Reflection.Assembly?> subject, string unexpected) { }
         public static aweXpect.Reflection.Results.HasAttributeResult<System.Reflection.Assembly?> Has<TAttribute>(this aweXpect.Core.IThat<System.Reflection.Assembly?> subject, bool inherit = true)
             where TAttribute : System.Attribute { }
@@ -598,6 +616,8 @@ namespace aweXpect.Reflection
     }
     public static class ThatConstructor
     {
+        public static aweXpect.Results.AndOrResult<System.Reflection.ConstructorInfo?, aweXpect.Core.IThat<System.Reflection.ConstructorInfo?>> DoesNotHave<TAttribute>(this aweXpect.Core.IThat<System.Reflection.ConstructorInfo?> subject, bool inherit = true)
+            where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Results.HasAttributeResult<System.Reflection.ConstructorInfo?> Has<TAttribute>(this aweXpect.Core.IThat<System.Reflection.ConstructorInfo?> subject, bool inherit = true)
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Results.HasAttributeResult<System.Reflection.ConstructorInfo?> Has<TAttribute>(this aweXpect.Core.IThat<System.Reflection.ConstructorInfo?> subject, System.Func<TAttribute, bool> predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
@@ -672,6 +692,10 @@ namespace aweXpect.Reflection
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>>> AreNotStatic(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.ConstructorInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.ConstructorInfo?>>> AreStatic(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.ConstructorInfo?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>>> AreStatic(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.ConstructorInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.ConstructorInfo?>>> DoNotHave<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.ConstructorInfo?>> subject, bool inherit = true)
+            where TAttribute : System.Attribute { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>>> DoNotHave<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>> subject, bool inherit = true)
+            where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Results.HaveAttributeResult<System.Reflection.ConstructorInfo?, System.Collections.Generic.IAsyncEnumerable<System.Reflection.ConstructorInfo?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.ConstructorInfo?>> subject, bool inherit = true)
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Results.HaveAttributeResult<System.Reflection.ConstructorInfo?, System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>> subject, bool inherit = true)
@@ -805,6 +829,8 @@ namespace aweXpect.Reflection
     }
     public static class ThatEvent
     {
+        public static aweXpect.Results.AndOrResult<System.Reflection.EventInfo?, aweXpect.Core.IThat<System.Reflection.EventInfo?>> DoesNotHave<TAttribute>(this aweXpect.Core.IThat<System.Reflection.EventInfo?> subject, bool inherit = true)
+            where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Results.HasAttributeResult<System.Reflection.EventInfo?> Has<TAttribute>(this aweXpect.Core.IThat<System.Reflection.EventInfo?> subject, bool inherit = true)
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Results.HasAttributeResult<System.Reflection.EventInfo?> Has<TAttribute>(this aweXpect.Core.IThat<System.Reflection.EventInfo?> subject, System.Func<TAttribute, bool> predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
@@ -824,6 +850,10 @@ namespace aweXpect.Reflection
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>>> AreNotSealed(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.EventInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.EventInfo?>>> AreSealed(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.EventInfo?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>>> AreSealed(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.EventInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.EventInfo?>>> DoNotHave<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.EventInfo?>> subject, bool inherit = true)
+            where TAttribute : System.Attribute { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>>> DoNotHave<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>> subject, bool inherit = true)
+            where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Results.HaveAttributeResult<System.Reflection.EventInfo?, System.Collections.Generic.IAsyncEnumerable<System.Reflection.EventInfo?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.EventInfo?>> subject, bool inherit = true)
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Results.HaveAttributeResult<System.Reflection.EventInfo?, System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>> subject, bool inherit = true)
@@ -835,6 +865,8 @@ namespace aweXpect.Reflection
     }
     public static class ThatField
     {
+        public static aweXpect.Results.AndOrResult<System.Reflection.FieldInfo?, aweXpect.Core.IThat<System.Reflection.FieldInfo?>> DoesNotHave<TAttribute>(this aweXpect.Core.IThat<System.Reflection.FieldInfo?> subject, bool inherit = true)
+            where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Results.HasAttributeResult<System.Reflection.FieldInfo?> Has<TAttribute>(this aweXpect.Core.IThat<System.Reflection.FieldInfo?> subject, bool inherit = true)
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Results.HasAttributeResult<System.Reflection.FieldInfo?> Has<TAttribute>(this aweXpect.Core.IThat<System.Reflection.FieldInfo?> subject, System.Func<TAttribute, bool> predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
@@ -869,6 +901,10 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.ThatFields.FieldsOfTypeResult<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>>> AreOfType<TField>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.FieldInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.FieldInfo?>>> AreStatic(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.FieldInfo?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>>> AreStatic(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.FieldInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.FieldInfo?>>> DoNotHave<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.FieldInfo?>> subject, bool inherit = true)
+            where TAttribute : System.Attribute { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>>> DoNotHave<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>> subject, bool inherit = true)
+            where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Results.HaveAttributeResult<System.Reflection.FieldInfo?, System.Collections.Generic.IAsyncEnumerable<System.Reflection.FieldInfo?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.FieldInfo?>> subject, bool inherit = true)
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Results.HaveAttributeResult<System.Reflection.FieldInfo?, System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>> subject, bool inherit = true)
@@ -983,6 +1019,8 @@ namespace aweXpect.Reflection
     }
     public static class ThatMethod
     {
+        public static aweXpect.Results.AndOrResult<System.Reflection.MethodInfo?, aweXpect.Core.IThat<System.Reflection.MethodInfo?>> DoesNotHave<TAttribute>(this aweXpect.Core.IThat<System.Reflection.MethodInfo?> subject, bool inherit = true)
+            where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Results.HasAttributeResult<System.Reflection.MethodInfo?> Has<TAttribute>(this aweXpect.Core.IThat<System.Reflection.MethodInfo?> subject, bool inherit = true)
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Results.HasAttributeResult<System.Reflection.MethodInfo?> Has<TAttribute>(this aweXpect.Core.IThat<System.Reflection.MethodInfo?> subject, System.Func<TAttribute, bool> predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
@@ -1089,6 +1127,10 @@ namespace aweXpect.Reflection
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo?>>> AreSealed(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.MethodInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.MethodInfo?>>> AreStatic(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.MethodInfo?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo?>>> AreStatic(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo?>> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.MethodInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.MethodInfo?>>> DoNotHave<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.MethodInfo?>> subject, bool inherit = true)
+            where TAttribute : System.Attribute { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo?>>> DoNotHave<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo?>> subject, bool inherit = true)
+            where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Results.HaveAttributeResult<System.Reflection.MethodInfo?, System.Collections.Generic.IAsyncEnumerable<System.Reflection.MethodInfo?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.MethodInfo?>> subject, bool inherit = true)
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Results.HaveAttributeResult<System.Reflection.MethodInfo?, System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo?>> subject, bool inherit = true)
@@ -1271,6 +1313,10 @@ namespace aweXpect.Reflection
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>>> AreWritable(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.PropertyInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.PropertyInfo?>>> AreWriteOnly(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.PropertyInfo?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>>> AreWriteOnly(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.PropertyInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.PropertyInfo?>>> DoNotHave<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.PropertyInfo?>> subject, bool inherit = true)
+            where TAttribute : System.Attribute { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>>> DoNotHave<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>> subject, bool inherit = true)
+            where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Results.HaveAttributeResult<System.Reflection.PropertyInfo?, System.Collections.Generic.IAsyncEnumerable<System.Reflection.PropertyInfo?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.PropertyInfo?>> subject, bool inherit = true)
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Results.HaveAttributeResult<System.Reflection.PropertyInfo?, System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>> subject, bool inherit = true)
@@ -1291,6 +1337,8 @@ namespace aweXpect.Reflection
     }
     public static class ThatProperty
     {
+        public static aweXpect.Results.AndOrResult<System.Reflection.PropertyInfo?, aweXpect.Core.IThat<System.Reflection.PropertyInfo?>> DoesNotHave<TAttribute>(this aweXpect.Core.IThat<System.Reflection.PropertyInfo?> subject, bool inherit = true)
+            where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Results.HasAttributeResult<System.Reflection.PropertyInfo?> Has<TAttribute>(this aweXpect.Core.IThat<System.Reflection.PropertyInfo?> subject, bool inherit = true)
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Results.HasAttributeResult<System.Reflection.PropertyInfo?> Has<TAttribute>(this aweXpect.Core.IThat<System.Reflection.PropertyInfo?> subject, System.Func<TAttribute, bool> predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
@@ -1327,6 +1375,8 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Results.TypeContainingMembersResult<System.Type?> ContainsFields(this aweXpect.Core.IThat<System.Type?> subject, System.Func<aweXpect.Reflection.Collections.Filtered.Fields, aweXpect.Reflection.Collections.Filtered.Fields> filter) { }
         public static aweXpect.Reflection.Results.TypeContainingMembersResult<System.Type?> ContainsMethods(this aweXpect.Core.IThat<System.Type?> subject, System.Func<aweXpect.Reflection.Collections.Filtered.Methods, aweXpect.Reflection.Collections.Filtered.Methods> filter) { }
         public static aweXpect.Reflection.Results.TypeContainingMembersResult<System.Type?> ContainsProperties(this aweXpect.Core.IThat<System.Type?> subject, System.Func<aweXpect.Reflection.Collections.Filtered.Properties, aweXpect.Reflection.Collections.Filtered.Properties> filter) { }
+        public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> DoesNotHave<TAttribute>(this aweXpect.Core.IThat<System.Type?> subject, bool inherit = true)
+            where TAttribute : System.Attribute { }
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> DoesNotInheritFrom(this aweXpect.Core.IThat<System.Type?> subject, System.Type baseType, bool forceDirect = false) { }
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> DoesNotInheritFrom<TBaseType>(this aweXpect.Core.IThat<System.Type?> subject, bool forceDirect = false) { }
         public static aweXpect.Reflection.Results.HasAttributeResult<System.Type?> Has<TAttribute>(this aweXpect.Core.IThat<System.Type?> subject, bool inherit = true)
@@ -1433,6 +1483,10 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Results.TypeContainingMembersResult<System.Collections.Generic.IEnumerable<System.Type?>> ContainMethods(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject, System.Func<aweXpect.Reflection.Collections.Filtered.Methods, aweXpect.Reflection.Collections.Filtered.Methods> filter) { }
         public static aweXpect.Reflection.Results.TypeContainingMembersResult<System.Collections.Generic.IAsyncEnumerable<System.Type?>> ContainProperties(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>> subject, System.Func<aweXpect.Reflection.Collections.Filtered.Properties, aweXpect.Reflection.Collections.Filtered.Properties> filter) { }
         public static aweXpect.Reflection.Results.TypeContainingMembersResult<System.Collections.Generic.IEnumerable<System.Type?>> ContainProperties(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject, System.Func<aweXpect.Reflection.Collections.Filtered.Properties, aweXpect.Reflection.Collections.Filtered.Properties> filter) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>>> DoNotHave<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>> subject, bool inherit = true)
+            where TAttribute : System.Attribute { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> DoNotHave<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject, bool inherit = true)
+            where TAttribute : System.Attribute { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>>> DoNotInheritFrom(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>> subject, System.Type baseType, bool forceDirect = false) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> DoNotInheritFrom(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject, System.Type baseType, bool forceDirect = false) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>>> DoNotInheritFrom<TBaseType>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>> subject, bool forceDirect = false) { }
@@ -1510,6 +1564,8 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Collections.Filtered.Types.StringEqualityResultType WithName(this aweXpect.Reflection.Collections.Filtered.Types @this, string expected) { }
         public static aweXpect.Reflection.Collections.Filtered.Types.StringEqualityResultType WithNamespace(this aweXpect.Reflection.Collections.Filtered.Types @this, string expected) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WithinNamespace(this aweXpect.Reflection.Collections.Filtered.Types @this, string expected) { }
+        public static aweXpect.Reflection.Collections.Filtered.Types Without<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Types @this, bool inherit = true)
+            where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Collections.Filtered.Types.StringEqualityResultType WithoutName(this aweXpect.Reflection.Collections.Filtered.Types @this, string unexpected) { }
         public class GenericTypes : aweXpect.Reflection.Collections.Filtered.Types
         {

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_netstandard2.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_netstandard2.0.txt
@@ -45,6 +45,8 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Collections.Filtered.Assemblies.StringEqualityResultType WithName(this aweXpect.Reflection.Collections.Filtered.Assemblies @this, string expected) { }
         public static aweXpect.Reflection.AssemblyFilters.AssembliesWithVersion WithVersion(this aweXpect.Reflection.Collections.Filtered.Assemblies @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Assemblies WithVersion(this aweXpect.Reflection.Collections.Filtered.Assemblies @this, System.Func<System.Version, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
+        public static aweXpect.Reflection.Collections.Filtered.Assemblies Without<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Assemblies @this, bool inherit = true)
+            where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Collections.Filtered.Assemblies.StringEqualityResultType WithoutName(this aweXpect.Reflection.Collections.Filtered.Assemblies @this, string unexpected) { }
         public class AssembliesWith : aweXpect.Reflection.Collections.Filtered.Assemblies
         {
@@ -156,6 +158,8 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.ConstructorFilters.ConstructorsWithNamedParameter<object?> WithRefParameterExactly(this aweXpect.Reflection.Collections.Filtered.Constructors @this, System.Type parameterType, string expected) { }
         public static aweXpect.Reflection.ConstructorFilters.ConstructorsWithParameter<T> WithRefParameterExactly<T>(this aweXpect.Reflection.Collections.Filtered.Constructors @this) { }
         public static aweXpect.Reflection.ConstructorFilters.ConstructorsWithNamedParameter<T> WithRefParameterExactly<T>(this aweXpect.Reflection.Collections.Filtered.Constructors @this, string expected) { }
+        public static aweXpect.Reflection.Collections.Filtered.Constructors Without<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Constructors @this)
+            where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Collections.Filtered.Constructors WithoutParameters(this aweXpect.Reflection.Collections.Filtered.Constructors @this) { }
         public class ConstructorsWith : aweXpect.Reflection.Collections.Filtered.Constructors
         {
@@ -221,6 +225,8 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.EventFilters.EventsWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Events @this, System.Func<TAttribute, bool>? predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Collections.Filtered.Events.StringEqualityResultType WithName(this aweXpect.Reflection.Collections.Filtered.Events @this, string expected) { }
+        public static aweXpect.Reflection.Collections.Filtered.Events Without<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Events @this, bool inherit = true)
+            where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Collections.Filtered.Events.StringEqualityResultType WithoutName(this aweXpect.Reflection.Collections.Filtered.Events @this, string unexpected) { }
         public class EventsWith : aweXpect.Reflection.Collections.Filtered.Events
         {
@@ -259,6 +265,8 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.FieldFilters.FieldsWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Fields @this, System.Func<TAttribute, bool>? predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Collections.Filtered.Fields.StringEqualityResultType WithName(this aweXpect.Reflection.Collections.Filtered.Fields @this, string expected) { }
+        public static aweXpect.Reflection.Collections.Filtered.Fields Without<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Fields @this)
+            where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Collections.Filtered.Fields.StringEqualityResultType WithoutName(this aweXpect.Reflection.Collections.Filtered.Fields @this, string unexpected) { }
         public class FieldsOfType : aweXpect.Reflection.Collections.Filtered.Fields
         {
@@ -387,6 +395,8 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.MethodFilters.MethodsWithNamedParameter<object?> WithRefParameterExactly(this aweXpect.Reflection.Collections.Filtered.Methods @this, System.Type parameterType, string expected) { }
         public static aweXpect.Reflection.MethodFilters.MethodsWithParameter<T> WithRefParameterExactly<T>(this aweXpect.Reflection.Collections.Filtered.Methods @this) { }
         public static aweXpect.Reflection.MethodFilters.MethodsWithNamedParameter<T> WithRefParameterExactly<T>(this aweXpect.Reflection.Collections.Filtered.Methods @this, string expected) { }
+        public static aweXpect.Reflection.Collections.Filtered.Methods Without<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Methods @this, bool inherit = true)
+            where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Collections.Filtered.Methods.StringEqualityResultType WithoutName(this aweXpect.Reflection.Collections.Filtered.Methods @this, string unexpected) { }
         public static aweXpect.Reflection.Collections.Filtered.Methods WithoutParameters(this aweXpect.Reflection.Collections.Filtered.Methods @this) { }
         public class GenericMethods : aweXpect.Reflection.Collections.Filtered.Methods
@@ -500,6 +510,8 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.PropertyFilters.PropertiesWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Properties @this, System.Func<TAttribute, bool>? predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Collections.Filtered.Properties.StringEqualityResultType WithName(this aweXpect.Reflection.Collections.Filtered.Properties @this, string expected) { }
+        public static aweXpect.Reflection.Collections.Filtered.Properties Without<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Properties @this, bool inherit = true)
+            where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Collections.Filtered.Properties.StringEqualityResultType WithoutName(this aweXpect.Reflection.Collections.Filtered.Properties @this, string unexpected) { }
         public class PropertiesOfType : aweXpect.Reflection.Collections.Filtered.Properties
         {
@@ -520,6 +532,8 @@ namespace aweXpect.Reflection
     }
     public static class ThatAssemblies
     {
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>>> DoNotHave<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>> subject, bool inherit = true)
+            where TAttribute : System.Attribute { }
         public static aweXpect.Results.StringEqualityTypeResult<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>>> DoNotHaveName(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>> subject, string unexpected) { }
         public static aweXpect.Reflection.Results.HaveAttributeResult<System.Reflection.Assembly?, System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>> subject, bool inherit = true)
             where TAttribute : System.Attribute { }
@@ -553,6 +567,8 @@ namespace aweXpect.Reflection
     }
     public static class ThatAssembly
     {
+        public static aweXpect.Results.AndOrResult<System.Reflection.Assembly?, aweXpect.Core.IThat<System.Reflection.Assembly?>> DoesNotHave<TAttribute>(this aweXpect.Core.IThat<System.Reflection.Assembly?> subject, bool inherit = true)
+            where TAttribute : System.Attribute { }
         public static aweXpect.Results.StringEqualityTypeResult<System.Reflection.Assembly?, aweXpect.Core.IThat<System.Reflection.Assembly?>> DoesNotHaveName(this aweXpect.Core.IThat<System.Reflection.Assembly?> subject, string unexpected) { }
         public static aweXpect.Reflection.Results.HasAttributeResult<System.Reflection.Assembly?> Has<TAttribute>(this aweXpect.Core.IThat<System.Reflection.Assembly?> subject, bool inherit = true)
             where TAttribute : System.Attribute { }
@@ -585,6 +601,8 @@ namespace aweXpect.Reflection
     }
     public static class ThatConstructor
     {
+        public static aweXpect.Results.AndOrResult<System.Reflection.ConstructorInfo?, aweXpect.Core.IThat<System.Reflection.ConstructorInfo?>> DoesNotHave<TAttribute>(this aweXpect.Core.IThat<System.Reflection.ConstructorInfo?> subject, bool inherit = true)
+            where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Results.HasAttributeResult<System.Reflection.ConstructorInfo?> Has<TAttribute>(this aweXpect.Core.IThat<System.Reflection.ConstructorInfo?> subject, bool inherit = true)
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Results.HasAttributeResult<System.Reflection.ConstructorInfo?> Has<TAttribute>(this aweXpect.Core.IThat<System.Reflection.ConstructorInfo?> subject, System.Func<TAttribute, bool> predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
@@ -657,6 +675,8 @@ namespace aweXpect.Reflection
     {
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>>> AreNotStatic(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>>> AreStatic(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>>> DoNotHave<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>> subject, bool inherit = true)
+            where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Results.HaveAttributeResult<System.Reflection.ConstructorInfo?, System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>> subject, bool inherit = true)
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Results.HaveAttributeResult<System.Reflection.ConstructorInfo?, System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>> subject, System.Func<TAttribute, bool> predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
@@ -725,6 +745,8 @@ namespace aweXpect.Reflection
     }
     public static class ThatEvent
     {
+        public static aweXpect.Results.AndOrResult<System.Reflection.EventInfo?, aweXpect.Core.IThat<System.Reflection.EventInfo?>> DoesNotHave<TAttribute>(this aweXpect.Core.IThat<System.Reflection.EventInfo?> subject, bool inherit = true)
+            where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Results.HasAttributeResult<System.Reflection.EventInfo?> Has<TAttribute>(this aweXpect.Core.IThat<System.Reflection.EventInfo?> subject, bool inherit = true)
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Results.HasAttributeResult<System.Reflection.EventInfo?> Has<TAttribute>(this aweXpect.Core.IThat<System.Reflection.EventInfo?> subject, System.Func<TAttribute, bool> predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
@@ -740,6 +762,8 @@ namespace aweXpect.Reflection
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>>> AreNotAbstract(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>>> AreNotSealed(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>>> AreSealed(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>>> DoNotHave<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>> subject, bool inherit = true)
+            where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Results.HaveAttributeResult<System.Reflection.EventInfo?, System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>> subject, bool inherit = true)
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Results.HaveAttributeResult<System.Reflection.EventInfo?, System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>> subject, System.Func<TAttribute, bool> predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
@@ -747,6 +771,8 @@ namespace aweXpect.Reflection
     }
     public static class ThatField
     {
+        public static aweXpect.Results.AndOrResult<System.Reflection.FieldInfo?, aweXpect.Core.IThat<System.Reflection.FieldInfo?>> DoesNotHave<TAttribute>(this aweXpect.Core.IThat<System.Reflection.FieldInfo?> subject, bool inherit = true)
+            where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Results.HasAttributeResult<System.Reflection.FieldInfo?> Has<TAttribute>(this aweXpect.Core.IThat<System.Reflection.FieldInfo?> subject, bool inherit = true)
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Results.HasAttributeResult<System.Reflection.FieldInfo?> Has<TAttribute>(this aweXpect.Core.IThat<System.Reflection.FieldInfo?> subject, System.Func<TAttribute, bool> predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
@@ -775,6 +801,8 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.ThatFields.FieldsOfTypeResult<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>>> AreOfType(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>> subject, System.Type fieldType) { }
         public static aweXpect.Reflection.ThatFields.FieldsOfTypeResult<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>>> AreOfType<TField>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>>> AreStatic(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>>> DoNotHave<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>> subject, bool inherit = true)
+            where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Results.HaveAttributeResult<System.Reflection.FieldInfo?, System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>> subject, bool inherit = true)
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Results.HaveAttributeResult<System.Reflection.FieldInfo?, System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>> subject, System.Func<TAttribute, bool> predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
@@ -855,6 +883,8 @@ namespace aweXpect.Reflection
     }
     public static class ThatMethod
     {
+        public static aweXpect.Results.AndOrResult<System.Reflection.MethodInfo?, aweXpect.Core.IThat<System.Reflection.MethodInfo?>> DoesNotHave<TAttribute>(this aweXpect.Core.IThat<System.Reflection.MethodInfo?> subject, bool inherit = true)
+            where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Results.HasAttributeResult<System.Reflection.MethodInfo?> Has<TAttribute>(this aweXpect.Core.IThat<System.Reflection.MethodInfo?> subject, bool inherit = true)
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Results.HasAttributeResult<System.Reflection.MethodInfo?> Has<TAttribute>(this aweXpect.Core.IThat<System.Reflection.MethodInfo?> subject, System.Func<TAttribute, bool> predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
@@ -953,6 +983,8 @@ namespace aweXpect.Reflection
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo?>>> AreNotStatic(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo?>>> AreSealed(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo?>>> AreStatic(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo?>> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo?>>> DoNotHave<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo?>> subject, bool inherit = true)
+            where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Results.HaveAttributeResult<System.Reflection.MethodInfo?, System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo?>> subject, bool inherit = true)
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Results.HaveAttributeResult<System.Reflection.MethodInfo?, System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo?>> subject, System.Func<TAttribute, bool> predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
@@ -1050,6 +1082,8 @@ namespace aweXpect.Reflection
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>>> AreStatic(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>>> AreWritable(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>>> AreWriteOnly(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>>> DoNotHave<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>> subject, bool inherit = true)
+            where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Results.HaveAttributeResult<System.Reflection.PropertyInfo?, System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>> subject, bool inherit = true)
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Results.HaveAttributeResult<System.Reflection.PropertyInfo?, System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>> subject, System.Func<TAttribute, bool> predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
@@ -1066,6 +1100,8 @@ namespace aweXpect.Reflection
     }
     public static class ThatProperty
     {
+        public static aweXpect.Results.AndOrResult<System.Reflection.PropertyInfo?, aweXpect.Core.IThat<System.Reflection.PropertyInfo?>> DoesNotHave<TAttribute>(this aweXpect.Core.IThat<System.Reflection.PropertyInfo?> subject, bool inherit = true)
+            where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Results.HasAttributeResult<System.Reflection.PropertyInfo?> Has<TAttribute>(this aweXpect.Core.IThat<System.Reflection.PropertyInfo?> subject, bool inherit = true)
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Results.HasAttributeResult<System.Reflection.PropertyInfo?> Has<TAttribute>(this aweXpect.Core.IThat<System.Reflection.PropertyInfo?> subject, System.Func<TAttribute, bool> predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
@@ -1102,6 +1138,8 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Results.TypeContainingMembersResult<System.Type?> ContainsFields(this aweXpect.Core.IThat<System.Type?> subject, System.Func<aweXpect.Reflection.Collections.Filtered.Fields, aweXpect.Reflection.Collections.Filtered.Fields> filter) { }
         public static aweXpect.Reflection.Results.TypeContainingMembersResult<System.Type?> ContainsMethods(this aweXpect.Core.IThat<System.Type?> subject, System.Func<aweXpect.Reflection.Collections.Filtered.Methods, aweXpect.Reflection.Collections.Filtered.Methods> filter) { }
         public static aweXpect.Reflection.Results.TypeContainingMembersResult<System.Type?> ContainsProperties(this aweXpect.Core.IThat<System.Type?> subject, System.Func<aweXpect.Reflection.Collections.Filtered.Properties, aweXpect.Reflection.Collections.Filtered.Properties> filter) { }
+        public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> DoesNotHave<TAttribute>(this aweXpect.Core.IThat<System.Type?> subject, bool inherit = true)
+            where TAttribute : System.Attribute { }
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> DoesNotInheritFrom(this aweXpect.Core.IThat<System.Type?> subject, System.Type baseType, bool forceDirect = false) { }
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> DoesNotInheritFrom<TBaseType>(this aweXpect.Core.IThat<System.Type?> subject, bool forceDirect = false) { }
         public static aweXpect.Reflection.Results.HasAttributeResult<System.Type?> Has<TAttribute>(this aweXpect.Core.IThat<System.Type?> subject, bool inherit = true)
@@ -1175,6 +1213,8 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Results.TypeContainingMembersResult<System.Collections.Generic.IEnumerable<System.Type?>> ContainFields(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject, System.Func<aweXpect.Reflection.Collections.Filtered.Fields, aweXpect.Reflection.Collections.Filtered.Fields> filter) { }
         public static aweXpect.Reflection.Results.TypeContainingMembersResult<System.Collections.Generic.IEnumerable<System.Type?>> ContainMethods(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject, System.Func<aweXpect.Reflection.Collections.Filtered.Methods, aweXpect.Reflection.Collections.Filtered.Methods> filter) { }
         public static aweXpect.Reflection.Results.TypeContainingMembersResult<System.Collections.Generic.IEnumerable<System.Type?>> ContainProperties(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject, System.Func<aweXpect.Reflection.Collections.Filtered.Properties, aweXpect.Reflection.Collections.Filtered.Properties> filter) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> DoNotHave<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject, bool inherit = true)
+            where TAttribute : System.Attribute { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> DoNotInheritFrom(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject, System.Type baseType, bool forceDirect = false) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> DoNotInheritFrom<TBaseType>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject, bool forceDirect = false) { }
         public static aweXpect.Reflection.Results.HaveAttributeResult<System.Type?, System.Collections.Generic.IEnumerable<System.Type?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject, bool inherit = true)
@@ -1243,6 +1283,8 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Collections.Filtered.Types.StringEqualityResultType WithName(this aweXpect.Reflection.Collections.Filtered.Types @this, string expected) { }
         public static aweXpect.Reflection.Collections.Filtered.Types.StringEqualityResultType WithNamespace(this aweXpect.Reflection.Collections.Filtered.Types @this, string expected) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WithinNamespace(this aweXpect.Reflection.Collections.Filtered.Types @this, string expected) { }
+        public static aweXpect.Reflection.Collections.Filtered.Types Without<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Types @this, bool inherit = true)
+            where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Collections.Filtered.Types.StringEqualityResultType WithoutName(this aweXpect.Reflection.Collections.Filtered.Types @this, string unexpected) { }
         public class GenericTypes : aweXpect.Reflection.Collections.Filtered.Types
         {

--- a/Tests/aweXpect.Reflection.Tests/Filters/AssemblyFilters.Without.AttributeTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/AssemblyFilters.Without.AttributeTests.cs
@@ -1,0 +1,51 @@
+﻿using System.Reflection;
+using aweXpect.Reflection.Collections;
+
+namespace aweXpect.Reflection.Tests.Filters;
+
+public sealed partial class AssemblyFilters
+{
+	public sealed class Without
+	{
+		public sealed class AttributeTests
+		{
+			[Fact]
+			public async Task ShouldFilterForAssembliesWithoutAttribute()
+			{
+				Filtered.Assemblies assemblies = In.AllLoadedAssemblies()
+					.Without<AssemblyTitleAttribute>();
+
+				await That(assemblies).DoesNotContain(typeof(AssemblyFilters).Assembly);
+				await That(assemblies.GetDescription())
+					.IsEqualTo("in all loaded assemblies without AssemblyTitleAttribute").AsPrefix();
+			}
+
+			[Fact]
+			public async Task WhenAttributeIsNeverApplied_ShouldKeepAllAssemblies()
+			{
+				Filtered.Assemblies assemblies = In.AllLoadedAssemblies()
+					.Without<NeverAppliedAssemblyAttribute>();
+
+				await That(assemblies).Contains(typeof(AssemblyFilters).Assembly);
+				await That(assemblies.GetDescription())
+					.IsEqualTo(
+						"in all loaded assemblies without AssemblyFilters.Without.AttributeTests.NeverAppliedAssemblyAttribute")
+					.AsPrefix();
+			}
+
+			[Fact]
+			public async Task WhenInheritIsSetToFalse_ShouldDescribeAsDirect()
+			{
+				Filtered.Assemblies assemblies = In.AllLoadedAssemblies()
+					.Without<AssemblyTitleAttribute>(false);
+
+				await That(assemblies).DoesNotContain(typeof(AssemblyFilters).Assembly);
+				await That(assemblies.GetDescription())
+					.IsEqualTo("in all loaded assemblies without direct AssemblyTitleAttribute").AsPrefix();
+			}
+
+			[AttributeUsage(AttributeTargets.Assembly)]
+			private sealed class NeverAppliedAssemblyAttribute : Attribute;
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/Filters/ConstructorFilters.Without.AttributeTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/ConstructorFilters.Without.AttributeTests.cs
@@ -1,0 +1,45 @@
+﻿using aweXpect.Reflection.Collections;
+
+namespace aweXpect.Reflection.Tests.Filters;
+
+public sealed partial class ConstructorFilters
+{
+	public sealed class Without
+	{
+		public sealed class AttributeTests
+		{
+			[Fact]
+			public async Task ShouldFilterForConstructorsWithoutAttribute()
+			{
+				Filtered.Constructors constructors = In.AssemblyContaining<AssemblyFilters>()
+					.Constructors().Without<BarAttribute>();
+
+				await That(constructors).IsNotEmpty()
+					.And.Contains(typeof(Dummy).GetConstructor(Type.EmptyTypes))
+					.And.DoesNotContain(typeof(Dummy).GetConstructor([typeof(string),]));
+				await That(constructors.GetDescription())
+					.IsEqualTo("constructors without ConstructorFilters.Without.AttributeTests.BarAttribute").AsPrefix();
+			}
+
+			[AttributeUsage(AttributeTargets.Constructor)]
+			private class BarAttribute : Attribute
+			{
+			}
+
+			// ReSharper disable UnusedMember.Local
+			private class Dummy
+			{
+				public Dummy()
+				{
+				}
+
+				[Bar]
+				// ReSharper disable once UnusedParameter.Local
+				public Dummy(string value)
+				{
+				}
+			}
+			// ReSharper restore UnusedMember.Local
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/Filters/EventFilters.Without.AttributeTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/EventFilters.Without.AttributeTests.cs
@@ -1,0 +1,58 @@
+﻿using aweXpect.Reflection.Collections;
+
+namespace aweXpect.Reflection.Tests.Filters;
+
+public sealed partial class EventFilters
+{
+	public sealed class Without
+	{
+		public sealed class AttributeTests
+		{
+			[Fact]
+			public async Task ShouldFilterForEventsWithoutAttribute()
+			{
+				Filtered.Events events = In.AssemblyContaining<AssemblyFilters>()
+					.Events().Without<BarAttribute>();
+
+				await That(events).IsNotEmpty()
+					.And.Contains(typeof(Dummy).GetEvent(nameof(Dummy.PlainEvent)))
+					.And.DoesNotContain(typeof(Dummy).GetEvent(nameof(Dummy.MyBarEvent)))
+					.And.DoesNotContain(typeof(DummyChild).GetEvent(nameof(DummyChild.MyBarEvent)));
+				await That(events.GetDescription())
+					.IsEqualTo("events without EventFilters.Without.AttributeTests.BarAttribute").AsPrefix();
+			}
+
+			[Fact]
+			public async Task WhenInheritIsSetToFalse_ShouldFilterForEventsWithoutAttributeDirectlySet()
+			{
+				Filtered.Events events = In.AssemblyContaining<AssemblyFilters>()
+					.Events().Without<BarAttribute>(false);
+
+				await That(events)
+					.Contains(typeof(DummyChild).GetEvent(nameof(DummyChild.MyBarEvent)))
+					.And.DoesNotContain(typeof(Dummy).GetEvent(nameof(Dummy.MyBarEvent)));
+				await That(events.GetDescription())
+					.IsEqualTo("events without direct EventFilters.Without.AttributeTests.BarAttribute").AsPrefix();
+			}
+
+			[AttributeUsage(AttributeTargets.Event)]
+			private class BarAttribute : Attribute
+			{
+			}
+
+#pragma warning disable CS0067 // Event is never used
+			private class Dummy
+			{
+				[Bar] public virtual event Action? MyBarEvent;
+
+				public event Action? PlainEvent;
+			}
+
+			private class DummyChild : Dummy
+			{
+				public override event Action? MyBarEvent;
+			}
+#pragma warning restore CS0067
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/Filters/FieldFilters.Without.AttributeTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/FieldFilters.Without.AttributeTests.cs
@@ -1,0 +1,39 @@
+﻿using aweXpect.Reflection.Collections;
+
+namespace aweXpect.Reflection.Tests.Filters;
+
+public sealed partial class FieldFilters
+{
+	public sealed class Without
+	{
+		public sealed class AttributeTests
+		{
+			[Fact]
+			public async Task ShouldFilterForFieldsWithoutAttribute()
+			{
+				Filtered.Fields fields = In.AssemblyContaining<AssemblyFilters>()
+					.Fields().Without<BarAttribute>();
+
+				await That(fields).IsNotEmpty()
+					.And.Contains(typeof(Dummy).GetField(nameof(Dummy.PlainField)))
+					.And.DoesNotContain(typeof(Dummy).GetField(nameof(Dummy.MyBarField)));
+				await That(fields.GetDescription())
+					.IsEqualTo("fields without FieldFilters.Without.AttributeTests.BarAttribute").AsPrefix();
+			}
+
+			[AttributeUsage(AttributeTargets.Field)]
+			private class BarAttribute : Attribute
+			{
+			}
+
+#pragma warning disable CS0649 // Field is never assigned to
+			private class Dummy
+			{
+				[Bar] public string? MyBarField;
+
+				public string? PlainField;
+			}
+#pragma warning restore CS0649
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.Without.AttributeTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.Without.AttributeTests.cs
@@ -1,0 +1,63 @@
+﻿using aweXpect.Reflection.Collections;
+
+namespace aweXpect.Reflection.Tests.Filters;
+
+public sealed partial class MethodFilters
+{
+	public sealed class Without
+	{
+		public sealed class AttributeTests
+		{
+			[Fact]
+			public async Task ShouldFilterForMethodsWithoutAttribute()
+			{
+				Filtered.Methods methods = In.AssemblyContaining<AssemblyFilters>()
+					.Methods().Without<BarAttribute>();
+
+				await That(methods).IsNotEmpty()
+					.And.Contains(typeof(Dummy).GetMethod(nameof(Dummy.PlainMethod)))
+					.And.DoesNotContain(typeof(Dummy).GetMethod(nameof(Dummy.MyBarMethod)))
+					.And.DoesNotContain(typeof(DummyChild).GetMethod(nameof(DummyChild.MyBarMethod)));
+				await That(methods.GetDescription())
+					.IsEqualTo("methods without MethodFilters.Without.AttributeTests.BarAttribute").AsPrefix();
+			}
+
+			[Fact]
+			public async Task WhenInheritIsSetToFalse_ShouldFilterForMethodsWithoutAttributeDirectlySet()
+			{
+				Filtered.Methods methods = In.AssemblyContaining<AssemblyFilters>()
+					.Methods().Without<BarAttribute>(false);
+
+				await That(methods)
+					.Contains(typeof(DummyChild).GetMethod(nameof(DummyChild.MyBarMethod)))
+					.And.DoesNotContain(typeof(Dummy).GetMethod(nameof(Dummy.MyBarMethod)));
+				await That(methods.GetDescription())
+					.IsEqualTo("methods without direct MethodFilters.Without.AttributeTests.BarAttribute").AsPrefix();
+			}
+
+			[AttributeUsage(AttributeTargets.Method)]
+			private class BarAttribute : Attribute
+			{
+			}
+
+			private class Dummy
+			{
+				[Bar]
+				public virtual void MyBarMethod()
+				{
+				}
+
+				public void PlainMethod()
+				{
+				}
+			}
+
+			private class DummyChild : Dummy
+			{
+				public override void MyBarMethod()
+				{
+				}
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/Filters/PropertyFilters.Without.AttributeTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/PropertyFilters.Without.AttributeTests.cs
@@ -1,0 +1,56 @@
+﻿using aweXpect.Reflection.Collections;
+
+namespace aweXpect.Reflection.Tests.Filters;
+
+public sealed partial class PropertyFilters
+{
+	public sealed class Without
+	{
+		public sealed class AttributeTests
+		{
+			[Fact]
+			public async Task ShouldFilterForPropertiesWithoutAttribute()
+			{
+				Filtered.Properties properties = In.AssemblyContaining<AssemblyFilters>()
+					.Properties().Without<BarAttribute>();
+
+				await That(properties).IsNotEmpty()
+					.And.Contains(typeof(Dummy).GetProperty(nameof(Dummy.PlainProperty)))
+					.And.DoesNotContain(typeof(Dummy).GetProperty(nameof(Dummy.MyBarProperty)))
+					.And.DoesNotContain(typeof(DummyChild).GetProperty(nameof(DummyChild.MyBarProperty)));
+				await That(properties.GetDescription())
+					.IsEqualTo("properties without PropertyFilters.Without.AttributeTests.BarAttribute").AsPrefix();
+			}
+
+			[Fact]
+			public async Task WhenInheritIsSetToFalse_ShouldFilterForPropertiesWithoutAttributeDirectlySet()
+			{
+				Filtered.Properties properties = In.AssemblyContaining<AssemblyFilters>()
+					.Properties().Without<BarAttribute>(false);
+
+				await That(properties)
+					.Contains(typeof(DummyChild).GetProperty(nameof(DummyChild.MyBarProperty)))
+					.And.DoesNotContain(typeof(Dummy).GetProperty(nameof(Dummy.MyBarProperty)));
+				await That(properties.GetDescription())
+					.IsEqualTo("properties without direct PropertyFilters.Without.AttributeTests.BarAttribute").AsPrefix();
+			}
+
+			[AttributeUsage(AttributeTargets.Property)]
+			private class BarAttribute : Attribute
+			{
+			}
+
+			private class Dummy
+			{
+				[Bar] public virtual int MyBarProperty { get; set; }
+
+				public int PlainProperty { get; set; }
+			}
+
+			private class DummyChild : Dummy
+			{
+				public override int MyBarProperty { get; set; }
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.Without.AttributeTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.Without.AttributeTests.cs
@@ -1,0 +1,50 @@
+﻿using aweXpect.Reflection.Collections;
+
+namespace aweXpect.Reflection.Tests.Filters;
+
+public sealed partial class TypeFilters
+{
+	public sealed class Without
+	{
+		public sealed class AttributeTests
+		{
+			[Fact]
+			public async Task ShouldFilterForTypesWithoutAttribute()
+			{
+				Filtered.Types types = In.AssemblyContaining<AssemblyFilters>()
+					.Types().Without<BarAttribute>();
+
+				await That(types).All().Satisfy(t => !Attribute.IsDefined(t!, typeof(BarAttribute), true))
+					.And.IsNotEmpty();
+				await That(types).DoesNotContain(typeof(BarClass)).And.DoesNotContain(typeof(BarChildClass));
+				await That(types.GetDescription())
+					.IsEqualTo("types without TypeFilters.Without.AttributeTests.BarAttribute").AsPrefix();
+			}
+
+			[Fact]
+			public async Task WhenInheritIsSetToFalse_ShouldFilterForTypesWithoutAttributeDirectlySet()
+			{
+				Filtered.Types types = In.AssemblyContaining<AssemblyFilters>()
+					.Types().Without<BarAttribute>(false);
+
+				await That(types).DoesNotContain(typeof(BarClass)).And.Contains(typeof(BarChildClass));
+				await That(types.GetDescription())
+					.IsEqualTo("types without direct TypeFilters.Without.AttributeTests.BarAttribute").AsPrefix();
+			}
+
+			[AttributeUsage(AttributeTargets.Class)]
+			private class BarAttribute : Attribute
+			{
+			}
+
+			[Bar]
+			private class BarClass
+			{
+			}
+
+			private class BarChildClass : BarClass
+			{
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatAssemblies.DoNotHave.AttributeTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatAssemblies.DoNotHave.AttributeTests.cs
@@ -1,0 +1,105 @@
+﻿using System.Collections.Generic;
+using System.Reflection;
+using aweXpect.Reflection.Tests.TestHelpers;
+using Xunit.Sdk;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatAssemblies
+{
+	public sealed class DoNotHave
+	{
+		public sealed class AttributeTests
+		{
+			[Fact]
+			public async Task WhenNoAssemblyHasAttribute_ShouldSucceed()
+			{
+				IEnumerable<Assembly?> subjects = new[]
+				{
+					Assembly.GetExecutingAssembly(), null,
+				};
+
+				async Task Act()
+				{
+					await That(subjects).DoNotHave<TestAttribute>();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenAnAssemblyHasAttribute_ShouldFail()
+			{
+				IEnumerable<Assembly?> subjects = new[]
+				{
+					Assembly.GetExecutingAssembly(),
+				};
+
+				async Task Act()
+				{
+					await That(subjects).DoNotHave<AssemblyTitleAttribute>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subjects
+					             all have no AssemblyTitleAttribute,
+					             but it contained not matching assemblies [
+					               aweXpect.Reflection.Tests, Version=*, Culture=neutral, PublicKeyToken=null
+					             ]
+					             """).AsWildcard();
+			}
+
+#if NET8_0_OR_GREATER
+			[Fact]
+			public async Task AsyncEnumerable_WhenAnAssemblyHasAttribute_ShouldFail()
+			{
+				IAsyncEnumerable<Assembly?> subjects = new[]
+				{
+					Assembly.GetExecutingAssembly(),
+				}.ToTestAsyncEnumerable<Assembly?>();
+
+				async Task Act()
+				{
+					await That(subjects).DoNotHave<AssemblyTitleAttribute>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subjects
+					             all have no AssemblyTitleAttribute,
+					             but it contained not matching assemblies [
+					               aweXpect.Reflection.Tests, Version=*, Culture=neutral, PublicKeyToken=null
+					             ]
+					             """).AsWildcard();
+			}
+#endif
+
+			[Fact]
+			public async Task Negated_WhenNoAssemblyHasAttribute_ShouldFail()
+			{
+				IEnumerable<Assembly?> subjects = new[]
+				{
+					Assembly.GetExecutingAssembly(),
+				};
+
+				async Task Act()
+				{
+					await That(subjects).DoesNotComplyWith(they => they.DoNotHave<TestAttribute>());
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subjects
+					             not all have no ThatAssemblies.DoNotHave.AttributeTests.TestAttribute,
+					             but it only contained matching assemblies [
+					               aweXpect.Reflection.Tests, Version=*, Culture=neutral, PublicKeyToken=null
+					             ]
+					             """).AsWildcard();
+			}
+
+			[AttributeUsage(AttributeTargets.Assembly)]
+			private class TestAttribute : Attribute;
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatAssembly.DoesNotHave.AttributeTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatAssembly.DoesNotHave.AttributeTests.cs
@@ -1,0 +1,47 @@
+﻿using System.Reflection;
+using Xunit.Sdk;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatAssembly
+{
+	public sealed class DoesNotHave
+	{
+		public sealed class AttributeTests
+		{
+			[Fact]
+			public async Task WhenAssemblyDoesNotHaveAttribute_ShouldSucceed()
+			{
+				Assembly subject = Assembly.GetExecutingAssembly();
+
+				async Task Act()
+				{
+					await That(subject).DoesNotHave<TestAttribute>();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenAssemblyHasAttribute_ShouldFail()
+			{
+				Assembly subject = Assembly.GetExecutingAssembly();
+
+				async Task Act()
+				{
+					await That(subject).DoesNotHave<AssemblyTitleAttribute>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has no AssemblyTitleAttribute,
+					             but it did in aweXpect.Reflection.Tests, Version=*, Culture=neutral, PublicKeyToken=null
+					             """).AsWildcard();
+			}
+
+			[AttributeUsage(AttributeTargets.Assembly)]
+			private class TestAttribute : Attribute;
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatConstructor.DoesNotHave.AttributeTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatConstructor.DoesNotHave.AttributeTests.cs
@@ -1,0 +1,64 @@
+﻿using System.Reflection;
+using Xunit.Sdk;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatConstructor
+{
+	public sealed class DoesNotHave
+	{
+		public sealed class AttributeTests
+		{
+			[Fact]
+			public async Task WhenConstructorDoesNotHaveAttribute_ShouldSucceed()
+			{
+				ConstructorInfo subject = typeof(TestClass).GetConstructor(Type.EmptyTypes)!;
+
+				async Task Act()
+				{
+					await That(subject).DoesNotHave<FooAttribute>();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenConstructorHasAttribute_ShouldFail()
+			{
+				ConstructorInfo subject = typeof(TestClass).GetConstructor([typeof(string),])!;
+
+				async Task Act()
+				{
+					await That(subject).DoesNotHave<FooAttribute>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has no ThatConstructor.DoesNotHave.AttributeTests.FooAttribute,
+					             but it did in ThatConstructor.DoesNotHave.AttributeTests.TestClass(string value)
+					             """);
+			}
+
+			[AttributeUsage(AttributeTargets.Constructor)]
+			private class FooAttribute : Attribute
+			{
+			}
+
+			// ReSharper disable UnusedMember.Local
+			private class TestClass
+			{
+				public TestClass()
+				{
+				}
+
+				[Foo]
+				// ReSharper disable once UnusedParameter.Local
+				public TestClass(string value)
+				{
+				}
+			}
+			// ReSharper restore UnusedMember.Local
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatConstructors.DoNotHave.AttributeTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatConstructors.DoNotHave.AttributeTests.cs
@@ -1,0 +1,122 @@
+﻿using System.Collections.Generic;
+using System.Reflection;
+using aweXpect.Reflection.Tests.TestHelpers;
+using Xunit.Sdk;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatConstructors
+{
+	public sealed class DoNotHave
+	{
+		public sealed class AttributeTests
+		{
+			[Fact]
+			public async Task WhenNoConstructorHasAttribute_ShouldSucceed()
+			{
+				IEnumerable<ConstructorInfo?> subject = new[]
+				{
+					typeof(TestClass).GetConstructor(Type.EmptyTypes), null,
+				};
+
+				async Task Act()
+				{
+					await That(subject).DoNotHave<FooAttribute>();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenAConstructorHasAttribute_ShouldFail()
+			{
+				IEnumerable<ConstructorInfo?> subject = new[]
+				{
+					typeof(TestClass).GetConstructor([typeof(string),]),
+				};
+
+				async Task Act()
+				{
+					await That(subject).DoNotHave<FooAttribute>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             all have no ThatConstructors.DoNotHave.AttributeTests.FooAttribute,
+					             but it contained not matching constructors [
+					               ThatConstructors.DoNotHave.AttributeTests.TestClass(string value)
+					             ]
+					             """);
+			}
+
+#if NET8_0_OR_GREATER
+			[Fact]
+			public async Task AsyncEnumerable_WhenAConstructorHasAttribute_ShouldFail()
+			{
+				IAsyncEnumerable<ConstructorInfo?> subject = new[]
+				{
+					typeof(TestClass).GetConstructor([typeof(string),]),
+				}.ToTestAsyncEnumerable<ConstructorInfo?>();
+
+				async Task Act()
+				{
+					await That(subject).DoNotHave<FooAttribute>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             all have no ThatConstructors.DoNotHave.AttributeTests.FooAttribute,
+					             but it contained not matching constructors [
+					               ThatConstructors.DoNotHave.AttributeTests.TestClass(string value)
+					             ]
+					             """);
+			}
+#endif
+
+			[Fact]
+			public async Task Negated_WhenNoConstructorHasAttribute_ShouldFail()
+			{
+				IEnumerable<ConstructorInfo?> subject = new[]
+				{
+					typeof(TestClass).GetConstructor(Type.EmptyTypes),
+				};
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(they => they.DoNotHave<FooAttribute>());
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             not all have no ThatConstructors.DoNotHave.AttributeTests.FooAttribute,
+					             but it only contained matching constructors [
+					               ThatConstructors.DoNotHave.AttributeTests.TestClass()
+					             ]
+					             """);
+			}
+
+			[AttributeUsage(AttributeTargets.Constructor)]
+			private class FooAttribute : Attribute
+			{
+			}
+
+			// ReSharper disable UnusedMember.Local
+			private class TestClass
+			{
+				public TestClass()
+				{
+				}
+
+				[Foo]
+				// ReSharper disable once UnusedParameter.Local
+				public TestClass(string value)
+				{
+				}
+			}
+			// ReSharper restore UnusedMember.Local
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatEvent.DoesNotHave.AttributeTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatEvent.DoesNotHave.AttributeTests.cs
@@ -1,0 +1,58 @@
+﻿using System.Reflection;
+using Xunit.Sdk;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatEvent
+{
+	public sealed class DoesNotHave
+	{
+		public sealed class AttributeTests
+		{
+			[Fact]
+			public async Task WhenEventDoesNotHaveAttribute_ShouldSucceed()
+			{
+				EventInfo subject = typeof(TestClass).GetEvent(nameof(TestClass.NoAttributeEvent))!;
+
+				async Task Act()
+				{
+					await That(subject).DoesNotHave<FooAttribute>();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenEventHasAttribute_ShouldFail()
+			{
+				EventInfo subject = typeof(TestClass).GetEvent(nameof(TestClass.TestEvent))!;
+
+				async Task Act()
+				{
+					await That(subject).DoesNotHave<FooAttribute>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has no ThatEvent.DoesNotHave.AttributeTests.FooAttribute,
+					             but it did in event Action ThatEvent.DoesNotHave.AttributeTests.TestClass.TestEvent
+					             """);
+			}
+
+			[AttributeUsage(AttributeTargets.Event)]
+			private class FooAttribute : Attribute
+			{
+			}
+
+#pragma warning disable CS0067 // Event is never used
+			private class TestClass
+			{
+				[Foo] public event Action? TestEvent;
+
+				public event Action? NoAttributeEvent;
+			}
+#pragma warning restore CS0067
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatEvents.DoNotHave.AttributeTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatEvents.DoNotHave.AttributeTests.cs
@@ -1,0 +1,116 @@
+﻿using System.Collections.Generic;
+using System.Reflection;
+using aweXpect.Reflection.Tests.TestHelpers;
+using Xunit.Sdk;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatEvents
+{
+	public sealed class DoNotHave
+	{
+		public sealed class AttributeTests
+		{
+			[Fact]
+			public async Task WhenNoEventHasAttribute_ShouldSucceed()
+			{
+				IEnumerable<EventInfo?> subject = new[]
+				{
+					typeof(TestClass).GetEvent(nameof(TestClass.NoAttributeEvent)), null,
+				};
+
+				async Task Act()
+				{
+					await That(subject).DoNotHave<FooAttribute>();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenAnEventHasAttribute_ShouldFail()
+			{
+				IEnumerable<EventInfo?> subject = new[]
+				{
+					typeof(TestClass).GetEvent(nameof(TestClass.TestEvent)),
+				};
+
+				async Task Act()
+				{
+					await That(subject).DoNotHave<FooAttribute>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             all have no ThatEvents.DoNotHave.AttributeTests.FooAttribute,
+					             but it contained not matching events [
+					               event Action ThatEvents.DoNotHave.AttributeTests.TestClass.TestEvent
+					             ]
+					             """);
+			}
+
+#if NET8_0_OR_GREATER
+			[Fact]
+			public async Task AsyncEnumerable_WhenAnEventHasAttribute_ShouldFail()
+			{
+				IAsyncEnumerable<EventInfo?> subject = new[]
+				{
+					typeof(TestClass).GetEvent(nameof(TestClass.TestEvent)),
+				}.ToTestAsyncEnumerable<EventInfo?>();
+
+				async Task Act()
+				{
+					await That(subject).DoNotHave<FooAttribute>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             all have no ThatEvents.DoNotHave.AttributeTests.FooAttribute,
+					             but it contained not matching events [
+					               event Action ThatEvents.DoNotHave.AttributeTests.TestClass.TestEvent
+					             ]
+					             """);
+			}
+#endif
+
+			[Fact]
+			public async Task Negated_WhenNoEventHasAttribute_ShouldFail()
+			{
+				IEnumerable<EventInfo?> subject = new[]
+				{
+					typeof(TestClass).GetEvent(nameof(TestClass.NoAttributeEvent)),
+				};
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(they => they.DoNotHave<FooAttribute>());
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             not all have no ThatEvents.DoNotHave.AttributeTests.FooAttribute,
+					             but it only contained matching events [
+					               event Action ThatEvents.DoNotHave.AttributeTests.TestClass.NoAttributeEvent
+					             ]
+					             """);
+			}
+
+			[AttributeUsage(AttributeTargets.Event)]
+			private class FooAttribute : Attribute
+			{
+			}
+
+#pragma warning disable CS0067 // Event is never used
+			private class TestClass
+			{
+				[Foo] public event Action? TestEvent;
+
+				public event Action? NoAttributeEvent;
+			}
+#pragma warning restore CS0067
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatField.DoesNotHave.AttributeTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatField.DoesNotHave.AttributeTests.cs
@@ -1,0 +1,58 @@
+﻿using System.Reflection;
+using Xunit.Sdk;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatField
+{
+	public sealed class DoesNotHave
+	{
+		public sealed class AttributeTests
+		{
+			[Fact]
+			public async Task WhenFieldDoesNotHaveAttribute_ShouldSucceed()
+			{
+				FieldInfo subject = typeof(TestClass).GetField(nameof(TestClass.NoAttributeField))!;
+
+				async Task Act()
+				{
+					await That(subject).DoesNotHave<FooAttribute>();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenFieldHasAttribute_ShouldFail()
+			{
+				FieldInfo subject = typeof(TestClass).GetField(nameof(TestClass.TestField))!;
+
+				async Task Act()
+				{
+					await That(subject).DoesNotHave<FooAttribute>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has no ThatField.DoesNotHave.AttributeTests.FooAttribute,
+					             but it did in string ThatField.DoesNotHave.AttributeTests.TestClass.TestField
+					             """);
+			}
+
+			[AttributeUsage(AttributeTargets.Field)]
+			private class FooAttribute : Attribute
+			{
+			}
+
+#pragma warning disable CS0414 // Field is assigned but its value is never used
+			private class TestClass
+			{
+				[Foo] public string TestField = "";
+
+				public string NoAttributeField = "";
+			}
+#pragma warning restore CS0414
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatFields.DoNotHave.AttributeTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatFields.DoNotHave.AttributeTests.cs
@@ -1,0 +1,116 @@
+﻿using System.Collections.Generic;
+using System.Reflection;
+using aweXpect.Reflection.Tests.TestHelpers;
+using Xunit.Sdk;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatFields
+{
+	public sealed class DoNotHave
+	{
+		public sealed class AttributeTests
+		{
+			[Fact]
+			public async Task WhenNoFieldHasAttribute_ShouldSucceed()
+			{
+				IEnumerable<FieldInfo?> subject = new[]
+				{
+					typeof(TestClass).GetField(nameof(TestClass.NoAttributeField)), null,
+				};
+
+				async Task Act()
+				{
+					await That(subject).DoNotHave<FooAttribute>();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenAFieldHasAttribute_ShouldFail()
+			{
+				IEnumerable<FieldInfo?> subject = new[]
+				{
+					typeof(TestClass).GetField(nameof(TestClass.TestField)),
+				};
+
+				async Task Act()
+				{
+					await That(subject).DoNotHave<FooAttribute>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             all have no ThatFields.DoNotHave.AttributeTests.FooAttribute,
+					             but it contained not matching fields [
+					               string ThatFields.DoNotHave.AttributeTests.TestClass.TestField
+					             ]
+					             """);
+			}
+
+#if NET8_0_OR_GREATER
+			[Fact]
+			public async Task AsyncEnumerable_WhenAFieldHasAttribute_ShouldFail()
+			{
+				IAsyncEnumerable<FieldInfo?> subject = new[]
+				{
+					typeof(TestClass).GetField(nameof(TestClass.TestField)),
+				}.ToTestAsyncEnumerable<FieldInfo?>();
+
+				async Task Act()
+				{
+					await That(subject).DoNotHave<FooAttribute>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             all have no ThatFields.DoNotHave.AttributeTests.FooAttribute,
+					             but it contained not matching fields [
+					               string ThatFields.DoNotHave.AttributeTests.TestClass.TestField
+					             ]
+					             """);
+			}
+#endif
+
+			[Fact]
+			public async Task Negated_WhenNoFieldHasAttribute_ShouldFail()
+			{
+				IEnumerable<FieldInfo?> subject = new[]
+				{
+					typeof(TestClass).GetField(nameof(TestClass.NoAttributeField)),
+				};
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(they => they.DoNotHave<FooAttribute>());
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             not all have no ThatFields.DoNotHave.AttributeTests.FooAttribute,
+					             but it only contained matching fields [
+					               string ThatFields.DoNotHave.AttributeTests.TestClass.NoAttributeField
+					             ]
+					             """);
+			}
+
+			[AttributeUsage(AttributeTargets.Field)]
+			private class FooAttribute : Attribute
+			{
+			}
+
+#pragma warning disable CS0414 // Field is assigned but its value is never used
+			private class TestClass
+			{
+				[Foo] public string TestField = "";
+
+				public string NoAttributeField = "";
+			}
+#pragma warning restore CS0414
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatMethod.DoesNotHave.AttributeTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethod.DoesNotHave.AttributeTests.cs
@@ -1,0 +1,61 @@
+﻿using System.Reflection;
+using Xunit.Sdk;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatMethod
+{
+	public sealed class DoesNotHave
+	{
+		public sealed class AttributeTests
+		{
+			[Fact]
+			public async Task WhenMethodDoesNotHaveAttribute_ShouldSucceed()
+			{
+				MethodInfo subject = typeof(TestClass).GetMethod(nameof(TestClass.NoAttributeMethod))!;
+
+				async Task Act()
+				{
+					await That(subject).DoesNotHave<FooAttribute>();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenMethodHasAttribute_ShouldFail()
+			{
+				MethodInfo subject = typeof(TestClass).GetMethod(nameof(TestClass.TestMethod))!;
+
+				async Task Act()
+				{
+					await That(subject).DoesNotHave<FooAttribute>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has no ThatMethod.DoesNotHave.AttributeTests.FooAttribute,
+					             but it did in void ThatMethod.DoesNotHave.AttributeTests.TestClass.TestMethod()
+					             """);
+			}
+
+			[AttributeUsage(AttributeTargets.Method)]
+			private class FooAttribute : Attribute
+			{
+			}
+
+			private class TestClass
+			{
+				[Foo]
+				public void TestMethod()
+				{
+				}
+
+				public void NoAttributeMethod()
+				{
+				}
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatMethods.DoNotHave.AttributeTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethods.DoNotHave.AttributeTests.cs
@@ -1,0 +1,119 @@
+﻿using System.Collections.Generic;
+using System.Reflection;
+using aweXpect.Reflection.Tests.TestHelpers;
+using Xunit.Sdk;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatMethods
+{
+	public sealed class DoNotHave
+	{
+		public sealed class AttributeTests
+		{
+			[Fact]
+			public async Task WhenNoMethodHasAttribute_ShouldSucceed()
+			{
+				IEnumerable<MethodInfo?> subject = new[]
+				{
+					typeof(TestClass).GetMethod(nameof(TestClass.NoAttributeMethod)), null,
+				};
+
+				async Task Act()
+				{
+					await That(subject).DoNotHave<FooAttribute>();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenAMethodHasAttribute_ShouldFail()
+			{
+				IEnumerable<MethodInfo?> subject = new[]
+				{
+					typeof(TestClass).GetMethod(nameof(TestClass.TestMethod)),
+				};
+
+				async Task Act()
+				{
+					await That(subject).DoNotHave<FooAttribute>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             all have no ThatMethods.DoNotHave.AttributeTests.FooAttribute,
+					             but it contained not matching methods [
+					               void ThatMethods.DoNotHave.AttributeTests.TestClass.TestMethod()
+					             ]
+					             """);
+			}
+
+#if NET8_0_OR_GREATER
+			[Fact]
+			public async Task AsyncEnumerable_WhenAMethodHasAttribute_ShouldFail()
+			{
+				IAsyncEnumerable<MethodInfo?> subject = new[]
+				{
+					typeof(TestClass).GetMethod(nameof(TestClass.TestMethod)),
+				}.ToTestAsyncEnumerable<MethodInfo?>();
+
+				async Task Act()
+				{
+					await That(subject).DoNotHave<FooAttribute>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             all have no ThatMethods.DoNotHave.AttributeTests.FooAttribute,
+					             but it contained not matching methods [
+					               void ThatMethods.DoNotHave.AttributeTests.TestClass.TestMethod()
+					             ]
+					             """);
+			}
+#endif
+
+			[Fact]
+			public async Task Negated_WhenNoMethodHasAttribute_ShouldFail()
+			{
+				IEnumerable<MethodInfo?> subject = new[]
+				{
+					typeof(TestClass).GetMethod(nameof(TestClass.NoAttributeMethod)),
+				};
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(they => they.DoNotHave<FooAttribute>());
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             not all have no ThatMethods.DoNotHave.AttributeTests.FooAttribute,
+					             but it only contained matching methods [
+					               void ThatMethods.DoNotHave.AttributeTests.TestClass.NoAttributeMethod()
+					             ]
+					             """);
+			}
+
+			[AttributeUsage(AttributeTargets.Method)]
+			private class FooAttribute : Attribute
+			{
+			}
+
+			private class TestClass
+			{
+				[Foo]
+				public void TestMethod()
+				{
+				}
+
+				public void NoAttributeMethod()
+				{
+				}
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatProperties.DoNotHave.AttributeTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatProperties.DoNotHave.AttributeTests.cs
@@ -1,0 +1,114 @@
+﻿using System.Collections.Generic;
+using System.Reflection;
+using aweXpect.Reflection.Tests.TestHelpers;
+using Xunit.Sdk;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatProperties
+{
+	public sealed class DoNotHave
+	{
+		public sealed class AttributeTests
+		{
+			[Fact]
+			public async Task WhenNoPropertyHasAttribute_ShouldSucceed()
+			{
+				IEnumerable<PropertyInfo?> subject = new[]
+				{
+					typeof(TestClass).GetProperty(nameof(TestClass.NoAttributeProperty)), null,
+				};
+
+				async Task Act()
+				{
+					await That(subject).DoNotHave<FooAttribute>();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenAPropertyHasAttribute_ShouldFail()
+			{
+				IEnumerable<PropertyInfo?> subject = new[]
+				{
+					typeof(TestClass).GetProperty(nameof(TestClass.TestProperty)),
+				};
+
+				async Task Act()
+				{
+					await That(subject).DoNotHave<FooAttribute>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             all have no ThatProperties.DoNotHave.AttributeTests.FooAttribute,
+					             but it contained not matching properties [
+					               public string ThatProperties.DoNotHave.AttributeTests.TestClass.TestProperty { get; set; }
+					             ]
+					             """);
+			}
+
+#if NET8_0_OR_GREATER
+			[Fact]
+			public async Task AsyncEnumerable_WhenAPropertyHasAttribute_ShouldFail()
+			{
+				IAsyncEnumerable<PropertyInfo?> subject = new[]
+				{
+					typeof(TestClass).GetProperty(nameof(TestClass.TestProperty)),
+				}.ToTestAsyncEnumerable<PropertyInfo?>();
+
+				async Task Act()
+				{
+					await That(subject).DoNotHave<FooAttribute>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             all have no ThatProperties.DoNotHave.AttributeTests.FooAttribute,
+					             but it contained not matching properties [
+					               public string ThatProperties.DoNotHave.AttributeTests.TestClass.TestProperty { get; set; }
+					             ]
+					             """);
+			}
+#endif
+
+			[Fact]
+			public async Task Negated_WhenNoPropertyHasAttribute_ShouldFail()
+			{
+				IEnumerable<PropertyInfo?> subject = new[]
+				{
+					typeof(TestClass).GetProperty(nameof(TestClass.NoAttributeProperty)),
+				};
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(they => they.DoNotHave<FooAttribute>());
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             not all have no ThatProperties.DoNotHave.AttributeTests.FooAttribute,
+					             but it only contained matching properties [
+					               public string ThatProperties.DoNotHave.AttributeTests.TestClass.NoAttributeProperty { get; set; }
+					             ]
+					             """);
+			}
+
+			[AttributeUsage(AttributeTargets.Property)]
+			private class FooAttribute : Attribute
+			{
+			}
+
+			private class TestClass
+			{
+				[Foo] public string TestProperty { get; set; } = "";
+
+				public string NoAttributeProperty { get; set; } = "";
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatProperty.DoesNotHave.AttributeTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatProperty.DoesNotHave.AttributeTests.cs
@@ -1,0 +1,56 @@
+﻿using System.Reflection;
+using Xunit.Sdk;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatProperty
+{
+	public sealed class DoesNotHave
+	{
+		public sealed class AttributeTests
+		{
+			[Fact]
+			public async Task WhenPropertyDoesNotHaveAttribute_ShouldSucceed()
+			{
+				PropertyInfo subject = typeof(TestClass).GetProperty(nameof(TestClass.NoAttributeProperty))!;
+
+				async Task Act()
+				{
+					await That(subject).DoesNotHave<FooAttribute>();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenPropertyHasAttribute_ShouldFail()
+			{
+				PropertyInfo subject = typeof(TestClass).GetProperty(nameof(TestClass.TestProperty))!;
+
+				async Task Act()
+				{
+					await That(subject).DoesNotHave<FooAttribute>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has no ThatProperty.DoesNotHave.AttributeTests.FooAttribute,
+					             but it did in public string ThatProperty.DoesNotHave.AttributeTests.TestClass.TestProperty { get; set; }
+					             """);
+			}
+
+			[AttributeUsage(AttributeTargets.Property)]
+			private class FooAttribute : Attribute
+			{
+			}
+
+			private class TestClass
+			{
+				[Foo] public string TestProperty { get; set; } = "";
+
+				public string NoAttributeProperty { get; set; } = "";
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatType.DoesNotHave.AttributeTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatType.DoesNotHave.AttributeTests.cs
@@ -1,0 +1,99 @@
+﻿using Xunit.Sdk;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatType
+{
+	public sealed class DoesNotHave
+	{
+		public sealed class AttributeTests
+		{
+			[Fact]
+			public async Task WhenTypeDoesNotHaveAttribute_ShouldSucceed()
+			{
+				Type subject = typeof(BarClass);
+
+				async Task Act()
+				{
+					await That(subject).DoesNotHave<FooAttribute>();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenTypeHasAttribute_ShouldFail()
+			{
+				Type subject = typeof(FooClass2);
+
+				async Task Act()
+				{
+					await That(subject).DoesNotHave<FooAttribute>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has no ThatType.DoesNotHave.AttributeTests.FooAttribute,
+					             but it did in ThatType.DoesNotHave.AttributeTests.FooClass2
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenTypeHasAttributeIndirectly_ShouldFail()
+			{
+				Type subject = typeof(FooChildClass2);
+
+				async Task Act()
+				{
+					await That(subject).DoesNotHave<FooAttribute>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             has no ThatType.DoesNotHave.AttributeTests.FooAttribute,
+					             but it did in ThatType.DoesNotHave.AttributeTests.FooChildClass2
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenTypeHasAttributeIndirectly_WhenInheritIsFalse_ShouldSucceed()
+			{
+				Type subject = typeof(FooChildClass2);
+
+				async Task Act()
+				{
+					await That(subject).DoesNotHave<FooAttribute>(false);
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[AttributeUsage(AttributeTargets.Class)]
+			private class FooAttribute : Attribute
+			{
+				public int Value { get; set; }
+			}
+
+			[AttributeUsage(AttributeTargets.Class)]
+			private class BarAttribute : Attribute
+			{
+			}
+
+			[Foo(Value = 2)]
+			private class FooClass2
+			{
+			}
+
+			[Bar]
+			private class BarClass
+			{
+			}
+
+			private class FooChildClass2 : FooClass2
+			{
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.DoNotHave.AttributeTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.DoNotHave.AttributeTests.cs
@@ -1,0 +1,191 @@
+﻿using System.Collections.Generic;
+using aweXpect.Reflection.Tests.TestHelpers;
+using Xunit.Sdk;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatTypes
+{
+	public sealed class DoNotHave
+	{
+		public sealed class AttributeTests
+		{
+			[Fact]
+			public async Task WhenNoTypeHasAttribute_ShouldSucceed()
+			{
+				List<Type?> subjects = [typeof(BarClass), null,];
+
+				async Task Act()
+				{
+					await That(subjects).DoNotHave<FooAttribute>();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenATypeHasAttribute_ShouldFail()
+			{
+				List<Type?> subjects = [typeof(FooClass2),];
+
+				async Task Act()
+				{
+					await That(subjects).DoNotHave<FooAttribute>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subjects
+					             all have no ThatTypes.DoNotHave.AttributeTests.FooAttribute,
+					             but it contained not matching types [
+					               ThatTypes.DoNotHave.AttributeTests.FooClass2
+					             ]
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenATypeHasAttributeIndirectly_ShouldFail()
+			{
+				List<Type?> subjects = [typeof(FooChildClass2),];
+
+				async Task Act()
+				{
+					await That(subjects).DoNotHave<FooAttribute>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subjects
+					             all have no ThatTypes.DoNotHave.AttributeTests.FooAttribute,
+					             but it contained not matching types [
+					               ThatTypes.DoNotHave.AttributeTests.FooChildClass2
+					             ]
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenATypeHasAttributeIndirectly_WhenInheritIsFalse_ShouldSucceed()
+			{
+				List<Type?> subjects = [typeof(FooChildClass2),];
+
+				async Task Act()
+				{
+					await That(subjects).DoNotHave<FooAttribute>(false);
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+#if NET8_0_OR_GREATER
+			[Fact]
+			public async Task AsyncEnumerable_WhenNoTypeHasAttribute_ShouldSucceed()
+			{
+				IAsyncEnumerable<Type?> subject = new[]
+				{
+					typeof(BarClass), null,
+				}.ToTestAsyncEnumerable<Type?>();
+
+				async Task Act()
+				{
+					await That(subject).DoNotHave<FooAttribute>();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task AsyncEnumerable_WhenATypeHasAttribute_ShouldFail()
+			{
+				IAsyncEnumerable<Type?> subject = new[]
+				{
+					typeof(FooClass2),
+				}.ToTestAsyncEnumerable<Type?>();
+
+				async Task Act()
+				{
+					await That(subject).DoNotHave<FooAttribute>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             all have no ThatTypes.DoNotHave.AttributeTests.FooAttribute,
+					             but it contained not matching types [
+					               ThatTypes.DoNotHave.AttributeTests.FooClass2
+					             ]
+					             """);
+			}
+#endif
+
+			[AttributeUsage(AttributeTargets.Class)]
+			private class FooAttribute : Attribute
+			{
+				public int Value { get; set; }
+			}
+
+			[Foo(Value = 2)]
+			private class FooClass2
+			{
+			}
+
+			private class BarClass
+			{
+			}
+
+			private class FooChildClass2 : FooClass2
+			{
+			}
+		}
+
+		public sealed class NegatedTests
+		{
+			[Fact]
+			public async Task WhenATypeHasAttribute_ShouldSucceed()
+			{
+				List<Type?> subjects = [typeof(FooClass2),];
+
+				async Task Act()
+				{
+					await That(subjects).DoesNotComplyWith(they => they.DoNotHave<FooAttribute>());
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenNoTypeHasAttribute_ShouldFail()
+			{
+				List<Type?> subjects = [typeof(BarClass),];
+
+				async Task Act()
+				{
+					await That(subjects).DoesNotComplyWith(they => they.DoNotHave<FooAttribute>());
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subjects
+					             not all have no ThatTypes.DoNotHave.NegatedTests.FooAttribute,
+					             but it only contained matching types [
+					               ThatTypes.DoNotHave.NegatedTests.BarClass
+					             ]
+					             """);
+			}
+
+			[AttributeUsage(AttributeTargets.Class)]
+			private class FooAttribute : Attribute
+			{
+				public int Value { get; set; }
+			}
+
+			[Foo(Value = 2)]
+			private class FooClass2
+			{
+			}
+
+			private class BarClass
+			{
+			}
+		}
+	}
+}


### PR DESCRIPTION
Mirror the positive attribute API in negated form across all member kinds:
- Filter `.Without<TAttribute>()` (with `inherit` where `With` has it) on types, properties, methods, fields, events, constructors and assemblies. Chain multiple `.Without<...>()` calls to exclude several attributes (an item must have none of them).
- Assertions `.DoesNotHave<TAttribute>()` (single) and `.DoNotHave<TAttribute>()` (many), both taking the optional `inherit` flag (default `true`).

The single-subject assertion reuses the positive `Has` constraint via `.Invert()`; the collection assertion uses a dedicated "none match" constraint. Subclass matching is consistent across filters and assertions (both route through `HasAttribute`).

No `OrWithout`/`Or*` combinator is added: the only sensible "without" semantics (has none of them) is already expressible by chaining separate `.Without<...>()` calls.

Includes full test coverage (100% line and branch on the new code), regenerated public API approval files, and README updates.

---

- *Fixes #279*