### PR TITLE
feat: add property getter/setter/init-setter filters and assertions

### DIFF
--- a/Source/aweXpect.Reflection/Filters/PropertyFilters.WhichHaveAGetter.cs
+++ b/Source/aweXpect.Reflection/Filters/PropertyFilters.WhichHaveAGetter.cs
@@ -1,0 +1,16 @@
+﻿using System.Reflection;
+using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Helpers;
+
+namespace aweXpect.Reflection;
+
+public static partial class PropertyFilters
+{
+	/// <summary>
+	///     Filters for properties that have a getter.
+	/// </summary>
+	public static Filtered.Properties WhichHaveAGetter(this Filtered.Properties @this)
+		=> @this.Which(Filter.Suffix<PropertyInfo>(
+			property => property.HasGetter(),
+			"with a getter "));
+}

--- a/Source/aweXpect.Reflection/Filters/PropertyFilters.WhichHaveASetter.cs
+++ b/Source/aweXpect.Reflection/Filters/PropertyFilters.WhichHaveASetter.cs
@@ -1,0 +1,16 @@
+﻿using System.Reflection;
+using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Helpers;
+
+namespace aweXpect.Reflection;
+
+public static partial class PropertyFilters
+{
+	/// <summary>
+	///     Filters for properties that have a (regular, non-init) setter.
+	/// </summary>
+	public static Filtered.Properties WhichHaveASetter(this Filtered.Properties @this)
+		=> @this.Which(Filter.Suffix<PropertyInfo>(
+			property => property.HasSetter(),
+			"with a setter "));
+}

--- a/Source/aweXpect.Reflection/Filters/PropertyFilters.WhichHaveAnInitSetter.cs
+++ b/Source/aweXpect.Reflection/Filters/PropertyFilters.WhichHaveAnInitSetter.cs
@@ -1,0 +1,16 @@
+﻿using System.Reflection;
+using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Helpers;
+
+namespace aweXpect.Reflection;
+
+public static partial class PropertyFilters
+{
+	/// <summary>
+	///     Filters for properties that have an init-only setter.
+	/// </summary>
+	public static Filtered.Properties WhichHaveAnInitSetter(this Filtered.Properties @this)
+		=> @this.Which(Filter.Suffix<PropertyInfo>(
+			property => property.HasInitSetter(),
+			"with an init setter "));
+}

--- a/Source/aweXpect.Reflection/Helpers/PropertyInfoHelpers.cs
+++ b/Source/aweXpect.Reflection/Helpers/PropertyInfoHelpers.cs
@@ -155,4 +155,27 @@ internal static class PropertyInfoHelpers
 	/// </summary>
 	public static bool IsWritable(this PropertyInfo? propertyInfo)
 		=> propertyInfo is { CanWrite: true, };
+
+	/// <summary>
+	///     Checks if the <paramref name="propertyInfo" /> has a getter.
+	/// </summary>
+	public static bool HasGetter(this PropertyInfo? propertyInfo)
+		=> propertyInfo?.GetMethod != null;
+
+	/// <summary>
+	///     Checks if the <paramref name="propertyInfo" /> has an init-only setter.
+	/// </summary>
+	/// <remarks>
+	///     A setter is init-only if its return parameter carries the
+	///     <c>System.Runtime.CompilerServices.IsExternalInit</c> required custom modifier.
+	/// </remarks>
+	public static bool HasInitSetter(this PropertyInfo? propertyInfo)
+		=> propertyInfo?.SetMethod?.ReturnParameter.GetRequiredCustomModifiers()
+			.Any(modifier => modifier.FullName == "System.Runtime.CompilerServices.IsExternalInit") == true;
+
+	/// <summary>
+	///     Checks if the <paramref name="propertyInfo" /> has a (regular, non-init) setter.
+	/// </summary>
+	public static bool HasSetter(this PropertyInfo? propertyInfo)
+		=> propertyInfo?.SetMethod != null && !propertyInfo.HasInitSetter();
 }

--- a/Source/aweXpect.Reflection/ThatProperties.HaveAGetter.cs
+++ b/Source/aweXpect.Reflection/ThatProperties.HaveAGetter.cs
@@ -1,0 +1,73 @@
+﻿using System.Collections.Generic;
+using System.Reflection;
+using System.Text;
+#if NET8_0_OR_GREATER
+using System.Threading;
+using System.Threading.Tasks;
+#endif
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Reflection.Helpers;
+using aweXpect.Results;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Reflection;
+
+public static partial class ThatProperties
+{
+	/// <summary>
+	///     Verifies that all items in the filtered collection of <see cref="PropertyInfo" /> have a getter.
+	/// </summary>
+	public static AndOrResult<IEnumerable<PropertyInfo?>, IThat<IEnumerable<PropertyInfo?>>> HaveAGetter(
+		this IThat<IEnumerable<PropertyInfo?>> subject)
+		=> new(subject.Get().ExpectationBuilder.AddConstraint<IEnumerable<PropertyInfo?>>((it, grammars)
+				=> new HaveAGetterConstraint(it, grammars)),
+			subject);
+
+#if NET8_0_OR_GREATER
+	/// <summary>
+	///     Verifies that all items in the filtered collection of <see cref="PropertyInfo" /> have a getter.
+	/// </summary>
+	public static AndOrResult<IAsyncEnumerable<PropertyInfo?>, IThat<IAsyncEnumerable<PropertyInfo?>>> HaveAGetter(
+		this IThat<IAsyncEnumerable<PropertyInfo?>> subject)
+		=> new(subject.Get().ExpectationBuilder.AddConstraint<IAsyncEnumerable<PropertyInfo?>>((it, grammars)
+				=> new HaveAGetterConstraint(it, grammars)),
+			subject);
+#endif
+
+	private sealed class HaveAGetterConstraint(string it, ExpectationGrammars grammars)
+		: CollectionConstraintResult<PropertyInfo?>(grammars),
+			IValueConstraint<IEnumerable<PropertyInfo?>>
+#if NET8_0_OR_GREATER
+			, IAsyncConstraint<IAsyncEnumerable<PropertyInfo?>>
+#endif
+	{
+#if NET8_0_OR_GREATER
+		public async Task<ConstraintResult> IsMetBy(IAsyncEnumerable<PropertyInfo?> actual,
+			CancellationToken cancellationToken)
+			=> await SetAsyncValue(actual, property => property.HasGetter());
+#endif
+
+		public ConstraintResult IsMetBy(IEnumerable<PropertyInfo?> actual)
+			=> SetValue(actual, property => property.HasGetter());
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("all have a getter");
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(it).Append(" contained properties without a getter ");
+			Formatter.Format(stringBuilder, NotMatching, FormattingOptions.Indented(indentation));
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("not all have a getter");
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(it).Append(" only contained properties with a getter ");
+			Formatter.Format(stringBuilder, Matching, FormattingOptions.Indented(indentation));
+		}
+	}
+}

