### PR TITLE
feat: add strong named assembly filter and assertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,6 +460,8 @@ on them directly:
 | by name                     | `.WithName("x")`                       | `.HasName("x")`                  | `.HaveName("x")`                  |
 | not by name                 | `.WithoutName("x")`                    | `.DoesNotHaveName("x")`          | `.DoNotHaveName("x")`             |
 | by target framework         | `.WhichTarget("net8.0")`               | `.Targets("net8.0")`             | `.Target("net8.0")`               |
+| strong named                | `.WhichAreStrongNamed()`               | `.IsStrongNamed()`               | `.AreStrongNamed()`               |
+| not strong named            | `.WhichAreNotStrongNamed()`            | `.IsNotStrongNamed()`            | `.AreNotStrongNamed()`            |
 | has attribute               | `.With<TAttribute>()`                  | `.Has<TAttribute>()`             | `.Have<TAttribute>()`             |
 | does not have attribute     | `.Without<TAttribute>()`               | `.DoesNotHave<TAttribute>()`     | `.DoNotHave<TAttribute>()`        |
 | depends on assembly         | `.WhichHaveADependencyOn("x")`         | `.HasADependencyOn("x")`         | `.HaveADependencyOn("x")`         |
@@ -482,6 +484,8 @@ await Expect.That(subject).Targets("net8.0");
 The target framework is matched against the short moniker form (e.g. `net8.0`, `netstandard2.0`, `net48`),
 derived from the assembly's `[TargetFramework]` attribute. Assemblies without that attribute are treated as
 having no target framework and never match.
+
+An assembly is considered strong named when its name carries a non-empty public key token.
 
 ## Combining filters
 

--- a/Source/aweXpect.Reflection/Filters/AssemblyFilters.WhichAreStrongNamed.cs
+++ b/Source/aweXpect.Reflection/Filters/AssemblyFilters.WhichAreStrongNamed.cs
@@ -1,0 +1,24 @@
+using System.Reflection;
+using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Helpers;
+
+namespace aweXpect.Reflection;
+
+public static partial class AssemblyFilters
+{
+	/// <summary>
+	///     Filter for assemblies that are strong named.
+	/// </summary>
+	public static Filtered.Assemblies WhichAreStrongNamed(this Filtered.Assemblies @this)
+		=> @this.Which(Filter.Suffix<Assembly>(
+			assembly => assembly.IsStrongNamed(),
+			" which are strong named"));
+
+	/// <summary>
+	///     Filter for assemblies that are not strong named.
+	/// </summary>
+	public static Filtered.Assemblies WhichAreNotStrongNamed(this Filtered.Assemblies @this)
+		=> @this.Which(Filter.Suffix<Assembly>(
+			assembly => !assembly.IsStrongNamed(),
+			" which are not strong named"));
+}

--- a/Source/aweXpect.Reflection/Helpers/AssemblyHelpers.cs
+++ b/Source/aweXpect.Reflection/Helpers/AssemblyHelpers.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.Versioning;
@@ -83,6 +83,15 @@ internal static class AssemblyHelpers
 	/// </remarks>
 	public static string? GetTargetFramework(this Assembly? assembly)
 		=> MapFrameworkName(assembly?.GetCustomAttribute<TargetFrameworkAttribute>()?.FrameworkName);
+
+	/// <summary>
+	///     Checks if the <paramref name="assembly" /> is strong named.
+	/// </summary>
+	/// <remarks>
+	///     An assembly is considered strong named if its name carries a non-empty public key token.
+	/// </remarks>
+	public static bool IsStrongNamed(this Assembly? assembly)
+		=> assembly?.GetName().GetPublicKeyToken() is { Length: > 0, };
 
 	/// <summary>
 	///     Maps a <see cref="TargetFrameworkAttribute.FrameworkName" /> (e.g. <c>.NETCoreApp,Version=v8.0</c>)

