### PR TITLE
feat: add `MemberScope` option for member navigation

### DIFF
--- a/Source/aweXpect.Reflection/Collections/Filtered.Events.cs
+++ b/Source/aweXpect.Reflection/Collections/Filtered.Events.cs
@@ -23,8 +23,9 @@ public static partial class Filtered
 		/// <summary>
 		///     Container for a filterable collection of <see cref="EventInfo" />.
 		/// </summary>
-		internal Events(Types types, string description) : base(types.SelectMany(type =>
-			type.GetDeclaredEvents()))
+		internal Events(Types types, string description,
+			MemberScope memberScope = MemberScope.DeclaredOnly) : base(types.SelectMany(type =>
+			type.GetDeclaredEvents(memberScope)))
 		{
 			_types = types;
 			_description = description;

--- a/Source/aweXpect.Reflection/Collections/Filtered.Fields.cs
+++ b/Source/aweXpect.Reflection/Collections/Filtered.Fields.cs
@@ -23,8 +23,9 @@ public static partial class Filtered
 		/// <summary>
 		///     Container for a filterable collection of <see cref="FieldInfo" />.
 		/// </summary>
-		internal Fields(Types types, string description) : base(types.SelectMany(type =>
-			type.GetDeclaredFields()))
+		internal Fields(Types types, string description,
+			MemberScope memberScope = MemberScope.DeclaredOnly) : base(types.SelectMany(type =>
+			type.GetDeclaredFields(memberScope)))
 		{
 			_types = types;
 			_description = description;

--- a/Source/aweXpect.Reflection/Collections/Filtered.Methods.cs
+++ b/Source/aweXpect.Reflection/Collections/Filtered.Methods.cs
@@ -23,8 +23,9 @@ public static partial class Filtered
 		/// <summary>
 		///     Container for a filterable collection of <see cref="MethodInfo" />.
 		/// </summary>
-		internal Methods(Types types, string description) : base(types.SelectMany(type =>
-			type.GetDeclaredMethods()))
+		internal Methods(Types types, string description,
+			MemberScope memberScope = MemberScope.DeclaredOnly) : base(types.SelectMany(type =>
+			type.GetDeclaredMethods(memberScope)))
 		{
 			_types = types;
 			_description = description;

--- a/Source/aweXpect.Reflection/Collections/Filtered.Properties.cs
+++ b/Source/aweXpect.Reflection/Collections/Filtered.Properties.cs
@@ -23,8 +23,9 @@ public static partial class Filtered
 		/// <summary>
 		///     Container for a filterable collection of <see cref="PropertyInfo" />.
 		/// </summary>
-		internal Properties(Types types, string description) : base(types.SelectMany(type =>
-			type.GetDeclaredProperties()))
+		internal Properties(Types types, string description,
+			MemberScope memberScope = MemberScope.DeclaredOnly) : base(types.SelectMany(type =>
+			type.GetDeclaredProperties(memberScope)))
 		{
 			_types = types;
 			_description = description;

--- a/Source/aweXpect.Reflection/Collections/Filtered.Types.cs
+++ b/Source/aweXpect.Reflection/Collections/Filtered.Types.cs
@@ -178,24 +178,32 @@ public static partial class Filtered
 		public Constructors Constructors() => new TypesMemberBuilder(this, MemberFilterState.Empty).Constructors();
 
 		/// <summary>
-		///     Get all events in the filtered types.
+		///     Get all events in the filtered types, including inherited members or only those declared directly
+		///     on the type according to the <paramref name="memberScope" />.
 		/// </summary>
-		public Events Events() => new TypesMemberBuilder(this, MemberFilterState.Empty).Events();
+		public Events Events(MemberScope memberScope = MemberScope.DeclaredOnly)
+			=> new TypesMemberBuilder(this, MemberFilterState.Empty).Events(memberScope);
 
 		/// <summary>
-		///     Get all fields in the filtered types.
+		///     Get all fields in the filtered types, including inherited members or only those declared directly
+		///     on the type according to the <paramref name="memberScope" />.
 		/// </summary>
-		public Fields Fields() => new TypesMemberBuilder(this, MemberFilterState.Empty).Fields();
+		public Fields Fields(MemberScope memberScope = MemberScope.DeclaredOnly)
+			=> new TypesMemberBuilder(this, MemberFilterState.Empty).Fields(memberScope);
 
 		/// <summary>
-		///     Get all methods in the filtered types.
+		///     Get all methods in the filtered types, including inherited members or only those declared directly
+		///     on the type according to the <paramref name="memberScope" />.
 		/// </summary>
-		public Methods Methods() => new TypesMemberBuilder(this, MemberFilterState.Empty).Methods();
+		public Methods Methods(MemberScope memberScope = MemberScope.DeclaredOnly)
+			=> new TypesMemberBuilder(this, MemberFilterState.Empty).Methods(memberScope);
 
 		/// <summary>
-		///     Get all properties in the filtered types.
+		///     Get all properties in the filtered types, including inherited members or only those declared directly
+		///     on the type according to the <paramref name="memberScope" />.
 		/// </summary>
-		public Properties Properties() => new TypesMemberBuilder(this, MemberFilterState.Empty).Properties();
+		public Properties Properties(MemberScope memberScope = MemberScope.DeclaredOnly)
+			=> new TypesMemberBuilder(this, MemberFilterState.Empty).Properties(memberScope);
 
 		/// <inheritdoc cref="IMembers.IProtected.Internal" />
 		IMembers IMembers.IProtected.Internal

--- a/Source/aweXpect.Reflection/Collections/IMembers.cs
+++ b/Source/aweXpect.Reflection/Collections/IMembers.cs
@@ -11,24 +11,28 @@ public interface IMemberSelectors
 	Filtered.Constructors Constructors();
 
 	/// <summary>
-	///     Get all methods matching the current member filter.
+	///     Get all methods matching the current member filter, including inherited members or only those
+	///     declared directly on the type according to the <paramref name="memberScope" />.
 	/// </summary>
-	Filtered.Methods Methods();
+	Filtered.Methods Methods(MemberScope memberScope = MemberScope.DeclaredOnly);
 
 	/// <summary>
-	///     Get all properties matching the current member filter.
+	///     Get all properties matching the current member filter, including inherited members or only those
+	///     declared directly on the type according to the <paramref name="memberScope" />.
 	/// </summary>
-	Filtered.Properties Properties();
+	Filtered.Properties Properties(MemberScope memberScope = MemberScope.DeclaredOnly);
 
 	/// <summary>
-	///     Get all fields matching the current member filter.
+	///     Get all fields matching the current member filter, including inherited members or only those
+	///     declared directly on the type according to the <paramref name="memberScope" />.
 	/// </summary>
-	Filtered.Fields Fields();
+	Filtered.Fields Fields(MemberScope memberScope = MemberScope.DeclaredOnly);
 
 	/// <summary>
-	///     Get all events matching the current member filter.
+	///     Get all events matching the current member filter, including inherited members or only those
+	///     declared directly on the type according to the <paramref name="memberScope" />.
 	/// </summary>
-	Filtered.Events Events();
+	Filtered.Events Events(MemberScope memberScope = MemberScope.DeclaredOnly);
 }
 
 /// <summary>
@@ -86,17 +90,20 @@ public interface IMembers : IMemberSelectors
 public interface ILimitedAbstractSealedMembers
 {
 	/// <summary>
-	///     Get all methods matching the current member filter.
+	///     Get all methods matching the current member filter, including inherited members or only those
+	///     declared directly on the type according to the <paramref name="memberScope" />.
 	/// </summary>
-	Filtered.Methods Methods();
+	Filtered.Methods Methods(MemberScope memberScope = MemberScope.DeclaredOnly);
 
 	/// <summary>
-	///     Get all properties matching the current member filter.
+	///     Get all properties matching the current member filter, including inherited members or only those
+	///     declared directly on the type according to the <paramref name="memberScope" />.
 	/// </summary>
-	Filtered.Properties Properties();
+	Filtered.Properties Properties(MemberScope memberScope = MemberScope.DeclaredOnly);
 
 	/// <summary>
-	///     Get all events matching the current member filter.
+	///     Get all events matching the current member filter, including inherited members or only those
+	///     declared directly on the type according to the <paramref name="memberScope" />.
 	/// </summary>
-	Filtered.Events Events();
+	Filtered.Events Events(MemberScope memberScope = MemberScope.DeclaredOnly);
 }

--- a/Source/aweXpect.Reflection/Collections/MemberScope.cs
+++ b/Source/aweXpect.Reflection/Collections/MemberScope.cs
@@ -1,0 +1,17 @@
+﻿namespace aweXpect.Reflection.Collections;
+
+/// <summary>
+///     Specifies which members are included when navigating from types to their members.
+/// </summary>
+public enum MemberScope
+{
+	/// <summary>
+	///     Only include members declared directly on the type, excluding inherited members.
+	/// </summary>
+	DeclaredOnly,
+
+	/// <summary>
+	///     Include members declared directly on the type as well as members inherited from base types.
+	/// </summary>
+	IncludingInherited,
+}

--- a/Source/aweXpect.Reflection/Collections/TypesMemberBuilder.cs
+++ b/Source/aweXpect.Reflection/Collections/TypesMemberBuilder.cs
@@ -32,30 +32,30 @@ internal sealed class TypesMemberBuilder :
 		return filter is null ? constructors : constructors.Which(filter);
 	}
 
-	public Filtered.Events Events()
+	public Filtered.Events Events(MemberScope memberScope = MemberScope.DeclaredOnly)
 	{
-		Filtered.Events events = new(_source, "events ");
+		Filtered.Events events = new(_source, "events ", memberScope);
 		IFilter<EventInfo>? filter = _state.BuildEventFilter();
 		return filter is null ? events : events.Which(filter);
 	}
 
-	public Filtered.Fields Fields()
+	public Filtered.Fields Fields(MemberScope memberScope = MemberScope.DeclaredOnly)
 	{
-		Filtered.Fields fields = new(_source, "fields ");
+		Filtered.Fields fields = new(_source, "fields ", memberScope);
 		IFilter<FieldInfo>? filter = _state.BuildFieldFilter();
 		return filter is null ? fields : fields.Which(filter);
 	}
 
-	public Filtered.Methods Methods()
+	public Filtered.Methods Methods(MemberScope memberScope = MemberScope.DeclaredOnly)
 	{
-		Filtered.Methods methods = new(_source, "methods ");
+		Filtered.Methods methods = new(_source, "methods ", memberScope);
 		IFilter<MethodInfo>? filter = _state.BuildMethodFilter();
 		return filter is null ? methods : methods.Which(filter);
 	}
 
-	public Filtered.Properties Properties()
+	public Filtered.Properties Properties(MemberScope memberScope = MemberScope.DeclaredOnly)
 	{
-		Filtered.Properties properties = new(_source, "properties ");
+		Filtered.Properties properties = new(_source, "properties ", memberScope);
 		IFilter<PropertyInfo>? filter = _state.BuildPropertyFilter();
 		return filter is null ? properties : properties.Which(filter);
 	}

--- a/Source/aweXpect.Reflection/Helpers/TypeHelpers.cs
+++ b/Source/aweXpect.Reflection/Helpers/TypeHelpers.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -53,11 +54,22 @@ internal static class TypeHelpers
 		try
 		{
 			CompilerGeneratedMembers included = IncludedCompilerGeneratedMembers;
-			return type
+			IEnumerable<EventInfo> events = type
 				.GetEvents(memberScope.ToBindingFlags() |
 				           BindingFlags.NonPublic |
 				           BindingFlags.Public |
-				           BindingFlags.Instance)
+				           BindingFlags.Instance);
+			if (memberScope == MemberScope.IncludingInherited)
+			{
+				events = events.Concat(type.GetInheritedPrivateMembers(
+					baseType => baseType.GetEvents(BindingFlags.DeclaredOnly |
+					                               BindingFlags.NonPublic |
+					                               BindingFlags.Instance),
+					@event => @event.AddMethod is not { IsPrivate: false, } &&
+					          @event.RemoveMethod is not { IsPrivate: false, }));
+			}
+
+			return events
 				.Where(m => !m.IsCompilerGenerated() ||
 				            included.HasFlag(CompilerGeneratedMembers.Events))
 				.ToArray();
@@ -82,12 +94,23 @@ internal static class TypeHelpers
 		try
 		{
 			CompilerGeneratedMembers included = IncludedCompilerGeneratedMembers;
-			return type
+			IEnumerable<FieldInfo> fields = type
 				.GetFields(memberScope.ToBindingFlags() |
 				           BindingFlags.NonPublic |
 				           BindingFlags.Public |
 				           BindingFlags.Instance |
-				           BindingFlags.Static)
+				           BindingFlags.Static);
+			if (memberScope == MemberScope.IncludingInherited)
+			{
+				fields = fields.Concat(type.GetInheritedPrivateMembers(
+					baseType => baseType.GetFields(BindingFlags.DeclaredOnly |
+					                               BindingFlags.NonPublic |
+					                               BindingFlags.Instance |
+					                               BindingFlags.Static),
+					field => field.IsPrivate));
+			}
+
+			return fields
 				.Where(m => !m.IsSpecialName)
 				.Where(m => !m.IsCompilerGenerated() ||
 				            included.HasFlag(CompilerGeneratedMembers.Fields))
@@ -114,13 +137,23 @@ internal static class TypeHelpers
 		{
 			CompilerGeneratedMembers includedCompilerGenerated = IncludedCompilerGeneratedMembers;
 			SpecialNameMembers includedSpecialName = IncludedSpecialNameMembers;
-			return type
+			IEnumerable<MethodInfo> methods = type
 				.GetMethods(memberScope.ToBindingFlags() |
 				            BindingFlags.NonPublic |
 				            BindingFlags.Public |
 				            BindingFlags.Static |
-				            BindingFlags.Instance |
-				            BindingFlags.Static)
+				            BindingFlags.Instance);
+			if (memberScope == MemberScope.IncludingInherited)
+			{
+				methods = methods.Concat(type.GetInheritedPrivateMembers(
+					baseType => baseType.GetMethods(BindingFlags.DeclaredOnly |
+					                                BindingFlags.NonPublic |
+					                                BindingFlags.Instance |
+					                                BindingFlags.Static),
+					method => method.IsPrivate));
+			}
+
+			return methods
 				.Where(m => IncludeMethod(m, includedCompilerGenerated, includedSpecialName))
 				.ToArray();
 		}
@@ -144,13 +177,24 @@ internal static class TypeHelpers
 		try
 		{
 			CompilerGeneratedMembers included = IncludedCompilerGeneratedMembers;
-			return type
+			IEnumerable<PropertyInfo> properties = type
 				.GetProperties(memberScope.ToBindingFlags() |
 				               BindingFlags.NonPublic |
 				               BindingFlags.Public |
 				               BindingFlags.Static |
-				               BindingFlags.Instance |
-				               BindingFlags.Static)
+				               BindingFlags.Instance);
+			if (memberScope == MemberScope.IncludingInherited)
+			{
+				properties = properties.Concat(type.GetInheritedPrivateMembers(
+					baseType => baseType.GetProperties(BindingFlags.DeclaredOnly |
+					                                   BindingFlags.NonPublic |
+					                                   BindingFlags.Instance |
+					                                   BindingFlags.Static),
+					property => property.GetMethod is not { IsPrivate: false, } &&
+					            property.SetMethod is not { IsPrivate: false, }));
+			}
+
+			return properties
 				.Where(m => !m.IsSpecialName)
 				.Where(m => !m.IsCompilerGenerated() ||
 				            included.HasFlag(CompilerGeneratedMembers.Properties))
@@ -171,12 +215,39 @@ internal static class TypeHelpers
 	/// <remarks>
 	///     <see cref="MemberScope.DeclaredOnly" /> restricts the search to members declared directly on the type, while
 	///     <see cref="MemberScope.IncludingInherited" /> also returns inherited members (including inherited static members
-	///     via <see cref="BindingFlags.FlattenHierarchy" />).
+	///     via <see cref="BindingFlags.FlattenHierarchy" />). Inherited <see langword="private" /> members are not covered
+	///     by <see cref="BindingFlags.FlattenHierarchy" /> and are collected separately via
+	///     <see cref="GetInheritedPrivateMembers{T}" />.
 	/// </remarks>
 	private static BindingFlags ToBindingFlags(this MemberScope memberScope)
 		=> memberScope == MemberScope.DeclaredOnly
 			? BindingFlags.DeclaredOnly
 			: BindingFlags.FlattenHierarchy;
+
+	/// <summary>
+	///     Collects the <see langword="private" /> members declared on the base types of the <paramref name="type" />.
+	/// </summary>
+	/// <remarks>
+	///     <see cref="BindingFlags.FlattenHierarchy" /> does not return <see langword="private" /> members of base types,
+	///     so they are gathered here by walking the base type chain and keeping only those members that reflection
+	///     excludes from the derived type (i.e. members without any non-private accessor).
+	/// </remarks>
+	private static IEnumerable<T> GetInheritedPrivateMembers<T>(
+		this Type type,
+		Func<Type, IEnumerable<T>> getDeclaredMembers,
+		Func<T, bool> isPrivate)
+	{
+		for (Type? baseType = type.BaseType; baseType is not null; baseType = baseType.BaseType)
+		{
+			foreach (T member in getDeclaredMembers(baseType))
+			{
+				if (isPrivate(member))
+				{
+					yield return member;
+				}
+			}
+		}
+	}
 
 	/// <summary>
 	///     The compiler-generated members that are currently included via customization.

--- a/Source/aweXpect.Reflection/Helpers/TypeHelpers.cs
+++ b/Source/aweXpect.Reflection/Helpers/TypeHelpers.cs
@@ -43,16 +43,18 @@ internal static class TypeHelpers
 	}
 
 	/// <summary>