--- a/Source/aweXpect.Reflection/ThatProperties.HaveASetter.cs
+++ b/Source/aweXpect.Reflection/ThatProperties.HaveASetter.cs
@@ -1,0 +1,75 @@
+﻿using System.Collections.Generic;
+using System.Reflection;
+using System.Text;
+#if NET8_0_OR_GREATER
+using System.Threading;
+using System.Threading.Tasks;
+#endif
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Reflection.Helpers;
+using aweXpect.Results;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Reflection;
+
+public static partial class ThatProperties
+{
+	/// <summary>
+	///     Verifies that all items in the filtered collection of <see cref="PropertyInfo" /> have a
+	///     (regular, non-init) setter.
+	/// </summary>
+	public static AndOrResult<IEnumerable<PropertyInfo?>, IThat<IEnumerable<PropertyInfo?>>> HaveASetter(
+		this IThat<IEnumerable<PropertyInfo?>> subject)
+		=> new(subject.Get().ExpectationBuilder.AddConstraint<IEnumerable<PropertyInfo?>>((it, grammars)
+				=> new HaveASetterConstraint(it, grammars)),
+			subject);
+
+#if NET8_0_OR_GREATER
+	/// <summary>
+	///     Verifies that all items in the filtered collection of <see cref="PropertyInfo" /> have a
+	///     (regular, non-init) setter.
+	/// </summary>
+	public static AndOrResult<IAsyncEnumerable<PropertyInfo?>, IThat<IAsyncEnumerable<PropertyInfo?>>> HaveASetter(
+		this IThat<IAsyncEnumerable<PropertyInfo?>> subject)
+		=> new(subject.Get().ExpectationBuilder.AddConstraint<IAsyncEnumerable<PropertyInfo?>>((it, grammars)
+				=> new HaveASetterConstraint(it, grammars)),
+			subject);
+#endif
+
+	private sealed class HaveASetterConstraint(string it, ExpectationGrammars grammars)
+		: CollectionConstraintResult<PropertyInfo?>(grammars),
+			IValueConstraint<IEnumerable<PropertyInfo?>>
+#if NET8_0_OR_GREATER
+			, IAsyncConstraint<IAsyncEnumerable<PropertyInfo?>>
+#endif
+	{
+#if NET8_0_OR_GREATER
+		public async Task<ConstraintResult> IsMetBy(IAsyncEnumerable<PropertyInfo?> actual,
+			CancellationToken cancellationToken)
+			=> await SetAsyncValue(actual, property => property.HasSetter());
+#endif
+
+		public ConstraintResult IsMetBy(IEnumerable<PropertyInfo?> actual)
+			=> SetValue(actual, property => property.HasSetter());
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("all have a setter");
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(it).Append(" contained properties without a setter ");
+			Formatter.Format(stringBuilder, NotMatching, FormattingOptions.Indented(indentation));
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("not all have a setter");
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(it).Append(" only contained properties with a setter ");
+			Formatter.Format(stringBuilder, Matching, FormattingOptions.Indented(indentation));
+		}
+	}
+}

