### PR TITLE
feat: add `In` entry points for externally-built member sequences

### DIFF
--- a/Source/aweXpect.Reflection/Collections/Filtered.Constructors.cs
+++ b/Source/aweXpect.Reflection/Collections/Filtered.Constructors.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using aweXpect.Core;
@@ -24,6 +25,15 @@ public static partial class Filtered
 			type.GetDeclaredConstructors()))
 		{
 			_types = types;
+			_description = description;
+		}
+
+		/// <summary>
+		///     Container for a filterable collection of the given <paramref name="constructors" />.
+		/// </summary>
+		internal Constructors(IEnumerable<ConstructorInfo> constructors, string description)
+			: base(constructors.WhereNotNull())
+		{
 			_description = description;
 		}
 

--- a/Source/aweXpect.Reflection/Collections/Filtered.Events.cs
+++ b/Source/aweXpect.Reflection/Collections/Filtered.Events.cs
@@ -32,6 +32,15 @@ public static partial class Filtered
 		}
 
 		/// <summary>
+		///     Container for a filterable collection of the given <paramref name="events" />.
+		/// </summary>
+		internal Events(IEnumerable<EventInfo> events, string description)
+			: base(events.WhereNotNull())
+		{
+			_description = description;
+		}
+
+		/// <summary>
 		///     Container for a filterable collection of <see cref="EventInfo" />.
 		/// </summary>
 		protected Events(Events inner) : base(inner, inner.Filters)

--- a/Source/aweXpect.Reflection/Collections/Filtered.Fields.cs
+++ b/Source/aweXpect.Reflection/Collections/Filtered.Fields.cs
@@ -32,6 +32,15 @@ public static partial class Filtered
 		}
 
 		/// <summary>
+		///     Container for a filterable collection of the given <paramref name="fields" />.
+		/// </summary>
+		internal Fields(IEnumerable<FieldInfo> fields, string description)
+			: base(fields.WhereNotNull())
+		{
+			_description = description;
+		}
+
+		/// <summary>
 		///     Container for a filterable collection of <see cref="FieldInfo" />.
 		/// </summary>
 		protected Fields(Fields inner) : base(inner, inner.Filters)

--- a/Source/aweXpect.Reflection/Collections/Filtered.Methods.cs
+++ b/Source/aweXpect.Reflection/Collections/Filtered.Methods.cs
@@ -32,6 +32,15 @@ public static partial class Filtered
 		}
 
 		/// <summary>
+		///     Container for a filterable collection of the given <paramref name="methods" />.
+		/// </summary>
+		internal Methods(IEnumerable<MethodInfo> methods, string description)
+			: base(methods.WhereNotNull())
+		{
+			_description = description;
+		}
+
+		/// <summary>
 		///     Container for a filterable collection of <see cref="MethodInfo" />.
 		/// </summary>
 		protected Methods(Methods inner) : base(inner, inner.Filters)

--- a/Source/aweXpect.Reflection/Collections/Filtered.Properties.cs
+++ b/Source/aweXpect.Reflection/Collections/Filtered.Properties.cs
@@ -32,6 +32,15 @@ public static partial class Filtered
 		}
 
 		/// <summary>
+		///     Container for a filterable collection of the given <paramref name="properties" />.
+		/// </summary>
+		internal Properties(IEnumerable<PropertyInfo> properties, string description)
+			: base(properties.WhereNotNull())
+		{
+			_description = description;
+		}
+
+		/// <summary>
 		///     Container for a filterable collection of <see cref="PropertyInfo" />.
 		/// </summary>
 		protected Properties(Properties inner) : base(inner, inner.Filters)

--- a/Source/aweXpect.Reflection/In.cs
+++ b/Source/aweXpect.Reflection/In.cs
@@ -93,6 +93,36 @@ public static class In
 	/// <summary>
 	///     Defines expectations on the types <paramref name="types" />
 	/// </summary>