-	///     Searches for events in the <paramref name="type" /> that were directly declared there.
+	///     Searches for events in the <paramref name="type" />, optionally including inherited ones according to the
+	///     <paramref name="memberScope" />.
 	/// </summary>
 	public static EventInfo[] GetDeclaredEvents(
-		this Type type)
+		this Type type,
+		MemberScope memberScope = MemberScope.DeclaredOnly)
 	{
 		try
 		{
 			CompilerGeneratedMembers included = IncludedCompilerGeneratedMembers;
 			return type
-				.GetEvents(BindingFlags.DeclaredOnly |
+				.GetEvents(memberScope.ToBindingFlags() |
 				           BindingFlags.NonPublic |
 				           BindingFlags.Public |
 				           BindingFlags.Instance)
@@ -70,16 +72,18 @@ internal static class TypeHelpers
 	}
 
 	/// <summary>
-	///     Searches for fields in the <paramref name="type" /> that were directly declared there.
+	///     Searches for fields in the <paramref name="type" />, optionally including inherited ones according to the
+	///     <paramref name="memberScope" />.
 	/// </summary>
 	public static FieldInfo[] GetDeclaredFields(
-		this Type type)
+		this Type type,
+		MemberScope memberScope = MemberScope.DeclaredOnly)
 	{
 		try
 		{
 			CompilerGeneratedMembers included = IncludedCompilerGeneratedMembers;
 			return type
-				.GetFields(BindingFlags.DeclaredOnly |
+				.GetFields(memberScope.ToBindingFlags() |
 				           BindingFlags.NonPublic |
 				           BindingFlags.Public |
 				           BindingFlags.Instance |
@@ -99,17 +103,19 @@ internal static class TypeHelpers
 	}
 
 	/// <summary>
-	///     Searches for methods in the <paramref name="type" /> that were directly declared there.
+	///     Searches for methods in the <paramref name="type" />, optionally including inherited ones according to the
+	///     <paramref name="memberScope" />.
 	/// </summary>
 	public static MethodInfo[] GetDeclaredMethods(
-		this Type type)
+		this Type type,
+		MemberScope memberScope = MemberScope.DeclaredOnly)
 	{
 		try
 		{
 			CompilerGeneratedMembers includedCompilerGenerated = IncludedCompilerGeneratedMembers;
 			SpecialNameMembers includedSpecialName = IncludedSpecialNameMembers;
 			return type
-				.GetMethods(BindingFlags.DeclaredOnly |
+				.GetMethods(memberScope.ToBindingFlags() |
 				            BindingFlags.NonPublic |
 				            BindingFlags.Public |
 				            BindingFlags.Static |
@@ -128,16 +134,18 @@ internal static class TypeHelpers
 	}
 
 	/// <summary>
-	///     Searches for properties in the <paramref name="type" /> that were directly declared there.
+	///     Searches for properties in the <paramref name="type" />, optionally including inherited ones according to the
+	///     <paramref name="memberScope" />.
 	/// </summary>
 	public static PropertyInfo[] GetDeclaredProperties(
-		this Type type)
+		this Type type,
+		MemberScope memberScope = MemberScope.DeclaredOnly)
 	{
 		try
 		{
 			CompilerGeneratedMembers included = IncludedCompilerGeneratedMembers;
 			return type
-				.GetProperties(BindingFlags.DeclaredOnly |
+				.GetProperties(memberScope.ToBindingFlags() |
 				               BindingFlags.NonPublic |
 				               BindingFlags.Public |
 				               BindingFlags.Static |
@@ -156,6 +164,19 @@ internal static class TypeHelpers
 			return [];
 		}
 	}
+
+	/// <summary>
+	///     Maps the <paramref name="memberScope" /> to the corresponding <see cref="BindingFlags" />.
+	/// </summary>
+	/// <remarks>
+	///     <see cref="MemberScope.DeclaredOnly" /> restricts the search to members declared directly on the type, while
+	///     <see cref="MemberScope.IncludingInherited" /> also returns inherited members (including inherited static members
+	///     via <see cref="BindingFlags.FlattenHierarchy" />).
+	/// </remarks>
+	private static BindingFlags ToBindingFlags(this MemberScope memberScope)
+		=> memberScope == MemberScope.DeclaredOnly
+			? BindingFlags.DeclaredOnly
+			: BindingFlags.FlattenHierarchy;
 
 	/// <summary>
 	///     The compiler-generated members that are currently included via customization.

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net10.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net10.0.txt
@@ -1782,11 +1782,11 @@ namespace aweXpect.Reflection.Collections
             public aweXpect.Reflection.Collections.IMemberSelectors Static { get; }
             public aweXpect.Reflection.Collections.Filtered.Assemblies Assemblies() { }
             public aweXpect.Reflection.Collections.Filtered.Constructors Constructors() { }
-            public aweXpect.Reflection.Collections.Filtered.Events Events() { }
-            public aweXpect.Reflection.Collections.Filtered.Fields Fields() { }
+            public aweXpect.Reflection.Collections.Filtered.Events Events(aweXpect.Reflection.Collections.MemberScope memberScope = 0) { }
+            public aweXpect.Reflection.Collections.Filtered.Fields Fields(aweXpect.Reflection.Collections.MemberScope memberScope = 0) { }
             public string GetDescription() { }
-            public aweXpect.Reflection.Collections.Filtered.Methods Methods() { }
-            public aweXpect.Reflection.Collections.Filtered.Properties Properties() { }
+            public aweXpect.Reflection.Collections.Filtered.Methods Methods(aweXpect.Reflection.Collections.MemberScope memberScope = 0) { }
+            public aweXpect.Reflection.Collections.Filtered.Properties Properties(aweXpect.Reflection.Collections.MemberScope memberScope = 0) { }
             public class StringEqualityResult : aweXpect.Reflection.Collections.Filtered.Types
             {
                 public aweXpect.Reflection.Collections.Filtered.Types.StringEqualityResult IgnoringCase(bool ignoreCase = true) { }
@@ -1828,9 +1828,9 @@ namespace aweXpect.Reflection.Collections
     }
     public interface ILimitedAbstractSealedMembers
     {
-        aweXpect.Reflection.Collections.Filtered.Events Events();
-        aweXpect.Reflection.Collections.Filtered.Methods Methods();
-        aweXpect.Reflection.Collections.Filtered.Properties Properties();
+        aweXpect.Reflection.Collections.Filtered.Events Events(aweXpect.Reflection.Collections.MemberScope memberScope = 0);
+        aweXpect.Reflection.Collections.Filtered.Methods Methods(aweXpect.Reflection.Collections.MemberScope memberScope = 0);
+        aweXpect.Reflection.Collections.Filtered.Properties Properties(aweXpect.Reflection.Collections.MemberScope memberScope = 0);
     }
     public interface ILimitedAbstractSealedTypeAssemblies
     {
@@ -1866,10 +1866,10 @@ namespace aweXpect.Reflection.Collections
     public interface IMemberSelectors
     {
         aweXpect.Reflection.Collections.Filtered.Constructors Constructors();
-        aweXpect.Reflection.Collections.Filtered.Events Events();
-        aweXpect.Reflection.Collections.Filtered.Fields Fields();
-        aweXpect.Reflection.Collections.Filtered.Methods Methods();
-        aweXpect.Reflection.Collections.Filtered.Properties Properties();
+        aweXpect.Reflection.Collections.Filtered.Events Events(aweXpect.Reflection.Collections.MemberScope memberScope = 0);
+        aweXpect.Reflection.Collections.Filtered.Fields Fields(aweXpect.Reflection.Collections.MemberScope memberScope = 0);
+        aweXpect.Reflection.Collections.Filtered.Methods Methods(aweXpect.Reflection.Collections.MemberScope memberScope = 0);
+        aweXpect.Reflection.Collections.Filtered.Properties Properties(aweXpect.Reflection.Collections.MemberScope memberScope = 0);
     }
     public interface IMembers : aweXpect.Reflection.Collections.IMemberSelectors
     {
@@ -1903,6 +1903,11 @@ namespace aweXpect.Reflection.Collections
         {
             aweXpect.Reflection.Collections.ITypeAssemblies Internal { get; }
         }
+    }
+    public enum MemberScope
+    {
+        DeclaredOnly = 0,
+        IncludingInherited = 1,
     }
 }
 namespace aweXpect.Reflection.Options

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net8.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net8.0.txt
@@ -1782,11 +1782,11 @@ namespace aweXpect.Reflection.Collections
             public aweXpect.Reflection.Collections.IMemberSelectors Static { get; }
             public aweXpect.Reflection.Collections.Filtered.Assemblies Assemblies() { }
             public aweXpect.Reflection.Collections.Filtered.Constructors Constructors() { }
-            public aweXpect.Reflection.Collections.Filtered.Events Events() { }
-            public aweXpect.Reflection.Collections.Filtered.Fields Fields() { }
+            public aweXpect.Reflection.Collections.Filtered.Events Events(aweXpect.Reflection.Collections.MemberScope memberScope = 0) { }
+            public aweXpect.Reflection.Collections.Filtered.Fields Fields(aweXpect.Reflection.Collections.MemberScope memberScope = 0) { }
             public string GetDescription() { }
-            public aweXpect.Reflection.Collections.Filtered.Methods Methods() { }
-            public aweXpect.Reflection.Collections.Filtered.Properties Properties() { }
+            public aweXpect.Reflection.Collections.Filtered.Methods Methods(aweXpect.Reflection.Collections.MemberScope memberScope = 0) { }
+            public aweXpect.Reflection.Collections.Filtered.Properties Properties(aweXpect.Reflection.Collections.MemberScope memberScope = 0) { }
             public class StringEqualityResult : aweXpect.Reflection.Collections.Filtered.Types
             {
                 public aweXpect.Reflection.Collections.Filtered.Types.StringEqualityResult IgnoringCase(bool ignoreCase = true) { }
@@ -1828,9 +1828,9 @@ namespace aweXpect.Reflection.Collections
     }
     public interface ILimitedAbstractSealedMembers
     {
-        aweXpect.Reflection.Collections.Filtered.Events Events();
-        aweXpect.Reflection.Collections.Filtered.Methods Methods();
-        aweXpect.Reflection.Collections.Filtered.Properties Properties();
+        aweXpect.Reflection.Collections.Filtered.Events Events(aweXpect.Reflection.Collections.MemberScope memberScope = 0);
+        aweXpect.Reflection.Collections.Filtered.Methods Methods(aweXpect.Reflection.Collections.MemberScope memberScope = 0);
+        aweXpect.Reflection.Collections.Filtered.Properties Properties(aweXpect.Reflection.Collections.MemberScope memberScope = 0);
     }
     public interface ILimitedAbstractSealedTypeAssemblies
     {
@@ -1866,10 +1866,10 @@ namespace aweXpect.Reflection.Collections
     public interface IMemberSelectors
     {
         aweXpect.Reflection.Collections.Filtered.Constructors Constructors();
-        aweXpect.Reflection.Collections.Filtered.Events Events();
-        aweXpect.Reflection.Collections.Filtered.Fields Fields();
-        aweXpect.Reflection.Collections.Filtered.Methods Methods();
-        aweXpect.Reflection.Collections.Filtered.Properties Properties();
+        aweXpect.Reflection.Collections.Filtered.Events Events(aweXpect.Reflection.Collections.MemberScope memberScope = 0);
+        aweXpect.Reflection.Collections.Filtered.Fields Fields(aweXpect.Reflection.Collections.MemberScope memberScope = 0);
+        aweXpect.Reflection.Collections.Filtered.Methods Methods(aweXpect.Reflection.Collections.MemberScope memberScope = 0);
+        aweXpect.Reflection.Collections.Filtered.Properties Properties(aweXpect.Reflection.Collections.MemberScope memberScope = 0);
     }
     public interface IMembers : aweXpect.Reflection.Collections.IMemberSelectors
     {
@@ -1903,6 +1903,11 @@ namespace aweXpect.Reflection.Collections
         {
             aweXpect.Reflection.Collections.ITypeAssemblies Internal { get; }
         }
+    }
+    public enum MemberScope
+    {
+        DeclaredOnly = 0,
+        IncludingInherited = 1,
     }
 }
 namespace aweXpect.Reflection.Options

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_netstandard2.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_netstandard2.0.txt
@@ -1501,11 +1501,11 @@ namespace aweXpect.Reflection.Collections
             public aweXpect.Reflection.Collections.IMemberSelectors Static { get; }
             public aweXpect.Reflection.Collections.Filtered.Assemblies Assemblies() { }
             public aweXpect.Reflection.Collections.Filtered.Constructors Constructors() { }
-            public aweXpect.Reflection.Collections.Filtered.Events Events() { }
-            public aweXpect.Reflection.Collections.Filtered.Fields Fields() { }
+            public aweXpect.Reflection.Collections.Filtered.Events Events(aweXpect.Reflection.Collections.MemberScope memberScope = 0) { }
+            public aweXpect.Reflection.Collections.Filtered.Fields Fields(aweXpect.Reflection.Collections.MemberScope memberScope = 0) { }
             public string GetDescription() { }
-            public aweXpect.Reflection.Collections.Filtered.Methods Methods() { }
-            public aweXpect.Reflection.Collections.Filtered.Properties Properties() { }
+            public aweXpect.Reflection.Collections.Filtered.Methods Methods(aweXpect.Reflection.Collections.MemberScope memberScope = 0) { }
+            public aweXpect.Reflection.Collections.Filtered.Properties Properties(aweXpect.Reflection.Collections.MemberScope memberScope = 0) { }
             public class StringEqualityResult : aweXpect.Reflection.Collections.Filtered.Types
             {
                 public aweXpect.Reflection.Collections.Filtered.Types.StringEqualityResult IgnoringCase(bool ignoreCase = true) { }
@@ -1546,9 +1546,9 @@ namespace aweXpect.Reflection.Collections
     }
     public interface ILimitedAbstractSealedMembers
     {
-        aweXpect.Reflection.Collections.Filtered.Events Events();
-        aweXpect.Reflection.Collections.Filtered.Methods Methods();
-        aweXpect.Reflection.Collections.Filtered.Properties Properties();
+        aweXpect.Reflection.Collections.Filtered.Events Events(aweXpect.Reflection.Collections.MemberScope memberScope = 0);
+        aweXpect.Reflection.Collections.Filtered.Methods Methods(aweXpect.Reflection.Collections.MemberScope memberScope = 0);
+        aweXpect.Reflection.Collections.Filtered.Properties Properties(aweXpect.Reflection.Collections.MemberScope memberScope = 0);
     }
     public interface ILimitedAbstractSealedTypeAssemblies
     {
@@ -1584,10 +1584,10 @@ namespace aweXpect.Reflection.Collections
     public interface IMemberSelectors
     {
         aweXpect.Reflection.Collections.Filtered.Constructors Constructors();
-        aweXpect.Reflection.Collections.Filtered.Events Events();
-        aweXpect.Reflection.Collections.Filtered.Fields Fields();
-        aweXpect.Reflection.Collections.Filtered.Methods Methods();
-        aweXpect.Reflection.Collections.Filtered.Properties Properties();
+        aweXpect.Reflection.Collections.Filtered.Events Events(aweXpect.Reflection.Collections.MemberScope memberScope = 0);
+        aweXpect.Reflection.Collections.Filtered.Fields Fields(aweXpect.Reflection.Collections.MemberScope memberScope = 0);
+        aweXpect.Reflection.Collections.Filtered.Methods Methods(aweXpect.Reflection.Collections.MemberScope memberScope = 0);
+        aweXpect.Reflection.Collections.Filtered.Properties Properties(aweXpect.Reflection.Collections.MemberScope memberScope = 0);
     }
     public interface IMembers : aweXpect.Reflection.Collections.IMemberSelectors
     {
@@ -1621,6 +1621,11 @@ namespace aweXpect.Reflection.Collections
         {
             aweXpect.Reflection.Collections.ITypeAssemblies Internal { get; }
         }
+    }
+    public enum MemberScope
+    {
+        DeclaredOnly = 0,
+        IncludingInherited = 1,
     }
 }
 namespace aweXpect.Reflection.Options

--- a/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.Events.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.Events.Tests.cs
@@ -38,6 +38,26 @@ public sealed partial class TypeFilters
 				await That(events).Contains(e => e.Name == nameof(DerivedClassWithMembers.DerivedEvent));
 				await That(events).Contains(e => e.Name == nameof(BaseClassWithMembers.BaseEvent));
 			}
+
+			[Fact]
+			public async Task WithIncludingInherited_ShouldIncludeInheritedPrivateMembers()
+			{
+				Filtered.Events events =
+					In.Type<DerivedClassWithMembers>().Events(MemberScope.IncludingInherited)
+						.WhichArePrivate();
+
+				await That(events).Contains(e => e.Name == "BasePrivateEvent");
+			}
+
+			[Fact]
+			public async Task WithDeclaredOnly_ShouldNotIncludeInheritedPrivateMembers()
+			{
+				Filtered.Events events =
+					In.Type<DerivedClassWithMembers>().Events(MemberScope.DeclaredOnly)
+						.WhichArePrivate();
+
+				await That(events).None().Satisfy(e => e.Name == "BasePrivateEvent");
+			}
 		}
 	}
 }

--- a/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.Events.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.Events.Tests.cs
@@ -1,0 +1,43 @@
+﻿using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Tests.TestHelpers.Types;
+
+namespace aweXpect.Reflection.Tests.Filters;
+
+public sealed partial class TypeFilters
+{
+	public sealed class Events
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WithDefaultScope_ShouldOnlyIncludeDeclaredMembers()
+			{
+				Filtered.Events events =
+					In.Type<DerivedClassWithMembers>().Events();
+
+				await That(events).Contains(e => e.Name == nameof(DerivedClassWithMembers.DerivedEvent));
+				await That(events).None().Satisfy(e => e.Name == nameof(BaseClassWithMembers.BaseEvent));
+			}
+
+			[Fact]
+			public async Task WithDeclaredOnly_ShouldOnlyIncludeDeclaredMembers()
+			{
+				Filtered.Events events =
+					In.Type<DerivedClassWithMembers>().Events(MemberScope.DeclaredOnly);
+
+				await That(events).Contains(e => e.Name == nameof(DerivedClassWithMembers.DerivedEvent));
+				await That(events).None().Satisfy(e => e.Name == nameof(BaseClassWithMembers.BaseEvent));
+			}
+
+			[Fact]
+			public async Task WithIncludingInherited_ShouldIncludeInheritedMembers()
+			{
+				Filtered.Events events =
+					In.Type<DerivedClassWithMembers>().Events(MemberScope.IncludingInherited);
+
+				await That(events).Contains(e => e.Name == nameof(DerivedClassWithMembers.DerivedEvent));
+				await That(events).Contains(e => e.Name == nameof(BaseClassWithMembers.BaseEvent));
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.Fields.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.Fields.Tests.cs
@@ -38,6 +38,26 @@ public sealed partial class TypeFilters
 				await That(fields).Contains(f => f.Name == nameof(DerivedClassWithMembers.DerivedField));
 				await That(fields).Contains(f => f.Name == nameof(BaseClassWithMembers.BaseField));
 			}
+
+			[Fact]
+			public async Task WithIncludingInherited_ShouldIncludeInheritedPrivateMembers()
+			{
+				Filtered.Fields fields =
+					In.Type<DerivedClassWithMembers>().Fields(MemberScope.IncludingInherited)
+						.WhichArePrivate();
+
+				await That(fields).Contains(f => f.Name == "_basePrivateField");
+			}
+
+			[Fact]
+			public async Task WithDeclaredOnly_ShouldNotIncludeInheritedPrivateMembers()
+			{
+				Filtered.Fields fields =
+					In.Type<DerivedClassWithMembers>().Fields(MemberScope.DeclaredOnly)
+						.WhichArePrivate();
+
+				await That(fields).None().Satisfy(f => f.Name == "_basePrivateField");
+			}
 		}
 	}
 }

--- a/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.Fields.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.Fields.Tests.cs
@@ -1,0 +1,43 @@
+﻿using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Tests.TestHelpers.Types;
+
+namespace aweXpect.Reflection.Tests.Filters;
+
+public sealed partial class TypeFilters
+{
+	public sealed class Fields
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WithDefaultScope_ShouldOnlyIncludeDeclaredMembers()
+			{
+				Filtered.Fields fields =
+					In.Type<DerivedClassWithMembers>().Fields();
+
+				await That(fields).Contains(f => f.Name == nameof(DerivedClassWithMembers.DerivedField));
+				await That(fields).None().Satisfy(f => f.Name == nameof(BaseClassWithMembers.BaseField));
+			}
+
+			[Fact]
+			public async Task WithDeclaredOnly_ShouldOnlyIncludeDeclaredMembers()
+			{
+				Filtered.Fields fields =
+					In.Type<DerivedClassWithMembers>().Fields(MemberScope.DeclaredOnly);
+
+				await That(fields).Contains(f => f.Name == nameof(DerivedClassWithMembers.DerivedField));
+				await That(fields).None().Satisfy(f => f.Name == nameof(BaseClassWithMembers.BaseField));
+			}
+
+			[Fact]
+			public async Task WithIncludingInherited_ShouldIncludeInheritedMembers()
+			{
+				Filtered.Fields fields =
+					In.Type<DerivedClassWithMembers>().Fields(MemberScope.IncludingInherited);
+
+				await That(fields).Contains(f => f.Name == nameof(DerivedClassWithMembers.DerivedField));
+				await That(fields).Contains(f => f.Name == nameof(BaseClassWithMembers.BaseField));
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.Methods.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.Methods.Tests.cs
@@ -1,0 +1,43 @@
+﻿using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Tests.TestHelpers.Types;
+
+namespace aweXpect.Reflection.Tests.Filters;
+
+public sealed partial class TypeFilters
+{
+	public sealed class Methods
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WithDefaultScope_ShouldOnlyIncludeDeclaredMembers()
+			{
+				Filtered.Methods methods =
+					In.Type<DerivedClassWithMembers>().Methods();
+
+				await That(methods).Contains(m => m.Name == nameof(DerivedClassWithMembers.DerivedMethod));
+				await That(methods).None().Satisfy(m => m.Name == nameof(BaseClassWithMembers.BaseMethod));
+			}
+
+			[Fact]
+			public async Task WithDeclaredOnly_ShouldOnlyIncludeDeclaredMembers()
+			{
+				Filtered.Methods methods =
+					In.Type<DerivedClassWithMembers>().Methods(MemberScope.DeclaredOnly);
+
+				await That(methods).Contains(m => m.Name == nameof(DerivedClassWithMembers.DerivedMethod));
+				await That(methods).None().Satisfy(m => m.Name == nameof(BaseClassWithMembers.BaseMethod));
+			}
+
+			[Fact]
+			public async Task WithIncludingInherited_ShouldIncludeInheritedMembers()
+			{
+				Filtered.Methods methods =
+					In.Type<DerivedClassWithMembers>().Methods(MemberScope.IncludingInherited);
+
+				await That(methods).Contains(m => m.Name == nameof(DerivedClassWithMembers.DerivedMethod));
+				await That(methods).Contains(m => m.Name == nameof(BaseClassWithMembers.BaseMethod));
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.Methods.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.Methods.Tests.cs
@@ -38,6 +38,26 @@ public sealed partial class TypeFilters
 				await That(methods).Contains(m => m.Name == nameof(DerivedClassWithMembers.DerivedMethod));
 				await That(methods).Contains(m => m.Name == nameof(BaseClassWithMembers.BaseMethod));
 			}
+
+			[Fact]
+			public async Task WithIncludingInherited_ShouldIncludeInheritedPrivateMembers()
+			{
+				Filtered.Methods methods =
+					In.Type<DerivedClassWithMembers>().Methods(MemberScope.IncludingInherited)
+						.WhichArePrivate();
+
+				await That(methods).Contains(m => m.Name == "BasePrivateMethod");
+			}
+
+			[Fact]
+			public async Task WithDeclaredOnly_ShouldNotIncludeInheritedPrivateMembers()
+			{
+				Filtered.Methods methods =
+					In.Type<DerivedClassWithMembers>().Methods(MemberScope.DeclaredOnly)
+						.WhichArePrivate();
+
+				await That(methods).None().Satisfy(m => m.Name == "BasePrivateMethod");
+			}
 		}
 	}
 }

--- a/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.Properties.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.Properties.Tests.cs
@@ -1,0 +1,54 @@
+﻿using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Tests.TestHelpers.Types;
+
+namespace aweXpect.Reflection.Tests.Filters;
+
+public sealed partial class TypeFilters
+{
+	public sealed class Properties
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WithDefaultScope_ShouldOnlyIncludeDeclaredMembers()
+			{
+				Filtered.Properties properties =
+					In.Type<DerivedClassWithMembers>().Properties();
+
+				await That(properties).Contains(p => p.Name == nameof(DerivedClassWithMembers.DerivedProperty));
+				await That(properties).None().Satisfy(p => p.Name == nameof(BaseClassWithMembers.BaseProperty));
+			}
+
+			[Fact]
+			public async Task WithDeclaredOnly_ShouldOnlyIncludeDeclaredMembers()
+			{
+				Filtered.Properties properties =
+					In.Type<DerivedClassWithMembers>().Properties(MemberScope.DeclaredOnly);
+
+				await That(properties).Contains(p => p.Name == nameof(DerivedClassWithMembers.DerivedProperty));
+				await That(properties).None().Satisfy(p => p.Name == nameof(BaseClassWithMembers.BaseProperty));
+			}
+
+			[Fact]
+			public async Task WithIncludingInherited_ShouldIncludeInheritedMembers()
+			{
+				Filtered.Properties properties =
+					In.Type<DerivedClassWithMembers>().Properties(MemberScope.IncludingInherited);
+
+				await That(properties).Contains(p => p.Name == nameof(DerivedClassWithMembers.DerivedProperty));
+				await That(properties).Contains(p => p.Name == nameof(BaseClassWithMembers.BaseProperty));
+			}
+
+			[Fact]
+			public async Task WithIncludingInherited_ShouldComposeWithAccessModifierFilter()
+			{
+				Filtered.Properties properties =
+					In.Type<DerivedClassWithMembers>().Public.Properties(MemberScope.IncludingInherited);
+
+				await That(properties).Contains(p => p.Name == nameof(DerivedClassWithMembers.DerivedProperty));
+				await That(properties).Contains(p => p.Name == nameof(BaseClassWithMembers.BaseProperty));
+				await That(properties).All().Satisfy(p => p.GetMethod?.IsPublic == true).And.IsNotEmpty();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.Properties.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.Properties.Tests.cs
@@ -49,6 +49,26 @@ public sealed partial class TypeFilters
 				await That(properties).Contains(p => p.Name == nameof(BaseClassWithMembers.BaseProperty));
 				await That(properties).All().Satisfy(p => p.GetMethod?.IsPublic == true).And.IsNotEmpty();
 			}
+
+			[Fact]
+			public async Task WithIncludingInherited_ShouldIncludeInheritedPrivateMembers()
+			{
+				Filtered.Properties properties =
+					In.Type<DerivedClassWithMembers>().Properties(MemberScope.IncludingInherited)
+						.WhichArePrivate();
+
+				await That(properties).Contains(p => p.Name == "BasePrivateProperty");
+			}
+
+			[Fact]
+			public async Task WithDeclaredOnly_ShouldNotIncludeInheritedPrivateMembers()
+			{
+				Filtered.Properties properties =
+					In.Type<DerivedClassWithMembers>().Properties(MemberScope.DeclaredOnly)
+						.WhichArePrivate();
+
+				await That(properties).None().Satisfy(p => p.Name == "BasePrivateProperty");
+			}
 		}
 	}
 }

