### PR TITLE
feat: add event handler type filters and assertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,13 +419,30 @@ In.AllLoadedAssemblies().Private.Fields()
 
 ### Events
 
-Events support [access modifiers](#access-modifiers),
-[attributes](#attributes),
-[names](#names-and-namespaces) and the `abstract` / `sealed` modifiers
-(`.WhichAreAbstract()` / `.IsAbstract()` / `.AreAbstract()`, likewise for `sealed`).
+In addition to [access modifiers](#access-modifiers),
+[attributes](#attributes) and
+[names](#names-and-namespaces):
+
+|                                       | Filter                                      | Assert (single)                 | Assert (many)                     |
+|---------------------------------------|---------------------------------------------|---------------------------------|-----------------------------------|
+| handler of type (or a subtype)        | `.OfType<T>()`                              | `.IsOfType<T>()`                | `.AreOfType<T>()`                 |
+| handler of exact type                 | `.OfExactType<T>()`                         | `.IsOfExactType<T>()`           | `.AreOfExactType<T>()`            |
+| abstract / sealed                     | `.WhichAreAbstract()` / `.WhichAreSealed()` | `.IsAbstract()` / `.IsSealed()` | `.AreAbstract()` / `.AreSealed()` |
+
+The `OfType` / `IsOfType` / `AreOfType` filters and assertions match the event's handler type (its
+`EventHandlerType`, e.g. `EventHandler<T>`); the `…ExactType` variants match only the exact handler type.
+Use `OrOfType<T>()` / `OrOfExactType<T>()` to allow several handler types.
+
+> **Negation:** the `abstract` and `sealed` rows have a negated form — `WhichAreNot…` on filters and
+> `IsNot…` / `AreNot…` on assertions (e.g. `WhichAreNotSealed()`, `IsNotSealed()`, `AreNotSealed()`).
 
 ```csharp
+// Every event must use the generic EventHandler<T> pattern
+await Expect.That(In.AllLoadedAssemblies().Public.Events())
+    .AreOfType(typeof(EventHandler<>));
+
 In.AllLoadedAssemblies().Public.Events()
+    .OfType<EventHandler>()
     .WithName("Changed").AsSuffix()
     .With<ObsoleteAttribute>()
 ```

--- a/Source/aweXpect.Reflection/Filters/EventFilters.OfExactType.cs
+++ b/Source/aweXpect.Reflection/Filters/EventFilters.OfExactType.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Reflection;
+using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Helpers;
+
+namespace aweXpect.Reflection;
+
+public static partial class EventFilters
+{
+	/// <summary>
+	///     Filter for events with a handler of exact type <typeparamref name="THandler" />.
+	/// </summary>
+	public static EventsOfType OfExactType<THandler>(this Filtered.Events @this)
+		=> OfExactType(@this, typeof(THandler));
+
+	/// <summary>
+	///     Filter for events with a handler of exact type <paramref name="handlerType" />.
+	/// </summary>
+	public static EventsOfType OfExactType(this Filtered.Events @this,
+		Type handlerType)
+	{
+		IChangeableFilter<EventInfo> filter = Filter.Suffix<EventInfo>(
+			eventInfo => eventInfo.EventHandlerType!.IsOrInheritsFrom(handlerType, true),
+			$"of exact type {Formatter.Format(handlerType)} ");
+		return new EventsOfType(@this.Which(filter), filter);
+	}
+
+	public partial class EventsOfType
+	{
+		/// <summary>
+		///     Allow an alternative type <typeparamref name="THandler" /> exactly.
+		/// </summary>
+		public EventsOfType OrOfExactType<THandler>()
+			=> OrOfExactType(typeof(THandler));
+
+		/// <summary>
+		///     Allow an alternative type <paramref name="handlerType" /> exactly.
+		/// </summary>
+		public EventsOfType OrOfExactType(Type handlerType)
+		{
+			filter.UpdateFilter(
+				(result, eventInfo)
+					=> result || eventInfo.EventHandlerType!.IsOrInheritsFrom(handlerType, true),
+				description
+					=> $"{description}or of exact type {Formatter.Format(handlerType)} ");
+			return this;
+		}
+	}
+}

--- a/Source/aweXpect.Reflection/Filters/EventFilters.OfType.cs
+++ b/Source/aweXpect.Reflection/Filters/EventFilters.OfType.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Reflection;
+using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Helpers;
+
+namespace aweXpect.Reflection;
+
+public static partial class EventFilters
+{
+	/// <summary>
+	///     Filter for events with a handler of type <typeparamref name="THandler" />.
+	/// </summary>
+	public static EventsOfType OfType<THandler>(this Filtered.Events @this)
+		=> OfType(@this, typeof(THandler));
+
+	/// <summary>
+	///     Filter for events with a handler of type <paramref name="handlerType" />.
+	/// </summary>
+	public static EventsOfType OfType(this Filtered.Events @this,
+		Type handlerType)
+	{
+		IChangeableFilter<EventInfo> filter = Filter.Suffix<EventInfo>(
+			eventInfo => eventInfo.EventHandlerType!.IsOrInheritsFrom(handlerType),
+			$"of type {Formatter.Format(handlerType)} ");
+		return new EventsOfType(@this.Which(filter), filter);
+	}
+
+	public partial class EventsOfType
+	{
+		/// <summary>
+		///     Allow an alternative type <typeparamref name="THandler" />.
+		/// </summary>
+		public EventsOfType OrOfType<THandler>()
+			=> OrOfType(typeof(THandler));
+
+		/// <summary>
+		///     Allow an alternative type <paramref name="handlerType" />.
+		/// </summary>
+		public EventsOfType OrOfType(Type handlerType)
+		{
+			filter.UpdateFilter(
+				(result, eventInfo)
+					=> result || eventInfo.EventHandlerType!.IsOrInheritsFrom(handlerType),
+				description
+					=> $"{description}or of type {Formatter.Format(handlerType)} ");
+			return this;
+		}
+	}
+}

--- a/Source/aweXpect.Reflection/Filters/EventFilters.cs
+++ b/Source/aweXpect.Reflection/Filters/EventFilters.cs
@@ -1,4 +1,5 @@
-﻿using aweXpect.Reflection.Collections;
+﻿using System.Reflection;
+using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection;
 
@@ -7,4 +8,9 @@ namespace aweXpect.Reflection;
 /// </summary>
 public static partial class EventFilters
 {
+	/// <summary>
+	///     Additional filters on events with a handler of a specific type.
+	/// </summary>
+	public partial class EventsOfType(Filtered.Events inner, IChangeableFilter<EventInfo> filter)
+		: Filtered.Events(inner);
 }

--- a/Source/aweXpect.Reflection/ThatEvent.IsOfExactType.cs
+++ b/Source/aweXpect.Reflection/ThatEvent.IsOfExactType.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Reflection;
+using aweXpect.Core;
+using aweXpect.Reflection.Helpers;
+using aweXpect.Reflection.Options;
+
+namespace aweXpect.Reflection;
+
+public static partial class ThatEvent
+{
+	/// <summary>
+	///     Verifies that the <see cref="EventInfo" /> has a handler of exactly type <typeparamref name="THandler" />.
+	/// </summary>
+	public static EventOfTypeResult<EventInfo?, IThat<EventInfo?>> IsOfExactType<THandler>(
+		this IThat<EventInfo?> subject)
+		=> IsOfExactType(subject, typeof(THandler));
+
+	/// <summary>
+	///     Verifies that the <see cref="EventInfo" /> has a handler of exactly type <paramref name="handlerType" />.
+	/// </summary>
+	public static EventOfTypeResult<EventInfo?, IThat<EventInfo?>> IsOfExactType(
+		this IThat<EventInfo?> subject, Type handlerType)
+	{
+		TypeFilterOptions typeFilterOptions = new();
+		typeFilterOptions.RegisterType(handlerType, true);
+		return new EventOfTypeResult<EventInfo?, IThat<EventInfo?>>(
+			subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new IsOfTypeConstraint(it, grammars, typeFilterOptions)),
+			subject,
+			typeFilterOptions);
+	}
+
+	public sealed partial class EventOfTypeResult<TValue, TResult>
+	{
+		/// <summary>
+		///     Allow an alternative exact type <typeparamref name="THandler" />.
+		/// </summary>
+		public EventOfTypeResult<TValue, TResult> OrOfExactType<THandler>()
+			=> OrOfExactType(typeof(THandler));
+
+		/// <summary>
+		///     Allow an alternative exact type <paramref name="handlerType" />.
+		/// </summary>
+		public EventOfTypeResult<TValue, TResult> OrOfExactType(Type handlerType)
+		{
+			typeFilterOptions.RegisterType(handlerType, true);
+			return this;
+		}
+	}
+}

--- a/Source/aweXpect.Reflection/ThatEvent.IsOfType.cs
+++ b/Source/aweXpect.Reflection/ThatEvent.IsOfType.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.Reflection;
+using System.Text;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Reflection.Helpers;
+using aweXpect.Reflection.Options;
+using aweXpect.Results;
+
+namespace aweXpect.Reflection;
+
+public static partial class ThatEvent
+{
+	/// <summary>
+	///     Verifies that the <see cref="EventInfo" /> has a handler of type <typeparamref name="THandler" /> (or a subtype).
+	/// </summary>
+	public static EventOfTypeResult<EventInfo?, IThat<EventInfo?>> IsOfType<THandler>(
+		this IThat<EventInfo?> subject)
+		=> IsOfType(subject, typeof(THandler));
+
+	/// <summary>
+	///     Verifies that the <see cref="EventInfo" /> has a handler of type <paramref name="handlerType" /> (or a subtype).
+	/// </summary>
+	public static EventOfTypeResult<EventInfo?, IThat<EventInfo?>> IsOfType(
+		this IThat<EventInfo?> subject, Type handlerType)
+	{
+		TypeFilterOptions typeFilterOptions = new();
+		typeFilterOptions.RegisterType(handlerType, false);
+		return new EventOfTypeResult<EventInfo?, IThat<EventInfo?>>(
+			subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new IsOfTypeConstraint(it, grammars, typeFilterOptions)),
+			subject,
+			typeFilterOptions);
+	}
+
+	/// <summary>
+	///     Result that allows chaining additional types for a single event.
+	/// </summary>
+	public sealed partial class EventOfTypeResult<TValue, TResult>(
+		ExpectationBuilder expectationBuilder,
+		TResult subject,
+		TypeFilterOptions typeFilterOptions)
+		: AndOrResult<TValue, TResult>(expectationBuilder, subject),
+			IOptionsProvider<TypeFilterOptions>
+		where TResult : IThat<TValue>
+	{
+		/// <inheritdoc cref="IOptionsProvider{TypeFilterOptions}.Options" />
+		TypeFilterOptions IOptionsProvider<TypeFilterOptions>.Options => typeFilterOptions;
+
+		/// <summary>
+		///     Allow an alternative type <typeparamref name="THandler" /> (or a subtype).
+		/// </summary>
+		public EventOfTypeResult<TValue, TResult> OrOfType<THandler>()
+			=> OrOfType(typeof(THandler));
+
+		/// <summary>
+		///     Allow an alternative type <paramref name="handlerType" /> (or a subtype).
+		/// </summary>
+		public EventOfTypeResult<TValue, TResult> OrOfType(Type handlerType)
+		{
+			typeFilterOptions.RegisterType(handlerType, false);
+			return this;
+		}
+	}
+
+	private sealed class IsOfTypeConstraint(
+		string it,
+		ExpectationGrammars grammars,
+		TypeFilterOptions typeFilterOptions)
+		: ConstraintResult.WithNotNullValue<EventInfo?>(it, grammars),
+			IValueConstraint<EventInfo?>
+	{
+		public ConstraintResult IsMetBy(EventInfo? actual)
+		{
+			Actual = actual;
+			Outcome = typeFilterOptions.Matches(actual?.EventHandlerType)
+				? Outcome.Success
+				: Outcome.Failure;
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(Grammars.HasFlag(ExpectationGrammars.Negated) ? "is not " : "is ");
+			typeFilterOptions.AppendOfTypeDescription(stringBuilder);
+		}
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("it was of type ").Append(Formatter.Format(Actual?.EventHandlerType));
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> AppendNormalExpectation(stringBuilder, indentation);
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("it did");
+	}
+}

--- a/Source/aweXpect.Reflection/ThatEvents.AreOfExactType.cs
+++ b/Source/aweXpect.Reflection/ThatEvents.AreOfExactType.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using aweXpect.Core;
+using aweXpect.Reflection.Helpers;
+using aweXpect.Reflection.Options;
+
+namespace aweXpect.Reflection;
+
+public static partial class ThatEvents
+{
+	/// <summary>
+	///     Verifies that all events in the filtered collection have a handler of exactly type
+	///     <typeparamref name="THandler" />.
+	/// </summary>
+	public static EventsOfTypeResult<IEnumerable<EventInfo?>, IThat<IEnumerable<EventInfo?>>>
+		AreOfExactType<THandler>(
+			this IThat<IEnumerable<EventInfo?>> subject)
+		=> AreOfExactType(subject, typeof(THandler));
+
+	/// <summary>
+	///     Verifies that all events in the filtered collection have a handler of exactly type
+	///     <paramref name="handlerType" />.
+	/// </summary>
+	public static EventsOfTypeResult<IEnumerable<EventInfo?>, IThat<IEnumerable<EventInfo?>>> AreOfExactType(
+		this IThat<IEnumerable<EventInfo?>> subject, Type handlerType)
+	{
+		TypeFilterOptions typeFilterOptions = new();
+		typeFilterOptions.RegisterType(handlerType, true);
+		return new EventsOfTypeResult<IEnumerable<EventInfo?>, IThat<IEnumerable<EventInfo?>>>(
+			subject.Get().ExpectationBuilder.AddConstraint<IEnumerable<EventInfo?>>((it, grammars)
+				=> new AreOfTypeConstraint(it, grammars | ExpectationGrammars.Plural, typeFilterOptions)),
+			subject,
+			typeFilterOptions);
+	}
+
+#if NET8_0_OR_GREATER
+	/// <summary>
+	///     Verifies that all events in the filtered collection have a handler of exactly type
+	///     <typeparamref name="THandler" />.
+	/// </summary>
+	public static EventsOfTypeResult<IAsyncEnumerable<EventInfo?>, IThat<IAsyncEnumerable<EventInfo?>>>
+		AreOfExactType<THandler>(
+			this IThat<IAsyncEnumerable<EventInfo?>> subject)
+		=> AreOfExactType(subject, typeof(THandler));
+
+	/// <summary>
+	///     Verifies that all events in the filtered collection have a handler of exactly type
+	///     <paramref name="handlerType" />.
+	/// </summary>
+	public static EventsOfTypeResult<IAsyncEnumerable<EventInfo?>, IThat<IAsyncEnumerable<EventInfo?>>>
+		AreOfExactType(
+			this IThat<IAsyncEnumerable<EventInfo?>> subject, Type handlerType)
+	{
+		TypeFilterOptions typeFilterOptions = new();
+		typeFilterOptions.RegisterType(handlerType, true);
+		return new EventsOfTypeResult<IAsyncEnumerable<EventInfo?>, IThat<IAsyncEnumerable<EventInfo?>>>(
+			subject.Get().ExpectationBuilder.AddConstraint<IAsyncEnumerable<EventInfo?>>((it, grammars)
+				=> new AreOfTypeConstraint(it, grammars | ExpectationGrammars.Plural, typeFilterOptions)),
+			subject,
+			typeFilterOptions);
+	}
+#endif
+
+	public sealed partial class EventsOfTypeResult<TValue, TResult>
+	{
+		/// <summary>
+		///     Allow an alternative exact type <typeparamref name="THandler" />.
+		/// </summary>
+		public EventsOfTypeResult<TValue, TResult> OrOfExactType<THandler>()
+			=> OrOfExactType(typeof(THandler));
+
+		/// <summary>
+		///     Allow an alternative exact type <paramref name="handlerType" />.
+		/// </summary>
+		public EventsOfTypeResult<TValue, TResult> OrOfExactType(Type handlerType)
+		{
+			typeFilterOptions.RegisterType(handlerType, true);
+			return this;
+		}
+	}
+}

--- a/Source/aweXpect.Reflection/ThatEvents.AreOfType.cs
+++ b/Source/aweXpect.Reflection/ThatEvents.AreOfType.cs
@@ -1,0 +1,147 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text;
+#if NET8_0_OR_GREATER
+using System.Threading;
+using System.Threading.Tasks;
+#endif
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Reflection.Helpers;
+using aweXpect.Reflection.Options;
+using aweXpect.Results;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Reflection;
+
+public static partial class ThatEvents
+{
+	/// <summary>
+	///     Verifies that all events in the filtered collection have a handler of type <typeparamref name="THandler" /> (or a
+	///     subtype).
+	/// </summary>
+	public static EventsOfTypeResult<IEnumerable<EventInfo?>, IThat<IEnumerable<EventInfo?>>>
+		AreOfType<THandler>(
+			this IThat<IEnumerable<EventInfo?>> subject)
+		=> AreOfType(subject, typeof(THandler));
+
+	/// <summary>
+	///     Verifies that all events in the filtered collection have a handler of type <paramref name="handlerType" /> (or a
+	///     subtype).
+	/// </summary>
+	public static EventsOfTypeResult<IEnumerable<EventInfo?>, IThat<IEnumerable<EventInfo?>>> AreOfType(
+		this IThat<IEnumerable<EventInfo?>> subject, Type handlerType)
+	{
+		TypeFilterOptions typeFilterOptions = new();
+		typeFilterOptions.RegisterType(handlerType, false);
+		return new EventsOfTypeResult<IEnumerable<EventInfo?>, IThat<IEnumerable<EventInfo?>>>(
+			subject.Get().ExpectationBuilder.AddConstraint<IEnumerable<EventInfo?>>((it, grammars)
+				=> new AreOfTypeConstraint(it, grammars | ExpectationGrammars.Plural, typeFilterOptions)),
+			subject,
+			typeFilterOptions);
+	}
+
+#if NET8_0_OR_GREATER
+	/// <summary>
+	///     Verifies that all events in the filtered collection have a handler of type <typeparamref name="THandler" /> (or a
+	///     subtype).
+	/// </summary>
+	public static EventsOfTypeResult<IAsyncEnumerable<EventInfo?>, IThat<IAsyncEnumerable<EventInfo?>>>
+		AreOfType<THandler>(
+			this IThat<IAsyncEnumerable<EventInfo?>> subject)
+		=> AreOfType(subject, typeof(THandler));
+
+	/// <summary>
+	///     Verifies that all events in the filtered collection have a handler of type <paramref name="handlerType" /> (or a
+	///     subtype).
+	/// </summary>
+	public static EventsOfTypeResult<IAsyncEnumerable<EventInfo?>, IThat<IAsyncEnumerable<EventInfo?>>>
+		AreOfType(
+			this IThat<IAsyncEnumerable<EventInfo?>> subject, Type handlerType)
+	{
+		TypeFilterOptions typeFilterOptions = new();
+		typeFilterOptions.RegisterType(handlerType, false);
+		return new EventsOfTypeResult<IAsyncEnumerable<EventInfo?>, IThat<IAsyncEnumerable<EventInfo?>>>(
+			subject.Get().ExpectationBuilder.AddConstraint<IAsyncEnumerable<EventInfo?>>((it, grammars)
+				=> new AreOfTypeConstraint(it, grammars | ExpectationGrammars.Plural, typeFilterOptions)),
+			subject,
+			typeFilterOptions);
+	}
+#endif
+
+	/// <summary>
+	///     Result that allows chaining additional types for event collections.
+	/// </summary>
+	public sealed partial class EventsOfTypeResult<TValue, TResult>(
+		ExpectationBuilder expectationBuilder,
+		TResult subject,
+		TypeFilterOptions typeFilterOptions)
+		: AndOrResult<TValue, TResult>(expectationBuilder, subject),
+			IOptionsProvider<TypeFilterOptions>
+		where TResult : IThat<TValue>
+	{
+		/// <inheritdoc cref="IOptionsProvider{TypeFilterOptions}.Options" />
+		TypeFilterOptions IOptionsProvider<TypeFilterOptions>.Options => typeFilterOptions;
+
+		/// <summary>
+		///     Allow an alternative type <typeparamref name="THandler" /> (or a subtype).
+		/// </summary>
+		public EventsOfTypeResult<TValue, TResult> OrOfType<THandler>()
+			=> OrOfType(typeof(THandler));
+
+		/// <summary>
+		///     Allow an alternative type <paramref name="handlerType" /> (or a subtype).
+		/// </summary>
+		public EventsOfTypeResult<TValue, TResult> OrOfType(Type handlerType)
+		{
+			typeFilterOptions.RegisterType(handlerType, false);
+			return this;
+		}
+	}
+
+	private sealed class AreOfTypeConstraint(
+		string it,
+		ExpectationGrammars grammars,
+		TypeFilterOptions typeFilterOptions)
+		: CollectionConstraintResult<EventInfo?>(grammars),
+			IValueConstraint<IEnumerable<EventInfo?>>
+#if NET8_0_OR_GREATER
+			, IAsyncConstraint<IAsyncEnumerable<EventInfo?>>
+#endif
+	{
+#if NET8_0_OR_GREATER
+		public async Task<ConstraintResult> IsMetBy(IAsyncEnumerable<EventInfo?> actual,
+			CancellationToken cancellationToken)
+			=> await SetAsyncValue(actual, @event => typeFilterOptions.Matches(@event?.EventHandlerType));
+#endif
+
+		public ConstraintResult IsMetBy(IEnumerable<EventInfo?> actual)
+			=> SetValue(actual, @event => typeFilterOptions.Matches(@event?.EventHandlerType));
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("all are ");
+			typeFilterOptions.AppendOfTypeDescription(stringBuilder);
+		}
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(it).Append(" contained not matching events ");
+			Formatter.Format(stringBuilder, NotMatching, FormattingOptions.Indented(indentation));
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append("not all are ");
+			typeFilterOptions.AppendOfTypeDescription(stringBuilder);
+		}
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(it).Append(" only contained matching events ");
+			Formatter.Format(stringBuilder, Matching, FormattingOptions.Indented(indentation));
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net10.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net10.0.txt
@@ -201,6 +201,10 @@ namespace aweXpect.Reflection
     }
     public static class EventFilters
     {
+        public static aweXpect.Reflection.EventFilters.EventsOfType OfExactType(this aweXpect.Reflection.Collections.Filtered.Events @this, System.Type handlerType) { }
+        public static aweXpect.Reflection.EventFilters.EventsOfType OfExactType<THandler>(this aweXpect.Reflection.Collections.Filtered.Events @this) { }
+        public static aweXpect.Reflection.EventFilters.EventsOfType OfType(this aweXpect.Reflection.Collections.Filtered.Events @this, System.Type handlerType) { }
+        public static aweXpect.Reflection.EventFilters.EventsOfType OfType<THandler>(this aweXpect.Reflection.Collections.Filtered.Events @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Events Which(this aweXpect.Reflection.Collections.Filtered.Events @this, System.Func<System.Reflection.EventInfo, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Reflection.Collections.Filtered.Events WhichAre(this aweXpect.Reflection.Collections.Filtered.Events @this, aweXpect.Reflection.Collections.AccessModifiers accessModifier) { }
         public static aweXpect.Reflection.Collections.Filtered.Events WhichAreAbstract(this aweXpect.Reflection.Collections.Filtered.Events @this) { }
@@ -228,6 +232,14 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Collections.Filtered.Events Without<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Events @this, bool inherit = true)
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Collections.Filtered.Events.StringEqualityResultType WithoutName(this aweXpect.Reflection.Collections.Filtered.Events @this, string unexpected) { }
+        public class EventsOfType : aweXpect.Reflection.Collections.Filtered.Events
+        {
+            public EventsOfType(aweXpect.Reflection.Collections.Filtered.Events inner, aweXpect.Reflection.Collections.IChangeableFilter<System.Reflection.EventInfo> filter) { }
+            public aweXpect.Reflection.EventFilters.EventsOfType OrOfExactType(System.Type handlerType) { }
+            public aweXpect.Reflection.EventFilters.EventsOfType OrOfExactType<THandler>() { }
+            public aweXpect.Reflection.EventFilters.EventsOfType OrOfType(System.Type handlerType) { }
+            public aweXpect.Reflection.EventFilters.EventsOfType OrOfType<THandler>() { }
+        }
         public class EventsWith : aweXpect.Reflection.Collections.Filtered.Events
         {
             public EventsWith(aweXpect.Reflection.Collections.Filtered.Events inner, aweXpect.Reflection.Collections.IChangeableFilter<System.Reflection.EventInfo> filter) { }
@@ -858,7 +870,20 @@ namespace aweXpect.Reflection
         public static aweXpect.Results.AndOrResult<System.Reflection.EventInfo?, aweXpect.Core.IThat<System.Reflection.EventInfo?>> IsAbstract(this aweXpect.Core.IThat<System.Reflection.EventInfo?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Reflection.EventInfo?, aweXpect.Core.IThat<System.Reflection.EventInfo?>> IsNotAbstract(this aweXpect.Core.IThat<System.Reflection.EventInfo?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Reflection.EventInfo?, aweXpect.Core.IThat<System.Reflection.EventInfo?>> IsNotSealed(this aweXpect.Core.IThat<System.Reflection.EventInfo?> subject) { }
+        public static aweXpect.Reflection.ThatEvent.EventOfTypeResult<System.Reflection.EventInfo?, aweXpect.Core.IThat<System.Reflection.EventInfo?>> IsOfExactType(this aweXpect.Core.IThat<System.Reflection.EventInfo?> subject, System.Type handlerType) { }
+        public static aweXpect.Reflection.ThatEvent.EventOfTypeResult<System.Reflection.EventInfo?, aweXpect.Core.IThat<System.Reflection.EventInfo?>> IsOfExactType<THandler>(this aweXpect.Core.IThat<System.Reflection.EventInfo?> subject) { }
+        public static aweXpect.Reflection.ThatEvent.EventOfTypeResult<System.Reflection.EventInfo?, aweXpect.Core.IThat<System.Reflection.EventInfo?>> IsOfType(this aweXpect.Core.IThat<System.Reflection.EventInfo?> subject, System.Type handlerType) { }
+        public static aweXpect.Reflection.ThatEvent.EventOfTypeResult<System.Reflection.EventInfo?, aweXpect.Core.IThat<System.Reflection.EventInfo?>> IsOfType<THandler>(this aweXpect.Core.IThat<System.Reflection.EventInfo?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Reflection.EventInfo?, aweXpect.Core.IThat<System.Reflection.EventInfo?>> IsSealed(this aweXpect.Core.IThat<System.Reflection.EventInfo?> subject) { }
+        public sealed class EventOfTypeResult<TValue, TResult> : aweXpect.Results.AndOrResult<TValue, TResult>, aweXpect.Core.IOptionsProvider<aweXpect.Reflection.Options.TypeFilterOptions>
+            where TResult : aweXpect.Core.IThat<TValue>
+        {
+            public EventOfTypeResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TResult subject, aweXpect.Reflection.Options.TypeFilterOptions typeFilterOptions) { }
+            public aweXpect.Reflection.ThatEvent.EventOfTypeResult<TValue, TResult> OrOfExactType(System.Type handlerType) { }
+            public aweXpect.Reflection.ThatEvent.EventOfTypeResult<TValue, TResult> OrOfExactType<THandler>() { }
+            public aweXpect.Reflection.ThatEvent.EventOfTypeResult<TValue, TResult> OrOfType(System.Type handlerType) { }
+            public aweXpect.Reflection.ThatEvent.EventOfTypeResult<TValue, TResult> OrOfType<THandler>() { }
+        }
     }
     public static class ThatEvents
     {
@@ -868,6 +893,14 @@ namespace aweXpect.Reflection
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>>> AreNotAbstract(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.EventInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.EventInfo?>>> AreNotSealed(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.EventInfo?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>>> AreNotSealed(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>> subject) { }
+        public static aweXpect.Reflection.ThatEvents.EventsOfTypeResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.EventInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.EventInfo?>>> AreOfExactType(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.EventInfo?>> subject, System.Type handlerType) { }
+        public static aweXpect.Reflection.ThatEvents.EventsOfTypeResult<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>>> AreOfExactType(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>> subject, System.Type handlerType) { }
+        public static aweXpect.Reflection.ThatEvents.EventsOfTypeResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.EventInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.EventInfo?>>> AreOfExactType<THandler>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.EventInfo?>> subject) { }
+        public static aweXpect.Reflection.ThatEvents.EventsOfTypeResult<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>>> AreOfExactType<THandler>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>> subject) { }
+        public static aweXpect.Reflection.ThatEvents.EventsOfTypeResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.EventInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.EventInfo?>>> AreOfType(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.EventInfo?>> subject, System.Type handlerType) { }
+        public static aweXpect.Reflection.ThatEvents.EventsOfTypeResult<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>>> AreOfType(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>> subject, System.Type handlerType) { }
+        public static aweXpect.Reflection.ThatEvents.EventsOfTypeResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.EventInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.EventInfo?>>> AreOfType<THandler>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.EventInfo?>> subject) { }
+        public static aweXpect.Reflection.ThatEvents.EventsOfTypeResult<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>>> AreOfType<THandler>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.EventInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.EventInfo?>>> AreSealed(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.EventInfo?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>>> AreSealed(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.EventInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.EventInfo?>>> DoNotHave<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.EventInfo?>> subject, bool inherit = true)
@@ -882,6 +915,15 @@ namespace aweXpect.Reflection
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Results.HaveAttributeResult<System.Reflection.EventInfo?, System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>> subject, System.Func<TAttribute, bool> predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
             where TAttribute : System.Attribute { }
+        public sealed class EventsOfTypeResult<TValue, TResult> : aweXpect.Results.AndOrResult<TValue, TResult>, aweXpect.Core.IOptionsProvider<aweXpect.Reflection.Options.TypeFilterOptions>
+            where TResult : aweXpect.Core.IThat<TValue>
+        {
+            public EventsOfTypeResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TResult subject, aweXpect.Reflection.Options.TypeFilterOptions typeFilterOptions) { }
+            public aweXpect.Reflection.ThatEvents.EventsOfTypeResult<TValue, TResult> OrOfExactType(System.Type handlerType) { }
+            public aweXpect.Reflection.ThatEvents.EventsOfTypeResult<TValue, TResult> OrOfExactType<THandler>() { }
+            public aweXpect.Reflection.ThatEvents.EventsOfTypeResult<TValue, TResult> OrOfType(System.Type handlerType) { }
+            public aweXpect.Reflection.ThatEvents.EventsOfTypeResult<TValue, TResult> OrOfType<THandler>() { }
+        }
     }
     public static class ThatField
     {

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net8.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net8.0.txt
@@ -201,6 +201,10 @@ namespace aweXpect.Reflection
     }
     public static class EventFilters
     {
+        public static aweXpect.Reflection.EventFilters.EventsOfType OfExactType(this aweXpect.Reflection.Collections.Filtered.Events @this, System.Type handlerType) { }
+        public static aweXpect.Reflection.EventFilters.EventsOfType OfExactType<THandler>(this aweXpect.Reflection.Collections.Filtered.Events @this) { }
+        public static aweXpect.Reflection.EventFilters.EventsOfType OfType(this aweXpect.Reflection.Collections.Filtered.Events @this, System.Type handlerType) { }
+        public static aweXpect.Reflection.EventFilters.EventsOfType OfType<THandler>(this aweXpect.Reflection.Collections.Filtered.Events @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Events Which(this aweXpect.Reflection.Collections.Filtered.Events @this, System.Func<System.Reflection.EventInfo, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Reflection.Collections.Filtered.Events WhichAre(this aweXpect.Reflection.Collections.Filtered.Events @this, aweXpect.Reflection.Collections.AccessModifiers accessModifier) { }
         public static aweXpect.Reflection.Collections.Filtered.Events WhichAreAbstract(this aweXpect.Reflection.Collections.Filtered.Events @this) { }
@@ -228,6 +232,14 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Collections.Filtered.Events Without<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Events @this, bool inherit = true)
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Collections.Filtered.Events.StringEqualityResultType WithoutName(this aweXpect.Reflection.Collections.Filtered.Events @this, string unexpected) { }
+        public class EventsOfType : aweXpect.Reflection.Collections.Filtered.Events
+        {
+            public EventsOfType(aweXpect.Reflection.Collections.Filtered.Events inner, aweXpect.Reflection.Collections.IChangeableFilter<System.Reflection.EventInfo> filter) { }
+            public aweXpect.Reflection.EventFilters.EventsOfType OrOfExactType(System.Type handlerType) { }
+            public aweXpect.Reflection.EventFilters.EventsOfType OrOfExactType<THandler>() { }
+            public aweXpect.Reflection.EventFilters.EventsOfType OrOfType(System.Type handlerType) { }
+            public aweXpect.Reflection.EventFilters.EventsOfType OrOfType<THandler>() { }
+        }
         public class EventsWith : aweXpect.Reflection.Collections.Filtered.Events
         {
             public EventsWith(aweXpect.Reflection.Collections.Filtered.Events inner, aweXpect.Reflection.Collections.IChangeableFilter<System.Reflection.EventInfo> filter) { }
@@ -858,7 +870,20 @@ namespace aweXpect.Reflection
         public static aweXpect.Results.AndOrResult<System.Reflection.EventInfo?, aweXpect.Core.IThat<System.Reflection.EventInfo?>> IsAbstract(this aweXpect.Core.IThat<System.Reflection.EventInfo?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Reflection.EventInfo?, aweXpect.Core.IThat<System.Reflection.EventInfo?>> IsNotAbstract(this aweXpect.Core.IThat<System.Reflection.EventInfo?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Reflection.EventInfo?, aweXpect.Core.IThat<System.Reflection.EventInfo?>> IsNotSealed(this aweXpect.Core.IThat<System.Reflection.EventInfo?> subject) { }
+        public static aweXpect.Reflection.ThatEvent.EventOfTypeResult<System.Reflection.EventInfo?, aweXpect.Core.IThat<System.Reflection.EventInfo?>> IsOfExactType(this aweXpect.Core.IThat<System.Reflection.EventInfo?> subject, System.Type handlerType) { }
+        public static aweXpect.Reflection.ThatEvent.EventOfTypeResult<System.Reflection.EventInfo?, aweXpect.Core.IThat<System.Reflection.EventInfo?>> IsOfExactType<THandler>(this aweXpect.Core.IThat<System.Reflection.EventInfo?> subject) { }
+        public static aweXpect.Reflection.ThatEvent.EventOfTypeResult<System.Reflection.EventInfo?, aweXpect.Core.IThat<System.Reflection.EventInfo?>> IsOfType(this aweXpect.Core.IThat<System.Reflection.EventInfo?> subject, System.Type handlerType) { }
+        public static aweXpect.Reflection.ThatEvent.EventOfTypeResult<System.Reflection.EventInfo?, aweXpect.Core.IThat<System.Reflection.EventInfo?>> IsOfType<THandler>(this aweXpect.Core.IThat<System.Reflection.EventInfo?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Reflection.EventInfo?, aweXpect.Core.IThat<System.Reflection.EventInfo?>> IsSealed(this aweXpect.Core.IThat<System.Reflection.EventInfo?> subject) { }
+        public sealed class EventOfTypeResult<TValue, TResult> : aweXpect.Results.AndOrResult<TValue, TResult>, aweXpect.Core.IOptionsProvider<aweXpect.Reflection.Options.TypeFilterOptions>
+            where TResult : aweXpect.Core.IThat<TValue>
+        {
+            public EventOfTypeResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TResult subject, aweXpect.Reflection.Options.TypeFilterOptions typeFilterOptions) { }
+            public aweXpect.Reflection.ThatEvent.EventOfTypeResult<TValue, TResult> OrOfExactType(System.Type handlerType) { }
+            public aweXpect.Reflection.ThatEvent.EventOfTypeResult<TValue, TResult> OrOfExactType<THandler>() { }
+            public aweXpect.Reflection.ThatEvent.EventOfTypeResult<TValue, TResult> OrOfType(System.Type handlerType) { }
+            public aweXpect.Reflection.ThatEvent.EventOfTypeResult<TValue, TResult> OrOfType<THandler>() { }
+        }
     }
     public static class ThatEvents
     {
@@ -868,6 +893,14 @@ namespace aweXpect.Reflection
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>>> AreNotAbstract(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.EventInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.EventInfo?>>> AreNotSealed(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.EventInfo?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>>> AreNotSealed(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>> subject) { }
+        public static aweXpect.Reflection.ThatEvents.EventsOfTypeResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.EventInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.EventInfo?>>> AreOfExactType(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.EventInfo?>> subject, System.Type handlerType) { }
+        public static aweXpect.Reflection.ThatEvents.EventsOfTypeResult<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>>> AreOfExactType(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>> subject, System.Type handlerType) { }
+        public static aweXpect.Reflection.ThatEvents.EventsOfTypeResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.EventInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.EventInfo?>>> AreOfExactType<THandler>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.EventInfo?>> subject) { }
+        public static aweXpect.Reflection.ThatEvents.EventsOfTypeResult<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>>> AreOfExactType<THandler>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>> subject) { }
+        public static aweXpect.Reflection.ThatEvents.EventsOfTypeResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.EventInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.EventInfo?>>> AreOfType(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.EventInfo?>> subject, System.Type handlerType) { }
+        public static aweXpect.Reflection.ThatEvents.EventsOfTypeResult<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>>> AreOfType(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>> subject, System.Type handlerType) { }
+        public static aweXpect.Reflection.ThatEvents.EventsOfTypeResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.EventInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.EventInfo?>>> AreOfType<THandler>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.EventInfo?>> subject) { }
+        public static aweXpect.Reflection.ThatEvents.EventsOfTypeResult<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>>> AreOfType<THandler>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.EventInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.EventInfo?>>> AreSealed(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.EventInfo?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>>> AreSealed(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Reflection.EventInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.EventInfo?>>> DoNotHave<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Reflection.EventInfo?>> subject, bool inherit = true)
@@ -882,6 +915,15 @@ namespace aweXpect.Reflection
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Results.HaveAttributeResult<System.Reflection.EventInfo?, System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>> subject, System.Func<TAttribute, bool> predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
             where TAttribute : System.Attribute { }
+        public sealed class EventsOfTypeResult<TValue, TResult> : aweXpect.Results.AndOrResult<TValue, TResult>, aweXpect.Core.IOptionsProvider<aweXpect.Reflection.Options.TypeFilterOptions>
+            where TResult : aweXpect.Core.IThat<TValue>
+        {
+            public EventsOfTypeResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TResult subject, aweXpect.Reflection.Options.TypeFilterOptions typeFilterOptions) { }
+            public aweXpect.Reflection.ThatEvents.EventsOfTypeResult<TValue, TResult> OrOfExactType(System.Type handlerType) { }
+            public aweXpect.Reflection.ThatEvents.EventsOfTypeResult<TValue, TResult> OrOfExactType<THandler>() { }
+            public aweXpect.Reflection.ThatEvents.EventsOfTypeResult<TValue, TResult> OrOfType(System.Type handlerType) { }
+            public aweXpect.Reflection.ThatEvents.EventsOfTypeResult<TValue, TResult> OrOfType<THandler>() { }
+        }
     }
     public static class ThatField
     {

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_netstandard2.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_netstandard2.0.txt
@@ -201,6 +201,10 @@ namespace aweXpect.Reflection
     }
     public static class EventFilters
     {
+        public static aweXpect.Reflection.EventFilters.EventsOfType OfExactType(this aweXpect.Reflection.Collections.Filtered.Events @this, System.Type handlerType) { }
+        public static aweXpect.Reflection.EventFilters.EventsOfType OfExactType<THandler>(this aweXpect.Reflection.Collections.Filtered.Events @this) { }
+        public static aweXpect.Reflection.EventFilters.EventsOfType OfType(this aweXpect.Reflection.Collections.Filtered.Events @this, System.Type handlerType) { }
+        public static aweXpect.Reflection.EventFilters.EventsOfType OfType<THandler>(this aweXpect.Reflection.Collections.Filtered.Events @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Events Which(this aweXpect.Reflection.Collections.Filtered.Events @this, System.Func<System.Reflection.EventInfo, bool> predicate, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "") { }
         public static aweXpect.Reflection.Collections.Filtered.Events WhichAre(this aweXpect.Reflection.Collections.Filtered.Events @this, aweXpect.Reflection.Collections.AccessModifiers accessModifier) { }
         public static aweXpect.Reflection.Collections.Filtered.Events WhichAreAbstract(this aweXpect.Reflection.Collections.Filtered.Events @this) { }
@@ -228,6 +232,14 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Collections.Filtered.Events Without<TAttribute>(this aweXpect.Reflection.Collections.Filtered.Events @this, bool inherit = true)
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Collections.Filtered.Events.StringEqualityResultType WithoutName(this aweXpect.Reflection.Collections.Filtered.Events @this, string unexpected) { }
+        public class EventsOfType : aweXpect.Reflection.Collections.Filtered.Events
+        {
+            public EventsOfType(aweXpect.Reflection.Collections.Filtered.Events inner, aweXpect.Reflection.Collections.IChangeableFilter<System.Reflection.EventInfo> filter) { }
+            public aweXpect.Reflection.EventFilters.EventsOfType OrOfExactType(System.Type handlerType) { }
+            public aweXpect.Reflection.EventFilters.EventsOfType OrOfExactType<THandler>() { }
+            public aweXpect.Reflection.EventFilters.EventsOfType OrOfType(System.Type handlerType) { }
+            public aweXpect.Reflection.EventFilters.EventsOfType OrOfType<THandler>() { }
+        }
         public class EventsWith : aweXpect.Reflection.Collections.Filtered.Events
         {
             public EventsWith(aweXpect.Reflection.Collections.Filtered.Events inner, aweXpect.Reflection.Collections.IChangeableFilter<System.Reflection.EventInfo> filter) { }
@@ -774,13 +786,30 @@ namespace aweXpect.Reflection
         public static aweXpect.Results.AndOrResult<System.Reflection.EventInfo?, aweXpect.Core.IThat<System.Reflection.EventInfo?>> IsAbstract(this aweXpect.Core.IThat<System.Reflection.EventInfo?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Reflection.EventInfo?, aweXpect.Core.IThat<System.Reflection.EventInfo?>> IsNotAbstract(this aweXpect.Core.IThat<System.Reflection.EventInfo?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Reflection.EventInfo?, aweXpect.Core.IThat<System.Reflection.EventInfo?>> IsNotSealed(this aweXpect.Core.IThat<System.Reflection.EventInfo?> subject) { }
+        public static aweXpect.Reflection.ThatEvent.EventOfTypeResult<System.Reflection.EventInfo?, aweXpect.Core.IThat<System.Reflection.EventInfo?>> IsOfExactType(this aweXpect.Core.IThat<System.Reflection.EventInfo?> subject, System.Type handlerType) { }
+        public static aweXpect.Reflection.ThatEvent.EventOfTypeResult<System.Reflection.EventInfo?, aweXpect.Core.IThat<System.Reflection.EventInfo?>> IsOfExactType<THandler>(this aweXpect.Core.IThat<System.Reflection.EventInfo?> subject) { }
+        public static aweXpect.Reflection.ThatEvent.EventOfTypeResult<System.Reflection.EventInfo?, aweXpect.Core.IThat<System.Reflection.EventInfo?>> IsOfType(this aweXpect.Core.IThat<System.Reflection.EventInfo?> subject, System.Type handlerType) { }
+        public static aweXpect.Reflection.ThatEvent.EventOfTypeResult<System.Reflection.EventInfo?, aweXpect.Core.IThat<System.Reflection.EventInfo?>> IsOfType<THandler>(this aweXpect.Core.IThat<System.Reflection.EventInfo?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Reflection.EventInfo?, aweXpect.Core.IThat<System.Reflection.EventInfo?>> IsSealed(this aweXpect.Core.IThat<System.Reflection.EventInfo?> subject) { }
+        public sealed class EventOfTypeResult<TValue, TResult> : aweXpect.Results.AndOrResult<TValue, TResult>, aweXpect.Core.IOptionsProvider<aweXpect.Reflection.Options.TypeFilterOptions>
+            where TResult : aweXpect.Core.IThat<TValue>
+        {
+            public EventOfTypeResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TResult subject, aweXpect.Reflection.Options.TypeFilterOptions typeFilterOptions) { }
+            public aweXpect.Reflection.ThatEvent.EventOfTypeResult<TValue, TResult> OrOfExactType(System.Type handlerType) { }
+            public aweXpect.Reflection.ThatEvent.EventOfTypeResult<TValue, TResult> OrOfExactType<THandler>() { }
+            public aweXpect.Reflection.ThatEvent.EventOfTypeResult<TValue, TResult> OrOfType(System.Type handlerType) { }
+            public aweXpect.Reflection.ThatEvent.EventOfTypeResult<TValue, TResult> OrOfType<THandler>() { }
+        }
     }
     public static class ThatEvents
     {
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>>> AreAbstract(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>>> AreNotAbstract(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>>> AreNotSealed(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>> subject) { }
+        public static aweXpect.Reflection.ThatEvents.EventsOfTypeResult<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>>> AreOfExactType(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>> subject, System.Type handlerType) { }
+        public static aweXpect.Reflection.ThatEvents.EventsOfTypeResult<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>>> AreOfExactType<THandler>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>> subject) { }
+        public static aweXpect.Reflection.ThatEvents.EventsOfTypeResult<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>>> AreOfType(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>> subject, System.Type handlerType) { }
+        public static aweXpect.Reflection.ThatEvents.EventsOfTypeResult<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>>> AreOfType<THandler>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>>> AreSealed(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>>> DoNotHave<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>> subject, bool inherit = true)
             where TAttribute : System.Attribute { }
@@ -788,6 +817,15 @@ namespace aweXpect.Reflection
             where TAttribute : System.Attribute { }
         public static aweXpect.Reflection.Results.HaveAttributeResult<System.Reflection.EventInfo?, System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>> Have<TAttribute>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Reflection.EventInfo?>> subject, System.Func<TAttribute, bool> predicate, bool inherit = true, [System.Runtime.CompilerServices.CallerArgumentExpression("predicate")] string doNotPopulateThisValue = "")
             where TAttribute : System.Attribute { }
+        public sealed class EventsOfTypeResult<TValue, TResult> : aweXpect.Results.AndOrResult<TValue, TResult>, aweXpect.Core.IOptionsProvider<aweXpect.Reflection.Options.TypeFilterOptions>
+            where TResult : aweXpect.Core.IThat<TValue>
+        {
+            public EventsOfTypeResult(aweXpect.Core.ExpectationBuilder expectationBuilder, TResult subject, aweXpect.Reflection.Options.TypeFilterOptions typeFilterOptions) { }
+            public aweXpect.Reflection.ThatEvents.EventsOfTypeResult<TValue, TResult> OrOfExactType(System.Type handlerType) { }
+            public aweXpect.Reflection.ThatEvents.EventsOfTypeResult<TValue, TResult> OrOfExactType<THandler>() { }
+            public aweXpect.Reflection.ThatEvents.EventsOfTypeResult<TValue, TResult> OrOfType(System.Type handlerType) { }
+            public aweXpect.Reflection.ThatEvents.EventsOfTypeResult<TValue, TResult> OrOfType<THandler>() { }
+        }
     }
     public static class ThatField
     {

--- a/Tests/aweXpect.Reflection.Tests/Filters/EventFilters.OfExactType.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/EventFilters.OfExactType.Tests.cs
@@ -36,6 +36,7 @@ public sealed partial class EventFilters
 			}
 		}
 
+#pragma warning disable CA2263 // tests intentionally exercise the non-generic Type overload
 		public sealed class TypeTests
 		{
 			[Fact]
@@ -90,6 +91,7 @@ public sealed partial class EventFilters
 					.AsPrefix();
 			}
 		}
+#pragma warning restore CA2263
 
 		public delegate void CustomHandler();
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/EventFilters.OfExactType.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/EventFilters.OfExactType.Tests.cs
@@ -1,0 +1,104 @@
+﻿using System;
+using aweXpect.Reflection.Collections;
+
+namespace aweXpect.Reflection.Tests.Filters;
+
+public sealed partial class EventFilters
+{
+	public sealed class OfExactType
+	{
+		public sealed class GenericTests
+		{
+			[Fact]
+			public async Task ShouldFilterForEventsWithExactHandlerType()
+			{
+				Filtered.Events events = In.Type<TestClass>()
+					.Events().OfExactType<EventHandler>();
+
+				await That(events).IsEqualTo([
+					typeof(TestClass).GetEvent(nameof(TestClass.EventHandlerEvent))!,
+				]).InAnyOrder();
+				await That(events.GetDescription())
+					.IsEqualTo("events of exact type EventHandler in type")
+					.AsPrefix();
+			}
+
+			[Fact]
+			public async Task ShouldNotFilterForEventsWhichOnlyInheritTheType()
+			{
+				Filtered.Events events = In.Type<TestClass>()
+					.Events().OfExactType<MulticastDelegate>();
+
+				await That(events).IsEmpty();
+				await That(events.GetDescription())
+					.IsEqualTo("events of exact type MulticastDelegate in type")
+					.AsPrefix();
+			}
+		}
+
+		public sealed class TypeTests
+		{
+			[Fact]
+			public async Task ShouldFilterForEventsWithExactHandlerType()
+			{
+				Filtered.Events events = In.Type<TestClass>()
+					.Events().OfExactType(typeof(EventHandler));
+
+				await That(events).IsEqualTo([
+					typeof(TestClass).GetEvent(nameof(TestClass.EventHandlerEvent))!,
+				]).InAnyOrder();
+				await That(events.GetDescription())
+					.IsEqualTo("events of exact type EventHandler in type")
+					.AsPrefix();
+			}
+		}
+
+		public sealed class OrOfExactTypeGenericTests
+		{
+			[Fact]
+			public async Task ShouldFilterForEventsWhichMatchAnyOfTheGivenExactTypes()
+			{
+				Filtered.Events events = In.Type<TestClass>()
+					.Events().OfExactType<EventHandler>().OrOfExactType<CustomHandler>();
+
+				await That(events).IsEqualTo([
+					typeof(TestClass).GetEvent(nameof(TestClass.EventHandlerEvent))!,
+					typeof(TestClass).GetEvent(nameof(TestClass.CustomHandlerEvent))!,
+				]).InAnyOrder();
+				await That(events.GetDescription())
+					.IsEqualTo(
+						"events of exact type EventHandler or of exact type EventFilters.OfExactType.CustomHandler in type")
+					.AsPrefix();
+			}
+		}
+
+		public sealed class OrOfExactTypeTests
+		{
+			[Fact]
+			public async Task ShouldFilterForEventsWhichMatchAnyOfTheGivenExactTypes()
+			{
+				Filtered.Events events = In.Type<TestClass>()
+					.Events().OfExactType<EventHandler>().OrOfExactType(typeof(CustomHandler));
+
+				await That(events).IsEqualTo([
+					typeof(TestClass).GetEvent(nameof(TestClass.EventHandlerEvent))!,
+					typeof(TestClass).GetEvent(nameof(TestClass.CustomHandlerEvent))!,
+				]).InAnyOrder();
+				await That(events.GetDescription())
+					.IsEqualTo(
+						"events of exact type EventHandler or of exact type EventFilters.OfExactType.CustomHandler in type")
+					.AsPrefix();
+			}
+		}
+
+		public delegate void CustomHandler();
+
+#pragma warning disable CS0067 // The event is never used
+		private class TestClass
+		{
+			public event EventHandler EventHandlerEvent = null!;
+			public event CustomHandler CustomHandlerEvent = null!;
+		}
+#pragma warning restore CS0067
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/Filters/EventFilters.OfType.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/EventFilters.OfType.Tests.cs
@@ -39,6 +39,7 @@ public sealed partial class EventFilters
 			}
 		}
 
+#pragma warning disable CA2263 // tests intentionally exercise the non-generic Type overload
 		public sealed class TypeTests
 		{
 			[Fact]
@@ -110,6 +111,7 @@ public sealed partial class EventFilters
 					.AsPrefix();
 			}
 		}
+#pragma warning restore CA2263
 
 		public delegate void CustomHandler();
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/EventFilters.OfType.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/EventFilters.OfType.Tests.cs
@@ -1,0 +1,124 @@
+﻿using System;
+using aweXpect.Reflection.Collections;
+
+namespace aweXpect.Reflection.Tests.Filters;
+
+public sealed partial class EventFilters
+{
+	public sealed class OfType
+	{
+		public sealed class GenericTests
+		{
+			[Fact]
+			public async Task ShouldFilterForEventsWhichInheritType()
+			{
+				Filtered.Events events = In.Type<TestClass>()
+					.Events().OfType<MulticastDelegate>();
+
+				await That(events).IsEqualTo([
+					typeof(TestClass).GetEvent(nameof(TestClass.EventHandlerEvent))!,
+					typeof(TestClass).GetEvent(nameof(TestClass.CustomHandlerEvent))!,
+				]).InAnyOrder();
+				await That(events.GetDescription())
+					.IsEqualTo("events of type MulticastDelegate in type")
+					.AsPrefix();
+			}
+
+			[Fact]
+			public async Task ShouldFilterForEventsWithExactHandlerType()
+			{
+				Filtered.Events events = In.Type<TestClass>()
+					.Events().OfType<EventHandler>();
+
+				await That(events).IsEqualTo([
+					typeof(TestClass).GetEvent(nameof(TestClass.EventHandlerEvent))!,
+				]).InAnyOrder();
+				await That(events.GetDescription())
+					.IsEqualTo("events of type EventHandler in type")
+					.AsPrefix();
+			}
+		}
+
+		public sealed class TypeTests
+		{
+			[Fact]
+			public async Task ShouldFilterForEventsWhichInheritType()
+			{
+				Filtered.Events events = In.Type<TestClass>()
+					.Events().OfType(typeof(MulticastDelegate));
+
+				await That(events).IsEqualTo([
+					typeof(TestClass).GetEvent(nameof(TestClass.EventHandlerEvent))!,
+					typeof(TestClass).GetEvent(nameof(TestClass.CustomHandlerEvent))!,
+				]).InAnyOrder();
+				await That(events.GetDescription())
+					.IsEqualTo("events of type MulticastDelegate in type")
+					.AsPrefix();
+			}
+		}
+
+		public sealed class OrOfTypeGenericTests
+		{
+			[Fact]
+			public async Task FirstCheckIsOfExactType_ShouldAllowInheritedTypes()
+			{
+				Filtered.Events events = In.Type<TestClass>()
+					.Events().OfExactType<EventHandler>().OrOfType<MulticastDelegate>();
+
+				await That(events).IsEqualTo([
+					typeof(TestClass).GetEvent(nameof(TestClass.EventHandlerEvent))!,
+					typeof(TestClass).GetEvent(nameof(TestClass.CustomHandlerEvent))!,
+				]).InAnyOrder();
+				await That(events.GetDescription())
+					.IsEqualTo(
+						"events of exact type EventHandler or of type MulticastDelegate in type")
+					.AsPrefix();
+			}
+
+			[Fact]
+			public async Task ShouldFilterForEventsWhichMatchAnyOfTheGivenTypes()
+			{
+				Filtered.Events events = In.Type<TestClass>()
+					.Events().OfType<EventHandler>().OrOfType<CustomHandler>();
+
+				await That(events).IsEqualTo([
+					typeof(TestClass).GetEvent(nameof(TestClass.EventHandlerEvent))!,
+					typeof(TestClass).GetEvent(nameof(TestClass.CustomHandlerEvent))!,
+				]).InAnyOrder();
+				await That(events.GetDescription())
+					.IsEqualTo(
+						"events of type EventHandler or of type EventFilters.OfType.CustomHandler in type")
+					.AsPrefix();
+			}
+		}
+
+		public sealed class OrOfTypeTests
+		{
+			[Fact]
+			public async Task ShouldFilterForEventsWhichMatchAnyOfTheGivenTypes()
+			{
+				Filtered.Events events = In.Type<TestClass>()
+					.Events().OfType<EventHandler>().OrOfType(typeof(CustomHandler));
+
+				await That(events).IsEqualTo([
+					typeof(TestClass).GetEvent(nameof(TestClass.EventHandlerEvent))!,
+					typeof(TestClass).GetEvent(nameof(TestClass.CustomHandlerEvent))!,
+				]).InAnyOrder();
+				await That(events.GetDescription())
+					.IsEqualTo(
+						"events of type EventHandler or of type EventFilters.OfType.CustomHandler in type")
+					.AsPrefix();
+			}
+		}
+
+		public delegate void CustomHandler();
+
+#pragma warning disable CS0067 // The event is never used
+		private class TestClass
+		{
+			public event EventHandler EventHandlerEvent = null!;
+			public event CustomHandler CustomHandlerEvent = null!;
+		}
+#pragma warning restore CS0067
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatEvent.IsOfExactType.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatEvent.IsOfExactType.Tests.cs
@@ -1,0 +1,159 @@
+﻿using System;
+using System.Reflection;
+using Xunit.Sdk;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatEvent
+{
+	public sealed class IsOfExactType
+	{
+		public sealed class GenericTests
+		{
+			[Fact]
+			public async Task WhenEventIsNull_ShouldFail()
+			{
+				EventInfo? subject = null;
+
+				async Task Act()
+				{
+					await That(subject).IsOfExactType<EventHandler>();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             is of exact type EventHandler,
+					             but it was <null>
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenEventIsOfExactType_ShouldSucceed()
+			{
+				EventInfo subject = typeof(TestClass).GetEvent(nameof(TestClass.EventHandlerEvent))!;
+
+				async Task Act()
+				{
+					await That(subject).IsOfExactType<EventHandler>();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenEventHandlerInheritsFromExpectedType_ShouldFail()
+			{
+				EventInfo subject = typeof(TestClass).GetEvent(nameof(TestClass.EventHandlerEvent))!;
+
+				async Task Act()
+				{
+					await That(subject).IsOfExactType<MulticastDelegate>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is of exact type MulticastDelegate,
+					             but it was of type EventHandler
+					             """);
+			}
+		}
+
+		public sealed class NegatedTests
+		{
+			[Fact]
+			public async Task WhenEventIsOfExactType_ShouldFail()
+			{
+				EventInfo subject = typeof(TestClass).GetEvent(nameof(TestClass.EventHandlerEvent))!;
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(it => it.IsOfExactType<EventHandler>());
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is not of exact type EventHandler,
+					             but it did
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenEventHandlerInheritsFromExpectedType_ShouldSucceed()
+			{
+				EventInfo subject = typeof(TestClass).GetEvent(nameof(TestClass.EventHandlerEvent))!;
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(it => it.IsOfExactType<MulticastDelegate>());
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+		public delegate void CustomHandler();
+
+#pragma warning disable CS0067 // The event is never used
+		private class TestClass
+		{
+			public event EventHandler EventHandlerEvent = null!;
+		}
+#pragma warning restore CS0067
+
+#pragma warning disable CA2263 // tests intentionally exercise the non-generic Type overload
+		public sealed class TypeTests
+		{
+			[Fact]
+			public async Task WhenEventIsOfExactType_ShouldSucceed()
+			{
+				EventInfo subject = typeof(TestClass).GetEvent(nameof(TestClass.EventHandlerEvent))!;
+
+				async Task Act()
+				{
+					await That(subject).IsOfExactType(typeof(EventHandler));
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenEventHandlerInheritsFromExpectedType_ShouldFail()
+			{
+				EventInfo subject = typeof(TestClass).GetEvent(nameof(TestClass.EventHandlerEvent))!;
+
+				async Task Act()
+				{
+					await That(subject).IsOfExactType(typeof(MulticastDelegate));
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is of exact type MulticastDelegate,
+					             but it was of type EventHandler
+					             """);
+			}
+		}
+
+		public sealed class OrOfExactTypeTests
+		{
+			[Fact]
+			public async Task WithMultipleOrOfExactType_ShouldSupportChaining()
+			{
+				EventInfo subject = typeof(TestClass).GetEvent(nameof(TestClass.EventHandlerEvent))!;
+
+				async Task Act()
+				{
+					await That(subject).IsOfExactType<MulticastDelegate>().OrOfType(typeof(Action))
+						.OrOfExactType<EventHandler>();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+#pragma warning restore CA2263
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatEvent.IsOfType.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatEvent.IsOfType.Tests.cs
@@ -1,0 +1,223 @@
+﻿using System;
+using System.Reflection;
+using Xunit.Sdk;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatEvent
+{
+	public sealed class IsOfType
+	{
+		public sealed class GenericTests
+		{
+			[Fact]
+			public async Task WhenEventIsNull_ShouldFail()
+			{
+				EventInfo? subject = null;
+
+				async Task Act()
+				{
+					await That(subject).IsOfType<EventHandler>();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             is of type EventHandler,
+					             but it was <null>
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenEventIsOfDifferentType_ShouldFail()
+			{
+				EventInfo subject = typeof(TestClass).GetEvent(nameof(TestClass.EventHandlerEvent))!;
+
+				async Task Act()
+				{
+					await That(subject).IsOfType<CustomHandler>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is of type ThatEvent.IsOfType.CustomHandler,
+					             but it was of type EventHandler
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenEventIsOfExpectedType_ShouldSucceed()
+			{
+				EventInfo subject = typeof(TestClass).GetEvent(nameof(TestClass.EventHandlerEvent))!;
+
+				async Task Act()
+				{
+					await That(subject).IsOfType<EventHandler>();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenEventHandlerInheritsFromExpectedType_ShouldSucceed()
+			{
+				EventInfo subject = typeof(TestClass).GetEvent(nameof(TestClass.EventHandlerEvent))!;
+
+				async Task Act()
+				{
+					await That(subject).IsOfType<MulticastDelegate>();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+		public sealed class OrOfExactTypeTests
+		{
+			[Fact]
+			public async Task WhenEventIsNoneOfTheTypes_ShouldFail()
+			{
+				EventInfo subject = typeof(TestClass).GetEvent(nameof(TestClass.EventHandlerEvent))!;
+
+				async Task Act()
+				{
+					await That(subject).IsOfType<CustomHandler>().OrOfExactType<Action>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is of type ThatEvent.IsOfType.CustomHandler or of exact type Action,
+					             but it was of type EventHandler
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenEventIsOneOfTheTypes_ShouldSucceed()
+			{
+				EventInfo subject = typeof(TestClass).GetEvent(nameof(TestClass.EventHandlerEvent))!;
+
+				async Task Act()
+				{
+					await That(subject).IsOfType<CustomHandler>().OrOfExactType<EventHandler>();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+		public sealed class NegatedTests
+		{
+			[Fact]
+			public async Task WhenEventIsOfDifferentType_ShouldSucceed()
+			{
+				EventInfo subject = typeof(TestClass).GetEvent(nameof(TestClass.EventHandlerEvent))!;
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(it => it.IsOfType<CustomHandler>());
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenEventIsOfExpectedType_ShouldFail()
+			{
+				EventInfo subject = typeof(TestClass).GetEvent(nameof(TestClass.EventHandlerEvent))!;
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(it => it.IsOfType<EventHandler>());
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is not of type EventHandler,
+					             but it did
+					             """);
+			}
+		}
+
+		public delegate void CustomHandler();
+
+#pragma warning disable CS0067 // The event is never used
+		private class TestClass
+		{
+			public event EventHandler EventHandlerEvent = null!;
+		}
+#pragma warning restore CS0067
+
+#pragma warning disable CA2263 // tests intentionally exercise the non-generic Type overload
+		public sealed class TypeTests
+		{
+			[Fact]
+			public async Task WhenEventIsOfDifferentType_ShouldFail()
+			{
+				EventInfo subject = typeof(TestClass).GetEvent(nameof(TestClass.EventHandlerEvent))!;
+
+				async Task Act()
+				{
+					await That(subject).IsOfType(typeof(CustomHandler));
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is of type ThatEvent.IsOfType.CustomHandler,
+					             but it was of type EventHandler
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenEventIsOfExpectedType_ShouldSucceed()
+			{
+				EventInfo subject = typeof(TestClass).GetEvent(nameof(TestClass.EventHandlerEvent))!;
+
+				async Task Act()
+				{
+					await That(subject).IsOfType(typeof(EventHandler));
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+		public sealed class OrOfTypeTests
+		{
+			[Fact]
+			public async Task WhenEventIsNoneOfTheTypes_ShouldFail()
+			{
+				EventInfo subject = typeof(TestClass).GetEvent(nameof(TestClass.EventHandlerEvent))!;
+
+				async Task Act()
+				{
+					await That(subject).IsOfType<CustomHandler>().OrOfType<Action>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is of type ThatEvent.IsOfType.CustomHandler or of type Action,
+					             but it was of type EventHandler
+					             """);
+			}
+
+			[Fact]
+			public async Task WithMultipleOrOfType_ShouldSupportChaining()
+			{
+				EventInfo subject = typeof(TestClass).GetEvent(nameof(TestClass.EventHandlerEvent))!;
+
+				async Task Act()
+				{
+					await That(subject).IsOfType<CustomHandler>().OrOfType(typeof(Action)).OrOfType<EventHandler>();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+#pragma warning restore CA2263
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatEvents.AreOfExactType.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatEvents.AreOfExactType.Tests.cs
@@ -1,0 +1,157 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Xunit.Sdk;
+#if NET8_0_OR_GREATER
+using aweXpect.Reflection.Tests.TestHelpers;
+#endif
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatEvents
+{
+	public sealed class AreOfExactType
+	{
+		public sealed class GenericTests
+		{
+			[Fact]
+			public async Task ShouldFailWhenEventsInheritFromType()
+			{
+				IEnumerable<EventInfo> subject =
+				[
+					typeof(TestClass).GetEvent(nameof(TestClass.EventHandlerEvent))!,
+				];
+
+				async Task Act()
+				{
+					await That(subject).AreOfExactType<MulticastDelegate>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             all are of exact type MulticastDelegate,
+					             but it contained not matching events [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task ShouldSucceedWhenAllEventsAreOfExactType()
+			{
+				IEnumerable<EventInfo> subject =
+				[
+					typeof(TestClass).GetEvent(nameof(TestClass.EventHandlerEvent))!,
+					typeof(TestClass).GetEvent(nameof(TestClass.OtherEventHandlerEvent))!,
+				];
+
+				async Task Act()
+				{
+					await That(subject).AreOfExactType<EventHandler>();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+		public sealed class OrOfExactTypeTests
+		{
+			[Fact]
+			public async Task WhenAllEventsAreOneOfTheExactTypes_ShouldSucceed()
+			{
+				IEnumerable<EventInfo> subject =
+				[
+					typeof(TestClass).GetEvent(nameof(TestClass.EventHandlerEvent))!,
+					typeof(TestClass).GetEvent(nameof(TestClass.CustomHandlerEvent))!,
+				];
+
+				async Task Act()
+				{
+					await That(subject).AreOfExactType<EventHandler>().OrOfExactType<CustomHandler>();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenEventStrictlyInheritsFromOrOfExactType_ShouldFail()
+			{
+				IEnumerable<EventInfo> subject =
+				[
+					typeof(TestClass).GetEvent(nameof(TestClass.EventHandlerEvent))!,
+				];
+
+				async Task Act()
+				{
+					await That(subject).AreOfExactType<Action>().OrOfExactType<MulticastDelegate>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             all are of exact type Action or of exact type MulticastDelegate,
+					             but it contained not matching events [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+		}
+
+#if NET8_0_OR_GREATER
+		public sealed class AsyncEnumerableTests
+		{
+			[Fact]
+			public async Task ShouldSucceedWhenAllEventsAreOfExactType()
+			{
+				IAsyncEnumerable<EventInfo?> subject = new[]
+				{
+					typeof(TestClass).GetEvent(nameof(TestClass.EventHandlerEvent))!,
+					typeof(TestClass).GetEvent(nameof(TestClass.OtherEventHandlerEvent))!,
+				}.ToTestAsyncEnumerable<EventInfo?>();
+
+				async Task Act()
+				{
+					await That(subject).AreOfExactType<EventHandler>();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task ShouldFailWhenEventsInheritFromType()
+			{
+				IAsyncEnumerable<EventInfo?> subject = new[]
+				{
+					typeof(TestClass).GetEvent(nameof(TestClass.EventHandlerEvent))!,
+				}.ToTestAsyncEnumerable<EventInfo?>();
+
+				async Task Act()
+				{
+					await That(subject).AreOfExactType<MulticastDelegate>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             all are of exact type MulticastDelegate,
+					             but it contained not matching events [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+		}
+#endif
+
+		public delegate void CustomHandler();
+
+#pragma warning disable CS0067 // The event is never used
+		private class TestClass
+		{
+			public event EventHandler EventHandlerEvent = null!;
+			public event EventHandler OtherEventHandlerEvent = null!;
+			public event CustomHandler CustomHandlerEvent = null!;
+		}
+#pragma warning restore CS0067
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatEvents.AreOfType.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatEvents.AreOfType.Tests.cs
@@ -1,0 +1,258 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Xunit.Sdk;
+#if NET8_0_OR_GREATER
+using aweXpect.Reflection.Tests.TestHelpers;
+#endif
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatEvents
+{
+	public sealed class AreOfType
+	{
+		public sealed class GenericTests
+		{
+			[Fact]
+			public async Task ShouldFailWhenSomeEventsAreNotOfType()
+			{
+				IEnumerable<EventInfo> subject =
+				[
+					typeof(TestClass).GetEvent(nameof(TestClass.EventHandlerEvent))!,
+					typeof(TestClass).GetEvent(nameof(TestClass.CustomHandlerEvent))!,
+				];
+
+				async Task Act()
+				{
+					await That(subject).AreOfType<EventHandler>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             all are of type EventHandler,
+					             but it contained not matching events [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task ShouldSucceedWhenAllEventsAreOfType()
+			{
+				IEnumerable<EventInfo> subject =
+				[
+					typeof(TestClass).GetEvent(nameof(TestClass.EventHandlerEvent))!,
+					typeof(TestClass).GetEvent(nameof(TestClass.OtherEventHandlerEvent))!,
+				];
+
+				async Task Act()
+				{
+					await That(subject).AreOfType<EventHandler>();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task ShouldSucceedWithInheritance()
+			{
+				IEnumerable<EventInfo> subject =
+				[
+					typeof(TestClass).GetEvent(nameof(TestClass.EventHandlerEvent))!,
+				];
+
+				async Task Act()
+				{
+					await That(subject).AreOfType<MulticastDelegate>();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+		public sealed class NegatedTests
+		{
+			[Fact]
+			public async Task WhenAllEventsAreOfType_ShouldFail()
+			{
+				IEnumerable<EventInfo> subject =
+				[
+					typeof(TestClass).GetEvent(nameof(TestClass.EventHandlerEvent))!,
+					typeof(TestClass).GetEvent(nameof(TestClass.OtherEventHandlerEvent))!,
+				];
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(they => they.AreOfType<EventHandler>());
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             not all are of type EventHandler,
+					             but it only contained matching events [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenSomeEventsAreNotOfType_ShouldSucceed()
+			{
+				IEnumerable<EventInfo> subject =
+				[
+					typeof(TestClass).GetEvent(nameof(TestClass.EventHandlerEvent))!,
+					typeof(TestClass).GetEvent(nameof(TestClass.CustomHandlerEvent))!,
+				];
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(they => they.AreOfType<EventHandler>());
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+#if NET8_0_OR_GREATER
+		public sealed class AsyncEnumerableTests
+		{
+			[Fact]
+			public async Task ShouldSucceedWhenAllEventsAreOfType()
+			{
+				IAsyncEnumerable<EventInfo?> subject = new[]
+				{
+					typeof(TestClass).GetEvent(nameof(TestClass.EventHandlerEvent))!,
+					typeof(TestClass).GetEvent(nameof(TestClass.OtherEventHandlerEvent))!,
+				}.ToTestAsyncEnumerable<EventInfo?>();
+
+				async Task Act()
+				{
+					await That(subject).AreOfType<EventHandler>();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task ShouldSucceedWithInheritance()
+			{
+				IAsyncEnumerable<EventInfo?> subject = new[]
+				{
+					typeof(TestClass).GetEvent(nameof(TestClass.EventHandlerEvent))!,
+				}.ToTestAsyncEnumerable<EventInfo?>();
+
+				async Task Act()
+				{
+					await That(subject).AreOfType<MulticastDelegate>();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task ShouldFailWhenSomeEventsAreNotOfType()
+			{
+				IAsyncEnumerable<EventInfo?> subject = new[]
+				{
+					typeof(TestClass).GetEvent(nameof(TestClass.EventHandlerEvent))!,
+					typeof(TestClass).GetEvent(nameof(TestClass.CustomHandlerEvent))!,
+				}.ToTestAsyncEnumerable<EventInfo?>();
+
+				async Task Act()
+				{
+					await That(subject).AreOfType<EventHandler>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             all are of type EventHandler,
+					             but it contained not matching events [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+		}
+#endif
+
+		public delegate void CustomHandler();
+
+#pragma warning disable CS0067 // The event is never used
+		private class TestClass
+		{
+			public event EventHandler EventHandlerEvent = null!;
+			public event EventHandler OtherEventHandlerEvent = null!;
+			public event CustomHandler CustomHandlerEvent = null!;
+		}
+#pragma warning restore CS0067
+
+#pragma warning disable CA2263 // tests intentionally exercise the non-generic Type overload
+		public sealed class TypeTests
+		{
+			[Fact]
+			public async Task ShouldSucceedWhenAllEventsAreOfType()
+			{
+				IEnumerable<EventInfo> subject =
+				[
+					typeof(TestClass).GetEvent(nameof(TestClass.EventHandlerEvent))!,
+					typeof(TestClass).GetEvent(nameof(TestClass.OtherEventHandlerEvent))!,
+				];
+
+				async Task Act()
+				{
+					await That(subject).AreOfType(typeof(EventHandler));
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+		public sealed class OrOfTypeTests
+		{
+			[Fact]
+			public async Task WhenAllEventsAreOneOfTheTypes_ShouldSucceed()
+			{
+				IEnumerable<EventInfo> subject =
+				[
+					typeof(TestClass).GetEvent(nameof(TestClass.EventHandlerEvent))!,
+					typeof(TestClass).GetEvent(nameof(TestClass.CustomHandlerEvent))!,
+				];
+
+				async Task Act()
+				{
+					await That(subject).AreOfType<EventHandler>().OrOfType(typeof(CustomHandler));
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSomeEventsAreNoneOfTheTypes_ShouldFail()
+			{
+				IEnumerable<EventInfo> subject =
+				[
+					typeof(TestClass).GetEvent(nameof(TestClass.EventHandlerEvent))!,
+					typeof(TestClass).GetEvent(nameof(TestClass.CustomHandlerEvent))!,
+				];
+
+				async Task Act()
+				{
+					await That(subject).AreOfType<Action>().OrOfType<EventHandler>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             all are of type Action or of type EventHandler,
+					             but it contained not matching events [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+		}
+#pragma warning restore CA2263
+	}
+}


### PR DESCRIPTION
Adds OfType/OfExactType filters and IsOfType/IsOfExactType (single) and AreOfType/AreOfExactType (collection) assertions for events, matching the EventInfo.EventHandlerType against a given type, mirroring the existing property and field functionality.

---

- *Implements #247*