-	public static Filtered.Types Types(params Type[] types)
+	public static Filtered.Types Types(params IEnumerable<Type> types)
 		=> new(types, $"in types {Formatter.Format(types)}");
+
+	/// <summary>
+	///     Defines expectations on the given <paramref name="constructors" />.
+	/// </summary>
+	public static Filtered.Constructors Constructors(params IEnumerable<ConstructorInfo> constructors)
+		=> new(constructors, $"in the constructors {Formatter.Format(constructors)}");
+
+	/// <summary>
+	///     Defines expectations on the given <paramref name="events" />.
+	/// </summary>
+	public static Filtered.Events Events(params IEnumerable<EventInfo> events)
+		=> new(events, $"in the events {Formatter.Format(events)}");
+
+	/// <summary>
+	///     Defines expectations on the given <paramref name="fields" />.
+	/// </summary>
+	public static Filtered.Fields Fields(params IEnumerable<FieldInfo> fields)
+		=> new(fields, $"in the fields {Formatter.Format(fields)}");
+
+	/// <summary>
+	///     Defines expectations on the given <paramref name="methods" />.
+	/// </summary>
+	public static Filtered.Methods Methods(params IEnumerable<MethodInfo> methods)
+		=> new(methods, $"in the methods {Formatter.Format(methods)}");
+
+	/// <summary>
+	///     Defines expectations on the given <paramref name="properties" />.
+	/// </summary>
+	public static Filtered.Properties Properties(params IEnumerable<PropertyInfo> properties)
+		=> new(properties, $"in the properties {Formatter.Format(properties)}");
 }

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net10.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net10.0.txt
@@ -292,11 +292,16 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Collections.Filtered.Assemblies Assemblies(params System.Reflection.Assembly?[] assemblies) { }
         public static aweXpect.Reflection.Collections.Filtered.Assemblies AssemblyContaining(System.Type type) { }
         public static aweXpect.Reflection.Collections.Filtered.Assemblies AssemblyContaining<TType>() { }
+        public static aweXpect.Reflection.Collections.Filtered.Constructors Constructors(System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo> constructors) { }
         public static aweXpect.Reflection.Collections.Filtered.Assemblies EntryAssembly() { }
+        public static aweXpect.Reflection.Collections.Filtered.Events Events(System.Collections.Generic.IEnumerable<System.Reflection.EventInfo> events) { }
         public static aweXpect.Reflection.Collections.Filtered.Assemblies ExecutingAssembly() { }
+        public static aweXpect.Reflection.Collections.Filtered.Fields Fields(System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo> fields) { }
+        public static aweXpect.Reflection.Collections.Filtered.Methods Methods(System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo> methods) { }
+        public static aweXpect.Reflection.Collections.Filtered.Properties Properties(System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo> properties) { }
         public static aweXpect.Reflection.Collections.Filtered.Types Type(System.Type type) { }
         public static aweXpect.Reflection.Collections.Filtered.Types Type<TType>() { }
-        public static aweXpect.Reflection.Collections.Filtered.Types Types(params System.Type[] types) { }
+        public static aweXpect.Reflection.Collections.Filtered.Types Types(System.Collections.Generic.IEnumerable<System.Type> types) { }
         public static aweXpect.Reflection.Collections.Filtered.Types Types<TType1, TType2>() { }
         public static aweXpect.Reflection.Collections.Filtered.Types Types<TType1, TType2, TType3>() { }
     }

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net8.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net8.0.txt
@@ -292,11 +292,16 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Collections.Filtered.Assemblies Assemblies(params System.Reflection.Assembly?[] assemblies) { }
         public static aweXpect.Reflection.Collections.Filtered.Assemblies AssemblyContaining(System.Type type) { }
         public static aweXpect.Reflection.Collections.Filtered.Assemblies AssemblyContaining<TType>() { }
+        public static aweXpect.Reflection.Collections.Filtered.Constructors Constructors(System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo> constructors) { }
         public static aweXpect.Reflection.Collections.Filtered.Assemblies EntryAssembly() { }