--- a/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/BaseClassWithMembers.cs
+++ b/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/BaseClassWithMembers.cs
@@ -1,0 +1,43 @@
+﻿namespace aweXpect.Reflection.Tests.TestHelpers.Types;
+
+public class BaseClassWithMembers
+{
+	// ReSharper disable once UnusedMember.Global
+	public int BaseProperty { get; set; }
+
+#pragma warning disable CS0649 // Field is never assigned to
+	// ReSharper disable once UnusedMember.Global
+	public int BaseField;
+#pragma warning restore CS0649
+
+#pragma warning disable CS0067 // Event is never used
+	// ReSharper disable once UnusedMember.Global
+	public event EventHandler? BaseEvent;
+#pragma warning restore CS0067
+
+#pragma warning disable CA1822 // Mark members as static
+	// ReSharper disable once UnusedMember.Global
+	public void BaseMethod() { }
+#pragma warning restore CA1822
+}
+
+public class DerivedClassWithMembers : BaseClassWithMembers
+{
+	// ReSharper disable once UnusedMember.Global
+	public int DerivedProperty { get; set; }
+
+#pragma warning disable CS0649 // Field is never assigned to
+	// ReSharper disable once UnusedMember.Global
+	public int DerivedField;
+#pragma warning restore CS0649
+
+#pragma warning disable CS0067 // Event is never used
+	// ReSharper disable once UnusedMember.Global
+	public event EventHandler? DerivedEvent;
+#pragma warning restore CS0067
+
+#pragma warning disable CA1822 // Mark members as static
+	// ReSharper disable once UnusedMember.Global
+	public void DerivedMethod() { }
+#pragma warning restore CA1822
+}