--- a/Source/aweXpect.Reflection/ThatAssemblies.AreStrongNamed.cs
+++ b/Source/aweXpect.Reflection/ThatAssemblies.AreStrongNamed.cs
@@ -1,0 +1,128 @@
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text;
+#if NET8_0_OR_GREATER
+using System.Threading;
+using System.Threading.Tasks;
+#endif
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Reflection.Helpers;
+using aweXpect.Results;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Reflection;
+
+public static partial class ThatAssemblies
+{
+	/// <summary>
+	///     Verifies that all items in the filtered collection of <see cref="Assembly" /> are strong named.
+	/// </summary>
+	public static AndOrResult<IEnumerable<Assembly?>, IThat<IEnumerable<Assembly?>>> AreStrongNamed(
+		this IThat<IEnumerable<Assembly?>> subject)
+		=> new(subject.Get().ExpectationBuilder.AddConstraint<IEnumerable<Assembly?>>((it, grammars)
+				=> new AreStrongNamedConstraint(it, grammars)),
+			subject);
+
+#if NET8_0_OR_GREATER
+	/// <summary>
+	///     Verifies that all items in the filtered collection of <see cref="Assembly" /> are strong named.
+	/// </summary>
+	public static AndOrResult<IAsyncEnumerable<Assembly?>, IThat<IAsyncEnumerable<Assembly?>>> AreStrongNamed(
+		this IThat<IAsyncEnumerable<Assembly?>> subject)
+		=> new(subject.Get().ExpectationBuilder.AddConstraint<IAsyncEnumerable<Assembly?>>((it, grammars)
+				=> new AreStrongNamedConstraint(it, grammars)),
+			subject);
+#endif
+
+	/// <summary>
+	///     Verifies that all items in the filtered collection of <see cref="Assembly" /> are not strong named.
+	/// </summary>
+	public static AndOrResult<IEnumerable<Assembly?>, IThat<IEnumerable<Assembly?>>> AreNotStrongNamed(
+		this IThat<IEnumerable<Assembly?>> subject)
+		=> new(subject.Get().ExpectationBuilder.AddConstraint<IEnumerable<Assembly?>>((it, grammars)
+				=> new AreNotStrongNamedConstraint(it, grammars)),
+			subject);
+
+#if NET8_0_OR_GREATER
+	/// <summary>
+	///     Verifies that all items in the filtered collection of <see cref="Assembly" /> are not strong named.
+	/// </summary>
+	public static AndOrResult<IAsyncEnumerable<Assembly?>, IThat<IAsyncEnumerable<Assembly?>>> AreNotStrongNamed(
+		this IThat<IAsyncEnumerable<Assembly?>> subject)
+		=> new(subject.Get().ExpectationBuilder.AddConstraint<IAsyncEnumerable<Assembly?>>((it, grammars)
+				=> new AreNotStrongNamedConstraint(it, grammars)),
+			subject);
+#endif
+
+	private sealed class AreStrongNamedConstraint(string it, ExpectationGrammars grammars)
+		: CollectionConstraintResult<Assembly?>(grammars),
+			IValueConstraint<IEnumerable<Assembly?>>
+#if NET8_0_OR_GREATER
+			, IAsyncConstraint<IAsyncEnumerable<Assembly?>>
+#endif
+	{
+#if NET8_0_OR_GREATER
+		public async Task<ConstraintResult> IsMetBy(IAsyncEnumerable<Assembly?> actual,
+			CancellationToken cancellationToken)
+			=> await SetAsyncValue(actual, assembly => assembly.IsStrongNamed());
+#endif
+
+		public ConstraintResult IsMetBy(IEnumerable<Assembly?> actual)
+			=> SetValue(actual, assembly => assembly.IsStrongNamed());
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("are all strong named");
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(it).Append(" contained not strong named assemblies ");
+			Formatter.Format(stringBuilder, NotMatching, FormattingOptions.Indented(indentation));
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("are not all strong named");
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(it).Append(" only contained strong named assemblies ");
+			Formatter.Format(stringBuilder, Matching, FormattingOptions.Indented(indentation));
+		}
+	}
+
+	private sealed class AreNotStrongNamedConstraint(string it, ExpectationGrammars grammars)
+		: CollectionConstraintResult<Assembly?>(grammars),
+			IValueConstraint<IEnumerable<Assembly?>>
+#if NET8_0_OR_GREATER
+			, IAsyncConstraint<IAsyncEnumerable<Assembly?>>
+#endif
+	{
+#if NET8_0_OR_GREATER
+		public async Task<ConstraintResult> IsMetBy(IAsyncEnumerable<Assembly?> actual,
+			CancellationToken cancellationToken)
+			=> await SetAsyncValue(actual, assembly => !assembly.IsStrongNamed());
+#endif
+
+		public ConstraintResult IsMetBy(IEnumerable<Assembly?> actual)
+			=> SetValue(actual, assembly => !assembly.IsStrongNamed());
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("are all not strong named");
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(it).Append(" contained strong named assemblies ");
+			Formatter.Format(stringBuilder, NotMatching, FormattingOptions.Indented(indentation));
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("also contain a strong named assembly");
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(it).Append(" only contained not strong named assemblies ");
+			Formatter.Format(stringBuilder, Matching, FormattingOptions.Indented(indentation));
+		}
+	}
+}