+        public static aweXpect.Reflection.Collections.Filtered.Events Events(System.Collections.Generic.IEnumerable<System.Reflection.EventInfo> events) { }
         public static aweXpect.Reflection.Collections.Filtered.Assemblies ExecutingAssembly() { }
+        public static aweXpect.Reflection.Collections.Filtered.Fields Fields(System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo> fields) { }
+        public static aweXpect.Reflection.Collections.Filtered.Methods Methods(System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo> methods) { }
+        public static aweXpect.Reflection.Collections.Filtered.Properties Properties(System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo> properties) { }
         public static aweXpect.Reflection.Collections.Filtered.Types Type(System.Type type) { }
         public static aweXpect.Reflection.Collections.Filtered.Types Type<TType>() { }
-        public static aweXpect.Reflection.Collections.Filtered.Types Types(params System.Type[] types) { }
+        public static aweXpect.Reflection.Collections.Filtered.Types Types(System.Collections.Generic.IEnumerable<System.Type> types) { }
         public static aweXpect.Reflection.Collections.Filtered.Types Types<TType1, TType2>() { }
         public static aweXpect.Reflection.Collections.Filtered.Types Types<TType1, TType2, TType3>() { }
     }

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_netstandard2.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_netstandard2.0.txt
@@ -292,11 +292,16 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Collections.Filtered.Assemblies Assemblies(params System.Reflection.Assembly?[] assemblies) { }
         public static aweXpect.Reflection.Collections.Filtered.Assemblies AssemblyContaining(System.Type type) { }
         public static aweXpect.Reflection.Collections.Filtered.Assemblies AssemblyContaining<TType>() { }
+        public static aweXpect.Reflection.Collections.Filtered.Constructors Constructors(System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo> constructors) { }
         public static aweXpect.Reflection.Collections.Filtered.Assemblies EntryAssembly() { }
+        public static aweXpect.Reflection.Collections.Filtered.Events Events(System.Collections.Generic.IEnumerable<System.Reflection.EventInfo> events) { }
         public static aweXpect.Reflection.Collections.Filtered.Assemblies ExecutingAssembly() { }
+        public static aweXpect.Reflection.Collections.Filtered.Fields Fields(System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo> fields) { }
+        public static aweXpect.Reflection.Collections.Filtered.Methods Methods(System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo> methods) { }
+        public static aweXpect.Reflection.Collections.Filtered.Properties Properties(System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo> properties) { }
         public static aweXpect.Reflection.Collections.Filtered.Types Type(System.Type type) { }
         public static aweXpect.Reflection.Collections.Filtered.Types Type<TType>() { }
-        public static aweXpect.Reflection.Collections.Filtered.Types Types(params System.Type[] types) { }
+        public static aweXpect.Reflection.Collections.Filtered.Types Types(System.Collections.Generic.IEnumerable<System.Type> types) { }
         public static aweXpect.Reflection.Collections.Filtered.Types Types<TType1, TType2>() { }
         public static aweXpect.Reflection.Collections.Filtered.Types Types<TType1, TType2, TType3>() { }
     }

--- a/Tests/aweXpect.Reflection.Tests/InTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/InTests.cs
@@ -74,6 +74,17 @@ public sealed class InTests
 	}
 
 	[Fact]
+	public async Task Constructors_WithEnumerable_ShouldContainProvidedConstructors()
+	{
+		IEnumerable<ConstructorInfo> constructors = typeof(ClassWithMembers).GetConstructors();
+
+		Filtered.Constructors sut = In.Constructors(constructors);
+
+		await That(sut).IsEqualTo(constructors).InAnyOrder();
+		await That(sut.GetDescription()).IsEqualTo("in the constructors ").AsPrefix();
+	}
+
+	[Fact]
 	public async Task EntryAssembly_ShouldContainExpectedAssembly()
 	{
 		Assembly? expectedAssembly = Assembly.GetEntryAssembly();
@@ -87,6 +98,17 @@ public sealed class InTests
 		await That(sut).IsEmpty();
 #endif
 		await That(sut.GetDescription()).IsEqualTo("in entry assembly");
+	}
+
+	[Fact]
+	public async Task Events_WithEnumerable_ShouldContainProvidedEvents()
+	{
+		IEnumerable<EventInfo> events = typeof(BaseClassWithMembers).GetEvents();
+
+		Filtered.Events sut = In.Events(events);
+
+		await That(sut).IsEqualTo(events).InAnyOrder();
+		await That(sut.GetDescription()).IsEqualTo("in the events ").AsPrefix();
 	}
 
 	[Fact]