--- a/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/BaseClassWithMembers.cs
+++ b/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/BaseClassWithMembers.cs
@@ -19,6 +19,24 @@ public class BaseClassWithMembers
 	// ReSharper disable once UnusedMember.Global
 	public void BaseMethod() { }
 #pragma warning restore CA1822
+
+	// ReSharper disable once UnusedMember.Local
+	private int BasePrivateProperty { get; set; }
+
+#pragma warning disable CS0169 // Field is never used
+	// ReSharper disable once UnusedMember.Local
+	private int _basePrivateField;
+#pragma warning restore CS0169
+
+#pragma warning disable CS0067 // Event is never used
+	// ReSharper disable once UnusedMember.Local
+	private event EventHandler? BasePrivateEvent;
+#pragma warning restore CS0067
+
+#pragma warning disable CA1822 // Mark members as static
+	// ReSharper disable once UnusedMember.Local
+	private void BasePrivateMethod() { }
+#pragma warning restore CA1822
 }
 
 public class DerivedClassWithMembers : BaseClassWithMembers


### PR DESCRIPTION
Add an optional `MemberScope` parameter to the `Properties()`, `Methods()`, `Fields()` and `Events()` member-navigation methods, allowing inherited members to be included.

The library already returned only declared members (`BindingFlags.DeclaredOnly`), so the parameter defaults to `MemberScope.DeclaredOnly` to preserve behavior; `MemberScope.IncludingInherited` is the new opt-in (mapped to `BindingFlags.FlattenHierarchy`).

---

- *Fixes #281*