--- a/Source/aweXpect.Reflection/ThatAssembly.IsStrongNamed.cs
+++ b/Source/aweXpect.Reflection/ThatAssembly.IsStrongNamed.cs
@@ -1,0 +1,59 @@
+using System.Reflection;
+using System.Text;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Reflection.Helpers;
+using aweXpect.Results;
+
+namespace aweXpect.Reflection;
+
+public static partial class ThatAssembly
+{
+	/// <summary>
+	///     Verifies that the <see cref="Assembly" /> is strong named.
+	/// </summary>
+	public static AndOrResult<Assembly?, IThat<Assembly?>> IsStrongNamed(
+		this IThat<Assembly?> subject)
+		=> new(subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new IsStrongNamedConstraint(it, grammars)),
+			subject);
+
+	/// <summary>
+	///     Verifies that the <see cref="Assembly" /> is not strong named.
+	/// </summary>
+	public static AndOrResult<Assembly?, IThat<Assembly?>> IsNotStrongNamed(
+		this IThat<Assembly?> subject)
+		=> new(subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new IsStrongNamedConstraint(it, grammars).Invert()),
+			subject);
+
+	private sealed class IsStrongNamedConstraint(string it, ExpectationGrammars grammars)
+		: ConstraintResult.WithNotNullValue<Assembly?>(it, grammars),
+			IValueConstraint<Assembly?>
+	{
+		public ConstraintResult IsMetBy(Assembly? actual)
+		{
+			Actual = actual;
+			Outcome = actual.IsStrongNamed() ? Outcome.Success : Outcome.Failure;
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("is strong named");
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(It).Append(" was not strong named ");
+			Formatter.Format(stringBuilder, Actual);
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("is not strong named");
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(It).Append(" was strong named ");
+			Formatter.Format(stringBuilder, Actual);
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net10.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net10.0.txt
@@ -34,6 +34,8 @@ namespace aweXpect.Reflection
     public static class AssemblyFilters
     {
         public static aweXpect.Reflection.Collections.Filtered.Assemblies Which(this aweXpect.Reflection.Collections.Filtered.Assemblies @this, System.Func<System.Reflection.Assembly, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
+        public static aweXpect.Reflection.Collections.Filtered.Assemblies WhichAreNotStrongNamed(this aweXpect.Reflection.Collections.Filtered.Assemblies @this) { }
+        public static aweXpect.Reflection.Collections.Filtered.Assemblies WhichAreStrongNamed(this aweXpect.Reflection.Collections.Filtered.Assemblies @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Assemblies.StringEqualityResultType WhichHaveADependencyOn(this aweXpect.Reflection.Collections.Filtered.Assemblies @this, string expected) { }
         public static aweXpect.Reflection.Collections.Filtered.Assemblies.StringEqualityResultType WhichHaveDependenciesOnlyOn(this aweXpect.Reflection.Collections.Filtered.Assemblies @this, params string[] allowed) { }
         public static aweXpect.Reflection.Collections.Filtered.Assemblies.StringEqualityResultType WhichHaveNoDependencyOn(this aweXpect.Reflection.Collections.Filtered.Assemblies @this, string unexpected) { }
@@ -552,6 +554,10 @@ namespace aweXpect.Reflection
     }
     public static class ThatAssemblies
     {
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.Assembly?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.Assembly?>>> AreNotStrongNamed(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.Assembly?>> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>>> AreNotStrongNamed(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.Assembly?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.Assembly?>>> AreStrongNamed(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.Assembly?>> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>>> AreStrongNamed(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.Assembly?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.Assembly?>>> DoNotHave<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.Assembly?>> subject, bool inherit = true)
             where TAttribute : System.Attribute { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>>> DoNotHave<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>> subject, bool inherit = true)
@@ -615,6 +621,8 @@ namespace aweXpect.Reflection
         public static aweXpect.Results.StringEqualityTypeResult<System.Reflection.Assembly?, aweXpect.Core.IThat<System.Reflection.Assembly?>> HasNoDependencyOn(this aweXpect.Core.IThat<System.Reflection.Assembly?> subject, string unexpected) { }
         public static aweXpect.Reflection.ThatAssembly.HasVersionResult HasVersion(this aweXpect.Core.IThat<System.Reflection.Assembly?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Reflection.Assembly?, aweXpect.Core.IThat<System.Reflection.Assembly?>> HasVersion(this aweXpect.Core.IThat<System.Reflection.Assembly?> subject, System.Func<System.Version, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
+        public static aweXpect.Results.AndOrResult<System.Reflection.Assembly?, aweXpect.Core.IThat<System.Reflection.Assembly?>> IsNotStrongNamed(this aweXpect.Core.IThat<System.Reflection.Assembly?> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Reflection.Assembly?, aweXpect.Core.IThat<System.Reflection.Assembly?>> IsStrongNamed(this aweXpect.Core.IThat<System.Reflection.Assembly?> subject) { }
         public static aweXpect.Results.StringEqualityTypeResult<System.Reflection.Assembly?, aweXpect.Core.IThat<System.Reflection.Assembly?>> Targets(this aweXpect.Core.IThat<System.Reflection.Assembly?> subject, string expected) { }
         public class HasVersionResult : aweXpect.Results.AndOrResult<System.Reflection.Assembly?, aweXpect.Core.IThat<System.Reflection.Assembly?>>
         {

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net8.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net8.0.txt
@@ -34,6 +34,8 @@ namespace aweXpect.Reflection
     public static class AssemblyFilters
     {
         public static aweXpect.Reflection.Collections.Filtered.Assemblies Which(this aweXpect.Reflection.Collections.Filtered.Assemblies @this, System.Func<System.Reflection.Assembly, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
+        public static aweXpect.Reflection.Collections.Filtered.Assemblies WhichAreNotStrongNamed(this aweXpect.Reflection.Collections.Filtered.Assemblies @this) { }
+        public static aweXpect.Reflection.Collections.Filtered.Assemblies WhichAreStrongNamed(this aweXpect.Reflection.Collections.Filtered.Assemblies @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Assemblies.StringEqualityResultType WhichHaveADependencyOn(this aweXpect.Reflection.Collections.Filtered.Assemblies @this, string expected) { }
         public static aweXpect.Reflection.Collections.Filtered.Assemblies.StringEqualityResultType WhichHaveDependenciesOnlyOn(this aweXpect.Reflection.Collections.Filtered.Assemblies @this, params string[] allowed) { }
         public static aweXpect.Reflection.Collections.Filtered.Assemblies.StringEqualityResultType WhichHaveNoDependencyOn(this aweXpect.Reflection.Collections.Filtered.Assemblies @this, string unexpected) { }
@@ -552,6 +554,10 @@ namespace aweXpect.Reflection
     }
     public static class ThatAssemblies
     {
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.Assembly?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.Assembly?>>> AreNotStrongNamed(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.Assembly?>> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>>> AreNotStrongNamed(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.Assembly?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.Assembly?>>> AreStrongNamed(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.Assembly?>> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>>> AreStrongNamed(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.Assembly?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.Assembly?>>> DoNotHave<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.Assembly?>> subject, bool inherit = true)
             where TAttribute : System.Attribute { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>>> DoNotHave<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>> subject, bool inherit = true)
@@ -615,6 +621,8 @@ namespace aweXpect.Reflection
         public static aweXpect.Results.StringEqualityTypeResult<System.Reflection.Assembly?, aweXpect.Core.IThat<System.Reflection.Assembly?>> HasNoDependencyOn(this aweXpect.Core.IThat<System.Reflection.Assembly?> subject, string unexpected) { }
         public static aweXpect.Reflection.ThatAssembly.HasVersionResult HasVersion(this aweXpect.Core.IThat<System.Reflection.Assembly?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Reflection.Assembly?, aweXpect.Core.IThat<System.Reflection.Assembly?>> HasVersion(this aweXpect.Core.IThat<System.Reflection.Assembly?> subject, System.Func<System.Version, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
+        public static aweXpect.Results.AndOrResult<System.Reflection.Assembly?, aweXpect.Core.IThat<System.Reflection.Assembly?>> IsNotStrongNamed(this aweXpect.Core.IThat<System.Reflection.Assembly?> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Reflection.Assembly?, aweXpect.Core.IThat<System.Reflection.Assembly?>> IsStrongNamed(this aweXpect.Core.IThat<System.Reflection.Assembly?> subject) { }
         public static aweXpect.Results.StringEqualityTypeResult<System.Reflection.Assembly?, aweXpect.Core.IThat<System.Reflection.Assembly?>> Targets(this aweXpect.Core.IThat<System.Reflection.Assembly?> subject, string expected) { }
         public class HasVersionResult : aweXpect.Results.AndOrResult<System.Reflection.Assembly?, aweXpect.Core.IThat<System.Reflection.Assembly?>>
         {

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_netstandard2.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_netstandard2.0.txt
@@ -34,6 +34,8 @@ namespace aweXpect.Reflection
     public static class AssemblyFilters
     {
         public static aweXpect.Reflection.Collections.Filtered.Assemblies Which(this aweXpect.Reflection.Collections.Filtered.Assemblies @this, System.Func<System.Reflection.Assembly, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
+        public static aweXpect.Reflection.Collections.Filtered.Assemblies WhichAreNotStrongNamed(this aweXpect.Reflection.Collections.Filtered.Assemblies @this) { }
+        public static aweXpect.Reflection.Collections.Filtered.Assemblies WhichAreStrongNamed(this aweXpect.Reflection.Collections.Filtered.Assemblies @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Assemblies.StringEqualityResultType WhichHaveADependencyOn(this aweXpect.Reflection.Collections.Filtered.Assemblies @this, string expected) { }
         public static aweXpect.Reflection.Collections.Filtered.Assemblies.StringEqualityResultType WhichHaveDependenciesOnlyOn(this aweXpect.Reflection.Collections.Filtered.Assemblies @this, params string[] allowed) { }
         public static aweXpect.Reflection.Collections.Filtered.Assemblies.StringEqualityResultType WhichHaveNoDependencyOn(this aweXpect.Reflection.Collections.Filtered.Assemblies @this, string unexpected) { }
@@ -552,6 +554,8 @@ namespace aweXpect.Reflection
     }
     public static class ThatAssemblies
     {
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>>> AreNotStrongNamed(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>>> AreStrongNamed(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>>> DoNotHave<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>> subject, bool inherit = true)
             where TAttribute : System.Attribute { }
         public static aweXpect.Results.StringEqualityTypeResult<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>>> DoNotHaveName(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.Assembly?>> subject, string unexpected) { }
@@ -600,6 +604,8 @@ namespace aweXpect.Reflection
         public static aweXpect.Results.StringEqualityTypeResult<System.Reflection.Assembly?, aweXpect.Core.IThat<System.Reflection.Assembly?>> HasNoDependencyOn(this aweXpect.Core.IThat<System.Reflection.Assembly?> subject, string unexpected) { }
         public static aweXpect.Reflection.ThatAssembly.HasVersionResult HasVersion(this aweXpect.Core.IThat<System.Reflection.Assembly?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Reflection.Assembly?, aweXpect.Core.IThat<System.Reflection.Assembly?>> HasVersion(this aweXpect.Core.IThat<System.Reflection.Assembly?> subject, System.Func<System.Version, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
+        public static aweXpect.Results.AndOrResult<System.Reflection.Assembly?, aweXpect.Core.IThat<System.Reflection.Assembly?>> IsNotStrongNamed(this aweXpect.Core.IThat<System.Reflection.Assembly?> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Reflection.Assembly?, aweXpect.Core.IThat<System.Reflection.Assembly?>> IsStrongNamed(this aweXpect.Core.IThat<System.Reflection.Assembly?> subject) { }
         public static aweXpect.Results.StringEqualityTypeResult<System.Reflection.Assembly?, aweXpect.Core.IThat<System.Reflection.Assembly?>> Targets(this aweXpect.Core.IThat<System.Reflection.Assembly?> subject, string expected) { }
         public class HasVersionResult : aweXpect.Results.AndOrResult<System.Reflection.Assembly?, aweXpect.Core.IThat<System.Reflection.Assembly?>>
         {

--- a/Tests/aweXpect.Reflection.Tests/Filters/AssemblyFilters.WhichAreNotStrongNamed.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/AssemblyFilters.WhichAreNotStrongNamed.Tests.cs
@@ -1,0 +1,42 @@
+using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Tests.TestHelpers;
+using aweXpect.Reflection.Tests.TestHelpers.Types;
+
+namespace aweXpect.Reflection.Tests.Filters;
+
+public sealed partial class AssemblyFilters
+{
+	public sealed class WhichAreNotStrongNamed
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task ShouldDescribeTheFilter()
+			{
+				Filtered.Assemblies assemblies = In.AllLoadedAssemblies()
+					.WhichAreNotStrongNamed();
+
+				await That(assemblies.GetDescription())
+					.IsEqualTo("in all loaded assemblies which are not strong named");
+			}
+
+			[Fact]
+			public async Task ShouldFilterForNotStrongNamedAssemblies()
+			{
+				Filtered.Assemblies assemblies = In.AssemblyContaining<PublicAbstractClass>()
+					.WhichAreNotStrongNamed();
+
+				await That(assemblies).All().Satisfy(assembly => !assembly.IsStrongNamed()).And.IsNotEmpty();
+			}
+
+			[Fact]
+			public async Task ShouldNotMatchStrongNamedAssemblies()
+			{
+				Filtered.Assemblies assemblies = In.AssemblyContaining(typeof(In))
+					.WhichAreNotStrongNamed();
+
+				await That(assemblies).IsEmpty();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/Filters/AssemblyFilters.WhichAreStrongNamed.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/AssemblyFilters.WhichAreStrongNamed.Tests.cs
@@ -1,0 +1,42 @@
+using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Tests.TestHelpers;
+using aweXpect.Reflection.Tests.TestHelpers.Types;
+
+namespace aweXpect.Reflection.Tests.Filters;
+
+public sealed partial class AssemblyFilters
+{
+	public sealed class WhichAreStrongNamed
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task ShouldDescribeTheFilter()
+			{
+				Filtered.Assemblies assemblies = In.AllLoadedAssemblies()
+					.WhichAreStrongNamed();
+
+				await That(assemblies.GetDescription())
+					.IsEqualTo("in all loaded assemblies which are strong named");
+			}
+
+			[Fact]
+			public async Task ShouldFilterForStrongNamedAssemblies()
+			{
+				Filtered.Assemblies assemblies = In.AllLoadedAssemblies()
+					.WhichAreStrongNamed();
+
+				await That(assemblies).All().Satisfy(assembly => assembly.IsStrongNamed()).And.IsNotEmpty();
+			}
+
+			[Fact]
+			public async Task ShouldNotMatchAssembliesWithoutStrongName()
+			{
+				Filtered.Assemblies assemblies = In.AssemblyContaining<PublicAbstractClass>()
+					.WhichAreStrongNamed();
+
+				await That(assemblies).IsEmpty();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/TestHelpers/AssemblyExtensions.cs
+++ b/Tests/aweXpect.Reflection.Tests/TestHelpers/AssemblyExtensions.cs
@@ -1,0 +1,13 @@
+using System.Reflection;
+
+namespace aweXpect.Reflection.Tests.TestHelpers;
+
+public static class AssemblyExtensions
+{
+	/// <summary>
+	///     Checks if the <paramref name="assembly" /> is strong named.
+	/// </summary>
+	/// <param name="assembly">The <see cref="Assembly" /> to check.</param>
+	public static bool IsStrongNamed(this Assembly? assembly)
+		=> assembly?.GetName().GetPublicKeyToken() is { Length: > 0, };
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatAssemblies.AreNotStrongNamed.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatAssemblies.AreNotStrongNamed.Tests.cs
@@ -1,0 +1,142 @@
+using System.Collections.Generic;
+using System.Reflection;
+using aweXpect.Reflection.Tests.TestHelpers.Types;
+#if NET8_0_OR_GREATER
+using aweXpect.Reflection.Tests.TestHelpers;
+#endif
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatAssemblies
+{
+	public sealed class AreNotStrongNamed
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenAllAssembliesAreNotStrongNamed_ShouldSucceed()
+			{
+				IEnumerable<Assembly?> subject = new[]
+				{
+					typeof(PublicAbstractClass).Assembly,
+				};
+
+				async Task Act()
+				{
+					await That(subject).AreNotStrongNamed();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenAssembliesContainStrongNamedAssemblies_ShouldFail()
+			{
+				IEnumerable<Assembly?> subject = new[]
+				{
+					typeof(In).Assembly, typeof(PublicAbstractClass).Assembly,
+				};
+
+				async Task Act()
+				{
+					await That(subject).AreNotStrongNamed();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             are all not strong named,
+					             but it contained strong named assemblies [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+		}
+
+		public sealed class NegatedTests
+		{
+			[Fact]
+			public async Task WhenAllAssembliesAreNotStrongNamed_ShouldFail()
+			{
+				IEnumerable<Assembly?> subject = new[]
+				{
+					typeof(PublicAbstractClass).Assembly,
+				};
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(they => they.AreNotStrongNamed());
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             also contain a strong named assembly,
+					             but it only contained not strong named assemblies [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenAssembliesContainStrongNamedAssemblies_ShouldSucceed()
+			{
+				IEnumerable<Assembly?> subject = new[]
+				{
+					typeof(In).Assembly, typeof(PublicAbstractClass).Assembly,
+				};
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(they => they.AreNotStrongNamed());
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+#if NET8_0_OR_GREATER
+		public sealed class AsyncEnumerableTests
+		{
+			[Fact]
+			public async Task WhenAllAssembliesAreNotStrongNamed_ShouldSucceed()
+			{
+				IAsyncEnumerable<Assembly?> subject = new[]
+				{
+					typeof(PublicAbstractClass).Assembly,
+				}.ToTestAsyncEnumerable<Assembly?>();
+
+				async Task Act()
+				{
+					await That(subject).AreNotStrongNamed();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenAssembliesContainStrongNamedAssemblies_ShouldFail()
+			{
+				IAsyncEnumerable<Assembly?> subject = new[]
+				{
+					typeof(In).Assembly, typeof(PublicAbstractClass).Assembly,
+				}.ToTestAsyncEnumerable<Assembly?>();
+
+				async Task Act()
+				{
+					await That(subject).AreNotStrongNamed();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             are all not strong named,
+					             but it contained strong named assemblies [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+		}
+#endif
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatAssemblies.AreStrongNamed.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatAssemblies.AreStrongNamed.Tests.cs
@@ -1,0 +1,142 @@
+using System.Collections.Generic;
+using System.Reflection;
+using aweXpect.Reflection.Tests.TestHelpers.Types;
+#if NET8_0_OR_GREATER
+using aweXpect.Reflection.Tests.TestHelpers;
+#endif
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatAssemblies
+{
+	public sealed class AreStrongNamed
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenAllAssembliesAreStrongNamed_ShouldSucceed()
+			{
+				IEnumerable<Assembly?> subject = new[]
+				{
+					typeof(In).Assembly, typeof(object).Assembly,
+				};
+
+				async Task Act()
+				{
+					await That(subject).AreStrongNamed();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenAssembliesContainNotStrongNamedAssemblies_ShouldFail()
+			{
+				IEnumerable<Assembly?> subject = new[]
+				{
+					typeof(In).Assembly, typeof(PublicAbstractClass).Assembly,
+				};
+
+				async Task Act()
+				{
+					await That(subject).AreStrongNamed();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             are all strong named,
+					             but it contained not strong named assemblies [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+		}
+
+		public sealed class NegatedTests
+		{
+			[Fact]
+			public async Task WhenAllAssembliesAreStrongNamed_ShouldFail()
+			{
+				IEnumerable<Assembly?> subject = new[]
+				{
+					typeof(In).Assembly, typeof(object).Assembly,
+				};
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(they => they.AreStrongNamed());
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             are not all strong named,
+					             but it only contained strong named assemblies [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenAssembliesContainNotStrongNamedAssemblies_ShouldSucceed()
+			{
+				IEnumerable<Assembly?> subject = new[]
+				{
+					typeof(In).Assembly, typeof(PublicAbstractClass).Assembly,
+				};
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(they => they.AreStrongNamed());
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+#if NET8_0_OR_GREATER
+		public sealed class AsyncEnumerableTests
+		{
+			[Fact]
+			public async Task WhenAllAssembliesAreStrongNamed_ShouldSucceed()
+			{
+				IAsyncEnumerable<Assembly?> subject = new[]
+				{
+					typeof(In).Assembly, typeof(object).Assembly,
+				}.ToTestAsyncEnumerable<Assembly?>();
+
+				async Task Act()
+				{
+					await That(subject).AreStrongNamed();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenAssembliesContainNotStrongNamedAssemblies_ShouldFail()
+			{
+				IAsyncEnumerable<Assembly?> subject = new[]
+				{
+					typeof(In).Assembly, typeof(PublicAbstractClass).Assembly,
+				}.ToTestAsyncEnumerable<Assembly?>();
+
+				async Task Act()
+				{
+					await That(subject).AreStrongNamed();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             are all strong named,
+					             but it contained not strong named assemblies [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+		}
+#endif
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatAssembly.IsNotStrongNamed.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatAssembly.IsNotStrongNamed.Tests.cs
@@ -1,0 +1,97 @@
+using System.Reflection;
+using aweXpect.Reflection.Tests.TestHelpers.Types;
+using Xunit.Sdk;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatAssembly
+{
+	public sealed class IsNotStrongNamed
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenAssemblyIsNotStrongNamed_ShouldSucceed()
+			{
+				Assembly subject = typeof(PublicAbstractClass).Assembly;
+
+				async Task Act()
+				{
+					await That(subject).IsNotStrongNamed();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenAssemblyIsNull_ShouldFail()
+			{
+				Assembly? subject = null;
+
+				async Task Act()
+				{
+					await That(subject).IsNotStrongNamed();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             is not strong named,
+					             but it was <null>
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenAssemblyIsStrongNamed_ShouldFail()
+			{
+				Assembly subject = typeof(In).Assembly;
+
+				async Task Act()
+				{
+					await That(subject).IsNotStrongNamed();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage($"""
+					              Expected that subject
+					              is not strong named,
+					              but it was strong named {Formatter.Format(subject)}
+					              """);
+			}
+		}
+
+		public sealed class NegatedTests
+		{
+			[Fact]
+			public async Task WhenAssemblyIsNotStrongNamed_ShouldFail()
+			{
+				Assembly subject = typeof(PublicAbstractClass).Assembly;
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(it => it.IsNotStrongNamed());
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is strong named,
+					              but it was not strong named {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenAssemblyIsStrongNamed_ShouldSucceed()
+			{
+				Assembly subject = typeof(In).Assembly;
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(it => it.IsNotStrongNamed());
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatAssembly.IsStrongNamed.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatAssembly.IsStrongNamed.Tests.cs
@@ -1,0 +1,97 @@
+using System.Reflection;
+using aweXpect.Reflection.Tests.TestHelpers.Types;
+using Xunit.Sdk;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatAssembly
+{
+	public sealed class IsStrongNamed
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenAssemblyIsNotStrongNamed_ShouldFail()
+			{
+				Assembly subject = typeof(PublicAbstractClass).Assembly;
+
+				async Task Act()
+				{
+					await That(subject).IsStrongNamed();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage($"""
+					              Expected that subject
+					              is strong named,
+					              but it was not strong named {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenAssemblyIsNull_ShouldFail()
+			{
+				Assembly? subject = null;
+
+				async Task Act()
+				{
+					await That(subject).IsStrongNamed();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             is strong named,
+					             but it was <null>
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenAssemblyIsStrongNamed_ShouldSucceed()
+			{
+				Assembly subject = typeof(In).Assembly;
+
+				async Task Act()
+				{
+					await That(subject).IsStrongNamed();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+		public sealed class NegatedTests
+		{
+			[Fact]
+			public async Task WhenAssemblyIsNotStrongNamed_ShouldSucceed()
+			{
+				Assembly subject = typeof(PublicAbstractClass).Assembly;
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(it => it.IsStrongNamed());
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenAssemblyIsStrongNamed_ShouldFail()
+			{
+				Assembly subject = typeof(In).Assembly;
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(it => it.IsStrongNamed());
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is not strong named,
+					              but it was strong named {Formatter.Format(subject)}
+					              """);
+			}
+		}
+	}
+}


### PR DESCRIPTION
Add filtering and assertion methods for strong named assemblies, mirroring the existing assembly API:

- Filter: WhichAreStrongNamed / WhichAreNotStrongNamed
- Single assertion: IsStrongNamed / IsNotStrongNamed
- Many assertion: AreStrongNamed / AreNotStrongNamed

An assembly is considered strong named when its name carries a non-empty public key token.

---

- *Fixes #226*