--- a/Source/aweXpect.Reflection/ThatProperties.HaveAnInitSetter.cs
+++ b/Source/aweXpect.Reflection/ThatProperties.HaveAnInitSetter.cs
@@ -1,0 +1,73 @@
+﻿using System.Collections.Generic;
+using System.Reflection;
+using System.Text;
+#if NET8_0_OR_GREATER
+using System.Threading;
+using System.Threading.Tasks;
+#endif
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Reflection.Helpers;
+using aweXpect.Results;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Reflection;
+
+public static partial class ThatProperties
+{
+	/// <summary>
+	///     Verifies that all items in the filtered collection of <see cref="PropertyInfo" /> have an init-only setter.
+	/// </summary>
+	public static AndOrResult<IEnumerable<PropertyInfo?>, IThat<IEnumerable<PropertyInfo?>>> HaveAnInitSetter(
+		this IThat<IEnumerable<PropertyInfo?>> subject)
+		=> new(subject.Get().ExpectationBuilder.AddConstraint<IEnumerable<PropertyInfo?>>((it, grammars)
+				=> new HaveAnInitSetterConstraint(it, grammars)),
+			subject);
+
+#if NET8_0_OR_GREATER
+	/// <summary>
+	///     Verifies that all items in the filtered collection of <see cref="PropertyInfo" /> have an init-only setter.
+	/// </summary>
+	public static AndOrResult<IAsyncEnumerable<PropertyInfo?>, IThat<IAsyncEnumerable<PropertyInfo?>>> HaveAnInitSetter(
+		this IThat<IAsyncEnumerable<PropertyInfo?>> subject)
+		=> new(subject.Get().ExpectationBuilder.AddConstraint<IAsyncEnumerable<PropertyInfo?>>((it, grammars)
+				=> new HaveAnInitSetterConstraint(it, grammars)),
+			subject);
+#endif
+
+	private sealed class HaveAnInitSetterConstraint(string it, ExpectationGrammars grammars)
+		: CollectionConstraintResult<PropertyInfo?>(grammars),
+			IValueConstraint<IEnumerable<PropertyInfo?>>
+#if NET8_0_OR_GREATER
+			, IAsyncConstraint<IAsyncEnumerable<PropertyInfo?>>
+#endif
+	{
+#if NET8_0_OR_GREATER
+		public async Task<ConstraintResult> IsMetBy(IAsyncEnumerable<PropertyInfo?> actual,
+			CancellationToken cancellationToken)
+			=> await SetAsyncValue(actual, property => property.HasInitSetter());
+#endif
+
+		public ConstraintResult IsMetBy(IEnumerable<PropertyInfo?> actual)
+			=> SetValue(actual, property => property.HasInitSetter());
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("all have an init setter");
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(it).Append(" contained properties without an init setter ");
+			Formatter.Format(stringBuilder, NotMatching, FormattingOptions.Indented(indentation));
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("not all have an init setter");
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(it).Append(" only contained properties with an init setter ");
+			Formatter.Format(stringBuilder, Matching, FormattingOptions.Indented(indentation));
+		}
+	}
+}

--- a/Source/aweXpect.Reflection/ThatProperty.HasAGetter.cs
+++ b/Source/aweXpect.Reflection/ThatProperty.HasAGetter.cs
@@ -1,0 +1,50 @@
+﻿using System.Reflection;
+using System.Text;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Reflection.Helpers;
+using aweXpect.Results;
+
+namespace aweXpect.Reflection;
+
+public static partial class ThatProperty
+{
+	/// <summary>
+	///     Verifies that the <see cref="PropertyInfo" /> has a getter.
+	/// </summary>
+	public static AndOrResult<PropertyInfo?, IThat<PropertyInfo?>> HasAGetter(
+		this IThat<PropertyInfo?> subject)
+		=> new(subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new HasAGetterConstraint(it, grammars)),
+			subject);
+
+	private sealed class HasAGetterConstraint(string it, ExpectationGrammars grammars)
+		: ConstraintResult.WithNotNullValue<PropertyInfo?>(it, grammars),
+			IValueConstraint<PropertyInfo?>
+	{
+		public ConstraintResult IsMetBy(PropertyInfo? actual)
+		{
+			Actual = actual;
+			Outcome = actual.HasGetter() ? Outcome.Success : Outcome.Failure;
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("has a getter");
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(It).Append(" did not have a getter ");
+			Formatter.Format(stringBuilder, Actual);
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("does not have a getter");
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(It).Append(" had a getter ");
+			Formatter.Format(stringBuilder, Actual);
+		}
+	}
+}

--- a/Source/aweXpect.Reflection/ThatProperty.HasASetter.cs
+++ b/Source/aweXpect.Reflection/ThatProperty.HasASetter.cs
@@ -1,0 +1,50 @@
+﻿using System.Reflection;
+using System.Text;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Reflection.Helpers;
+using aweXpect.Results;
+
+namespace aweXpect.Reflection;
+
+public static partial class ThatProperty
+{
+	/// <summary>
+	///     Verifies that the <see cref="PropertyInfo" /> has a (regular, non-init) setter.
+	/// </summary>
+	public static AndOrResult<PropertyInfo?, IThat<PropertyInfo?>> HasASetter(
+		this IThat<PropertyInfo?> subject)
+		=> new(subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new HasASetterConstraint(it, grammars)),
+			subject);
+
+	private sealed class HasASetterConstraint(string it, ExpectationGrammars grammars)
+		: ConstraintResult.WithNotNullValue<PropertyInfo?>(it, grammars),
+			IValueConstraint<PropertyInfo?>
+	{
+		public ConstraintResult IsMetBy(PropertyInfo? actual)
+		{
+			Actual = actual;
+			Outcome = actual.HasSetter() ? Outcome.Success : Outcome.Failure;
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("has a setter");
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(It).Append(" did not have a setter ");
+			Formatter.Format(stringBuilder, Actual);
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("does not have a setter");
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(It).Append(" had a setter ");
+			Formatter.Format(stringBuilder, Actual);
+		}
+	}
+}

