### PR TITLE
refactor: mark static test helper methods as static

### DIFF
--- a/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.Without.AttributeTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.Without.AttributeTests.cs
@@ -47,7 +47,7 @@ public sealed partial class MethodFilters
 				{
 				}
 
-				public void PlainMethod()
+				public static void PlainMethod()
 				{
 				}
 			}

--- a/Tests/aweXpect.Reflection.Tests/ThatMethod.DoesNotHave.AttributeTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethod.DoesNotHave.AttributeTests.cs
@@ -48,11 +48,11 @@ public sealed partial class ThatMethod
 			private class TestClass
 			{
 				[Foo]
-				public void TestMethod()
+				public static void TestMethod()
 				{
 				}
 
-				public void NoAttributeMethod()
+				public static void NoAttributeMethod()
 				{
 				}
 			}

--- a/Tests/aweXpect.Reflection.Tests/ThatMethods.DoNotHave.AttributeTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethods.DoNotHave.AttributeTests.cs
@@ -106,11 +106,11 @@ public sealed partial class ThatMethods
 			private class TestClass
 			{
 				[Foo]
-				public void TestMethod()
+				public static void TestMethod()
 				{
 				}
 
-				public void NoAttributeMethod()
+				public static void NoAttributeMethod()
 				{
 				}
 			}


### PR DESCRIPTION
These dummy methods used in reflection-based attribute tests do not access instance data. Marking them static resolves the Sonar code smells. Verified the MethodFormatter does not render a `static` modifier, so asserted failure messages are unchanged, and GetMethods/GetMethod still resolve static members.