### PR TITLE
refactor: drop no-op `inherit` flag from field and constructor attribute assertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,9 +168,10 @@ Shared by all types, members, and assemblies.
 | any of several attributes          | `.With<T1>().OrWith<T2>()`  | -                            | -                           |
 | does not have attribute            | `.Without<TAttribute>()`    | `.DoesNotHave<TAttribute>()` | `.DoNotHave<TAttribute>()`  |
 
-All attribute filters and assertions (`With`, `OrWith`, `Without`, `Has`, `Have`, `DoesNotHave`, `DoNotHave`,
+Most attribute filters and assertions (`With`, `OrWith`, `Without`, `Has`, `Have`, `DoesNotHave`, `DoNotHave`,
 `OrHas`, `OrHave`) take an optional `inherit` parameter (default `true`) that controls whether attributes
-inherited from base types are considered: `.With<TAttribute>(inherit: false)`. Chain multiple
+inherited from base types are considered: `.With<TAttribute>(inherit: false)`. Fields and constructors cannot
+inherit attributes, so their attribute filters and assertions omit the parameter. Chain multiple
 `.Without<TAttribute>()` calls to exclude several attributes (an item must have none of them).
 
 ```csharp

--- a/Source/aweXpect.Reflection/Results/HasAttributeWithoutInheritResult.cs
+++ b/Source/aweXpect.Reflection/Results/HasAttributeWithoutInheritResult.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+using aweXpect.Core;
+using aweXpect.Reflection.Helpers;
+using aweXpect.Reflection.Options;
+using aweXpect.Results;
+
+namespace aweXpect.Reflection.Results;
+
+/// <summary>
+///     Allows chaining of multiple attributes for members whose attributes cannot be inherited
+///     (fields and constructors).
+/// </summary>
+public sealed class HasAttributeWithoutInheritResult<TMember>(
+	ExpectationBuilder expectationBuilder,
+	IThat<TMember> subject,
+	AttributeFilterOptions<TMember> attributeFilterOptions)
+	: AndOrResult<TMember, IThat<TMember>>(expectationBuilder, subject),
+		IOptionsProvider<AttributeFilterOptions<TMember>>
+{
+	/// <inheritdoc cref="IOptionsProvider{AttributeFilterOptions}.Options" />
+	AttributeFilterOptions<TMember> IOptionsProvider<AttributeFilterOptions<TMember>>.Options
+		=> attributeFilterOptions;
+
+	/// <summary>
+	///     Allows an alternative attribute of type <typeparamref name="TAttribute" />.
+	/// </summary>
+	public HasAttributeWithoutInheritResult<TMember> OrHas<TAttribute>()
+		where TAttribute : Attribute
+	{
+		attributeFilterOptions.RegisterAttribute<TAttribute>(true);
+		return this;
+	}
+
+	/// <summary>
+	///     Allows an alternative attribute of type <typeparamref name="TAttribute" /> that
+	///     matches the <paramref name="predicate" />.
+	/// </summary>
+	public HasAttributeWithoutInheritResult<TMember> OrHas<TAttribute>(
+		Func<TAttribute, bool> predicate,
+		[CallerArgumentExpression("predicate")]
+		string doNotPopulateThisValue = "")
+		where TAttribute : Attribute
+	{
+		attributeFilterOptions.RegisterAttribute(true, predicate, doNotPopulateThisValue.TrimCommonWhiteSpace());
+		return this;
+	}
+}

--- a/Source/aweXpect.Reflection/Results/HaveAttributeWithoutInheritResult.cs
+++ b/Source/aweXpect.Reflection/Results/HaveAttributeWithoutInheritResult.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+using aweXpect.Core;
+using aweXpect.Reflection.Helpers;
+using aweXpect.Reflection.Options;
+using aweXpect.Results;
+
+namespace aweXpect.Reflection.Results;
+
+/// <summary>
+///     Allows chaining of multiple attributes for members whose attributes cannot be inherited
+///     (fields and constructors).
+/// </summary>
+public sealed class HaveAttributeWithoutInheritResult<TMember, TResult>(
+	ExpectationBuilder expectationBuilder,
+	IThat<TResult> subject,
+	AttributeFilterOptions<TMember> attributeFilterOptions)
+	: AndOrResult<TResult, IThat<TResult>>(expectationBuilder, subject),
+		IOptionsProvider<AttributeFilterOptions<TMember>>
+{
+	/// <inheritdoc cref="IOptionsProvider{AttributeFilterOptions}.Options" />
+	AttributeFilterOptions<TMember> IOptionsProvider<AttributeFilterOptions<TMember>>.Options
+		=> attributeFilterOptions;
+
+	/// <summary>
+	///     Allows an alternative attribute of type <typeparamref name="TAttribute" />.
+	/// </summary>
+	public HaveAttributeWithoutInheritResult<TMember, TResult> OrHave<TAttribute>()
+		where TAttribute : Attribute
+	{
+		attributeFilterOptions.RegisterAttribute<TAttribute>(true);
+		return this;
+	}
+
+	/// <summary>
+	///     Allows an alternative attribute of type <typeparamref name="TAttribute" /> that
+	///     matches the <paramref name="predicate" />.
+	/// </summary>
+	public HaveAttributeWithoutInheritResult<TMember, TResult> OrHave<TAttribute>(
+		Func<TAttribute, bool> predicate,
+		[CallerArgumentExpression("predicate")]
+		string doNotPopulateThisValue = "")
+		where TAttribute : Attribute
+	{
+		attributeFilterOptions.RegisterAttribute(true, predicate, doNotPopulateThisValue.TrimCommonWhiteSpace());
+		return this;
+	}
+}

--- a/Source/aweXpect.Reflection/ThatConstructor.DoesNotHave.cs
+++ b/Source/aweXpect.Reflection/ThatConstructor.DoesNotHave.cs
@@ -14,17 +14,13 @@ public static partial class ThatConstructor
 	///     Verifies that the <see cref="ConstructorInfo" /> does not have attribute of type
 	///     <typeparamref name="TAttribute" />.
 	/// </summary>
-	/// <remarks>
-	///     The optional parameter <paramref name="inherit" /> (default value <see langword="true" />) specifies, if
-	///     the attribute can be inherited from a base type.
-	/// </remarks>
 	public static AndOrResult<ConstructorInfo?, IThat<ConstructorInfo?>> DoesNotHave<TAttribute>(
-		this IThat<ConstructorInfo?> subject, bool inherit = true)
+		this IThat<ConstructorInfo?> subject)
 		where TAttribute : Attribute
 	{
 		AttributeFilterOptions<ConstructorInfo?> attributeFilterOptions =
 			new((a, attributeType, p, i) => a.HasAttribute(attributeType, p, i));
-		attributeFilterOptions.RegisterAttribute<TAttribute>(inherit);
+		attributeFilterOptions.RegisterAttribute<TAttribute>(true);
 		return new AndOrResult<ConstructorInfo?, IThat<ConstructorInfo?>>(subject.Get().ExpectationBuilder.AddConstraint(
 				(it, grammars)
 					=> new HasAttributeConstraint(it, grammars, attributeFilterOptions).Invert()),

--- a/Source/aweXpect.Reflection/ThatConstructor.Has.cs
+++ b/Source/aweXpect.Reflection/ThatConstructor.Has.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -15,19 +15,16 @@ public static partial class ThatConstructor
 	/// <summary>
 	///     Verifies that the <see cref="ConstructorInfo" /> has attribute of type <typeparamref name="TAttribute" />.
 	/// </summary>
-	/// <remarks>
-	///     The optional parameter <paramref name="inherit" /> (default value <see langword="true" />) specifies, if
-	///     the attribute can be inherited from a base type.
-	/// </remarks>
-	public static HasAttributeResult<ConstructorInfo?> Has<TAttribute>(this IThat<ConstructorInfo?> subject,
-		bool inherit = true)
+	public static HasAttributeWithoutInheritResult<ConstructorInfo?> Has<TAttribute>(
+		this IThat<ConstructorInfo?> subject)
 		where TAttribute : Attribute
 	{
 		AttributeFilterOptions<ConstructorInfo?> attributeFilterOptions =
 			new((a, attributeType, p, i) => a.HasAttribute(attributeType, p, i));
-		attributeFilterOptions.RegisterAttribute<TAttribute>(inherit);
-		return new HasAttributeResult<ConstructorInfo?>(subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new HasAttributeConstraint(it, grammars, attributeFilterOptions)),
+		attributeFilterOptions.RegisterAttribute<TAttribute>(true);
+		return new HasAttributeWithoutInheritResult<ConstructorInfo?>(subject.Get().ExpectationBuilder.AddConstraint(
+				(it, grammars)
+					=> new HasAttributeConstraint(it, grammars, attributeFilterOptions)),
 			subject,
 			attributeFilterOptions);
 	}
@@ -36,23 +33,19 @@ public static partial class ThatConstructor
 	///     Verifies that the <see cref="ConstructorInfo" /> has attribute of type <typeparamref name="TAttribute" /> that
 	///     matches the <paramref name="predicate" />.
 	/// </summary>
-	/// <remarks>
-	///     The optional parameter <paramref name="inherit" /> (default value <see langword="true" />) specifies, if
-	///     the attribute can be inherited from a base type.
-	/// </remarks>
-	public static HasAttributeResult<ConstructorInfo?> Has<TAttribute>(
+	public static HasAttributeWithoutInheritResult<ConstructorInfo?> Has<TAttribute>(
 		this IThat<ConstructorInfo?> subject,
 		Func<TAttribute, bool> predicate,
-		bool inherit = true,
 		[CallerArgumentExpression("predicate")]
 		string doNotPopulateThisValue = "")
 		where TAttribute : Attribute
 	{
 		AttributeFilterOptions<ConstructorInfo?> attributeFilterOptions =
 			new((a, attributeType, p, i) => a.HasAttribute(attributeType, p, i));
-		attributeFilterOptions.RegisterAttribute(inherit, predicate, doNotPopulateThisValue);
-		return new HasAttributeResult<ConstructorInfo?>(subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new HasAttributeConstraint(it, grammars, attributeFilterOptions)),
+		attributeFilterOptions.RegisterAttribute(true, predicate, doNotPopulateThisValue);
+		return new HasAttributeWithoutInheritResult<ConstructorInfo?>(subject.Get().ExpectationBuilder.AddConstraint(
+				(it, grammars)
+					=> new HasAttributeConstraint(it, grammars, attributeFilterOptions)),
 			subject,
 			attributeFilterOptions);
 	}

--- a/Source/aweXpect.Reflection/ThatConstructors.DoNotHave.cs
+++ b/Source/aweXpect.Reflection/ThatConstructors.DoNotHave.cs
@@ -22,17 +22,13 @@ public static partial class ThatConstructors
 	///     Verifies that none of the items in the filtered collection of <see cref="ConstructorInfo" /> have
 	///     attribute of type <typeparamref name="TAttribute" />.
 	/// </summary>
-	/// <remarks>
-	///     The optional parameter <paramref name="inherit" /> (default value <see langword="true" /> specifies, if
-	///     the attribute can be inherited from a base type.
-	/// </remarks>
 	public static AndOrResult<IEnumerable<ConstructorInfo?>, IThat<IEnumerable<ConstructorInfo?>>> DoNotHave<TAttribute>(
-		this IThat<IEnumerable<ConstructorInfo?>> subject, bool inherit = true)
+		this IThat<IEnumerable<ConstructorInfo?>> subject)
 		where TAttribute : Attribute
 	{
 		AttributeFilterOptions<ConstructorInfo?> attributeFilterOptions =
 			new((a, attributeType, p, i) => a.HasAttribute(attributeType, p, i));
-		attributeFilterOptions.RegisterAttribute<TAttribute>(inherit);
+		attributeFilterOptions.RegisterAttribute<TAttribute>(true);
 		return new AndOrResult<IEnumerable<ConstructorInfo?>, IThat<IEnumerable<ConstructorInfo?>>>(
 			subject.Get().ExpectationBuilder.AddConstraint<IEnumerable<ConstructorInfo?>>((it, grammars)
 				=> new DoNotHaveAttributeConstraint(it, grammars | ExpectationGrammars.Plural, attributeFilterOptions)),
@@ -44,18 +40,14 @@ public static partial class ThatConstructors
 	///     Verifies that none of the items in the filtered collection of <see cref="ConstructorInfo" /> have
 	///     attribute of type <typeparamref name="TAttribute" />.
 	/// </summary>
-	/// <remarks>
-	///     The optional parameter <paramref name="inherit" /> (default value <see langword="true" /> specifies, if
-	///     the attribute can be inherited from a base type.
-	/// </remarks>
 	public static AndOrResult<IAsyncEnumerable<ConstructorInfo?>, IThat<IAsyncEnumerable<ConstructorInfo?>>>
 		DoNotHave<TAttribute>(
-			this IThat<IAsyncEnumerable<ConstructorInfo?>> subject, bool inherit = true)
+			this IThat<IAsyncEnumerable<ConstructorInfo?>> subject)
 		where TAttribute : Attribute
 	{
 		AttributeFilterOptions<ConstructorInfo?> attributeFilterOptions =
 			new((a, attributeType, p, i) => a.HasAttribute(attributeType, p, i));
-		attributeFilterOptions.RegisterAttribute<TAttribute>(inherit);
+		attributeFilterOptions.RegisterAttribute<TAttribute>(true);
 		return new AndOrResult<IAsyncEnumerable<ConstructorInfo?>, IThat<IAsyncEnumerable<ConstructorInfo?>>>(
 			subject.Get().ExpectationBuilder.AddConstraint<IAsyncEnumerable<ConstructorInfo?>>((it, grammars)
 				=> new DoNotHaveAttributeConstraint(it, grammars | ExpectationGrammars.Plural, attributeFilterOptions)),

--- a/Source/aweXpect.Reflection/ThatConstructors.Have.cs
+++ b/Source/aweXpect.Reflection/ThatConstructors.Have.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Runtime.CompilerServices;
@@ -23,18 +23,14 @@ public static partial class ThatConstructors
 	///     Verifies that all items in the filtered collection of <see cref="ConstructorInfo" /> have
 	///     attribute of type <typeparamref name="TAttribute" />.
 	/// </summary>
-	/// <remarks>
-	///     The optional parameter <paramref name="inherit" /> (default value <see langword="true" /> specifies, if
-	///     the attribute can be inherited from a base type.
-	/// </remarks>
-	public static HaveAttributeResult<ConstructorInfo?, IEnumerable<ConstructorInfo?>> Have<TAttribute>(
-		this IThat<IEnumerable<ConstructorInfo?>> subject, bool inherit = true)
+	public static HaveAttributeWithoutInheritResult<ConstructorInfo?, IEnumerable<ConstructorInfo?>> Have<TAttribute>(
+		this IThat<IEnumerable<ConstructorInfo?>> subject)
 		where TAttribute : Attribute
 	{
 		AttributeFilterOptions<ConstructorInfo?> attributeFilterOptions =
 			new((a, attributeType, p, i) => a.HasAttribute(attributeType, p, i));
-		attributeFilterOptions.RegisterAttribute<TAttribute>(inherit);
-		return new HaveAttributeResult<ConstructorInfo?, IEnumerable<ConstructorInfo?>>(
+		attributeFilterOptions.RegisterAttribute<TAttribute>(true);
+		return new HaveAttributeWithoutInheritResult<ConstructorInfo?, IEnumerable<ConstructorInfo?>>(
 			subject.Get().ExpectationBuilder.AddConstraint<IEnumerable<ConstructorInfo?>>((it, grammars)
 				=> new HaveAttributeConstraint(it, grammars | ExpectationGrammars.Plural, attributeFilterOptions)),
 			subject,
@@ -45,22 +41,17 @@ public static partial class ThatConstructors
 	///     Verifies that all items in the filtered collection of <see cref="ConstructorInfo" /> have
 	///     attribute of type <typeparamref name="TAttribute" />.
 	/// </summary>
-	/// <remarks>
-	///     The optional parameter <paramref name="inherit" /> (default value <see langword="true" /> specifies, if
-	///     the attribute can be inherited from a base type.
-	/// </remarks>
-	public static HaveAttributeResult<ConstructorInfo?, IEnumerable<ConstructorInfo?>> Have<TAttribute>(
+	public static HaveAttributeWithoutInheritResult<ConstructorInfo?, IEnumerable<ConstructorInfo?>> Have<TAttribute>(
 		this IThat<IEnumerable<ConstructorInfo?>> subject,
 		Func<TAttribute, bool> predicate,
-		bool inherit = true,
 		[CallerArgumentExpression("predicate")]
 		string doNotPopulateThisValue = "")
 		where TAttribute : Attribute
 	{
 		AttributeFilterOptions<ConstructorInfo?> attributeFilterOptions =
 			new((a, attributeType, p, i) => a.HasAttribute(attributeType, p, i));
-		attributeFilterOptions.RegisterAttribute(inherit, predicate, doNotPopulateThisValue);
-		return new HaveAttributeResult<ConstructorInfo?, IEnumerable<ConstructorInfo?>>(
+		attributeFilterOptions.RegisterAttribute(true, predicate, doNotPopulateThisValue);
+		return new HaveAttributeWithoutInheritResult<ConstructorInfo?, IEnumerable<ConstructorInfo?>>(
 			subject.Get().ExpectationBuilder.AddConstraint<IEnumerable<ConstructorInfo?>>((it, grammars)
 				=> new HaveAttributeConstraint(it, grammars | ExpectationGrammars.Plural, attributeFilterOptions)),
 			subject,
@@ -72,18 +63,15 @@ public static partial class ThatConstructors
 	///     Verifies that all items in the filtered collection of <see cref="ConstructorInfo" /> have
 	///     attribute of type <typeparamref name="TAttribute" />.
 	/// </summary>
-	/// <remarks>
-	///     The optional parameter <paramref name="inherit" /> (default value <see langword="true" /> specifies, if
-	///     the attribute can be inherited from a base type.
-	/// </remarks>
-	public static HaveAttributeResult<ConstructorInfo?, IAsyncEnumerable<ConstructorInfo?>> Have<TAttribute>(
-		this IThat<IAsyncEnumerable<ConstructorInfo?>> subject, bool inherit = true)
+	public static HaveAttributeWithoutInheritResult<ConstructorInfo?, IAsyncEnumerable<ConstructorInfo?>>
+		Have<TAttribute>(
+			this IThat<IAsyncEnumerable<ConstructorInfo?>> subject)
 		where TAttribute : Attribute
 	{
 		AttributeFilterOptions<ConstructorInfo?> attributeFilterOptions =
 			new((a, attributeType, p, i) => a.HasAttribute(attributeType, p, i));
-		attributeFilterOptions.RegisterAttribute<TAttribute>(inherit);
-		return new HaveAttributeResult<ConstructorInfo?, IAsyncEnumerable<ConstructorInfo?>>(
+		attributeFilterOptions.RegisterAttribute<TAttribute>(true);
+		return new HaveAttributeWithoutInheritResult<ConstructorInfo?, IAsyncEnumerable<ConstructorInfo?>>(
 			subject.Get().ExpectationBuilder.AddConstraint<IAsyncEnumerable<ConstructorInfo?>>((it, grammars)
 				=> new HaveAttributeConstraint(it, grammars | ExpectationGrammars.Plural, attributeFilterOptions)),
 			subject,
@@ -96,22 +84,18 @@ public static partial class ThatConstructors
 	///     Verifies that all items in the filtered collection of <see cref="ConstructorInfo" /> have
 	///     attribute of type <typeparamref name="TAttribute" />.
 	/// </summary>
-	/// <remarks>
-	///     The optional parameter <paramref name="inherit" /> (default value <see langword="true" /> specifies, if
-	///     the attribute can be inherited from a base type.
-	/// </remarks>
-	public static HaveAttributeResult<ConstructorInfo?, IAsyncEnumerable<ConstructorInfo?>> Have<TAttribute>(
-		this IThat<IAsyncEnumerable<ConstructorInfo?>> subject,
-		Func<TAttribute, bool> predicate,
-		bool inherit = true,
-		[CallerArgumentExpression("predicate")]
-		string doNotPopulateThisValue = "")
+	public static HaveAttributeWithoutInheritResult<ConstructorInfo?, IAsyncEnumerable<ConstructorInfo?>>
+		Have<TAttribute>(
+			this IThat<IAsyncEnumerable<ConstructorInfo?>> subject,
+			Func<TAttribute, bool> predicate,
+			[CallerArgumentExpression("predicate")]
+			string doNotPopulateThisValue = "")
 		where TAttribute : Attribute
 	{
 		AttributeFilterOptions<ConstructorInfo?> attributeFilterOptions =
 			new((a, attributeType, p, i) => a.HasAttribute(attributeType, p, i));
-		attributeFilterOptions.RegisterAttribute(inherit, predicate, doNotPopulateThisValue);
-		return new HaveAttributeResult<ConstructorInfo?, IAsyncEnumerable<ConstructorInfo?>>(
+		attributeFilterOptions.RegisterAttribute(true, predicate, doNotPopulateThisValue);
+		return new HaveAttributeWithoutInheritResult<ConstructorInfo?, IAsyncEnumerable<ConstructorInfo?>>(
 			subject.Get().ExpectationBuilder.AddConstraint<IAsyncEnumerable<ConstructorInfo?>>((it, grammars)
 				=> new HaveAttributeConstraint(it, grammars | ExpectationGrammars.Plural, attributeFilterOptions)),
 			subject,

--- a/Source/aweXpect.Reflection/ThatField.DoesNotHave.cs
+++ b/Source/aweXpect.Reflection/ThatField.DoesNotHave.cs
@@ -13,17 +13,12 @@ public static partial class ThatField
 	/// <summary>
 	///     Verifies that the <see cref="FieldInfo" /> does not have attribute of type <typeparamref name="TAttribute" />.
 	/// </summary>
-	/// <remarks>
-	///     The optional parameter <paramref name="inherit" /> (default value <see langword="true" />) specifies, if
-	///     the attribute can be inherited from a base type.
-	/// </remarks>
-	public static AndOrResult<FieldInfo?, IThat<FieldInfo?>> DoesNotHave<TAttribute>(
-		this IThat<FieldInfo?> subject, bool inherit = true)
+	public static AndOrResult<FieldInfo?, IThat<FieldInfo?>> DoesNotHave<TAttribute>(this IThat<FieldInfo?> subject)
 		where TAttribute : Attribute
 	{
 		AttributeFilterOptions<FieldInfo?> attributeFilterOptions =
 			new((a, attributeType, p, i) => a.HasAttribute(attributeType, p, i));
-		attributeFilterOptions.RegisterAttribute<TAttribute>(inherit);
+		attributeFilterOptions.RegisterAttribute<TAttribute>(true);
 		return new AndOrResult<FieldInfo?, IThat<FieldInfo?>>(subject.Get().ExpectationBuilder.AddConstraint(
 				(it, grammars)
 					=> new HasAttributeConstraint(it, grammars, attributeFilterOptions).Invert()),

--- a/Source/aweXpect.Reflection/ThatField.Has.cs
+++ b/Source/aweXpect.Reflection/ThatField.Has.cs
@@ -15,18 +15,15 @@ public static partial class ThatField
 	/// <summary>
 	///     Verifies that the <see cref="FieldInfo" /> has attribute of type <typeparamref name="TAttribute" />.
 	/// </summary>
-	/// <remarks>
-	///     The optional parameter <paramref name="inherit" /> (default value <see langword="true" />) specifies, if
-	///     the attribute can be inherited from a base type.
-	/// </remarks>
-	public static HasAttributeResult<FieldInfo?> Has<TAttribute>(this IThat<FieldInfo?> subject, bool inherit = true)
+	public static HasAttributeWithoutInheritResult<FieldInfo?> Has<TAttribute>(this IThat<FieldInfo?> subject)
 		where TAttribute : Attribute
 	{
 		AttributeFilterOptions<FieldInfo?> attributeFilterOptions =
 			new((a, attributeType, p, i) => a.HasAttribute(attributeType, p, i));
-		attributeFilterOptions.RegisterAttribute<TAttribute>(inherit);
-		return new HasAttributeResult<FieldInfo?>(subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new HasAttributeConstraint(it, grammars, attributeFilterOptions)),
+		attributeFilterOptions.RegisterAttribute<TAttribute>(true);
+		return new HasAttributeWithoutInheritResult<FieldInfo?>(subject.Get().ExpectationBuilder.AddConstraint(
+				(it, grammars)
+					=> new HasAttributeConstraint(it, grammars, attributeFilterOptions)),
 			subject,
 			attributeFilterOptions);
 	}
@@ -35,23 +32,19 @@ public static partial class ThatField
 	///     Verifies that the <see cref="FieldInfo" /> has attribute of type <typeparamref name="TAttribute" /> that
 	///     matches the <paramref name="predicate" />.
 	/// </summary>
-	/// <remarks>
-	///     The optional parameter <paramref name="inherit" /> (default value <see langword="true" />) specifies, if
-	///     the attribute can be inherited from a base type.
-	/// </remarks>
-	public static HasAttributeResult<FieldInfo?> Has<TAttribute>(
+	public static HasAttributeWithoutInheritResult<FieldInfo?> Has<TAttribute>(
 		this IThat<FieldInfo?> subject,
 		Func<TAttribute, bool> predicate,
-		bool inherit = true,
 		[CallerArgumentExpression("predicate")]
 		string doNotPopulateThisValue = "")
 		where TAttribute : Attribute
 	{
 		AttributeFilterOptions<FieldInfo?> attributeFilterOptions =
 			new((a, attributeType, p, i) => a.HasAttribute(attributeType, p, i));
-		attributeFilterOptions.RegisterAttribute(inherit, predicate, doNotPopulateThisValue.TrimCommonWhiteSpace());
-		return new HasAttributeResult<FieldInfo?>(subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
-				=> new HasAttributeConstraint(it, grammars, attributeFilterOptions)),
+		attributeFilterOptions.RegisterAttribute(true, predicate, doNotPopulateThisValue.TrimCommonWhiteSpace());
+		return new HasAttributeWithoutInheritResult<FieldInfo?>(subject.Get().ExpectationBuilder.AddConstraint(
+				(it, grammars)
+					=> new HasAttributeConstraint(it, grammars, attributeFilterOptions)),
 			subject,
 			attributeFilterOptions);
 	}

--- a/Source/aweXpect.Reflection/ThatFields.DoNotHave.cs
+++ b/Source/aweXpect.Reflection/ThatFields.DoNotHave.cs
@@ -22,17 +22,13 @@ public static partial class ThatFields
 	///     Verifies that none of the items in the filtered collection of <see cref="FieldInfo" /> have
 	///     attribute of type <typeparamref name="TAttribute" />.
 	/// </summary>
-	/// <remarks>
-	///     The optional parameter <paramref name="inherit" /> (default value <see langword="true" /> specifies, if
-	///     the attribute can be inherited from a base type.
-	/// </remarks>
 	public static AndOrResult<IEnumerable<FieldInfo?>, IThat<IEnumerable<FieldInfo?>>> DoNotHave<TAttribute>(
-		this IThat<IEnumerable<FieldInfo?>> subject, bool inherit = true)
+		this IThat<IEnumerable<FieldInfo?>> subject)
 		where TAttribute : Attribute
 	{
 		AttributeFilterOptions<FieldInfo?> attributeFilterOptions =
 			new((a, attributeType, p, i) => a.HasAttribute(attributeType, p, i));
-		attributeFilterOptions.RegisterAttribute<TAttribute>(inherit);
+		attributeFilterOptions.RegisterAttribute<TAttribute>(true);
 		return new AndOrResult<IEnumerable<FieldInfo?>, IThat<IEnumerable<FieldInfo?>>>(
 			subject.Get().ExpectationBuilder.AddConstraint<IEnumerable<FieldInfo?>>((it, grammars)
 				=> new DoNotHaveAttributeConstraint(it, grammars | ExpectationGrammars.Plural, attributeFilterOptions)),
@@ -44,17 +40,13 @@ public static partial class ThatFields
 	///     Verifies that none of the items in the filtered collection of <see cref="FieldInfo" /> have
 	///     attribute of type <typeparamref name="TAttribute" />.
 	/// </summary>
-	/// <remarks>
-	///     The optional parameter <paramref name="inherit" /> (default value <see langword="true" /> specifies, if
-	///     the attribute can be inherited from a base type.
-	/// </remarks>
 	public static AndOrResult<IAsyncEnumerable<FieldInfo?>, IThat<IAsyncEnumerable<FieldInfo?>>> DoNotHave<TAttribute>(
-		this IThat<IAsyncEnumerable<FieldInfo?>> subject, bool inherit = true)
+		this IThat<IAsyncEnumerable<FieldInfo?>> subject)
 		where TAttribute : Attribute
 	{
 		AttributeFilterOptions<FieldInfo?> attributeFilterOptions =
 			new((a, attributeType, p, i) => a.HasAttribute(attributeType, p, i));
-		attributeFilterOptions.RegisterAttribute<TAttribute>(inherit);
+		attributeFilterOptions.RegisterAttribute<TAttribute>(true);
 		return new AndOrResult<IAsyncEnumerable<FieldInfo?>, IThat<IAsyncEnumerable<FieldInfo?>>>(
 			subject.Get().ExpectationBuilder.AddConstraint<IAsyncEnumerable<FieldInfo?>>((it, grammars)
 				=> new DoNotHaveAttributeConstraint(it, grammars | ExpectationGrammars.Plural, attributeFilterOptions)),

--- a/Source/aweXpect.Reflection/ThatFields.Have.cs
+++ b/Source/aweXpect.Reflection/ThatFields.Have.cs
@@ -23,18 +23,14 @@ public static partial class ThatFields
 	///     Verifies that all items in the filtered collection of <see cref="FieldInfo" /> have
 	///     attribute of type <typeparamref name="TAttribute" />.
 	/// </summary>
-	/// <remarks>
-	///     The optional parameter <paramref name="inherit" /> (default value <see langword="true" /> specifies, if
-	///     the attribute can be inherited from a base type.
-	/// </remarks>
-	public static HaveAttributeResult<FieldInfo?, IEnumerable<FieldInfo?>> Have<TAttribute>(
-		this IThat<IEnumerable<FieldInfo?>> subject, bool inherit = true)
+	public static HaveAttributeWithoutInheritResult<FieldInfo?, IEnumerable<FieldInfo?>> Have<TAttribute>(
+		this IThat<IEnumerable<FieldInfo?>> subject)
 		where TAttribute : Attribute
 	{
 		AttributeFilterOptions<FieldInfo?> attributeFilterOptions =
 			new((a, attributeType, p, i) => a.HasAttribute(attributeType, p, i));
-		attributeFilterOptions.RegisterAttribute<TAttribute>(inherit);
-		return new HaveAttributeResult<FieldInfo?, IEnumerable<FieldInfo?>>(
+		attributeFilterOptions.RegisterAttribute<TAttribute>(true);
+		return new HaveAttributeWithoutInheritResult<FieldInfo?, IEnumerable<FieldInfo?>>(
 			subject.Get().ExpectationBuilder.AddConstraint<IEnumerable<FieldInfo?>>((it, grammars)
 				=> new HaveAttributeConstraint(it, grammars | ExpectationGrammars.Plural, attributeFilterOptions)),
 			subject,
@@ -45,22 +41,17 @@ public static partial class ThatFields
 	///     Verifies that all items in the filtered collection of <see cref="FieldInfo" /> have
 	///     attribute of type <typeparamref name="TAttribute" />.
 	/// </summary>
-	/// <remarks>
-	///     The optional parameter <paramref name="inherit" /> (default value <see langword="true" /> specifies, if
-	///     the attribute can be inherited from a base type.
-	/// </remarks>
-	public static HaveAttributeResult<FieldInfo?, IEnumerable<FieldInfo?>> Have<TAttribute>(
+	public static HaveAttributeWithoutInheritResult<FieldInfo?, IEnumerable<FieldInfo?>> Have<TAttribute>(
 		this IThat<IEnumerable<FieldInfo?>> subject,
 		Func<TAttribute, bool> predicate,
-		bool inherit = true,
 		[CallerArgumentExpression("predicate")]
 		string doNotPopulateThisValue = "")
 		where TAttribute : Attribute
 	{
 		AttributeFilterOptions<FieldInfo?> attributeFilterOptions =
 			new((a, attributeType, p, i) => a.HasAttribute(attributeType, p, i));
-		attributeFilterOptions.RegisterAttribute(inherit, predicate, doNotPopulateThisValue.TrimCommonWhiteSpace());
-		return new HaveAttributeResult<FieldInfo?, IEnumerable<FieldInfo?>>(
+		attributeFilterOptions.RegisterAttribute(true, predicate, doNotPopulateThisValue.TrimCommonWhiteSpace());
+		return new HaveAttributeWithoutInheritResult<FieldInfo?, IEnumerable<FieldInfo?>>(
 			subject.Get().ExpectationBuilder.AddConstraint<IEnumerable<FieldInfo?>>((it, grammars)
 				=> new HaveAttributeConstraint(it, grammars | ExpectationGrammars.Plural, attributeFilterOptions)),
 			subject,
@@ -72,18 +63,14 @@ public static partial class ThatFields
 	///     Verifies that all items in the filtered collection of <see cref="FieldInfo" /> have
 	///     attribute of type <typeparamref name="TAttribute" />.
 	/// </summary>
-	/// <remarks>
-	///     The optional parameter <paramref name="inherit" /> (default value <see langword="true" /> specifies, if
-	///     the attribute can be inherited from a base type.
-	/// </remarks>
-	public static HaveAttributeResult<FieldInfo?, IAsyncEnumerable<FieldInfo?>> Have<TAttribute>(
-		this IThat<IAsyncEnumerable<FieldInfo?>> subject, bool inherit = true)
+	public static HaveAttributeWithoutInheritResult<FieldInfo?, IAsyncEnumerable<FieldInfo?>> Have<TAttribute>(
+		this IThat<IAsyncEnumerable<FieldInfo?>> subject)
 		where TAttribute : Attribute
 	{
 		AttributeFilterOptions<FieldInfo?> attributeFilterOptions =
 			new((a, attributeType, p, i) => a.HasAttribute(attributeType, p, i));
-		attributeFilterOptions.RegisterAttribute<TAttribute>(inherit);
-		return new HaveAttributeResult<FieldInfo?, IAsyncEnumerable<FieldInfo?>>(
+		attributeFilterOptions.RegisterAttribute<TAttribute>(true);
+		return new HaveAttributeWithoutInheritResult<FieldInfo?, IAsyncEnumerable<FieldInfo?>>(
 			subject.Get().ExpectationBuilder.AddConstraint<IAsyncEnumerable<FieldInfo?>>((it, grammars)
 				=> new HaveAttributeConstraint(it, grammars | ExpectationGrammars.Plural, attributeFilterOptions)),
 			subject,
@@ -96,22 +83,17 @@ public static partial class ThatFields
 	///     Verifies that all items in the filtered collection of <see cref="FieldInfo" /> have
 	///     attribute of type <typeparamref name="TAttribute" />.
 	/// </summary>
-	/// <remarks>
-	///     The optional parameter <paramref name="inherit" /> (default value <see langword="true" /> specifies, if
-	///     the attribute can be inherited from a base type.
-	/// </remarks>
-	public static HaveAttributeResult<FieldInfo?, IAsyncEnumerable<FieldInfo?>> Have<TAttribute>(
+	public static HaveAttributeWithoutInheritResult<FieldInfo?, IAsyncEnumerable<FieldInfo?>> Have<TAttribute>(
 		this IThat<IAsyncEnumerable<FieldInfo?>> subject,
 		Func<TAttribute, bool> predicate,
-		bool inherit = true,
 		[CallerArgumentExpression("predicate")]
 		string doNotPopulateThisValue = "")
 		where TAttribute : Attribute
 	{
 		AttributeFilterOptions<FieldInfo?> attributeFilterOptions =
 			new((a, attributeType, p, i) => a.HasAttribute(attributeType, p, i));
-		attributeFilterOptions.RegisterAttribute(inherit, predicate, doNotPopulateThisValue.TrimCommonWhiteSpace());
-		return new HaveAttributeResult<FieldInfo?, IAsyncEnumerable<FieldInfo?>>(
+		attributeFilterOptions.RegisterAttribute(true, predicate, doNotPopulateThisValue.TrimCommonWhiteSpace());
+		return new HaveAttributeWithoutInheritResult<FieldInfo?, IAsyncEnumerable<FieldInfo?>>(
 			subject.Get().ExpectationBuilder.AddConstraint<IAsyncEnumerable<FieldInfo?>>((it, grammars)
 				=> new HaveAttributeConstraint(it, grammars | ExpectationGrammars.Plural, attributeFilterOptions)),
 			subject,

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net10.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net10.0.txt
@@ -616,11 +616,11 @@ namespace aweXpect.Reflection
     }
     public static class ThatConstructor
     {
-        public static aweXpect.Results.AndOrResult<System.Reflection.ConstructorInfo?, aweXpect.Core.IThat<System.Reflection.ConstructorInfo?>> DoesNotHave<TAttribute>(this aweXpect.Core.IThat<System.Reflection.ConstructorInfo?> subject, bool inherit = true)
+        public static aweXpect.Results.AndOrResult<System.Reflection.ConstructorInfo?, aweXpect.Core.IThat<System.Reflection.ConstructorInfo?>> DoesNotHave<TAttribute>(this aweXpect.Core.IThat<System.Reflection.ConstructorInfo?> subject)
             where TAttribute : System.Attribute { }
-        public static aweXpect.Reflection.Results.HasAttributeResult<System.Reflection.ConstructorInfo?> Has<TAttribute>(this aweXpect.Core.IThat<System.Reflection.ConstructorInfo?> subject, bool inherit = true)
+        public static aweXpect.Reflection.Results.HasAttributeWithoutInheritResult<System.Reflection.ConstructorInfo?> Has<TAttribute>(this aweXpect.Core.IThat<System.Reflection.ConstructorInfo?> subject)
             where TAttribute : System.Attribute { }
-        public static aweXpect.Reflection.Results.HasAttributeResult<System.Reflection.ConstructorInfo?> Has<TAttribute>(this aweXpect.Core.IThat<System.Reflection.ConstructorInfo?> subject, System.Func<TAttribute, bool> predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
+        public static aweXpect.Reflection.Results.HasAttributeWithoutInheritResult<System.Reflection.ConstructorInfo?> Has<TAttribute>(this aweXpect.Core.IThat<System.Reflection.ConstructorInfo?> subject, System.Func<TAttribute, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
             where TAttribute : System.Attribute { }
         public static aweXpect.Results.AndOrResult<System.Reflection.ConstructorInfo?, aweXpect.Core.IThat<System.Reflection.ConstructorInfo?>> HasInParameter(this aweXpect.Core.IThat<System.Reflection.ConstructorInfo?> subject) { }
         public static aweXpect.Reflection.Results.ParameterCollectionResult<System.Reflection.ConstructorInfo?, object?> HasInParameter(this aweXpect.Core.IThat<System.Reflection.ConstructorInfo?> subject, System.Type parameterType) { }
@@ -692,17 +692,17 @@ namespace aweXpect.Reflection
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>>> AreNotStatic(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.ConstructorInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.ConstructorInfo?>>> AreStatic(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.ConstructorInfo?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>>> AreStatic(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>> subject) { }
-        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.ConstructorInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.ConstructorInfo?>>> DoNotHave<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.ConstructorInfo?>> subject, bool inherit = true)
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.ConstructorInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.ConstructorInfo?>>> DoNotHave<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.ConstructorInfo?>> subject)
             where TAttribute : System.Attribute { }
-        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>>> DoNotHave<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>> subject, bool inherit = true)
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>>> DoNotHave<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>> subject)
             where TAttribute : System.Attribute { }
-        public static aweXpect.Reflection.Results.HaveAttributeResult<System.Reflection.ConstructorInfo?, System.Collections.Generic.IAsyncEnumerable<System.Reflection.ConstructorInfo?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.ConstructorInfo?>> subject, bool inherit = true)
+        public static aweXpect.Reflection.Results.HaveAttributeWithoutInheritResult<System.Reflection.ConstructorInfo?, System.Collections.Generic.IAsyncEnumerable<System.Reflection.ConstructorInfo?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.ConstructorInfo?>> subject)
             where TAttribute : System.Attribute { }
-        public static aweXpect.Reflection.Results.HaveAttributeResult<System.Reflection.ConstructorInfo?, System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>> subject, bool inherit = true)
+        public static aweXpect.Reflection.Results.HaveAttributeWithoutInheritResult<System.Reflection.ConstructorInfo?, System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>> subject)
             where TAttribute : System.Attribute { }
-        public static aweXpect.Reflection.Results.HaveAttributeResult<System.Reflection.ConstructorInfo?, System.Collections.Generic.IAsyncEnumerable<System.Reflection.ConstructorInfo?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.ConstructorInfo?>> subject, System.Func<TAttribute, bool> predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
+        public static aweXpect.Reflection.Results.HaveAttributeWithoutInheritResult<System.Reflection.ConstructorInfo?, System.Collections.Generic.IAsyncEnumerable<System.Reflection.ConstructorInfo?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.ConstructorInfo?>> subject, System.Func<TAttribute, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
             where TAttribute : System.Attribute { }
-        public static aweXpect.Reflection.Results.HaveAttributeResult<System.Reflection.ConstructorInfo?, System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>> subject, System.Func<TAttribute, bool> predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
+        public static aweXpect.Reflection.Results.HaveAttributeWithoutInheritResult<System.Reflection.ConstructorInfo?, System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>> subject, System.Func<TAttribute, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
             where TAttribute : System.Attribute { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.ConstructorInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.ConstructorInfo?>>> HaveInParameter(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.ConstructorInfo?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>>> HaveInParameter(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>> subject) { }
@@ -865,11 +865,11 @@ namespace aweXpect.Reflection
     }
     public static class ThatField
     {
-        public static aweXpect.Results.AndOrResult<System.Reflection.FieldInfo?, aweXpect.Core.IThat<System.Reflection.FieldInfo?>> DoesNotHave<TAttribute>(this aweXpect.Core.IThat<System.Reflection.FieldInfo?> subject, bool inherit = true)
+        public static aweXpect.Results.AndOrResult<System.Reflection.FieldInfo?, aweXpect.Core.IThat<System.Reflection.FieldInfo?>> DoesNotHave<TAttribute>(this aweXpect.Core.IThat<System.Reflection.FieldInfo?> subject)
             where TAttribute : System.Attribute { }
-        public static aweXpect.Reflection.Results.HasAttributeResult<System.Reflection.FieldInfo?> Has<TAttribute>(this aweXpect.Core.IThat<System.Reflection.FieldInfo?> subject, bool inherit = true)
+        public static aweXpect.Reflection.Results.HasAttributeWithoutInheritResult<System.Reflection.FieldInfo?> Has<TAttribute>(this aweXpect.Core.IThat<System.Reflection.FieldInfo?> subject)
             where TAttribute : System.Attribute { }
-        public static aweXpect.Reflection.Results.HasAttributeResult<System.Reflection.FieldInfo?> Has<TAttribute>(this aweXpect.Core.IThat<System.Reflection.FieldInfo?> subject, System.Func<TAttribute, bool> predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
+        public static aweXpect.Reflection.Results.HasAttributeWithoutInheritResult<System.Reflection.FieldInfo?> Has<TAttribute>(this aweXpect.Core.IThat<System.Reflection.FieldInfo?> subject, System.Func<TAttribute, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
             where TAttribute : System.Attribute { }
         public static aweXpect.Results.AndOrResult<System.Reflection.FieldInfo?, aweXpect.Core.IThat<System.Reflection.FieldInfo?>> IsNotStatic(this aweXpect.Core.IThat<System.Reflection.FieldInfo?> subject) { }
         public static aweXpect.Reflection.ThatField.FieldOfTypeResult<System.Reflection.FieldInfo?, aweXpect.Core.IThat<System.Reflection.FieldInfo?>> IsOfExactType(this aweXpect.Core.IThat<System.Reflection.FieldInfo?> subject, System.Type fieldType) { }
@@ -901,17 +901,17 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.ThatFields.FieldsOfTypeResult<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>>> AreOfType<TField>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.FieldInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.FieldInfo?>>> AreStatic(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.FieldInfo?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>>> AreStatic(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>> subject) { }
-        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.FieldInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.FieldInfo?>>> DoNotHave<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.FieldInfo?>> subject, bool inherit = true)
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.FieldInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.FieldInfo?>>> DoNotHave<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.FieldInfo?>> subject)
             where TAttribute : System.Attribute { }
-        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>>> DoNotHave<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>> subject, bool inherit = true)
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>>> DoNotHave<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>> subject)
             where TAttribute : System.Attribute { }
-        public static aweXpect.Reflection.Results.HaveAttributeResult<System.Reflection.FieldInfo?, System.Collections.Generic.IAsyncEnumerable<System.Reflection.FieldInfo?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.FieldInfo?>> subject, bool inherit = true)
+        public static aweXpect.Reflection.Results.HaveAttributeWithoutInheritResult<System.Reflection.FieldInfo?, System.Collections.Generic.IAsyncEnumerable<System.Reflection.FieldInfo?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.FieldInfo?>> subject)
             where TAttribute : System.Attribute { }
-        public static aweXpect.Reflection.Results.HaveAttributeResult<System.Reflection.FieldInfo?, System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>> subject, bool inherit = true)
+        public static aweXpect.Reflection.Results.HaveAttributeWithoutInheritResult<System.Reflection.FieldInfo?, System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>> subject)
             where TAttribute : System.Attribute { }
-        public static aweXpect.Reflection.Results.HaveAttributeResult<System.Reflection.FieldInfo?, System.Collections.Generic.IAsyncEnumerable<System.Reflection.FieldInfo?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.FieldInfo?>> subject, System.Func<TAttribute, bool> predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
+        public static aweXpect.Reflection.Results.HaveAttributeWithoutInheritResult<System.Reflection.FieldInfo?, System.Collections.Generic.IAsyncEnumerable<System.Reflection.FieldInfo?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.FieldInfo?>> subject, System.Func<TAttribute, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
             where TAttribute : System.Attribute { }
-        public static aweXpect.Reflection.Results.HaveAttributeResult<System.Reflection.FieldInfo?, System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>> subject, System.Func<TAttribute, bool> predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
+        public static aweXpect.Reflection.Results.HaveAttributeWithoutInheritResult<System.Reflection.FieldInfo?, System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>> subject, System.Func<TAttribute, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
             where TAttribute : System.Attribute { }
         public sealed class FieldsOfTypeResult<TValue, TResult> : aweXpect.Results.AndOrResult<TValue, TResult>, aweXpect.Core.IOptionsProvider<aweXpect.Reflection.Options.TypeFilterOptions>
             where TResult : aweXpect.Core.IThat<TValue>
@@ -1992,12 +1992,28 @@ namespace aweXpect.Reflection.Results
         public aweXpect.Reflection.Results.HasAttributeResult<TMember> OrHas<TAttribute>(System.Func<TAttribute, bool> predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
             where TAttribute : System.Attribute { }
     }
+    public sealed class HasAttributeWithoutInheritResult<TMember> : aweXpect.Results.AndOrResult<TMember, aweXpect.Core.IThat<TMember>>, aweXpect.Core.IOptionsProvider<aweXpect.Reflection.Options.AttributeFilterOptions<TMember>>
+    {
+        public HasAttributeWithoutInheritResult(aweXpect.Core.ExpectationBuilder expectationBuilder, aweXpect.Core.IThat<TMember> subject, aweXpect.Reflection.Options.AttributeFilterOptions<TMember> attributeFilterOptions) { }
+        public aweXpect.Reflection.Results.HasAttributeWithoutInheritResult<TMember> OrHas<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public aweXpect.Reflection.Results.HasAttributeWithoutInheritResult<TMember> OrHas<TAttribute>(System.Func<TAttribute, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
+            where TAttribute : System.Attribute { }
+    }
     public sealed class HaveAttributeResult<TMember, TResult> : aweXpect.Results.AndOrResult<TResult, aweXpect.Core.IThat<TResult>>, aweXpect.Core.IOptionsProvider<aweXpect.Reflection.Options.AttributeFilterOptions<TMember>>
     {
         public HaveAttributeResult(aweXpect.Core.ExpectationBuilder expectationBuilder, aweXpect.Core.IThat<TResult> subject, aweXpect.Reflection.Options.AttributeFilterOptions<TMember> attributeFilterOptions) { }
         public aweXpect.Reflection.Results.HaveAttributeResult<TMember, TResult> OrHave<TAttribute>(bool inherit = true)
             where TAttribute : System.Attribute { }
         public aweXpect.Reflection.Results.HaveAttributeResult<TMember, TResult> OrHave<TAttribute>(System.Func<TAttribute, bool> predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
+            where TAttribute : System.Attribute { }
+    }
+    public sealed class HaveAttributeWithoutInheritResult<TMember, TResult> : aweXpect.Results.AndOrResult<TResult, aweXpect.Core.IThat<TResult>>, aweXpect.Core.IOptionsProvider<aweXpect.Reflection.Options.AttributeFilterOptions<TMember>>
+    {
+        public HaveAttributeWithoutInheritResult(aweXpect.Core.ExpectationBuilder expectationBuilder, aweXpect.Core.IThat<TResult> subject, aweXpect.Reflection.Options.AttributeFilterOptions<TMember> attributeFilterOptions) { }
+        public aweXpect.Reflection.Results.HaveAttributeWithoutInheritResult<TMember, TResult> OrHave<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public aweXpect.Reflection.Results.HaveAttributeWithoutInheritResult<TMember, TResult> OrHave<TAttribute>(System.Func<TAttribute, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
             where TAttribute : System.Attribute { }
     }
     public class NamedParameterCollectionResult<TThat, TParameter> : aweXpect.Reflection.Results.ParameterCollectionResult<TThat, TParameter>, aweXpect.Core.IOptionsProvider<aweXpect.Options.StringEqualityOptions>

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net8.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net8.0.txt
@@ -616,11 +616,11 @@ namespace aweXpect.Reflection
     }
     public static class ThatConstructor
     {
-        public static aweXpect.Results.AndOrResult<System.Reflection.ConstructorInfo?, aweXpect.Core.IThat<System.Reflection.ConstructorInfo?>> DoesNotHave<TAttribute>(this aweXpect.Core.IThat<System.Reflection.ConstructorInfo?> subject, bool inherit = true)
+        public static aweXpect.Results.AndOrResult<System.Reflection.ConstructorInfo?, aweXpect.Core.IThat<System.Reflection.ConstructorInfo?>> DoesNotHave<TAttribute>(this aweXpect.Core.IThat<System.Reflection.ConstructorInfo?> subject)
             where TAttribute : System.Attribute { }
-        public static aweXpect.Reflection.Results.HasAttributeResult<System.Reflection.ConstructorInfo?> Has<TAttribute>(this aweXpect.Core.IThat<System.Reflection.ConstructorInfo?> subject, bool inherit = true)
+        public static aweXpect.Reflection.Results.HasAttributeWithoutInheritResult<System.Reflection.ConstructorInfo?> Has<TAttribute>(this aweXpect.Core.IThat<System.Reflection.ConstructorInfo?> subject)
             where TAttribute : System.Attribute { }
-        public static aweXpect.Reflection.Results.HasAttributeResult<System.Reflection.ConstructorInfo?> Has<TAttribute>(this aweXpect.Core.IThat<System.Reflection.ConstructorInfo?> subject, System.Func<TAttribute, bool> predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
+        public static aweXpect.Reflection.Results.HasAttributeWithoutInheritResult<System.Reflection.ConstructorInfo?> Has<TAttribute>(this aweXpect.Core.IThat<System.Reflection.ConstructorInfo?> subject, System.Func<TAttribute, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
             where TAttribute : System.Attribute { }
         public static aweXpect.Results.AndOrResult<System.Reflection.ConstructorInfo?, aweXpect.Core.IThat<System.Reflection.ConstructorInfo?>> HasInParameter(this aweXpect.Core.IThat<System.Reflection.ConstructorInfo?> subject) { }
         public static aweXpect.Reflection.Results.ParameterCollectionResult<System.Reflection.ConstructorInfo?, object?> HasInParameter(this aweXpect.Core.IThat<System.Reflection.ConstructorInfo?> subject, System.Type parameterType) { }
@@ -692,17 +692,17 @@ namespace aweXpect.Reflection
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>>> AreNotStatic(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.ConstructorInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.ConstructorInfo?>>> AreStatic(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.ConstructorInfo?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>>> AreStatic(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>> subject) { }
-        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.ConstructorInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.ConstructorInfo?>>> DoNotHave<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.ConstructorInfo?>> subject, bool inherit = true)
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.ConstructorInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.ConstructorInfo?>>> DoNotHave<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.ConstructorInfo?>> subject)
             where TAttribute : System.Attribute { }
-        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>>> DoNotHave<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>> subject, bool inherit = true)
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>>> DoNotHave<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>> subject)
             where TAttribute : System.Attribute { }
-        public static aweXpect.Reflection.Results.HaveAttributeResult<System.Reflection.ConstructorInfo?, System.Collections.Generic.IAsyncEnumerable<System.Reflection.ConstructorInfo?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.ConstructorInfo?>> subject, bool inherit = true)
+        public static aweXpect.Reflection.Results.HaveAttributeWithoutInheritResult<System.Reflection.ConstructorInfo?, System.Collections.Generic.IAsyncEnumerable<System.Reflection.ConstructorInfo?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.ConstructorInfo?>> subject)
             where TAttribute : System.Attribute { }
-        public static aweXpect.Reflection.Results.HaveAttributeResult<System.Reflection.ConstructorInfo?, System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>> subject, bool inherit = true)
+        public static aweXpect.Reflection.Results.HaveAttributeWithoutInheritResult<System.Reflection.ConstructorInfo?, System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>> subject)
             where TAttribute : System.Attribute { }
-        public static aweXpect.Reflection.Results.HaveAttributeResult<System.Reflection.ConstructorInfo?, System.Collections.Generic.IAsyncEnumerable<System.Reflection.ConstructorInfo?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.ConstructorInfo?>> subject, System.Func<TAttribute, bool> predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
+        public static aweXpect.Reflection.Results.HaveAttributeWithoutInheritResult<System.Reflection.ConstructorInfo?, System.Collections.Generic.IAsyncEnumerable<System.Reflection.ConstructorInfo?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.ConstructorInfo?>> subject, System.Func<TAttribute, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
             where TAttribute : System.Attribute { }
-        public static aweXpect.Reflection.Results.HaveAttributeResult<System.Reflection.ConstructorInfo?, System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>> subject, System.Func<TAttribute, bool> predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
+        public static aweXpect.Reflection.Results.HaveAttributeWithoutInheritResult<System.Reflection.ConstructorInfo?, System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>> subject, System.Func<TAttribute, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
             where TAttribute : System.Attribute { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.ConstructorInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.ConstructorInfo?>>> HaveInParameter(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.ConstructorInfo?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>>> HaveInParameter(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>> subject) { }
@@ -865,11 +865,11 @@ namespace aweXpect.Reflection
     }
     public static class ThatField
     {
-        public static aweXpect.Results.AndOrResult<System.Reflection.FieldInfo?, aweXpect.Core.IThat<System.Reflection.FieldInfo?>> DoesNotHave<TAttribute>(this aweXpect.Core.IThat<System.Reflection.FieldInfo?> subject, bool inherit = true)
+        public static aweXpect.Results.AndOrResult<System.Reflection.FieldInfo?, aweXpect.Core.IThat<System.Reflection.FieldInfo?>> DoesNotHave<TAttribute>(this aweXpect.Core.IThat<System.Reflection.FieldInfo?> subject)
             where TAttribute : System.Attribute { }
-        public static aweXpect.Reflection.Results.HasAttributeResult<System.Reflection.FieldInfo?> Has<TAttribute>(this aweXpect.Core.IThat<System.Reflection.FieldInfo?> subject, bool inherit = true)
+        public static aweXpect.Reflection.Results.HasAttributeWithoutInheritResult<System.Reflection.FieldInfo?> Has<TAttribute>(this aweXpect.Core.IThat<System.Reflection.FieldInfo?> subject)
             where TAttribute : System.Attribute { }
-        public static aweXpect.Reflection.Results.HasAttributeResult<System.Reflection.FieldInfo?> Has<TAttribute>(this aweXpect.Core.IThat<System.Reflection.FieldInfo?> subject, System.Func<TAttribute, bool> predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
+        public static aweXpect.Reflection.Results.HasAttributeWithoutInheritResult<System.Reflection.FieldInfo?> Has<TAttribute>(this aweXpect.Core.IThat<System.Reflection.FieldInfo?> subject, System.Func<TAttribute, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
             where TAttribute : System.Attribute { }
         public static aweXpect.Results.AndOrResult<System.Reflection.FieldInfo?, aweXpect.Core.IThat<System.Reflection.FieldInfo?>> IsNotStatic(this aweXpect.Core.IThat<System.Reflection.FieldInfo?> subject) { }
         public static aweXpect.Reflection.ThatField.FieldOfTypeResult<System.Reflection.FieldInfo?, aweXpect.Core.IThat<System.Reflection.FieldInfo?>> IsOfExactType(this aweXpect.Core.IThat<System.Reflection.FieldInfo?> subject, System.Type fieldType) { }
@@ -901,17 +901,17 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.ThatFields.FieldsOfTypeResult<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>>> AreOfType<TField>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.FieldInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.FieldInfo?>>> AreStatic(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.FieldInfo?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>>> AreStatic(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>> subject) { }
-        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.FieldInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.FieldInfo?>>> DoNotHave<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.FieldInfo?>> subject, bool inherit = true)
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.FieldInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.FieldInfo?>>> DoNotHave<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.FieldInfo?>> subject)
             where TAttribute : System.Attribute { }
-        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>>> DoNotHave<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>> subject, bool inherit = true)
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>>> DoNotHave<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>> subject)
             where TAttribute : System.Attribute { }
-        public static aweXpect.Reflection.Results.HaveAttributeResult<System.Reflection.FieldInfo?, System.Collections.Generic.IAsyncEnumerable<System.Reflection.FieldInfo?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.FieldInfo?>> subject, bool inherit = true)
+        public static aweXpect.Reflection.Results.HaveAttributeWithoutInheritResult<System.Reflection.FieldInfo?, System.Collections.Generic.IAsyncEnumerable<System.Reflection.FieldInfo?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.FieldInfo?>> subject)
             where TAttribute : System.Attribute { }
-        public static aweXpect.Reflection.Results.HaveAttributeResult<System.Reflection.FieldInfo?, System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>> subject, bool inherit = true)
+        public static aweXpect.Reflection.Results.HaveAttributeWithoutInheritResult<System.Reflection.FieldInfo?, System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>> subject)
             where TAttribute : System.Attribute { }
-        public static aweXpect.Reflection.Results.HaveAttributeResult<System.Reflection.FieldInfo?, System.Collections.Generic.IAsyncEnumerable<System.Reflection.FieldInfo?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.FieldInfo?>> subject, System.Func<TAttribute, bool> predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
+        public static aweXpect.Reflection.Results.HaveAttributeWithoutInheritResult<System.Reflection.FieldInfo?, System.Collections.Generic.IAsyncEnumerable<System.Reflection.FieldInfo?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.FieldInfo?>> subject, System.Func<TAttribute, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
             where TAttribute : System.Attribute { }
-        public static aweXpect.Reflection.Results.HaveAttributeResult<System.Reflection.FieldInfo?, System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>> subject, System.Func<TAttribute, bool> predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
+        public static aweXpect.Reflection.Results.HaveAttributeWithoutInheritResult<System.Reflection.FieldInfo?, System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>> subject, System.Func<TAttribute, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
             where TAttribute : System.Attribute { }
         public sealed class FieldsOfTypeResult<TValue, TResult> : aweXpect.Results.AndOrResult<TValue, TResult>, aweXpect.Core.IOptionsProvider<aweXpect.Reflection.Options.TypeFilterOptions>
             where TResult : aweXpect.Core.IThat<TValue>
@@ -1992,12 +1992,28 @@ namespace aweXpect.Reflection.Results
         public aweXpect.Reflection.Results.HasAttributeResult<TMember> OrHas<TAttribute>(System.Func<TAttribute, bool> predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
             where TAttribute : System.Attribute { }
     }
+    public sealed class HasAttributeWithoutInheritResult<TMember> : aweXpect.Results.AndOrResult<TMember, aweXpect.Core.IThat<TMember>>, aweXpect.Core.IOptionsProvider<aweXpect.Reflection.Options.AttributeFilterOptions<TMember>>
+    {
+        public HasAttributeWithoutInheritResult(aweXpect.Core.ExpectationBuilder expectationBuilder, aweXpect.Core.IThat<TMember> subject, aweXpect.Reflection.Options.AttributeFilterOptions<TMember> attributeFilterOptions) { }
+        public aweXpect.Reflection.Results.HasAttributeWithoutInheritResult<TMember> OrHas<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public aweXpect.Reflection.Results.HasAttributeWithoutInheritResult<TMember> OrHas<TAttribute>(System.Func<TAttribute, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
+            where TAttribute : System.Attribute { }
+    }
     public sealed class HaveAttributeResult<TMember, TResult> : aweXpect.Results.AndOrResult<TResult, aweXpect.Core.IThat<TResult>>, aweXpect.Core.IOptionsProvider<aweXpect.Reflection.Options.AttributeFilterOptions<TMember>>
     {
         public HaveAttributeResult(aweXpect.Core.ExpectationBuilder expectationBuilder, aweXpect.Core.IThat<TResult> subject, aweXpect.Reflection.Options.AttributeFilterOptions<TMember> attributeFilterOptions) { }
         public aweXpect.Reflection.Results.HaveAttributeResult<TMember, TResult> OrHave<TAttribute>(bool inherit = true)
             where TAttribute : System.Attribute { }
         public aweXpect.Reflection.Results.HaveAttributeResult<TMember, TResult> OrHave<TAttribute>(System.Func<TAttribute, bool> predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
+            where TAttribute : System.Attribute { }
+    }
+    public sealed class HaveAttributeWithoutInheritResult<TMember, TResult> : aweXpect.Results.AndOrResult<TResult, aweXpect.Core.IThat<TResult>>, aweXpect.Core.IOptionsProvider<aweXpect.Reflection.Options.AttributeFilterOptions<TMember>>
+    {
+        public HaveAttributeWithoutInheritResult(aweXpect.Core.ExpectationBuilder expectationBuilder, aweXpect.Core.IThat<TResult> subject, aweXpect.Reflection.Options.AttributeFilterOptions<TMember> attributeFilterOptions) { }
+        public aweXpect.Reflection.Results.HaveAttributeWithoutInheritResult<TMember, TResult> OrHave<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public aweXpect.Reflection.Results.HaveAttributeWithoutInheritResult<TMember, TResult> OrHave<TAttribute>(System.Func<TAttribute, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
             where TAttribute : System.Attribute { }
     }
     public class NamedParameterCollectionResult<TThat, TParameter> : aweXpect.Reflection.Results.ParameterCollectionResult<TThat, TParameter>, aweXpect.Core.IOptionsProvider<aweXpect.Options.StringEqualityOptions>

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_netstandard2.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_netstandard2.0.txt
@@ -601,11 +601,11 @@ namespace aweXpect.Reflection
     }
     public static class ThatConstructor
     {
-        public static aweXpect.Results.AndOrResult<System.Reflection.ConstructorInfo?, aweXpect.Core.IThat<System.Reflection.ConstructorInfo?>> DoesNotHave<TAttribute>(this aweXpect.Core.IThat<System.Reflection.ConstructorInfo?> subject, bool inherit = true)
+        public static aweXpect.Results.AndOrResult<System.Reflection.ConstructorInfo?, aweXpect.Core.IThat<System.Reflection.ConstructorInfo?>> DoesNotHave<TAttribute>(this aweXpect.Core.IThat<System.Reflection.ConstructorInfo?> subject)
             where TAttribute : System.Attribute { }
-        public static aweXpect.Reflection.Results.HasAttributeResult<System.Reflection.ConstructorInfo?> Has<TAttribute>(this aweXpect.Core.IThat<System.Reflection.ConstructorInfo?> subject, bool inherit = true)
+        public static aweXpect.Reflection.Results.HasAttributeWithoutInheritResult<System.Reflection.ConstructorInfo?> Has<TAttribute>(this aweXpect.Core.IThat<System.Reflection.ConstructorInfo?> subject)
             where TAttribute : System.Attribute { }
-        public static aweXpect.Reflection.Results.HasAttributeResult<System.Reflection.ConstructorInfo?> Has<TAttribute>(this aweXpect.Core.IThat<System.Reflection.ConstructorInfo?> subject, System.Func<TAttribute, bool> predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
+        public static aweXpect.Reflection.Results.HasAttributeWithoutInheritResult<System.Reflection.ConstructorInfo?> Has<TAttribute>(this aweXpect.Core.IThat<System.Reflection.ConstructorInfo?> subject, System.Func<TAttribute, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
             where TAttribute : System.Attribute { }
         public static aweXpect.Results.AndOrResult<System.Reflection.ConstructorInfo?, aweXpect.Core.IThat<System.Reflection.ConstructorInfo?>> HasInParameter(this aweXpect.Core.IThat<System.Reflection.ConstructorInfo?> subject) { }
         public static aweXpect.Reflection.Results.ParameterCollectionResult<System.Reflection.ConstructorInfo?, object?> HasInParameter(this aweXpect.Core.IThat<System.Reflection.ConstructorInfo?> subject, System.Type parameterType) { }
@@ -675,11 +675,11 @@ namespace aweXpect.Reflection
     {
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>>> AreNotStatic(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>>> AreStatic(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>> subject) { }
-        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>>> DoNotHave<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>> subject, bool inherit = true)
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>>> DoNotHave<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>> subject)
             where TAttribute : System.Attribute { }
-        public static aweXpect.Reflection.Results.HaveAttributeResult<System.Reflection.ConstructorInfo?, System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>> subject, bool inherit = true)
+        public static aweXpect.Reflection.Results.HaveAttributeWithoutInheritResult<System.Reflection.ConstructorInfo?, System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>> subject)
             where TAttribute : System.Attribute { }
-        public static aweXpect.Reflection.Results.HaveAttributeResult<System.Reflection.ConstructorInfo?, System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>> subject, System.Func<TAttribute, bool> predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
+        public static aweXpect.Reflection.Results.HaveAttributeWithoutInheritResult<System.Reflection.ConstructorInfo?, System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>> subject, System.Func<TAttribute, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
             where TAttribute : System.Attribute { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>>> HaveInParameter(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>> subject) { }
         public static aweXpect.Reflection.Results.ParameterCollectionResult<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>, object?> HaveInParameter(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo?>> subject, System.Type parameterType) { }
@@ -771,11 +771,11 @@ namespace aweXpect.Reflection
     }
     public static class ThatField
     {
-        public static aweXpect.Results.AndOrResult<System.Reflection.FieldInfo?, aweXpect.Core.IThat<System.Reflection.FieldInfo?>> DoesNotHave<TAttribute>(this aweXpect.Core.IThat<System.Reflection.FieldInfo?> subject, bool inherit = true)
+        public static aweXpect.Results.AndOrResult<System.Reflection.FieldInfo?, aweXpect.Core.IThat<System.Reflection.FieldInfo?>> DoesNotHave<TAttribute>(this aweXpect.Core.IThat<System.Reflection.FieldInfo?> subject)
             where TAttribute : System.Attribute { }
-        public static aweXpect.Reflection.Results.HasAttributeResult<System.Reflection.FieldInfo?> Has<TAttribute>(this aweXpect.Core.IThat<System.Reflection.FieldInfo?> subject, bool inherit = true)
+        public static aweXpect.Reflection.Results.HasAttributeWithoutInheritResult<System.Reflection.FieldInfo?> Has<TAttribute>(this aweXpect.Core.IThat<System.Reflection.FieldInfo?> subject)
             where TAttribute : System.Attribute { }
-        public static aweXpect.Reflection.Results.HasAttributeResult<System.Reflection.FieldInfo?> Has<TAttribute>(this aweXpect.Core.IThat<System.Reflection.FieldInfo?> subject, System.Func<TAttribute, bool> predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
+        public static aweXpect.Reflection.Results.HasAttributeWithoutInheritResult<System.Reflection.FieldInfo?> Has<TAttribute>(this aweXpect.Core.IThat<System.Reflection.FieldInfo?> subject, System.Func<TAttribute, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
             where TAttribute : System.Attribute { }
         public static aweXpect.Results.AndOrResult<System.Reflection.FieldInfo?, aweXpect.Core.IThat<System.Reflection.FieldInfo?>> IsNotStatic(this aweXpect.Core.IThat<System.Reflection.FieldInfo?> subject) { }
         public static aweXpect.Reflection.ThatField.FieldOfTypeResult<System.Reflection.FieldInfo?, aweXpect.Core.IThat<System.Reflection.FieldInfo?>> IsOfExactType(this aweXpect.Core.IThat<System.Reflection.FieldInfo?> subject, System.Type fieldType) { }
@@ -801,11 +801,11 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.ThatFields.FieldsOfTypeResult<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>>> AreOfType(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>> subject, System.Type fieldType) { }
         public static aweXpect.Reflection.ThatFields.FieldsOfTypeResult<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>>> AreOfType<TField>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>>> AreStatic(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>> subject) { }
-        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>>> DoNotHave<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>> subject, bool inherit = true)
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>>> DoNotHave<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>> subject)
             where TAttribute : System.Attribute { }
-        public static aweXpect.Reflection.Results.HaveAttributeResult<System.Reflection.FieldInfo?, System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>> subject, bool inherit = true)
+        public static aweXpect.Reflection.Results.HaveAttributeWithoutInheritResult<System.Reflection.FieldInfo?, System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>> subject)
             where TAttribute : System.Attribute { }
-        public static aweXpect.Reflection.Results.HaveAttributeResult<System.Reflection.FieldInfo?, System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>> subject, System.Func<TAttribute, bool> predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
+        public static aweXpect.Reflection.Results.HaveAttributeWithoutInheritResult<System.Reflection.FieldInfo?, System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo?>> subject, System.Func<TAttribute, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
             where TAttribute : System.Attribute { }
         public sealed class FieldsOfTypeResult<TValue, TResult> : aweXpect.Results.AndOrResult<TValue, TResult>, aweXpect.Core.IOptionsProvider<aweXpect.Reflection.Options.TypeFilterOptions>
             where TResult : aweXpect.Core.IThat<TValue>
@@ -1710,12 +1710,28 @@ namespace aweXpect.Reflection.Results
         public aweXpect.Reflection.Results.HasAttributeResult<TMember> OrHas<TAttribute>(System.Func<TAttribute, bool> predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
             where TAttribute : System.Attribute { }
     }
+    public sealed class HasAttributeWithoutInheritResult<TMember> : aweXpect.Results.AndOrResult<TMember, aweXpect.Core.IThat<TMember>>, aweXpect.Core.IOptionsProvider<aweXpect.Reflection.Options.AttributeFilterOptions<TMember>>
+    {
+        public HasAttributeWithoutInheritResult(aweXpect.Core.ExpectationBuilder expectationBuilder, aweXpect.Core.IThat<TMember> subject, aweXpect.Reflection.Options.AttributeFilterOptions<TMember> attributeFilterOptions) { }
+        public aweXpect.Reflection.Results.HasAttributeWithoutInheritResult<TMember> OrHas<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public aweXpect.Reflection.Results.HasAttributeWithoutInheritResult<TMember> OrHas<TAttribute>(System.Func<TAttribute, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
+            where TAttribute : System.Attribute { }
+    }
     public sealed class HaveAttributeResult<TMember, TResult> : aweXpect.Results.AndOrResult<TResult, aweXpect.Core.IThat<TResult>>, aweXpect.Core.IOptionsProvider<aweXpect.Reflection.Options.AttributeFilterOptions<TMember>>
     {
         public HaveAttributeResult(aweXpect.Core.ExpectationBuilder expectationBuilder, aweXpect.Core.IThat<TResult> subject, aweXpect.Reflection.Options.AttributeFilterOptions<TMember> attributeFilterOptions) { }
         public aweXpect.Reflection.Results.HaveAttributeResult<TMember, TResult> OrHave<TAttribute>(bool inherit = true)
             where TAttribute : System.Attribute { }
         public aweXpect.Reflection.Results.HaveAttributeResult<TMember, TResult> OrHave<TAttribute>(System.Func<TAttribute, bool> predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
+            where TAttribute : System.Attribute { }
+    }
+    public sealed class HaveAttributeWithoutInheritResult<TMember, TResult> : aweXpect.Results.AndOrResult<TResult, aweXpect.Core.IThat<TResult>>, aweXpect.Core.IOptionsProvider<aweXpect.Reflection.Options.AttributeFilterOptions<TMember>>
+    {
+        public HaveAttributeWithoutInheritResult(aweXpect.Core.ExpectationBuilder expectationBuilder, aweXpect.Core.IThat<TResult> subject, aweXpect.Reflection.Options.AttributeFilterOptions<TMember> attributeFilterOptions) { }
+        public aweXpect.Reflection.Results.HaveAttributeWithoutInheritResult<TMember, TResult> OrHave<TAttribute>()
+            where TAttribute : System.Attribute { }
+        public aweXpect.Reflection.Results.HaveAttributeWithoutInheritResult<TMember, TResult> OrHave<TAttribute>(System.Func<TAttribute, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
             where TAttribute : System.Attribute { }
     }
     public class NamedParameterCollectionResult<TThat, TParameter> : aweXpect.Reflection.Results.ParameterCollectionResult<TThat, TParameter>, aweXpect.Core.IOptionsProvider<aweXpect.Options.StringEqualityOptions>

--- a/Tests/aweXpect.Reflection.Tests/ThatConstructors.Have.AttributeTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatConstructors.Have.AttributeTests.cs
@@ -321,7 +321,7 @@ public sealed partial class ThatConstructors
 
 					async Task Act()
 					{
-						await That(subject).Have<TestAttribute>(false);
+						await That(subject).Have<TestAttribute>();
 					}
 
 					await That(Act).DoesNotThrow();


### PR DESCRIPTION
Fields and constructors cannot inherit attributes — the BCL ignores the `inherit` argument of `GetCustomAttributes` for them, so the parameter was a no-op knob.

Remove `inherit` from `Has`/`Have`/`DoesNotHave`/`DoNotHave` (and the `OrHas`/`OrHave` chaining) for fields and constructors, matching the filter side (`With`/`Without`), which already omits it. `ThatField`/`ThatConstructor` `Has`/`Have` now return dedicated `HasAttributeWithoutInheritResult`/`HaveAttributeWithoutInheritResult` types whose `OrHas`/`OrHave` likewise take no `inherit` argument.

All other member kinds (types, properties, methods, events, assemblies) keep `inherit`.

Regenerates the public API approval files and updates the README note.