@@ -110,11 +132,52 @@ public sealed class InTests
 	}
 
 	[Fact]
+	public async Task Fields_WithSingleField_ShouldContainProvidedField()
+	{
+		FieldInfo field = typeof(ClassWithMembers).GetField(nameof(ClassWithMembers.Field))!;
+
+		Filtered.Fields sut = In.Fields(field);
+
+		await That(sut).HasSingle().Which.IsEqualTo(field);
+	}
+
+	[Fact]
 	public async Task Methods_ShouldExcludeCompilerGeneratedAccessors()
 	{
 		Filtered.Methods methods = In.Type<ClassWithMembers>().Methods();
 
 		await That(methods).All().Satisfy(method => !method.IsSpecialName).And.IsNotEmpty();
+	}
+
+	[Fact]
+	public async Task Methods_WithSingleMethod_ShouldContainProvidedMethod()
+	{
+		MethodInfo method = typeof(ClassWithMembers).GetMethod(nameof(ClassWithMembers.Method))!;
+
+		Filtered.Methods sut = In.Methods(method);
+
+		await That(sut).HasSingle().Which.IsEqualTo(method);
+	}
+
+	[Fact]
+	public async Task Properties_ShouldComposeWithFilter()
+	{
+		IEnumerable<PropertyInfo> properties = typeof(ClassWithMembers).GetProperties();
+
+		Filtered.Properties sut = In.Properties(properties).Which(property => property.CanWrite);
+
+		await That(sut).All().Satisfy(property => property.CanWrite).And.IsNotEmpty();
+	}
+
+	[Fact]
+	public async Task Properties_WithEnumerable_ShouldContainProvidedProperties()
+	{
+		IEnumerable<PropertyInfo> properties = typeof(ClassWithMembers).GetProperties();
+
+		Filtered.Properties sut = In.Properties(properties);
+
+		await That(sut).IsEqualTo(properties).InAnyOrder();
+		await That(sut.GetDescription()).IsEqualTo("in the properties ").AsPrefix();
 	}
 
 	[Fact]
@@ -146,6 +209,16 @@ public sealed class InTests
 		Filtered.Types sut = In.Assemblies(assembly).Types();
 
 		await That(sut).IsEqualTo([typeof(PublicClass), typeof(InternalClass),]).InAnyOrder();
+	}
+
+	[Fact]
+	public async Task Types_WithEnumerable_ShouldIncludeSpecifiedTypes()
+	{
+		IEnumerable<Type> types = [typeof(InTests), typeof(InternalClass),];
+
+		Filtered.Types sut = In.Types(types);
+
+		await That(sut).IsEqualTo([typeof(InTests), typeof(InternalClass),]).InAnyOrder();
 	}
 
 	[Fact]


### PR DESCRIPTION
Allow feeding pre-collected reflection objects into the fluent assertion API instead of only navigating down from `In.<assemblies/types>()`. Adds `In.Constructors`, `In.Events`, `In.Fields`, `In.Methods` and `In.Properties`, each accepting `params IEnumerable<T>`, backed by new sequence constructors on the corresponding `Filtered.*` collections.

Also widens `In.Types(params Type[])` to `In.Types(params IEnumerable<Type>)` for symmetry. This is source-compatible for typical callers but a binary- breaking change to the `In.Types` signature.

---

- *Fixes #280*