--- a/Source/aweXpect.Reflection/ThatProperty.HasAnInitSetter.cs
+++ b/Source/aweXpect.Reflection/ThatProperty.HasAnInitSetter.cs
@@ -1,0 +1,50 @@
+﻿using System.Reflection;
+using System.Text;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Reflection.Helpers;
+using aweXpect.Results;
+
+namespace aweXpect.Reflection;
+
+public static partial class ThatProperty
+{
+	/// <summary>
+	///     Verifies that the <see cref="PropertyInfo" /> has an init-only setter.
+	/// </summary>
+	public static AndOrResult<PropertyInfo?, IThat<PropertyInfo?>> HasAnInitSetter(
+		this IThat<PropertyInfo?> subject)
+		=> new(subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new HasAnInitSetterConstraint(it, grammars)),
+			subject);
+
+	private sealed class HasAnInitSetterConstraint(string it, ExpectationGrammars grammars)
+		: ConstraintResult.WithNotNullValue<PropertyInfo?>(it, grammars),
+			IValueConstraint<PropertyInfo?>
+	{
+		public ConstraintResult IsMetBy(PropertyInfo? actual)
+		{
+			Actual = actual;
+			Outcome = actual.HasInitSetter() ? Outcome.Success : Outcome.Failure;
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("has an init setter");
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(It).Append(" did not have an init setter ");
+			Formatter.Format(stringBuilder, Actual);
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("does not have an init setter");
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(It).Append(" had an init setter ");
+			Formatter.Format(stringBuilder, Actual);
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net10.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net10.0.txt
@@ -510,6 +510,9 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Collections.Filtered.Properties WhichAreStatic(this aweXpect.Reflection.Collections.Filtered.Properties @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Properties WhichAreWritable(this aweXpect.Reflection.Collections.Filtered.Properties @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Properties WhichAreWriteOnly(this aweXpect.Reflection.Collections.Filtered.Properties @this) { }
+        public static aweXpect.Reflection.Collections.Filtered.Properties WhichHaveAGetter(this aweXpect.Reflection.Collections.Filtered.Properties @this) { }
+        public static aweXpect.Reflection.Collections.Filtered.Properties WhichHaveASetter(this aweXpect.Reflection.Collections.Filtered.Properties @this) { }
+        public static aweXpect.Reflection.Collections.Filtered.Properties WhichHaveAnInitSetter(this aweXpect.Reflection.Collections.Filtered.Properties @this) { }
         public static aweXpect.Reflection.PropertyFilters.PropertiesWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Properties @this, bool inherit = true)
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.PropertyFilters.PropertiesWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Properties @this, System.Func<TAttribute, bool>? predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
@@ -1330,6 +1333,12 @@ namespace aweXpect.Reflection
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Results.HaveAttributeResult<System.Reflection.PropertyInfo?, System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>> subject, System.Func<TAttribute, bool> predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
             where TAttribute : System.Attribute { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.PropertyInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.PropertyInfo?>>> HaveAGetter(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.PropertyInfo?>> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>>> HaveAGetter(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.PropertyInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.PropertyInfo?>>> HaveASetter(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.PropertyInfo?>> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>>> HaveASetter(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.PropertyInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.PropertyInfo?>>> HaveAnInitSetter(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.PropertyInfo?>> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>>> HaveAnInitSetter(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>> subject) { }
         public sealed class PropertiesOfTypeResult<TValue, TResult> : aweXpect.Results.AndOrResult<TValue, TResult>, aweXpect.Core.IOptionsProvider<aweXpect.Reflection.Options.TypeFilterOptions>
             where TResult : aweXpect.Core.IThat<TValue>
         {
@@ -1348,6 +1357,9 @@ namespace aweXpect.Reflection
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Results.HasAttributeResult<System.Reflection.PropertyInfo?> Has<TAttribute>(this aweXpect.Core.IThat<System.Reflection.PropertyInfo?> subject, System.Func<TAttribute, bool> predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
             where TAttribute : System.Attribute { }
+        public static aweXpect.Results.AndOrResult<System.Reflection.PropertyInfo?, aweXpect.Core.IThat<System.Reflection.PropertyInfo?>> HasAGetter(this aweXpect.Core.IThat<System.Reflection.PropertyInfo?> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Reflection.PropertyInfo?, aweXpect.Core.IThat<System.Reflection.PropertyInfo?>> HasASetter(this aweXpect.Core.IThat<System.Reflection.PropertyInfo?> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Reflection.PropertyInfo?, aweXpect.Core.IThat<System.Reflection.PropertyInfo?>> HasAnInitSetter(this aweXpect.Core.IThat<System.Reflection.PropertyInfo?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Reflection.PropertyInfo?, aweXpect.Core.IThat<System.Reflection.PropertyInfo?>> IsAbstract(this aweXpect.Core.IThat<System.Reflection.PropertyInfo?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Reflection.PropertyInfo?, aweXpect.Core.IThat<System.Reflection.PropertyInfo?>> IsNotAbstract(this aweXpect.Core.IThat<System.Reflection.PropertyInfo?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Reflection.PropertyInfo?, aweXpect.Core.IThat<System.Reflection.PropertyInfo?>> IsNotSealed(this aweXpect.Core.IThat<System.Reflection.PropertyInfo?> subject) { }

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net8.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net8.0.txt
@@ -510,6 +510,9 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Collections.Filtered.Properties WhichAreStatic(this aweXpect.Reflection.Collections.Filtered.Properties @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Properties WhichAreWritable(this aweXpect.Reflection.Collections.Filtered.Properties @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Properties WhichAreWriteOnly(this aweXpect.Reflection.Collections.Filtered.Properties @this) { }
+        public static aweXpect.Reflection.Collections.Filtered.Properties WhichHaveAGetter(this aweXpect.Reflection.Collections.Filtered.Properties @this) { }
+        public static aweXpect.Reflection.Collections.Filtered.Properties WhichHaveASetter(this aweXpect.Reflection.Collections.Filtered.Properties @this) { }
+        public static aweXpect.Reflection.Collections.Filtered.Properties WhichHaveAnInitSetter(this aweXpect.Reflection.Collections.Filtered.Properties @this) { }
         public static aweXpect.Reflection.PropertyFilters.PropertiesWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Properties @this, bool inherit = true)
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.PropertyFilters.PropertiesWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Properties @this, System.Func<TAttribute, bool>? predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
@@ -1330,6 +1333,12 @@ namespace aweXpect.Reflection
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Results.HaveAttributeResult<System.Reflection.PropertyInfo?, System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>> subject, System.Func<TAttribute, bool> predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
             where TAttribute : System.Attribute { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.PropertyInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.PropertyInfo?>>> HaveAGetter(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.PropertyInfo?>> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>>> HaveAGetter(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.PropertyInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.PropertyInfo?>>> HaveASetter(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.PropertyInfo?>> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>>> HaveASetter(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.PropertyInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.PropertyInfo?>>> HaveAnInitSetter(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.PropertyInfo?>> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>>> HaveAnInitSetter(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>> subject) { }
         public sealed class PropertiesOfTypeResult<TValue, TResult> : aweXpect.Results.AndOrResult<TValue, TResult>, aweXpect.Core.IOptionsProvider<aweXpect.Reflection.Options.TypeFilterOptions>
             where TResult : aweXpect.Core.IThat<TValue>
         {
@@ -1348,6 +1357,9 @@ namespace aweXpect.Reflection
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Results.HasAttributeResult<System.Reflection.PropertyInfo?> Has<TAttribute>(this aweXpect.Core.IThat<System.Reflection.PropertyInfo?> subject, System.Func<TAttribute, bool> predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
             where TAttribute : System.Attribute { }
+        public static aweXpect.Results.AndOrResult<System.Reflection.PropertyInfo?, aweXpect.Core.IThat<System.Reflection.PropertyInfo?>> HasAGetter(this aweXpect.Core.IThat<System.Reflection.PropertyInfo?> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Reflection.PropertyInfo?, aweXpect.Core.IThat<System.Reflection.PropertyInfo?>> HasASetter(this aweXpect.Core.IThat<System.Reflection.PropertyInfo?> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Reflection.PropertyInfo?, aweXpect.Core.IThat<System.Reflection.PropertyInfo?>> HasAnInitSetter(this aweXpect.Core.IThat<System.Reflection.PropertyInfo?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Reflection.PropertyInfo?, aweXpect.Core.IThat<System.Reflection.PropertyInfo?>> IsAbstract(this aweXpect.Core.IThat<System.Reflection.PropertyInfo?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Reflection.PropertyInfo?, aweXpect.Core.IThat<System.Reflection.PropertyInfo?>> IsNotAbstract(this aweXpect.Core.IThat<System.Reflection.PropertyInfo?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Reflection.PropertyInfo?, aweXpect.Core.IThat<System.Reflection.PropertyInfo?>> IsNotSealed(this aweXpect.Core.IThat<System.Reflection.PropertyInfo?> subject) { }

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_netstandard2.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_netstandard2.0.txt
@@ -510,6 +510,9 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Collections.Filtered.Properties WhichAreStatic(this aweXpect.Reflection.Collections.Filtered.Properties @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Properties WhichAreWritable(this aweXpect.Reflection.Collections.Filtered.Properties @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Properties WhichAreWriteOnly(this aweXpect.Reflection.Collections.Filtered.Properties @this) { }
+        public static aweXpect.Reflection.Collections.Filtered.Properties WhichHaveAGetter(this aweXpect.Reflection.Collections.Filtered.Properties @this) { }
+        public static aweXpect.Reflection.Collections.Filtered.Properties WhichHaveASetter(this aweXpect.Reflection.Collections.Filtered.Properties @this) { }
+        public static aweXpect.Reflection.Collections.Filtered.Properties WhichHaveAnInitSetter(this aweXpect.Reflection.Collections.Filtered.Properties @this) { }
         public static aweXpect.Reflection.PropertyFilters.PropertiesWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Properties @this, bool inherit = true)
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.PropertyFilters.PropertiesWith With<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Properties @this, System.Func<TAttribute, bool>? predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
@@ -1093,6 +1096,9 @@ namespace aweXpect.Reflection
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Results.HaveAttributeResult<System.Reflection.PropertyInfo?, System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>> subject, System.Func<TAttribute, bool> predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
             where TAttribute : System.Attribute { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>>> HaveAGetter(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>>> HaveASetter(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>>> HaveAnInitSetter(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo?>> subject) { }
         public sealed class PropertiesOfTypeResult<TValue, TResult> : aweXpect.Results.AndOrResult<TValue, TResult>, aweXpect.Core.IOptionsProvider<aweXpect.Reflection.Options.TypeFilterOptions>
             where TResult : aweXpect.Core.IThat<TValue>
         {
@@ -1111,6 +1117,9 @@ namespace aweXpect.Reflection
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Results.HasAttributeResult<System.Reflection.PropertyInfo?> Has<TAttribute>(this aweXpect.Core.IThat<System.Reflection.PropertyInfo?> subject, System.Func<TAttribute, bool> predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
             where TAttribute : System.Attribute { }
+        public static aweXpect.Results.AndOrResult<System.Reflection.PropertyInfo?, aweXpect.Core.IThat<System.Reflection.PropertyInfo?>> HasAGetter(this aweXpect.Core.IThat<System.Reflection.PropertyInfo?> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Reflection.PropertyInfo?, aweXpect.Core.IThat<System.Reflection.PropertyInfo?>> HasASetter(this aweXpect.Core.IThat<System.Reflection.PropertyInfo?> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Reflection.PropertyInfo?, aweXpect.Core.IThat<System.Reflection.PropertyInfo?>> HasAnInitSetter(this aweXpect.Core.IThat<System.Reflection.PropertyInfo?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Reflection.PropertyInfo?, aweXpect.Core.IThat<System.Reflection.PropertyInfo?>> IsAbstract(this aweXpect.Core.IThat<System.Reflection.PropertyInfo?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Reflection.PropertyInfo?, aweXpect.Core.IThat<System.Reflection.PropertyInfo?>> IsNotAbstract(this aweXpect.Core.IThat<System.Reflection.PropertyInfo?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Reflection.PropertyInfo?, aweXpect.Core.IThat<System.Reflection.PropertyInfo?>> IsNotSealed(this aweXpect.Core.IThat<System.Reflection.PropertyInfo?> subject) { }

--- a/Tests/aweXpect.Reflection.Tests/Filters/PropertyFilters.WhichHaveAGetter.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/PropertyFilters.WhichHaveAGetter.Tests.cs
@@ -1,0 +1,32 @@
+﻿using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Tests.TestHelpers.Types;
+
+namespace aweXpect.Reflection.Tests.Filters;
+
+public sealed partial class PropertyFilters
+{
+	public sealed class WhichHaveAGetter
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task ShouldAllowFilteringForPropertiesWithAGetter()
+			{
+				Filtered.Properties properties = In.Type<TestClassWithPropertyAccessors>()
+					.Properties().WhichHaveAGetter();
+
+				await That(properties).HaveAGetter().And.IsNotEmpty();
+			}
+
+			[Fact]
+			public async Task ShouldUpdateTheDescription()
+			{
+				Filtered.Properties properties = In.AssemblyContaining<TestClassWithPropertyAccessors>()
+					.Properties().WhichHaveAGetter();
+
+				await That(properties.GetDescription())
+					.IsEqualTo("properties with a getter in assembly").AsPrefix();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/Filters/PropertyFilters.WhichHaveASetter.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/PropertyFilters.WhichHaveASetter.Tests.cs
@@ -1,0 +1,32 @@
+﻿using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Tests.TestHelpers.Types;
+
+namespace aweXpect.Reflection.Tests.Filters;
+
+public sealed partial class PropertyFilters
+{
+	public sealed class WhichHaveASetter
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task ShouldAllowFilteringForPropertiesWithASetter()
+			{
+				Filtered.Properties properties = In.Type<TestClassWithPropertyAccessors>()
+					.Properties().WhichHaveASetter();
+
+				await That(properties).HaveASetter().And.IsNotEmpty();
+			}
+
+			[Fact]
+			public async Task ShouldUpdateTheDescription()
+			{
+				Filtered.Properties properties = In.AssemblyContaining<TestClassWithPropertyAccessors>()
+					.Properties().WhichHaveASetter();
+
+				await That(properties.GetDescription())
+					.IsEqualTo("properties with a setter in assembly").AsPrefix();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/Filters/PropertyFilters.WhichHaveAnInitSetter.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/PropertyFilters.WhichHaveAnInitSetter.Tests.cs
@@ -1,0 +1,32 @@
+﻿using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Tests.TestHelpers.Types;
+
+namespace aweXpect.Reflection.Tests.Filters;
+
+public sealed partial class PropertyFilters
+{
+	public sealed class WhichHaveAnInitSetter
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task ShouldAllowFilteringForPropertiesWithAnInitSetter()
+			{
+				Filtered.Properties properties = In.Type<TestClassWithPropertyAccessors>()
+					.Properties().WhichHaveAnInitSetter();
+
+				await That(properties).HaveAnInitSetter().And.IsNotEmpty();
+			}
+
+			[Fact]
+			public async Task ShouldUpdateTheDescription()
+			{
+				Filtered.Properties properties = In.AssemblyContaining<TestClassWithPropertyAccessors>()
+					.Properties().WhichHaveAnInitSetter();
+
+				await That(properties.GetDescription())
+					.IsEqualTo("properties with an init setter in assembly").AsPrefix();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/TestHelpers/IsExternalInit.cs
+++ b/Tests/aweXpect.Reflection.Tests/TestHelpers/IsExternalInit.cs
@@ -1,0 +1,10 @@
+﻿#if NETFRAMEWORK
+// ReSharper disable once CheckNamespace
+namespace System.Runtime.CompilerServices
+{
+	/// <summary>
+	///     Polyfill required so that <c>init</c>-only setters can be compiled for .NET Framework targets.
+	/// </summary>
+	internal static class IsExternalInit;
+}
+#endif

--- a/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/TestClassWithPropertyAccessors.cs
+++ b/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/TestClassWithPropertyAccessors.cs
@@ -1,0 +1,23 @@
+﻿namespace aweXpect.Reflection.Tests.TestHelpers.Types;
+
+public class TestClassWithPropertyAccessors
+{
+	private string _setterOnly = "";
+
+	// Getter only
+	public string WithGetterOnly { get; } = "";
+
+	// Getter and a regular setter
+	public string WithGetterAndSetter { get; set; } = "";
+
+	// Getter and an init-only setter
+	public string WithGetterAndInitSetter { get; init; } = "";
+
+	// Regular setter only (no getter)
+	public string WithSetterOnly
+	{
+		set => _setterOnly = value;
+	}
+
+	public string GetSetterOnly() => _setterOnly;
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatProperties.HaveAGetter.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatProperties.HaveAGetter.Tests.cs
@@ -1,0 +1,88 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using aweXpect.Reflection.Tests.TestHelpers.Types;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatProperties
+{
+	public sealed class HaveAGetter
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenAllPropertiesHaveAGetter_ShouldSucceed()
+			{
+				IEnumerable<PropertyInfo> subject = typeof(TestClassWithPropertyAccessors)
+					.GetProperties().Where(property => property.CanRead);
+
+				async Task Act()
+				{
+					await That(subject).HaveAGetter();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenPropertiesContainPropertiesWithoutAGetter_ShouldFail()
+			{
+				IEnumerable<PropertyInfo> subject = typeof(TestClassWithPropertyAccessors)
+					.GetProperties();
+
+				async Task Act()
+				{
+					await That(subject).HaveAGetter();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             all have a getter,
+					             but it contained properties without a getter [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+		}
+
+		public sealed class NegatedTests
+		{
+			[Fact]
+			public async Task WhenAllPropertiesHaveAGetter_ShouldFail()
+			{
+				IEnumerable<PropertyInfo> subject = typeof(TestClassWithPropertyAccessors)
+					.GetProperties().Where(property => property.CanRead);
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(they => they.HaveAGetter());
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             not all have a getter,
+					             but it only contained properties with a getter [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenPropertiesContainPropertiesWithoutAGetter_ShouldSucceed()
+			{
+				IEnumerable<PropertyInfo> subject = typeof(TestClassWithPropertyAccessors)
+					.GetProperties();
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(they => they.HaveAGetter());
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatProperties.HaveASetter.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatProperties.HaveASetter.Tests.cs
@@ -1,0 +1,97 @@
+﻿using System.Collections.Generic;
+using System.Reflection;
+using aweXpect.Reflection.Tests.TestHelpers.Types;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatProperties
+{
+	public sealed class HaveASetter
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenAllPropertiesHaveASetter_ShouldSucceed()
+			{
+				IEnumerable<PropertyInfo> subject =
+				[
+					typeof(TestClassWithPropertyAccessors)
+						.GetProperty(nameof(TestClassWithPropertyAccessors.WithGetterAndSetter))!,
+					typeof(TestClassWithPropertyAccessors)
+						.GetProperty(nameof(TestClassWithPropertyAccessors.WithSetterOnly))!,
+				];
+
+				async Task Act()
+				{
+					await That(subject).HaveASetter();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenPropertiesContainPropertiesWithoutASetter_ShouldFail()
+			{
+				IEnumerable<PropertyInfo> subject = typeof(TestClassWithPropertyAccessors)
+					.GetProperties();
+
+				async Task Act()
+				{
+					await That(subject).HaveASetter();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             all have a setter,
+					             but it contained properties without a setter [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+		}
+
+		public sealed class NegatedTests
+		{
+			[Fact]
+			public async Task WhenAllPropertiesHaveASetter_ShouldFail()
+			{
+				IEnumerable<PropertyInfo> subject =
+				[
+					typeof(TestClassWithPropertyAccessors)
+						.GetProperty(nameof(TestClassWithPropertyAccessors.WithGetterAndSetter))!,
+					typeof(TestClassWithPropertyAccessors)
+						.GetProperty(nameof(TestClassWithPropertyAccessors.WithSetterOnly))!,
+				];
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(they => they.HaveASetter());
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             not all have a setter,
+					             but it only contained properties with a setter [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenPropertiesContainPropertiesWithoutASetter_ShouldSucceed()
+			{
+				IEnumerable<PropertyInfo> subject = typeof(TestClassWithPropertyAccessors)
+					.GetProperties();
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(they => they.HaveASetter());
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatProperties.HaveAnInitSetter.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatProperties.HaveAnInitSetter.Tests.cs
@@ -1,0 +1,93 @@
+﻿using System.Collections.Generic;
+using System.Reflection;
+using aweXpect.Reflection.Tests.TestHelpers.Types;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatProperties
+{
+	public sealed class HaveAnInitSetter
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenAllPropertiesHaveAnInitSetter_ShouldSucceed()
+			{
+				IEnumerable<PropertyInfo> subject =
+				[
+					typeof(TestClassWithPropertyAccessors)
+						.GetProperty(nameof(TestClassWithPropertyAccessors.WithGetterAndInitSetter))!,
+				];
+
+				async Task Act()
+				{
+					await That(subject).HaveAnInitSetter();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenPropertiesContainPropertiesWithoutAnInitSetter_ShouldFail()
+			{
+				IEnumerable<PropertyInfo> subject = typeof(TestClassWithPropertyAccessors)
+					.GetProperties();
+
+				async Task Act()
+				{
+					await That(subject).HaveAnInitSetter();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             all have an init setter,
+					             but it contained properties without an init setter [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+		}
+
+		public sealed class NegatedTests
+		{
+			[Fact]
+			public async Task WhenAllPropertiesHaveAnInitSetter_ShouldFail()
+			{
+				IEnumerable<PropertyInfo> subject =
+				[
+					typeof(TestClassWithPropertyAccessors)
+						.GetProperty(nameof(TestClassWithPropertyAccessors.WithGetterAndInitSetter))!,
+				];
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(they => they.HaveAnInitSetter());
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             not all have an init setter,
+					             but it only contained properties with an init setter [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenPropertiesContainPropertiesWithoutAnInitSetter_ShouldSucceed()
+			{
+				IEnumerable<PropertyInfo> subject = typeof(TestClassWithPropertyAccessors)
+					.GetProperties();
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(they => they.HaveAnInitSetter());
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatProperty.HasAGetter.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatProperty.HasAGetter.Tests.cs
@@ -1,0 +1,100 @@
+﻿using System.Reflection;
+using aweXpect.Reflection.Tests.TestHelpers.Types;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatProperty
+{
+	public sealed class HasAGetter
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenPropertyHasAGetter_ShouldSucceed()
+			{
+				PropertyInfo subject = typeof(TestClassWithPropertyAccessors)
+					.GetProperty(nameof(TestClassWithPropertyAccessors.WithGetterOnly))!;
+
+				async Task Act()
+				{
+					await That(subject).HasAGetter();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenPropertyHasNoGetter_ShouldFail()
+			{
+				PropertyInfo subject = typeof(TestClassWithPropertyAccessors)
+					.GetProperty(nameof(TestClassWithPropertyAccessors.WithSetterOnly))!;
+
+				async Task Act()
+				{
+					await That(subject).HasAGetter();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage($"""
+					              Expected that subject
+					              has a getter,
+					              but it did not have a getter {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenPropertyIsNull_ShouldFail()
+			{
+				PropertyInfo? subject = null;
+
+				async Task Act()
+				{
+					await That(subject).HasAGetter();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             has a getter,
+					             but it was <null>
+					             """);
+			}
+		}
+
+		public sealed class NegatedTests
+		{
+			[Fact]
+			public async Task WhenPropertyHasAGetter_ShouldFail()
+			{
+				PropertyInfo subject = typeof(TestClassWithPropertyAccessors)
+					.GetProperty(nameof(TestClassWithPropertyAccessors.WithGetterOnly))!;
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(it => it.HasAGetter());
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage($"""
+					              Expected that subject
+					              does not have a getter,
+					              but it had a getter {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenPropertyHasNoGetter_ShouldSucceed()
+			{
+				PropertyInfo subject = typeof(TestClassWithPropertyAccessors)
+					.GetProperty(nameof(TestClassWithPropertyAccessors.WithSetterOnly))!;
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(it => it.HasAGetter());
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatProperty.HasASetter.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatProperty.HasASetter.Tests.cs
@@ -1,0 +1,100 @@
+﻿using System.Reflection;
+using aweXpect.Reflection.Tests.TestHelpers.Types;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatProperty
+{
+	public sealed class HasASetter
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenPropertyHasASetter_ShouldSucceed()
+			{
+				PropertyInfo subject = typeof(TestClassWithPropertyAccessors)
+					.GetProperty(nameof(TestClassWithPropertyAccessors.WithGetterAndSetter))!;
+
+				async Task Act()
+				{
+					await That(subject).HasASetter();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenPropertyHasOnlyAnInitSetter_ShouldFail()
+			{
+				PropertyInfo subject = typeof(TestClassWithPropertyAccessors)
+					.GetProperty(nameof(TestClassWithPropertyAccessors.WithGetterAndInitSetter))!;
+
+				async Task Act()
+				{
+					await That(subject).HasASetter();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage($"""
+					              Expected that subject
+					              has a setter,
+					              but it did not have a setter {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenPropertyIsNull_ShouldFail()
+			{
+				PropertyInfo? subject = null;
+
+				async Task Act()
+				{
+					await That(subject).HasASetter();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             has a setter,
+					             but it was <null>
+					             """);
+			}
+		}
+
+		public sealed class NegatedTests
+		{
+			[Fact]
+			public async Task WhenPropertyHasASetter_ShouldFail()
+			{
+				PropertyInfo subject = typeof(TestClassWithPropertyAccessors)
+					.GetProperty(nameof(TestClassWithPropertyAccessors.WithGetterAndSetter))!;
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(it => it.HasASetter());
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage($"""
+					              Expected that subject
+					              does not have a setter,
+					              but it had a setter {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenPropertyHasOnlyAnInitSetter_ShouldSucceed()
+			{
+				PropertyInfo subject = typeof(TestClassWithPropertyAccessors)
+					.GetProperty(nameof(TestClassWithPropertyAccessors.WithGetterAndInitSetter))!;
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(it => it.HasASetter());
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatProperty.HasAnInitSetter.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatProperty.HasAnInitSetter.Tests.cs
@@ -1,0 +1,100 @@
+﻿using System.Reflection;
+using aweXpect.Reflection.Tests.TestHelpers.Types;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatProperty
+{
+	public sealed class HasAnInitSetter
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenPropertyHasAnInitSetter_ShouldSucceed()
+			{
+				PropertyInfo subject = typeof(TestClassWithPropertyAccessors)
+					.GetProperty(nameof(TestClassWithPropertyAccessors.WithGetterAndInitSetter))!;
+
+				async Task Act()
+				{
+					await That(subject).HasAnInitSetter();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenPropertyHasARegularSetter_ShouldFail()
+			{
+				PropertyInfo subject = typeof(TestClassWithPropertyAccessors)
+					.GetProperty(nameof(TestClassWithPropertyAccessors.WithGetterAndSetter))!;
+
+				async Task Act()
+				{
+					await That(subject).HasAnInitSetter();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage($"""
+					              Expected that subject
+					              has an init setter,
+					              but it did not have an init setter {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenPropertyIsNull_ShouldFail()
+			{
+				PropertyInfo? subject = null;
+
+				async Task Act()
+				{
+					await That(subject).HasAnInitSetter();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             has an init setter,
+					             but it was <null>
+					             """);
+			}
+		}
+
+		public sealed class NegatedTests
+		{
+			[Fact]
+			public async Task WhenPropertyHasAnInitSetter_ShouldFail()
+			{
+				PropertyInfo subject = typeof(TestClassWithPropertyAccessors)
+					.GetProperty(nameof(TestClassWithPropertyAccessors.WithGetterAndInitSetter))!;
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(it => it.HasAnInitSetter());
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage($"""
+					              Expected that subject
+					              does not have an init setter,
+					              but it had an init setter {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenPropertyHasARegularSetter_ShouldSucceed()
+			{
+				PropertyInfo subject = typeof(TestClassWithPropertyAccessors)
+					.GetProperty(nameof(TestClassWithPropertyAccessors.WithGetterAndSetter))!;
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(it => it.HasAnInitSetter());
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}


### PR DESCRIPTION
Add filtering and assertion methods to distinguish property accessor kinds, notably init-only setters used for immutable records and DTOs:

- Filters: WhichHaveAGetter, WhichHaveASetter, WhichHaveAnInitSetter
- Single assertions: HasAGetter, HasASetter, HasAnInitSetter
- Many assertions: HaveAGetter, HaveASetter, HaveAnInitSetter

HasASetter matches only regular (non-init) setters, so it is mutually exclusive with HasAnInitSetter; this is what immutability convention tests need. Init detection inspects the IsExternalInit required custom modifier by full name so it works on netstandard2.0 (where the type is absent); test helpers get an IsExternalInit polyfill for the net48 test target.

---

- *Fixes #241*