### PR TITLE
feat: add WhichAreObsolete filter and IsObsolete/AreObsolete assertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,22 @@ await Expect.That(type).Has<ObsoleteAttribute>(a => a.Message == "Use NewClass i
 await Expect.That(methods).Have<FactAttribute>();
 ```
 
+### Obsolete
+
+Shared by all types and members: a self-documenting shorthand for the `ObsoleteAttribute` (so that
+`.WhichAreObsolete()` reads better than `.With<ObsoleteAttribute>()` in architecture rules).
+
+|              | Filter                   | Assert (single)    | Assert (many)       |
+|--------------|--------------------------|--------------------|---------------------|
+| obsolete     | `.WhichAreObsolete()`    | `.IsObsolete()`    | `.AreObsolete()`    |
+| not obsolete | `.WhichAreNotObsolete()` | `.IsNotObsolete()` | `.AreNotObsolete()` |
+
+```csharp
+// Verify that nothing public is marked [Obsolete]
+await Expect.That(In.AssemblyContaining<MyClass>().Types().WhichArePublic())
+    .AreNotObsolete();
+```
+
 ### Names and namespaces
 
 Shared by all types and members.

--- a/Source/aweXpect.Reflection/Filters/ConstructorFilters.WhichAreObsolete.cs
+++ b/Source/aweXpect.Reflection/Filters/ConstructorFilters.WhichAreObsolete.cs
@@ -1,0 +1,24 @@
+using System.Reflection;
+using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Helpers;
+
+namespace aweXpect.Reflection;
+
+public static partial class ConstructorFilters
+{
+	/// <summary>
+	///     Filters for constructors that are obsolete (marked with the <see cref="System.ObsoleteAttribute" />).
+	/// </summary>
+	public static Filtered.Constructors WhichAreObsolete(this Filtered.Constructors @this)
+		=> @this.Which(Filter.Prefix<ConstructorInfo>(
+			constructor => constructor.IsObsolete(),
+			"obsolete "));
+
+	/// <summary>
+	///     Filters for constructors that are not obsolete (not marked with the <see cref="System.ObsoleteAttribute" />).
+	/// </summary>
+	public static Filtered.Constructors WhichAreNotObsolete(this Filtered.Constructors @this)
+		=> @this.Which(Filter.Prefix<ConstructorInfo>(
+			constructor => !constructor.IsObsolete(),
+			"non-obsolete "));
+}

--- a/Source/aweXpect.Reflection/Filters/EventFilters.WhichAreObsolete.cs
+++ b/Source/aweXpect.Reflection/Filters/EventFilters.WhichAreObsolete.cs
@@ -1,0 +1,24 @@
+using System.Reflection;
+using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Helpers;
+
+namespace aweXpect.Reflection;
+
+public static partial class EventFilters
+{
+	/// <summary>
+	///     Filters for events that are obsolete (marked with the <see cref="System.ObsoleteAttribute" />).
+	/// </summary>
+	public static Filtered.Events WhichAreObsolete(this Filtered.Events @this)
+		=> @this.Which(Filter.Prefix<EventInfo>(
+			eventInfo => eventInfo.IsObsolete(),
+			"obsolete "));
+
+	/// <summary>
+	///     Filters for events that are not obsolete (not marked with the <see cref="System.ObsoleteAttribute" />).
+	/// </summary>
+	public static Filtered.Events WhichAreNotObsolete(this Filtered.Events @this)
+		=> @this.Which(Filter.Prefix<EventInfo>(
+			eventInfo => !eventInfo.IsObsolete(),
+			"non-obsolete "));
+}

--- a/Source/aweXpect.Reflection/Filters/FieldFilters.WhichAreObsolete.cs
+++ b/Source/aweXpect.Reflection/Filters/FieldFilters.WhichAreObsolete.cs
@@ -1,0 +1,24 @@
+using System.Reflection;
+using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Helpers;
+
+namespace aweXpect.Reflection;
+
+public static partial class FieldFilters
+{
+	/// <summary>
+	///     Filters for fields that are obsolete (marked with the <see cref="System.ObsoleteAttribute" />).
+	/// </summary>
+	public static Filtered.Fields WhichAreObsolete(this Filtered.Fields @this)
+		=> @this.Which(Filter.Prefix<FieldInfo>(
+			field => field.IsObsolete(),
+			"obsolete "));
+
+	/// <summary>
+	///     Filters for fields that are not obsolete (not marked with the <see cref="System.ObsoleteAttribute" />).
+	/// </summary>
+	public static Filtered.Fields WhichAreNotObsolete(this Filtered.Fields @this)
+		=> @this.Which(Filter.Prefix<FieldInfo>(
+			field => !field.IsObsolete(),
+			"non-obsolete "));
+}

--- a/Source/aweXpect.Reflection/Filters/MethodFilters.WhichAreObsolete.cs
+++ b/Source/aweXpect.Reflection/Filters/MethodFilters.WhichAreObsolete.cs
@@ -1,0 +1,24 @@
+using System.Reflection;
+using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Helpers;
+
+namespace aweXpect.Reflection;
+
+public static partial class MethodFilters
+{
+	/// <summary>
+	///     Filters for methods that are obsolete (marked with the <see cref="System.ObsoleteAttribute" />).
+	/// </summary>
+	public static Filtered.Methods WhichAreObsolete(this Filtered.Methods @this)
+		=> @this.Which(Filter.Prefix<MethodInfo>(
+			method => method.IsObsolete(),
+			"obsolete "));
+
+	/// <summary>
+	///     Filters for methods that are not obsolete (not marked with the <see cref="System.ObsoleteAttribute" />).
+	/// </summary>
+	public static Filtered.Methods WhichAreNotObsolete(this Filtered.Methods @this)
+		=> @this.Which(Filter.Prefix<MethodInfo>(
+			method => !method.IsObsolete(),
+			"non-obsolete "));
+}

--- a/Source/aweXpect.Reflection/Filters/PropertyFilters.WhichAreObsolete.cs
+++ b/Source/aweXpect.Reflection/Filters/PropertyFilters.WhichAreObsolete.cs
@@ -1,0 +1,24 @@
+using System.Reflection;
+using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Helpers;
+
+namespace aweXpect.Reflection;
+
+public static partial class PropertyFilters
+{
+	/// <summary>
+	///     Filters for properties that are obsolete (marked with the <see cref="System.ObsoleteAttribute" />).
+	/// </summary>
+	public static Filtered.Properties WhichAreObsolete(this Filtered.Properties @this)
+		=> @this.Which(Filter.Prefix<PropertyInfo>(
+			property => property.IsObsolete(),
+			"obsolete "));
+
+	/// <summary>
+	///     Filters for properties that are not obsolete (not marked with the <see cref="System.ObsoleteAttribute" />).
+	/// </summary>
+	public static Filtered.Properties WhichAreNotObsolete(this Filtered.Properties @this)
+		=> @this.Which(Filter.Prefix<PropertyInfo>(
+			property => !property.IsObsolete(),
+			"non-obsolete "));
+}

--- a/Source/aweXpect.Reflection/Filters/TypeFilters.WhichAreObsolete.cs
+++ b/Source/aweXpect.Reflection/Filters/TypeFilters.WhichAreObsolete.cs
@@ -1,0 +1,24 @@
+using System;
+using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Helpers;
+
+namespace aweXpect.Reflection;
+
+public static partial class TypeFilters
+{
+	/// <summary>
+	///     Filters for types that are obsolete (marked with the <see cref="ObsoleteAttribute" />).
+	/// </summary>
+	public static Filtered.Types WhichAreObsolete(this Filtered.Types @this)
+		=> @this.Which(Filter.Prefix<Type>(
+			type => type.IsObsolete(),
+			"obsolete "));
+
+	/// <summary>
+	///     Filters for types that are not obsolete (not marked with the <see cref="ObsoleteAttribute" />).
+	/// </summary>
+	public static Filtered.Types WhichAreNotObsolete(this Filtered.Types @this)
+		=> @this.Which(Filter.Prefix<Type>(
+			type => !type.IsObsolete(),
+			"non-obsolete "));
+}

--- a/Source/aweXpect.Reflection/Helpers/MemberInfoHelpers.cs
+++ b/Source/aweXpect.Reflection/Helpers/MemberInfoHelpers.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Reflection;
 using aweXpect.Reflection.Collections;
 
@@ -9,6 +9,13 @@ namespace aweXpect.Reflection.Helpers;
 /// </summary>
 internal static class MemberInfoHelpers
 {
+	/// <summary>
+	///     Checks if the <paramref name="memberInfo" /> is obsolete (marked with the <see cref="ObsoleteAttribute" />).
+	/// </summary>
+	public static bool IsObsolete(this MemberInfo? memberInfo)
+		=> memberInfo is not null &&
+		   Attribute.GetCustomAttributes(memberInfo, typeof(ObsoleteAttribute), inherit: true).Length > 0;
+
 	/// <summary>
 	///     Checks if the <paramref name="memberInfo" /> has the specified <paramref name="accessModifiers" />.
 	/// </summary>

--- a/Source/aweXpect.Reflection/ThatMember.IsObsolete.cs
+++ b/Source/aweXpect.Reflection/ThatMember.IsObsolete.cs
@@ -1,0 +1,68 @@
+using System.Reflection;
+using System.Text;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Reflection.Helpers;
+using aweXpect.Results;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Reflection;
+
+public static partial class ThatMember
+{
+	/// <summary>
+	///     Verifies that the <typeparamref name="TMember" /> is obsolete (marked with the
+	///     <see cref="System.ObsoleteAttribute" />).
+	/// </summary>
+	public static AndOrResult<TMember, IThat<TMember>> IsObsolete<TMember>(
+		this IThat<TMember> subject)
+		where TMember : MemberInfo?
+		=> new(subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new IsObsoleteConstraint<TMember>(it, grammars)),
+			subject);
+
+	/// <summary>
+	///     Verifies that the <typeparamref name="TMember" /> is not obsolete (not marked with the
+	///     <see cref="System.ObsoleteAttribute" />).
+	/// </summary>
+	public static AndOrResult<TMember, IThat<TMember>> IsNotObsolete<TMember>(
+		this IThat<TMember> subject)
+		where TMember : MemberInfo?
+		=> new(subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new IsObsoleteConstraint<TMember>(it, grammars).Invert()),
+			subject);
+
+	private sealed class IsObsoleteConstraint<TMember>(
+		string it,
+		ExpectationGrammars grammars)
+		: ConstraintResult.WithNotNullValue<TMember>(it, grammars),
+			IValueConstraint<TMember>
+		where TMember : MemberInfo?
+	{
+		public ConstraintResult IsMetBy(TMember actual)
+		{
+			Actual = actual;
+			Outcome = actual.IsObsolete() ? Outcome.Success : Outcome.Failure;
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("is obsolete");
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(It).Append(" was non-obsolete ");
+			Formatter.Format(stringBuilder, Actual);
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("is not obsolete");
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(It).Append(" was obsolete ");
+			Formatter.Format(stringBuilder, Actual);
+		}
+	}
+}

--- a/Source/aweXpect.Reflection/ThatMembers.AreInternal.cs
+++ b/Source/aweXpect.Reflection/ThatMembers.AreInternal.cs
@@ -15,7 +15,7 @@ using aweXpect.Results;
 
 namespace aweXpect.Reflection;
 
-public static partial class ThatMember
+public static partial class ThatMembers
 {
 	/// <summary>
 	///     Verifies that all items in the filtered collection of <typeparamref name="TMember" /> are internal.

--- a/Source/aweXpect.Reflection/ThatMembers.AreObsolete.cs
+++ b/Source/aweXpect.Reflection/ThatMembers.AreObsolete.cs
@@ -14,7 +14,7 @@ using aweXpect.Results;
 
 namespace aweXpect.Reflection;
 
-public static partial class ThatMember
+public static partial class ThatMembers
 {
 	/// <summary>
 	///     Verifies that all items in the filtered collection of <typeparamref name="TMember" /> are obsolete (marked with

--- a/Source/aweXpect.Reflection/ThatMembers.AreObsolete.cs
+++ b/Source/aweXpect.Reflection/ThatMembers.AreObsolete.cs
@@ -1,0 +1,142 @@
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text;
+#if NET8_0_OR_GREATER
+using System.Threading;
+using System.Threading.Tasks;
+#endif
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Reflection.Helpers;
+using aweXpect.Results;
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Reflection;
+
+public static partial class ThatMember
+{
+	/// <summary>
+	///     Verifies that all items in the filtered collection of <typeparamref name="TMember" /> are obsolete (marked with
+	///     the <see cref="System.ObsoleteAttribute" />).
+	/// </summary>
+	public static AndOrResult<IEnumerable<TMember>, IThat<IEnumerable<TMember>>> AreObsolete<TMember>(
+		this IThat<IEnumerable<TMember>> subject)
+		where TMember : MemberInfo?
+		=> new(subject.Get().ExpectationBuilder.AddConstraint<IEnumerable<TMember>>((it, grammars)
+				=> new AreObsoleteConstraint<TMember>(it, grammars)),
+			subject);
+
+#if NET8_0_OR_GREATER
+	/// <summary>
+	///     Verifies that all items in the filtered collection of <typeparamref name="TMember" /> are obsolete (marked with
+	///     the <see cref="System.ObsoleteAttribute" />).
+	/// </summary>
+	public static AndOrResult<IAsyncEnumerable<TMember>, IThat<IAsyncEnumerable<TMember>>> AreObsolete<TMember>(
+		this IThat<IAsyncEnumerable<TMember>> subject)
+		where TMember : MemberInfo?
+		=> new(subject.Get().ExpectationBuilder.AddConstraint<IAsyncEnumerable<TMember>>((it, grammars)
+				=> new AreObsoleteConstraint<TMember>(it, grammars)),
+			subject);
+#endif
+
+	/// <summary>
+	///     Verifies that all items in the filtered collection of <typeparamref name="TMember" /> are not obsolete (not
+	///     marked with the <see cref="System.ObsoleteAttribute" />).
+	/// </summary>
+	public static AndOrResult<IEnumerable<TMember>, IThat<IEnumerable<TMember>>> AreNotObsolete<TMember>(
+		this IThat<IEnumerable<TMember>> subject)
+		where TMember : MemberInfo?
+		=> new(subject.Get().ExpectationBuilder.AddConstraint<IEnumerable<TMember>>((it, grammars)
+				=> new AreNotObsoleteConstraint<TMember>(it, grammars)),
+			subject);
+
+#if NET8_0_OR_GREATER
+	/// <summary>
+	///     Verifies that all items in the filtered collection of <typeparamref name="TMember" /> are not obsolete (not
+	///     marked with the <see cref="System.ObsoleteAttribute" />).
+	/// </summary>
+	public static AndOrResult<IAsyncEnumerable<TMember>, IThat<IAsyncEnumerable<TMember>>> AreNotObsolete<TMember>(
+		this IThat<IAsyncEnumerable<TMember>> subject)
+		where TMember : MemberInfo?
+		=> new(subject.Get().ExpectationBuilder.AddConstraint<IAsyncEnumerable<TMember>>((it, grammars)
+				=> new AreNotObsoleteConstraint<TMember>(it, grammars)),
+			subject);
+#endif
+
+	private sealed class AreObsoleteConstraint<TMember>(
+		string it,
+		ExpectationGrammars grammars)
+		: CollectionConstraintResult<TMember>(grammars),
+			IValueConstraint<IEnumerable<TMember>>
+#if NET8_0_OR_GREATER
+			, IAsyncConstraint<IAsyncEnumerable<TMember>>
+#endif
+		where TMember : MemberInfo?
+	{
+#if NET8_0_OR_GREATER
+		public async Task<ConstraintResult> IsMetBy(IAsyncEnumerable<TMember> actual,
+			CancellationToken cancellationToken)
+			=> await SetAsyncValue(actual, member => member.IsObsolete());
+#endif
+
+		public ConstraintResult IsMetBy(IEnumerable<TMember> actual)
+			=> SetValue(actual, member => member.IsObsolete());
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("are all obsolete");
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(it).Append(" contained non-obsolete items ");
+			Formatter.Format(stringBuilder, NotMatching, FormattingOptions.Indented(indentation));
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("are not all obsolete");
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(it).Append(" only contained obsolete items ");
+			Formatter.Format(stringBuilder, Matching, FormattingOptions.Indented(indentation));
+		}
+	}
+
+	private sealed class AreNotObsoleteConstraint<TMember>(
+		string it,
+		ExpectationGrammars grammars)
+		: CollectionConstraintResult<TMember>(grammars),
+			IValueConstraint<IEnumerable<TMember>>
+#if NET8_0_OR_GREATER
+			, IAsyncConstraint<IAsyncEnumerable<TMember>>
+#endif
+		where TMember : MemberInfo?
+	{
+#if NET8_0_OR_GREATER
+		public async Task<ConstraintResult> IsMetBy(IAsyncEnumerable<TMember> actual,
+			CancellationToken cancellationToken)
+			=> await SetAsyncValue(actual, member => !member.IsObsolete());
+#endif
+
+		public ConstraintResult IsMetBy(IEnumerable<TMember> actual)
+			=> SetValue(actual, member => !member.IsObsolete());
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("are all not obsolete");
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(it).Append(" contained obsolete items ");
+			Formatter.Format(stringBuilder, NotMatching, FormattingOptions.Indented(indentation));
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("also contain an obsolete item");
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(it).Append(" only contained non-obsolete items ");
+			Formatter.Format(stringBuilder, Matching, FormattingOptions.Indented(indentation));
+		}
+	}
+}

--- a/Source/aweXpect.Reflection/ThatMembers.ArePrivate.cs
+++ b/Source/aweXpect.Reflection/ThatMembers.ArePrivate.cs
@@ -15,7 +15,7 @@ using aweXpect.Results;
 
 namespace aweXpect.Reflection;
 
-public static partial class ThatMember
+public static partial class ThatMembers
 {
 	/// <summary>
 	///     Verifies that all items in the filtered collection of <typeparamref name="TMember" /> are private.

--- a/Source/aweXpect.Reflection/ThatMembers.ArePrivateProtected.cs
+++ b/Source/aweXpect.Reflection/ThatMembers.ArePrivateProtected.cs
@@ -15,7 +15,7 @@ using aweXpect.Results;
 
 namespace aweXpect.Reflection;
 
-public static partial class ThatMember
+public static partial class ThatMembers
 {
 	/// <summary>
 	///     Verifies that all items in the filtered collection of <typeparamref name="TMember" /> are private protected.

--- a/Source/aweXpect.Reflection/ThatMembers.AreProtected.cs
+++ b/Source/aweXpect.Reflection/ThatMembers.AreProtected.cs
@@ -15,7 +15,7 @@ using aweXpect.Results;
 
 namespace aweXpect.Reflection;
 
-public static partial class ThatMember
+public static partial class ThatMembers
 {
 	/// <summary>
 	///     Verifies that all items in the filtered collection of <typeparamref name="TMember" /> are protected.

--- a/Source/aweXpect.Reflection/ThatMembers.AreProtectedInternal.cs
+++ b/Source/aweXpect.Reflection/ThatMembers.AreProtectedInternal.cs
@@ -15,7 +15,7 @@ using aweXpect.Results;
 
 namespace aweXpect.Reflection;
 
-public static partial class ThatMember
+public static partial class ThatMembers
 {
 	/// <summary>
 	///     Verifies that all items in the filtered collection of <typeparamref name="TMember" /> are protected internal.

--- a/Source/aweXpect.Reflection/ThatMembers.ArePublic.cs
+++ b/Source/aweXpect.Reflection/ThatMembers.ArePublic.cs
@@ -15,7 +15,7 @@ using aweXpect.Results;
 
 namespace aweXpect.Reflection;
 
-public static partial class ThatMember
+public static partial class ThatMembers
 {
 	/// <summary>
 	///     Verifies that all items in the filtered collection of <typeparamref name="TMember" /> are public.

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net10.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net10.0.txt
@@ -1023,6 +1023,41 @@ namespace aweXpect.Reflection
     }
     public static class ThatMember
     {
+        public static aweXpect.Results.StringEqualityTypeResult<TMember, aweXpect.Core.IThat<TMember>> DoesNotHaveName<TMember>(this aweXpect.Core.IThat<TMember> subject, string unexpected)
+            where TMember : System.Reflection.MemberInfo? { }
+        public static aweXpect.Results.StringEqualityTypeResult<TMember, aweXpect.Core.IThat<TMember>> HasName<TMember>(this aweXpect.Core.IThat<TMember> subject, string expected)
+            where TMember : System.Reflection.MemberInfo? { }
+        public static aweXpect.Results.AndOrResult<TMember, aweXpect.Core.IThat<TMember>> IsInternal<TMember>(this aweXpect.Core.IThat<TMember> subject)
+            where TMember : System.Reflection.MemberInfo? { }
+        public static aweXpect.Results.AndOrResult<TMember, aweXpect.Core.IThat<TMember>> IsNotInternal<TMember>(this aweXpect.Core.IThat<TMember> subject)
+            where TMember : System.Reflection.MemberInfo? { }
+        public static aweXpect.Results.AndOrResult<TMember, aweXpect.Core.IThat<TMember>> IsNotObsolete<TMember>(this aweXpect.Core.IThat<TMember> subject)
+            where TMember : System.Reflection.MemberInfo? { }
+        public static aweXpect.Results.AndOrResult<TMember, aweXpect.Core.IThat<TMember>> IsNotPrivate<TMember>(this aweXpect.Core.IThat<TMember> subject)
+            where TMember : System.Reflection.MemberInfo? { }
+        public static aweXpect.Results.AndOrResult<TMember, aweXpect.Core.IThat<TMember>> IsNotPrivateProtected<TMember>(this aweXpect.Core.IThat<TMember> subject)
+            where TMember : System.Reflection.MemberInfo? { }
+        public static aweXpect.Results.AndOrResult<TMember, aweXpect.Core.IThat<TMember>> IsNotProtected<TMember>(this aweXpect.Core.IThat<TMember> subject)
+            where TMember : System.Reflection.MemberInfo? { }
+        public static aweXpect.Results.AndOrResult<TMember, aweXpect.Core.IThat<TMember>> IsNotProtectedInternal<TMember>(this aweXpect.Core.IThat<TMember> subject)
+            where TMember : System.Reflection.MemberInfo? { }
+        public static aweXpect.Results.AndOrResult<TMember, aweXpect.Core.IThat<TMember>> IsNotPublic<TMember>(this aweXpect.Core.IThat<TMember> subject)
+            where TMember : System.Reflection.MemberInfo? { }
+        public static aweXpect.Results.AndOrResult<TMember, aweXpect.Core.IThat<TMember>> IsObsolete<TMember>(this aweXpect.Core.IThat<TMember> subject)
+            where TMember : System.Reflection.MemberInfo? { }
+        public static aweXpect.Results.AndOrResult<TMember, aweXpect.Core.IThat<TMember>> IsPrivate<TMember>(this aweXpect.Core.IThat<TMember> subject)
+            where TMember : System.Reflection.MemberInfo? { }
+        public static aweXpect.Results.AndOrResult<TMember, aweXpect.Core.IThat<TMember>> IsPrivateProtected<TMember>(this aweXpect.Core.IThat<TMember> subject)
+            where TMember : System.Reflection.MemberInfo? { }
+        public static aweXpect.Results.AndOrResult<TMember, aweXpect.Core.IThat<TMember>> IsProtected<TMember>(this aweXpect.Core.IThat<TMember> subject)
+            where TMember : System.Reflection.MemberInfo? { }
+        public static aweXpect.Results.AndOrResult<TMember, aweXpect.Core.IThat<TMember>> IsProtectedInternal<TMember>(this aweXpect.Core.IThat<TMember> subject)
+            where TMember : System.Reflection.MemberInfo? { }
+        public static aweXpect.Results.AndOrResult<TMember, aweXpect.Core.IThat<TMember>> IsPublic<TMember>(this aweXpect.Core.IThat<TMember> subject)
+            where TMember : System.Reflection.MemberInfo? { }
+    }
+    public static class ThatMembers
+    {
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<TMember>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TMember>>> AreInternal<TMember>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TMember>> subject)
             where TMember : System.Reflection.MemberInfo? { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TMember>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>>> AreInternal<TMember>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>> subject)
@@ -1079,41 +1114,6 @@ namespace aweXpect.Reflection
             where TMember : System.Reflection.MemberInfo? { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TMember>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>>> ArePublic<TMember>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>> subject)
             where TMember : System.Reflection.MemberInfo? { }
-        public static aweXpect.Results.StringEqualityTypeResult<TMember, aweXpect.Core.IThat<TMember>> DoesNotHaveName<TMember>(this aweXpect.Core.IThat<TMember> subject, string unexpected)
-            where TMember : System.Reflection.MemberInfo? { }
-        public static aweXpect.Results.StringEqualityTypeResult<TMember, aweXpect.Core.IThat<TMember>> HasName<TMember>(this aweXpect.Core.IThat<TMember> subject, string expected)
-            where TMember : System.Reflection.MemberInfo? { }
-        public static aweXpect.Results.AndOrResult<TMember, aweXpect.Core.IThat<TMember>> IsInternal<TMember>(this aweXpect.Core.IThat<TMember> subject)
-            where TMember : System.Reflection.MemberInfo? { }
-        public static aweXpect.Results.AndOrResult<TMember, aweXpect.Core.IThat<TMember>> IsNotInternal<TMember>(this aweXpect.Core.IThat<TMember> subject)
-            where TMember : System.Reflection.MemberInfo? { }
-        public static aweXpect.Results.AndOrResult<TMember, aweXpect.Core.IThat<TMember>> IsNotObsolete<TMember>(this aweXpect.Core.IThat<TMember> subject)
-            where TMember : System.Reflection.MemberInfo? { }
-        public static aweXpect.Results.AndOrResult<TMember, aweXpect.Core.IThat<TMember>> IsNotPrivate<TMember>(this aweXpect.Core.IThat<TMember> subject)
-            where TMember : System.Reflection.MemberInfo? { }
-        public static aweXpect.Results.AndOrResult<TMember, aweXpect.Core.IThat<TMember>> IsNotPrivateProtected<TMember>(this aweXpect.Core.IThat<TMember> subject)
-            where TMember : System.Reflection.MemberInfo? { }
-        public static aweXpect.Results.AndOrResult<TMember, aweXpect.Core.IThat<TMember>> IsNotProtected<TMember>(this aweXpect.Core.IThat<TMember> subject)
-            where TMember : System.Reflection.MemberInfo? { }
-        public static aweXpect.Results.AndOrResult<TMember, aweXpect.Core.IThat<TMember>> IsNotProtectedInternal<TMember>(this aweXpect.Core.IThat<TMember> subject)
-            where TMember : System.Reflection.MemberInfo? { }
-        public static aweXpect.Results.AndOrResult<TMember, aweXpect.Core.IThat<TMember>> IsNotPublic<TMember>(this aweXpect.Core.IThat<TMember> subject)
-            where TMember : System.Reflection.MemberInfo? { }
-        public static aweXpect.Results.AndOrResult<TMember, aweXpect.Core.IThat<TMember>> IsObsolete<TMember>(this aweXpect.Core.IThat<TMember> subject)
-            where TMember : System.Reflection.MemberInfo? { }
-        public static aweXpect.Results.AndOrResult<TMember, aweXpect.Core.IThat<TMember>> IsPrivate<TMember>(this aweXpect.Core.IThat<TMember> subject)
-            where TMember : System.Reflection.MemberInfo? { }
-        public static aweXpect.Results.AndOrResult<TMember, aweXpect.Core.IThat<TMember>> IsPrivateProtected<TMember>(this aweXpect.Core.IThat<TMember> subject)
-            where TMember : System.Reflection.MemberInfo? { }
-        public static aweXpect.Results.AndOrResult<TMember, aweXpect.Core.IThat<TMember>> IsProtected<TMember>(this aweXpect.Core.IThat<TMember> subject)
-            where TMember : System.Reflection.MemberInfo? { }
-        public static aweXpect.Results.AndOrResult<TMember, aweXpect.Core.IThat<TMember>> IsProtectedInternal<TMember>(this aweXpect.Core.IThat<TMember> subject)
-            where TMember : System.Reflection.MemberInfo? { }
-        public static aweXpect.Results.AndOrResult<TMember, aweXpect.Core.IThat<TMember>> IsPublic<TMember>(this aweXpect.Core.IThat<TMember> subject)
-            where TMember : System.Reflection.MemberInfo? { }
-    }
-    public static class ThatMembers
-    {
         public static aweXpect.Results.StringEqualityTypeResult<System.Collections.Generic.IAsyncEnumerable<TMember>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TMember>>> DoNotHaveName<TMember>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TMember>> subject, string unexpected)
             where TMember : System.Reflection.MemberInfo? { }
         public static aweXpect.Results.StringEqualityTypeResult<System.Collections.Generic.IEnumerable<TMember>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>>> DoNotHaveName<TMember>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>> subject, string unexpected)

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net10.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net10.0.txt
@@ -84,12 +84,14 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Collections.Filtered.Constructors WhichAreInternal(this aweXpect.Reflection.Collections.Filtered.Constructors @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Constructors WhichAreNot(this aweXpect.Reflection.Collections.Filtered.Constructors @this, aweXpect.Reflection.Collections.AccessModifiers accessModifier) { }
         public static aweXpect.Reflection.Collections.Filtered.Constructors WhichAreNotInternal(this aweXpect.Reflection.Collections.Filtered.Constructors @this) { }
+        public static aweXpect.Reflection.Collections.Filtered.Constructors WhichAreNotObsolete(this aweXpect.Reflection.Collections.Filtered.Constructors @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Constructors WhichAreNotPrivate(this aweXpect.Reflection.Collections.Filtered.Constructors @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Constructors WhichAreNotPrivateProtected(this aweXpect.Reflection.Collections.Filtered.Constructors @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Constructors WhichAreNotProtected(this aweXpect.Reflection.Collections.Filtered.Constructors @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Constructors WhichAreNotProtectedInternal(this aweXpect.Reflection.Collections.Filtered.Constructors @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Constructors WhichAreNotPublic(this aweXpect.Reflection.Collections.Filtered.Constructors @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Constructors WhichAreNotStatic(this aweXpect.Reflection.Collections.Filtered.Constructors @this) { }
+        public static aweXpect.Reflection.Collections.Filtered.Constructors WhichAreObsolete(this aweXpect.Reflection.Collections.Filtered.Constructors @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Constructors WhichArePrivate(this aweXpect.Reflection.Collections.Filtered.Constructors @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Constructors WhichArePrivateProtected(this aweXpect.Reflection.Collections.Filtered.Constructors @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Constructors WhichAreProtected(this aweXpect.Reflection.Collections.Filtered.Constructors @this) { }
@@ -214,12 +216,14 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Collections.Filtered.Events WhichAreNot(this aweXpect.Reflection.Collections.Filtered.Events @this, aweXpect.Reflection.Collections.AccessModifiers accessModifier) { }
         public static aweXpect.Reflection.Collections.Filtered.Events WhichAreNotAbstract(this aweXpect.Reflection.Collections.Filtered.Events @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Events WhichAreNotInternal(this aweXpect.Reflection.Collections.Filtered.Events @this) { }
+        public static aweXpect.Reflection.Collections.Filtered.Events WhichAreNotObsolete(this aweXpect.Reflection.Collections.Filtered.Events @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Events WhichAreNotPrivate(this aweXpect.Reflection.Collections.Filtered.Events @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Events WhichAreNotPrivateProtected(this aweXpect.Reflection.Collections.Filtered.Events @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Events WhichAreNotProtected(this aweXpect.Reflection.Collections.Filtered.Events @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Events WhichAreNotProtectedInternal(this aweXpect.Reflection.Collections.Filtered.Events @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Events WhichAreNotPublic(this aweXpect.Reflection.Collections.Filtered.Events @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Events WhichAreNotSealed(this aweXpect.Reflection.Collections.Filtered.Events @this) { }
+        public static aweXpect.Reflection.Collections.Filtered.Events WhichAreObsolete(this aweXpect.Reflection.Collections.Filtered.Events @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Events WhichArePrivate(this aweXpect.Reflection.Collections.Filtered.Events @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Events WhichArePrivateProtected(this aweXpect.Reflection.Collections.Filtered.Events @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Events WhichAreProtected(this aweXpect.Reflection.Collections.Filtered.Events @this) { }
@@ -264,6 +268,7 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Collections.Filtered.Fields WhichAreNot(this aweXpect.Reflection.Collections.Filtered.Fields @this, aweXpect.Reflection.Collections.AccessModifiers accessModifier) { }
         public static aweXpect.Reflection.Collections.Filtered.Fields WhichAreNotConstant(this aweXpect.Reflection.Collections.Filtered.Fields @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Fields WhichAreNotInternal(this aweXpect.Reflection.Collections.Filtered.Fields @this) { }
+        public static aweXpect.Reflection.Collections.Filtered.Fields WhichAreNotObsolete(this aweXpect.Reflection.Collections.Filtered.Fields @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Fields WhichAreNotPrivate(this aweXpect.Reflection.Collections.Filtered.Fields @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Fields WhichAreNotPrivateProtected(this aweXpect.Reflection.Collections.Filtered.Fields @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Fields WhichAreNotProtected(this aweXpect.Reflection.Collections.Filtered.Fields @this) { }
@@ -271,6 +276,7 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Collections.Filtered.Fields WhichAreNotPublic(this aweXpect.Reflection.Collections.Filtered.Fields @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Fields WhichAreNotReadOnly(this aweXpect.Reflection.Collections.Filtered.Fields @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Fields WhichAreNotStatic(this aweXpect.Reflection.Collections.Filtered.Fields @this) { }
+        public static aweXpect.Reflection.Collections.Filtered.Fields WhichAreObsolete(this aweXpect.Reflection.Collections.Filtered.Fields @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Fields WhichArePrivate(this aweXpect.Reflection.Collections.Filtered.Fields @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Fields WhichArePrivateProtected(this aweXpect.Reflection.Collections.Filtered.Fields @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Fields WhichAreProtected(this aweXpect.Reflection.Collections.Filtered.Fields @this) { }
@@ -336,6 +342,7 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Collections.Filtered.Methods WhichAreNotAsync(this aweXpect.Reflection.Collections.Filtered.Methods @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Methods WhichAreNotGeneric(this aweXpect.Reflection.Collections.Filtered.Methods @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Methods WhichAreNotInternal(this aweXpect.Reflection.Collections.Filtered.Methods @this) { }
+        public static aweXpect.Reflection.Collections.Filtered.Methods WhichAreNotObsolete(this aweXpect.Reflection.Collections.Filtered.Methods @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Methods WhichAreNotPrivate(this aweXpect.Reflection.Collections.Filtered.Methods @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Methods WhichAreNotPrivateProtected(this aweXpect.Reflection.Collections.Filtered.Methods @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Methods WhichAreNotProtected(this aweXpect.Reflection.Collections.Filtered.Methods @this) { }
@@ -344,6 +351,7 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Collections.Filtered.Methods WhichAreNotSealed(this aweXpect.Reflection.Collections.Filtered.Methods @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Methods WhichAreNotStatic(this aweXpect.Reflection.Collections.Filtered.Methods @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Methods WhichAreNotVirtual(this aweXpect.Reflection.Collections.Filtered.Methods @this) { }
+        public static aweXpect.Reflection.Collections.Filtered.Methods WhichAreObsolete(this aweXpect.Reflection.Collections.Filtered.Methods @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Methods WhichArePrivate(this aweXpect.Reflection.Collections.Filtered.Methods @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Methods WhichArePrivateProtected(this aweXpect.Reflection.Collections.Filtered.Methods @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Methods WhichAreProtected(this aweXpect.Reflection.Collections.Filtered.Methods @this) { }
@@ -517,6 +525,7 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Collections.Filtered.Properties WhichAreNotAbstract(this aweXpect.Reflection.Collections.Filtered.Properties @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Properties WhichAreNotIndexers(this aweXpect.Reflection.Collections.Filtered.Properties @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Properties WhichAreNotInternal(this aweXpect.Reflection.Collections.Filtered.Properties @this) { }
+        public static aweXpect.Reflection.Collections.Filtered.Properties WhichAreNotObsolete(this aweXpect.Reflection.Collections.Filtered.Properties @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Properties WhichAreNotPrivate(this aweXpect.Reflection.Collections.Filtered.Properties @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Properties WhichAreNotPrivateProtected(this aweXpect.Reflection.Collections.Filtered.Properties @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Properties WhichAreNotProtected(this aweXpect.Reflection.Collections.Filtered.Properties @this) { }
@@ -526,6 +535,7 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Collections.Filtered.Properties WhichAreNotSealed(this aweXpect.Reflection.Collections.Filtered.Properties @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Properties WhichAreNotStatic(this aweXpect.Reflection.Collections.Filtered.Properties @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Properties WhichAreNotVirtual(this aweXpect.Reflection.Collections.Filtered.Properties @this) { }
+        public static aweXpect.Reflection.Collections.Filtered.Properties WhichAreObsolete(this aweXpect.Reflection.Collections.Filtered.Properties @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Properties WhichArePrivate(this aweXpect.Reflection.Collections.Filtered.Properties @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Properties WhichArePrivateProtected(this aweXpect.Reflection.Collections.Filtered.Properties @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Properties WhichAreProtected(this aweXpect.Reflection.Collections.Filtered.Properties @this) { }
@@ -1021,6 +1031,10 @@ namespace aweXpect.Reflection
             where TMember : System.Reflection.MemberInfo? { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TMember>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>>> AreNotInternal<TMember>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>> subject)
             where TMember : System.Reflection.MemberInfo? { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<TMember>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TMember>>> AreNotObsolete<TMember>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TMember>> subject)
+            where TMember : System.Reflection.MemberInfo? { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TMember>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>>> AreNotObsolete<TMember>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>> subject)
+            where TMember : System.Reflection.MemberInfo? { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<TMember>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TMember>>> AreNotPrivate<TMember>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TMember>> subject)
             where TMember : System.Reflection.MemberInfo? { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TMember>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>>> AreNotPrivate<TMember>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>> subject)
@@ -1040,6 +1054,10 @@ namespace aweXpect.Reflection
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<TMember>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TMember>>> AreNotPublic<TMember>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TMember>> subject)
             where TMember : System.Reflection.MemberInfo? { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TMember>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>>> AreNotPublic<TMember>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>> subject)
+            where TMember : System.Reflection.MemberInfo? { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<TMember>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TMember>>> AreObsolete<TMember>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TMember>> subject)
+            where TMember : System.Reflection.MemberInfo? { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TMember>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>>> AreObsolete<TMember>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>> subject)
             where TMember : System.Reflection.MemberInfo? { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<TMember>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TMember>>> ArePrivate<TMember>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TMember>> subject)
             where TMember : System.Reflection.MemberInfo? { }
@@ -1069,6 +1087,8 @@ namespace aweXpect.Reflection
             where TMember : System.Reflection.MemberInfo? { }
         public static aweXpect.Results.AndOrResult<TMember, aweXpect.Core.IThat<TMember>> IsNotInternal<TMember>(this aweXpect.Core.IThat<TMember> subject)
             where TMember : System.Reflection.MemberInfo? { }
+        public static aweXpect.Results.AndOrResult<TMember, aweXpect.Core.IThat<TMember>> IsNotObsolete<TMember>(this aweXpect.Core.IThat<TMember> subject)
+            where TMember : System.Reflection.MemberInfo? { }
         public static aweXpect.Results.AndOrResult<TMember, aweXpect.Core.IThat<TMember>> IsNotPrivate<TMember>(this aweXpect.Core.IThat<TMember> subject)
             where TMember : System.Reflection.MemberInfo? { }
         public static aweXpect.Results.AndOrResult<TMember, aweXpect.Core.IThat<TMember>> IsNotPrivateProtected<TMember>(this aweXpect.Core.IThat<TMember> subject)
@@ -1078,6 +1098,8 @@ namespace aweXpect.Reflection
         public static aweXpect.Results.AndOrResult<TMember, aweXpect.Core.IThat<TMember>> IsNotProtectedInternal<TMember>(this aweXpect.Core.IThat<TMember> subject)
             where TMember : System.Reflection.MemberInfo? { }
         public static aweXpect.Results.AndOrResult<TMember, aweXpect.Core.IThat<TMember>> IsNotPublic<TMember>(this aweXpect.Core.IThat<TMember> subject)
+            where TMember : System.Reflection.MemberInfo? { }
+        public static aweXpect.Results.AndOrResult<TMember, aweXpect.Core.IThat<TMember>> IsObsolete<TMember>(this aweXpect.Core.IThat<TMember> subject)
             where TMember : System.Reflection.MemberInfo? { }
         public static aweXpect.Results.AndOrResult<TMember, aweXpect.Core.IThat<TMember>> IsPrivate<TMember>(this aweXpect.Core.IThat<TMember> subject)
             where TMember : System.Reflection.MemberInfo? { }
@@ -1689,6 +1711,7 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreNotInterfaces(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreNotInternal(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreNotNested(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
+        public static aweXpect.Reflection.Collections.Filtered.Types WhichAreNotObsolete(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreNotPrivate(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreNotPrivateProtected(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreNotProtected(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
@@ -1701,6 +1724,7 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreNotSealed(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreNotStatic(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreNotStructs(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
+        public static aweXpect.Reflection.Collections.Filtered.Types WhichAreObsolete(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichArePrivate(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichArePrivateProtected(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreProtected(this aweXpect.Reflection.Collections.Filtered.Types @this) { }

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net8.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net8.0.txt
@@ -1023,6 +1023,41 @@ namespace aweXpect.Reflection
     }
     public static class ThatMember
     {
+        public static aweXpect.Results.StringEqualityTypeResult<TMember, aweXpect.Core.IThat<TMember>> DoesNotHaveName<TMember>(this aweXpect.Core.IThat<TMember> subject, string unexpected)
+            where TMember : System.Reflection.MemberInfo? { }
+        public static aweXpect.Results.StringEqualityTypeResult<TMember, aweXpect.Core.IThat<TMember>> HasName<TMember>(this aweXpect.Core.IThat<TMember> subject, string expected)
+            where TMember : System.Reflection.MemberInfo? { }
+        public static aweXpect.Results.AndOrResult<TMember, aweXpect.Core.IThat<TMember>> IsInternal<TMember>(this aweXpect.Core.IThat<TMember> subject)
+            where TMember : System.Reflection.MemberInfo? { }
+        public static aweXpect.Results.AndOrResult<TMember, aweXpect.Core.IThat<TMember>> IsNotInternal<TMember>(this aweXpect.Core.IThat<TMember> subject)
+            where TMember : System.Reflection.MemberInfo? { }
+        public static aweXpect.Results.AndOrResult<TMember, aweXpect.Core.IThat<TMember>> IsNotObsolete<TMember>(this aweXpect.Core.IThat<TMember> subject)
+            where TMember : System.Reflection.MemberInfo? { }
+        public static aweXpect.Results.AndOrResult<TMember, aweXpect.Core.IThat<TMember>> IsNotPrivate<TMember>(this aweXpect.Core.IThat<TMember> subject)
+            where TMember : System.Reflection.MemberInfo? { }
+        public static aweXpect.Results.AndOrResult<TMember, aweXpect.Core.IThat<TMember>> IsNotPrivateProtected<TMember>(this aweXpect.Core.IThat<TMember> subject)
+            where TMember : System.Reflection.MemberInfo? { }
+        public static aweXpect.Results.AndOrResult<TMember, aweXpect.Core.IThat<TMember>> IsNotProtected<TMember>(this aweXpect.Core.IThat<TMember> subject)
+            where TMember : System.Reflection.MemberInfo? { }
+        public static aweXpect.Results.AndOrResult<TMember, aweXpect.Core.IThat<TMember>> IsNotProtectedInternal<TMember>(this aweXpect.Core.IThat<TMember> subject)
+            where TMember : System.Reflection.MemberInfo? { }
+        public static aweXpect.Results.AndOrResult<TMember, aweXpect.Core.IThat<TMember>> IsNotPublic<TMember>(this aweXpect.Core.IThat<TMember> subject)
+            where TMember : System.Reflection.MemberInfo? { }
+        public static aweXpect.Results.AndOrResult<TMember, aweXpect.Core.IThat<TMember>> IsObsolete<TMember>(this aweXpect.Core.IThat<TMember> subject)
+            where TMember : System.Reflection.MemberInfo? { }
+        public static aweXpect.Results.AndOrResult<TMember, aweXpect.Core.IThat<TMember>> IsPrivate<TMember>(this aweXpect.Core.IThat<TMember> subject)
+            where TMember : System.Reflection.MemberInfo? { }
+        public static aweXpect.Results.AndOrResult<TMember, aweXpect.Core.IThat<TMember>> IsPrivateProtected<TMember>(this aweXpect.Core.IThat<TMember> subject)
+            where TMember : System.Reflection.MemberInfo? { }
+        public static aweXpect.Results.AndOrResult<TMember, aweXpect.Core.IThat<TMember>> IsProtected<TMember>(this aweXpect.Core.IThat<TMember> subject)
+            where TMember : System.Reflection.MemberInfo? { }
+        public static aweXpect.Results.AndOrResult<TMember, aweXpect.Core.IThat<TMember>> IsProtectedInternal<TMember>(this aweXpect.Core.IThat<TMember> subject)
+            where TMember : System.Reflection.MemberInfo? { }
+        public static aweXpect.Results.AndOrResult<TMember, aweXpect.Core.IThat<TMember>> IsPublic<TMember>(this aweXpect.Core.IThat<TMember> subject)
+            where TMember : System.Reflection.MemberInfo? { }
+    }
+    public static class ThatMembers
+    {
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<TMember>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TMember>>> AreInternal<TMember>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TMember>> subject)
             where TMember : System.Reflection.MemberInfo? { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TMember>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>>> AreInternal<TMember>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>> subject)
@@ -1079,41 +1114,6 @@ namespace aweXpect.Reflection
             where TMember : System.Reflection.MemberInfo? { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TMember>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>>> ArePublic<TMember>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>> subject)
             where TMember : System.Reflection.MemberInfo? { }
-        public static aweXpect.Results.StringEqualityTypeResult<TMember, aweXpect.Core.IThat<TMember>> DoesNotHaveName<TMember>(this aweXpect.Core.IThat<TMember> subject, string unexpected)
-            where TMember : System.Reflection.MemberInfo? { }
-        public static aweXpect.Results.StringEqualityTypeResult<TMember, aweXpect.Core.IThat<TMember>> HasName<TMember>(this aweXpect.Core.IThat<TMember> subject, string expected)
-            where TMember : System.Reflection.MemberInfo? { }
-        public static aweXpect.Results.AndOrResult<TMember, aweXpect.Core.IThat<TMember>> IsInternal<TMember>(this aweXpect.Core.IThat<TMember> subject)
-            where TMember : System.Reflection.MemberInfo? { }
-        public static aweXpect.Results.AndOrResult<TMember, aweXpect.Core.IThat<TMember>> IsNotInternal<TMember>(this aweXpect.Core.IThat<TMember> subject)
-            where TMember : System.Reflection.MemberInfo? { }
-        public static aweXpect.Results.AndOrResult<TMember, aweXpect.Core.IThat<TMember>> IsNotObsolete<TMember>(this aweXpect.Core.IThat<TMember> subject)
-            where TMember : System.Reflection.MemberInfo? { }
-        public static aweXpect.Results.AndOrResult<TMember, aweXpect.Core.IThat<TMember>> IsNotPrivate<TMember>(this aweXpect.Core.IThat<TMember> subject)
-            where TMember : System.Reflection.MemberInfo? { }
-        public static aweXpect.Results.AndOrResult<TMember, aweXpect.Core.IThat<TMember>> IsNotPrivateProtected<TMember>(this aweXpect.Core.IThat<TMember> subject)
-            where TMember : System.Reflection.MemberInfo? { }
-        public static aweXpect.Results.AndOrResult<TMember, aweXpect.Core.IThat<TMember>> IsNotProtected<TMember>(this aweXpect.Core.IThat<TMember> subject)
-            where TMember : System.Reflection.MemberInfo? { }
-        public static aweXpect.Results.AndOrResult<TMember, aweXpect.Core.IThat<TMember>> IsNotProtectedInternal<TMember>(this aweXpect.Core.IThat<TMember> subject)
-            where TMember : System.Reflection.MemberInfo? { }
-        public static aweXpect.Results.AndOrResult<TMember, aweXpect.Core.IThat<TMember>> IsNotPublic<TMember>(this aweXpect.Core.IThat<TMember> subject)
-            where TMember : System.Reflection.MemberInfo? { }
-        public static aweXpect.Results.AndOrResult<TMember, aweXpect.Core.IThat<TMember>> IsObsolete<TMember>(this aweXpect.Core.IThat<TMember> subject)
-            where TMember : System.Reflection.MemberInfo? { }
-        public static aweXpect.Results.AndOrResult<TMember, aweXpect.Core.IThat<TMember>> IsPrivate<TMember>(this aweXpect.Core.IThat<TMember> subject)
-            where TMember : System.Reflection.MemberInfo? { }
-        public static aweXpect.Results.AndOrResult<TMember, aweXpect.Core.IThat<TMember>> IsPrivateProtected<TMember>(this aweXpect.Core.IThat<TMember> subject)
-            where TMember : System.Reflection.MemberInfo? { }
-        public static aweXpect.Results.AndOrResult<TMember, aweXpect.Core.IThat<TMember>> IsProtected<TMember>(this aweXpect.Core.IThat<TMember> subject)
-            where TMember : System.Reflection.MemberInfo? { }
-        public static aweXpect.Results.AndOrResult<TMember, aweXpect.Core.IThat<TMember>> IsProtectedInternal<TMember>(this aweXpect.Core.IThat<TMember> subject)
-            where TMember : System.Reflection.MemberInfo? { }
-        public static aweXpect.Results.AndOrResult<TMember, aweXpect.Core.IThat<TMember>> IsPublic<TMember>(this aweXpect.Core.IThat<TMember> subject)
-            where TMember : System.Reflection.MemberInfo? { }
-    }
-    public static class ThatMembers
-    {
         public static aweXpect.Results.StringEqualityTypeResult<System.Collections.Generic.IAsyncEnumerable<TMember>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TMember>>> DoNotHaveName<TMember>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TMember>> subject, string unexpected)
             where TMember : System.Reflection.MemberInfo? { }
         public static aweXpect.Results.StringEqualityTypeResult<System.Collections.Generic.IEnumerable<TMember>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>>> DoNotHaveName<TMember>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>> subject, string unexpected)

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net8.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net8.0.txt
@@ -84,12 +84,14 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Collections.Filtered.Constructors WhichAreInternal(this aweXpect.Reflection.Collections.Filtered.Constructors @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Constructors WhichAreNot(this aweXpect.Reflection.Collections.Filtered.Constructors @this, aweXpect.Reflection.Collections.AccessModifiers accessModifier) { }
         public static aweXpect.Reflection.Collections.Filtered.Constructors WhichAreNotInternal(this aweXpect.Reflection.Collections.Filtered.Constructors @this) { }
+        public static aweXpect.Reflection.Collections.Filtered.Constructors WhichAreNotObsolete(this aweXpect.Reflection.Collections.Filtered.Constructors @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Constructors WhichAreNotPrivate(this aweXpect.Reflection.Collections.Filtered.Constructors @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Constructors WhichAreNotPrivateProtected(this aweXpect.Reflection.Collections.Filtered.Constructors @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Constructors WhichAreNotProtected(this aweXpect.Reflection.Collections.Filtered.Constructors @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Constructors WhichAreNotProtectedInternal(this aweXpect.Reflection.Collections.Filtered.Constructors @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Constructors WhichAreNotPublic(this aweXpect.Reflection.Collections.Filtered.Constructors @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Constructors WhichAreNotStatic(this aweXpect.Reflection.Collections.Filtered.Constructors @this) { }
+        public static aweXpect.Reflection.Collections.Filtered.Constructors WhichAreObsolete(this aweXpect.Reflection.Collections.Filtered.Constructors @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Constructors WhichArePrivate(this aweXpect.Reflection.Collections.Filtered.Constructors @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Constructors WhichArePrivateProtected(this aweXpect.Reflection.Collections.Filtered.Constructors @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Constructors WhichAreProtected(this aweXpect.Reflection.Collections.Filtered.Constructors @this) { }
@@ -214,12 +216,14 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Collections.Filtered.Events WhichAreNot(this aweXpect.Reflection.Collections.Filtered.Events @this, aweXpect.Reflection.Collections.AccessModifiers accessModifier) { }
         public static aweXpect.Reflection.Collections.Filtered.Events WhichAreNotAbstract(this aweXpect.Reflection.Collections.Filtered.Events @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Events WhichAreNotInternal(this aweXpect.Reflection.Collections.Filtered.Events @this) { }
+        public static aweXpect.Reflection.Collections.Filtered.Events WhichAreNotObsolete(this aweXpect.Reflection.Collections.Filtered.Events @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Events WhichAreNotPrivate(this aweXpect.Reflection.Collections.Filtered.Events @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Events WhichAreNotPrivateProtected(this aweXpect.Reflection.Collections.Filtered.Events @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Events WhichAreNotProtected(this aweXpect.Reflection.Collections.Filtered.Events @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Events WhichAreNotProtectedInternal(this aweXpect.Reflection.Collections.Filtered.Events @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Events WhichAreNotPublic(this aweXpect.Reflection.Collections.Filtered.Events @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Events WhichAreNotSealed(this aweXpect.Reflection.Collections.Filtered.Events @this) { }
+        public static aweXpect.Reflection.Collections.Filtered.Events WhichAreObsolete(this aweXpect.Reflection.Collections.Filtered.Events @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Events WhichArePrivate(this aweXpect.Reflection.Collections.Filtered.Events @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Events WhichArePrivateProtected(this aweXpect.Reflection.Collections.Filtered.Events @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Events WhichAreProtected(this aweXpect.Reflection.Collections.Filtered.Events @this) { }
@@ -264,6 +268,7 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Collections.Filtered.Fields WhichAreNot(this aweXpect.Reflection.Collections.Filtered.Fields @this, aweXpect.Reflection.Collections.AccessModifiers accessModifier) { }
         public static aweXpect.Reflection.Collections.Filtered.Fields WhichAreNotConstant(this aweXpect.Reflection.Collections.Filtered.Fields @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Fields WhichAreNotInternal(this aweXpect.Reflection.Collections.Filtered.Fields @this) { }
+        public static aweXpect.Reflection.Collections.Filtered.Fields WhichAreNotObsolete(this aweXpect.Reflection.Collections.Filtered.Fields @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Fields WhichAreNotPrivate(this aweXpect.Reflection.Collections.Filtered.Fields @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Fields WhichAreNotPrivateProtected(this aweXpect.Reflection.Collections.Filtered.Fields @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Fields WhichAreNotProtected(this aweXpect.Reflection.Collections.Filtered.Fields @this) { }
@@ -271,6 +276,7 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Collections.Filtered.Fields WhichAreNotPublic(this aweXpect.Reflection.Collections.Filtered.Fields @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Fields WhichAreNotReadOnly(this aweXpect.Reflection.Collections.Filtered.Fields @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Fields WhichAreNotStatic(this aweXpect.Reflection.Collections.Filtered.Fields @this) { }
+        public static aweXpect.Reflection.Collections.Filtered.Fields WhichAreObsolete(this aweXpect.Reflection.Collections.Filtered.Fields @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Fields WhichArePrivate(this aweXpect.Reflection.Collections.Filtered.Fields @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Fields WhichArePrivateProtected(this aweXpect.Reflection.Collections.Filtered.Fields @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Fields WhichAreProtected(this aweXpect.Reflection.Collections.Filtered.Fields @this) { }
@@ -336,6 +342,7 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Collections.Filtered.Methods WhichAreNotAsync(this aweXpect.Reflection.Collections.Filtered.Methods @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Methods WhichAreNotGeneric(this aweXpect.Reflection.Collections.Filtered.Methods @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Methods WhichAreNotInternal(this aweXpect.Reflection.Collections.Filtered.Methods @this) { }
+        public static aweXpect.Reflection.Collections.Filtered.Methods WhichAreNotObsolete(this aweXpect.Reflection.Collections.Filtered.Methods @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Methods WhichAreNotPrivate(this aweXpect.Reflection.Collections.Filtered.Methods @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Methods WhichAreNotPrivateProtected(this aweXpect.Reflection.Collections.Filtered.Methods @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Methods WhichAreNotProtected(this aweXpect.Reflection.Collections.Filtered.Methods @this) { }
@@ -344,6 +351,7 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Collections.Filtered.Methods WhichAreNotSealed(this aweXpect.Reflection.Collections.Filtered.Methods @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Methods WhichAreNotStatic(this aweXpect.Reflection.Collections.Filtered.Methods @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Methods WhichAreNotVirtual(this aweXpect.Reflection.Collections.Filtered.Methods @this) { }
+        public static aweXpect.Reflection.Collections.Filtered.Methods WhichAreObsolete(this aweXpect.Reflection.Collections.Filtered.Methods @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Methods WhichArePrivate(this aweXpect.Reflection.Collections.Filtered.Methods @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Methods WhichArePrivateProtected(this aweXpect.Reflection.Collections.Filtered.Methods @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Methods WhichAreProtected(this aweXpect.Reflection.Collections.Filtered.Methods @this) { }
@@ -517,6 +525,7 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Collections.Filtered.Properties WhichAreNotAbstract(this aweXpect.Reflection.Collections.Filtered.Properties @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Properties WhichAreNotIndexers(this aweXpect.Reflection.Collections.Filtered.Properties @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Properties WhichAreNotInternal(this aweXpect.Reflection.Collections.Filtered.Properties @this) { }
+        public static aweXpect.Reflection.Collections.Filtered.Properties WhichAreNotObsolete(this aweXpect.Reflection.Collections.Filtered.Properties @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Properties WhichAreNotPrivate(this aweXpect.Reflection.Collections.Filtered.Properties @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Properties WhichAreNotPrivateProtected(this aweXpect.Reflection.Collections.Filtered.Properties @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Properties WhichAreNotProtected(this aweXpect.Reflection.Collections.Filtered.Properties @this) { }
@@ -526,6 +535,7 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Collections.Filtered.Properties WhichAreNotSealed(this aweXpect.Reflection.Collections.Filtered.Properties @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Properties WhichAreNotStatic(this aweXpect.Reflection.Collections.Filtered.Properties @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Properties WhichAreNotVirtual(this aweXpect.Reflection.Collections.Filtered.Properties @this) { }
+        public static aweXpect.Reflection.Collections.Filtered.Properties WhichAreObsolete(this aweXpect.Reflection.Collections.Filtered.Properties @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Properties WhichArePrivate(this aweXpect.Reflection.Collections.Filtered.Properties @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Properties WhichArePrivateProtected(this aweXpect.Reflection.Collections.Filtered.Properties @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Properties WhichAreProtected(this aweXpect.Reflection.Collections.Filtered.Properties @this) { }
@@ -1021,6 +1031,10 @@ namespace aweXpect.Reflection
             where TMember : System.Reflection.MemberInfo? { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TMember>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>>> AreNotInternal<TMember>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>> subject)
             where TMember : System.Reflection.MemberInfo? { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<TMember>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TMember>>> AreNotObsolete<TMember>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TMember>> subject)
+            where TMember : System.Reflection.MemberInfo? { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TMember>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>>> AreNotObsolete<TMember>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>> subject)
+            where TMember : System.Reflection.MemberInfo? { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<TMember>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TMember>>> AreNotPrivate<TMember>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TMember>> subject)
             where TMember : System.Reflection.MemberInfo? { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TMember>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>>> AreNotPrivate<TMember>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>> subject)
@@ -1040,6 +1054,10 @@ namespace aweXpect.Reflection
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<TMember>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TMember>>> AreNotPublic<TMember>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TMember>> subject)
             where TMember : System.Reflection.MemberInfo? { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TMember>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>>> AreNotPublic<TMember>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>> subject)
+            where TMember : System.Reflection.MemberInfo? { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<TMember>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TMember>>> AreObsolete<TMember>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TMember>> subject)
+            where TMember : System.Reflection.MemberInfo? { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TMember>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>>> AreObsolete<TMember>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>> subject)
             where TMember : System.Reflection.MemberInfo? { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<TMember>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TMember>>> ArePrivate<TMember>(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<TMember>> subject)
             where TMember : System.Reflection.MemberInfo? { }
@@ -1069,6 +1087,8 @@ namespace aweXpect.Reflection
             where TMember : System.Reflection.MemberInfo? { }
         public static aweXpect.Results.AndOrResult<TMember, aweXpect.Core.IThat<TMember>> IsNotInternal<TMember>(this aweXpect.Core.IThat<TMember> subject)
             where TMember : System.Reflection.MemberInfo? { }
+        public static aweXpect.Results.AndOrResult<TMember, aweXpect.Core.IThat<TMember>> IsNotObsolete<TMember>(this aweXpect.Core.IThat<TMember> subject)
+            where TMember : System.Reflection.MemberInfo? { }
         public static aweXpect.Results.AndOrResult<TMember, aweXpect.Core.IThat<TMember>> IsNotPrivate<TMember>(this aweXpect.Core.IThat<TMember> subject)
             where TMember : System.Reflection.MemberInfo? { }
         public static aweXpect.Results.AndOrResult<TMember, aweXpect.Core.IThat<TMember>> IsNotPrivateProtected<TMember>(this aweXpect.Core.IThat<TMember> subject)
@@ -1078,6 +1098,8 @@ namespace aweXpect.Reflection
         public static aweXpect.Results.AndOrResult<TMember, aweXpect.Core.IThat<TMember>> IsNotProtectedInternal<TMember>(this aweXpect.Core.IThat<TMember> subject)
             where TMember : System.Reflection.MemberInfo? { }
         public static aweXpect.Results.AndOrResult<TMember, aweXpect.Core.IThat<TMember>> IsNotPublic<TMember>(this aweXpect.Core.IThat<TMember> subject)
+            where TMember : System.Reflection.MemberInfo? { }
+        public static aweXpect.Results.AndOrResult<TMember, aweXpect.Core.IThat<TMember>> IsObsolete<TMember>(this aweXpect.Core.IThat<TMember> subject)
             where TMember : System.Reflection.MemberInfo? { }
         public static aweXpect.Results.AndOrResult<TMember, aweXpect.Core.IThat<TMember>> IsPrivate<TMember>(this aweXpect.Core.IThat<TMember> subject)
             where TMember : System.Reflection.MemberInfo? { }
@@ -1689,6 +1711,7 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreNotInterfaces(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreNotInternal(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreNotNested(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
+        public static aweXpect.Reflection.Collections.Filtered.Types WhichAreNotObsolete(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreNotPrivate(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreNotPrivateProtected(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreNotProtected(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
@@ -1701,6 +1724,7 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreNotSealed(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreNotStatic(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreNotStructs(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
+        public static aweXpect.Reflection.Collections.Filtered.Types WhichAreObsolete(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichArePrivate(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichArePrivateProtected(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreProtected(this aweXpect.Reflection.Collections.Filtered.Types @this) { }

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_netstandard2.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_netstandard2.0.txt
@@ -907,34 +907,6 @@ namespace aweXpect.Reflection
     }
     public static class ThatMember
     {
-        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TMember>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>>> AreInternal<TMember>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>> subject)
-            where TMember : System.Reflection.MemberInfo? { }
-        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TMember>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>>> AreNotInternal<TMember>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>> subject)
-            where TMember : System.Reflection.MemberInfo? { }
-        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TMember>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>>> AreNotObsolete<TMember>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>> subject)
-            where TMember : System.Reflection.MemberInfo? { }
-        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TMember>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>>> AreNotPrivate<TMember>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>> subject)
-            where TMember : System.Reflection.MemberInfo? { }
-        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TMember>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>>> AreNotPrivateProtected<TMember>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>> subject)
-            where TMember : System.Reflection.MemberInfo? { }
-        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TMember>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>>> AreNotProtected<TMember>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>> subject)
-            where TMember : System.Reflection.MemberInfo? { }
-        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TMember>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>>> AreNotProtectedInternal<TMember>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>> subject)
-            where TMember : System.Reflection.MemberInfo? { }
-        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TMember>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>>> AreNotPublic<TMember>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>> subject)
-            where TMember : System.Reflection.MemberInfo? { }
-        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TMember>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>>> AreObsolete<TMember>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>> subject)
-            where TMember : System.Reflection.MemberInfo? { }
-        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TMember>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>>> ArePrivate<TMember>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>> subject)
-            where TMember : System.Reflection.MemberInfo? { }
-        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TMember>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>>> ArePrivateProtected<TMember>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>> subject)
-            where TMember : System.Reflection.MemberInfo? { }
-        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TMember>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>>> AreProtected<TMember>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>> subject)
-            where TMember : System.Reflection.MemberInfo? { }
-        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TMember>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>>> AreProtectedInternal<TMember>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>> subject)
-            where TMember : System.Reflection.MemberInfo? { }
-        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TMember>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>>> ArePublic<TMember>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>> subject)
-            where TMember : System.Reflection.MemberInfo? { }
         public static aweXpect.Results.StringEqualityTypeResult<TMember, aweXpect.Core.IThat<TMember>> DoesNotHaveName<TMember>(this aweXpect.Core.IThat<TMember> subject, string unexpected)
             where TMember : System.Reflection.MemberInfo? { }
         public static aweXpect.Results.StringEqualityTypeResult<TMember, aweXpect.Core.IThat<TMember>> HasName<TMember>(this aweXpect.Core.IThat<TMember> subject, string expected)
@@ -970,6 +942,34 @@ namespace aweXpect.Reflection
     }
     public static class ThatMembers
     {
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TMember>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>>> AreInternal<TMember>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>> subject)
+            where TMember : System.Reflection.MemberInfo? { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TMember>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>>> AreNotInternal<TMember>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>> subject)
+            where TMember : System.Reflection.MemberInfo? { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TMember>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>>> AreNotObsolete<TMember>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>> subject)
+            where TMember : System.Reflection.MemberInfo? { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TMember>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>>> AreNotPrivate<TMember>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>> subject)
+            where TMember : System.Reflection.MemberInfo? { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TMember>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>>> AreNotPrivateProtected<TMember>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>> subject)
+            where TMember : System.Reflection.MemberInfo? { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TMember>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>>> AreNotProtected<TMember>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>> subject)
+            where TMember : System.Reflection.MemberInfo? { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TMember>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>>> AreNotProtectedInternal<TMember>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>> subject)
+            where TMember : System.Reflection.MemberInfo? { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TMember>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>>> AreNotPublic<TMember>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>> subject)
+            where TMember : System.Reflection.MemberInfo? { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TMember>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>>> AreObsolete<TMember>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>> subject)
+            where TMember : System.Reflection.MemberInfo? { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TMember>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>>> ArePrivate<TMember>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>> subject)
+            where TMember : System.Reflection.MemberInfo? { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TMember>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>>> ArePrivateProtected<TMember>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>> subject)
+            where TMember : System.Reflection.MemberInfo? { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TMember>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>>> AreProtected<TMember>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>> subject)
+            where TMember : System.Reflection.MemberInfo? { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TMember>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>>> AreProtectedInternal<TMember>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>> subject)
+            where TMember : System.Reflection.MemberInfo? { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TMember>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>>> ArePublic<TMember>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>> subject)
+            where TMember : System.Reflection.MemberInfo? { }
         public static aweXpect.Results.StringEqualityTypeResult<System.Collections.Generic.IEnumerable<TMember>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>>> DoNotHaveName<TMember>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>> subject, string unexpected)
             where TMember : System.Reflection.MemberInfo? { }
         public static aweXpect.Results.StringEqualityTypeResult<System.Collections.Generic.IEnumerable<TMember>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>>> HaveName<TMember>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>> subject, string expected)

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_netstandard2.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_netstandard2.0.txt
@@ -84,12 +84,14 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Collections.Filtered.Constructors WhichAreInternal(this aweXpect.Reflection.Collections.Filtered.Constructors @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Constructors WhichAreNot(this aweXpect.Reflection.Collections.Filtered.Constructors @this, aweXpect.Reflection.Collections.AccessModifiers accessModifier) { }
         public static aweXpect.Reflection.Collections.Filtered.Constructors WhichAreNotInternal(this aweXpect.Reflection.Collections.Filtered.Constructors @this) { }
+        public static aweXpect.Reflection.Collections.Filtered.Constructors WhichAreNotObsolete(this aweXpect.Reflection.Collections.Filtered.Constructors @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Constructors WhichAreNotPrivate(this aweXpect.Reflection.Collections.Filtered.Constructors @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Constructors WhichAreNotPrivateProtected(this aweXpect.Reflection.Collections.Filtered.Constructors @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Constructors WhichAreNotProtected(this aweXpect.Reflection.Collections.Filtered.Constructors @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Constructors WhichAreNotProtectedInternal(this aweXpect.Reflection.Collections.Filtered.Constructors @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Constructors WhichAreNotPublic(this aweXpect.Reflection.Collections.Filtered.Constructors @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Constructors WhichAreNotStatic(this aweXpect.Reflection.Collections.Filtered.Constructors @this) { }
+        public static aweXpect.Reflection.Collections.Filtered.Constructors WhichAreObsolete(this aweXpect.Reflection.Collections.Filtered.Constructors @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Constructors WhichArePrivate(this aweXpect.Reflection.Collections.Filtered.Constructors @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Constructors WhichArePrivateProtected(this aweXpect.Reflection.Collections.Filtered.Constructors @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Constructors WhichAreProtected(this aweXpect.Reflection.Collections.Filtered.Constructors @this) { }
@@ -214,12 +216,14 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Collections.Filtered.Events WhichAreNot(this aweXpect.Reflection.Collections.Filtered.Events @this, aweXpect.Reflection.Collections.AccessModifiers accessModifier) { }
         public static aweXpect.Reflection.Collections.Filtered.Events WhichAreNotAbstract(this aweXpect.Reflection.Collections.Filtered.Events @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Events WhichAreNotInternal(this aweXpect.Reflection.Collections.Filtered.Events @this) { }
+        public static aweXpect.Reflection.Collections.Filtered.Events WhichAreNotObsolete(this aweXpect.Reflection.Collections.Filtered.Events @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Events WhichAreNotPrivate(this aweXpect.Reflection.Collections.Filtered.Events @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Events WhichAreNotPrivateProtected(this aweXpect.Reflection.Collections.Filtered.Events @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Events WhichAreNotProtected(this aweXpect.Reflection.Collections.Filtered.Events @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Events WhichAreNotProtectedInternal(this aweXpect.Reflection.Collections.Filtered.Events @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Events WhichAreNotPublic(this aweXpect.Reflection.Collections.Filtered.Events @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Events WhichAreNotSealed(this aweXpect.Reflection.Collections.Filtered.Events @this) { }
+        public static aweXpect.Reflection.Collections.Filtered.Events WhichAreObsolete(this aweXpect.Reflection.Collections.Filtered.Events @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Events WhichArePrivate(this aweXpect.Reflection.Collections.Filtered.Events @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Events WhichArePrivateProtected(this aweXpect.Reflection.Collections.Filtered.Events @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Events WhichAreProtected(this aweXpect.Reflection.Collections.Filtered.Events @this) { }
@@ -264,6 +268,7 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Collections.Filtered.Fields WhichAreNot(this aweXpect.Reflection.Collections.Filtered.Fields @this, aweXpect.Reflection.Collections.AccessModifiers accessModifier) { }
         public static aweXpect.Reflection.Collections.Filtered.Fields WhichAreNotConstant(this aweXpect.Reflection.Collections.Filtered.Fields @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Fields WhichAreNotInternal(this aweXpect.Reflection.Collections.Filtered.Fields @this) { }
+        public static aweXpect.Reflection.Collections.Filtered.Fields WhichAreNotObsolete(this aweXpect.Reflection.Collections.Filtered.Fields @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Fields WhichAreNotPrivate(this aweXpect.Reflection.Collections.Filtered.Fields @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Fields WhichAreNotPrivateProtected(this aweXpect.Reflection.Collections.Filtered.Fields @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Fields WhichAreNotProtected(this aweXpect.Reflection.Collections.Filtered.Fields @this) { }
@@ -271,6 +276,7 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Collections.Filtered.Fields WhichAreNotPublic(this aweXpect.Reflection.Collections.Filtered.Fields @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Fields WhichAreNotReadOnly(this aweXpect.Reflection.Collections.Filtered.Fields @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Fields WhichAreNotStatic(this aweXpect.Reflection.Collections.Filtered.Fields @this) { }
+        public static aweXpect.Reflection.Collections.Filtered.Fields WhichAreObsolete(this aweXpect.Reflection.Collections.Filtered.Fields @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Fields WhichArePrivate(this aweXpect.Reflection.Collections.Filtered.Fields @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Fields WhichArePrivateProtected(this aweXpect.Reflection.Collections.Filtered.Fields @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Fields WhichAreProtected(this aweXpect.Reflection.Collections.Filtered.Fields @this) { }
@@ -336,6 +342,7 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Collections.Filtered.Methods WhichAreNotAsync(this aweXpect.Reflection.Collections.Filtered.Methods @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Methods WhichAreNotGeneric(this aweXpect.Reflection.Collections.Filtered.Methods @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Methods WhichAreNotInternal(this aweXpect.Reflection.Collections.Filtered.Methods @this) { }
+        public static aweXpect.Reflection.Collections.Filtered.Methods WhichAreNotObsolete(this aweXpect.Reflection.Collections.Filtered.Methods @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Methods WhichAreNotPrivate(this aweXpect.Reflection.Collections.Filtered.Methods @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Methods WhichAreNotPrivateProtected(this aweXpect.Reflection.Collections.Filtered.Methods @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Methods WhichAreNotProtected(this aweXpect.Reflection.Collections.Filtered.Methods @this) { }
@@ -344,6 +351,7 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Collections.Filtered.Methods WhichAreNotSealed(this aweXpect.Reflection.Collections.Filtered.Methods @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Methods WhichAreNotStatic(this aweXpect.Reflection.Collections.Filtered.Methods @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Methods WhichAreNotVirtual(this aweXpect.Reflection.Collections.Filtered.Methods @this) { }
+        public static aweXpect.Reflection.Collections.Filtered.Methods WhichAreObsolete(this aweXpect.Reflection.Collections.Filtered.Methods @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Methods WhichArePrivate(this aweXpect.Reflection.Collections.Filtered.Methods @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Methods WhichArePrivateProtected(this aweXpect.Reflection.Collections.Filtered.Methods @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Methods WhichAreProtected(this aweXpect.Reflection.Collections.Filtered.Methods @this) { }
@@ -517,6 +525,7 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Collections.Filtered.Properties WhichAreNotAbstract(this aweXpect.Reflection.Collections.Filtered.Properties @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Properties WhichAreNotIndexers(this aweXpect.Reflection.Collections.Filtered.Properties @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Properties WhichAreNotInternal(this aweXpect.Reflection.Collections.Filtered.Properties @this) { }
+        public static aweXpect.Reflection.Collections.Filtered.Properties WhichAreNotObsolete(this aweXpect.Reflection.Collections.Filtered.Properties @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Properties WhichAreNotPrivate(this aweXpect.Reflection.Collections.Filtered.Properties @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Properties WhichAreNotPrivateProtected(this aweXpect.Reflection.Collections.Filtered.Properties @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Properties WhichAreNotProtected(this aweXpect.Reflection.Collections.Filtered.Properties @this) { }
@@ -526,6 +535,7 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Collections.Filtered.Properties WhichAreNotSealed(this aweXpect.Reflection.Collections.Filtered.Properties @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Properties WhichAreNotStatic(this aweXpect.Reflection.Collections.Filtered.Properties @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Properties WhichAreNotVirtual(this aweXpect.Reflection.Collections.Filtered.Properties @this) { }
+        public static aweXpect.Reflection.Collections.Filtered.Properties WhichAreObsolete(this aweXpect.Reflection.Collections.Filtered.Properties @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Properties WhichArePrivate(this aweXpect.Reflection.Collections.Filtered.Properties @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Properties WhichArePrivateProtected(this aweXpect.Reflection.Collections.Filtered.Properties @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Properties WhichAreProtected(this aweXpect.Reflection.Collections.Filtered.Properties @this) { }
@@ -901,6 +911,8 @@ namespace aweXpect.Reflection
             where TMember : System.Reflection.MemberInfo? { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TMember>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>>> AreNotInternal<TMember>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>> subject)
             where TMember : System.Reflection.MemberInfo? { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TMember>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>>> AreNotObsolete<TMember>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>> subject)
+            where TMember : System.Reflection.MemberInfo? { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TMember>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>>> AreNotPrivate<TMember>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>> subject)
             where TMember : System.Reflection.MemberInfo? { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TMember>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>>> AreNotPrivateProtected<TMember>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>> subject)
@@ -910,6 +922,8 @@ namespace aweXpect.Reflection
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TMember>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>>> AreNotProtectedInternal<TMember>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>> subject)
             where TMember : System.Reflection.MemberInfo? { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TMember>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>>> AreNotPublic<TMember>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>> subject)
+            where TMember : System.Reflection.MemberInfo? { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TMember>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>>> AreObsolete<TMember>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>> subject)
             where TMember : System.Reflection.MemberInfo? { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<TMember>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>>> ArePrivate<TMember>(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<TMember>> subject)
             where TMember : System.Reflection.MemberInfo? { }
@@ -929,6 +943,8 @@ namespace aweXpect.Reflection
             where TMember : System.Reflection.MemberInfo? { }
         public static aweXpect.Results.AndOrResult<TMember, aweXpect.Core.IThat<TMember>> IsNotInternal<TMember>(this aweXpect.Core.IThat<TMember> subject)
             where TMember : System.Reflection.MemberInfo? { }
+        public static aweXpect.Results.AndOrResult<TMember, aweXpect.Core.IThat<TMember>> IsNotObsolete<TMember>(this aweXpect.Core.IThat<TMember> subject)
+            where TMember : System.Reflection.MemberInfo? { }
         public static aweXpect.Results.AndOrResult<TMember, aweXpect.Core.IThat<TMember>> IsNotPrivate<TMember>(this aweXpect.Core.IThat<TMember> subject)
             where TMember : System.Reflection.MemberInfo? { }
         public static aweXpect.Results.AndOrResult<TMember, aweXpect.Core.IThat<TMember>> IsNotPrivateProtected<TMember>(this aweXpect.Core.IThat<TMember> subject)
@@ -938,6 +954,8 @@ namespace aweXpect.Reflection
         public static aweXpect.Results.AndOrResult<TMember, aweXpect.Core.IThat<TMember>> IsNotProtectedInternal<TMember>(this aweXpect.Core.IThat<TMember> subject)
             where TMember : System.Reflection.MemberInfo? { }
         public static aweXpect.Results.AndOrResult<TMember, aweXpect.Core.IThat<TMember>> IsNotPublic<TMember>(this aweXpect.Core.IThat<TMember> subject)
+            where TMember : System.Reflection.MemberInfo? { }
+        public static aweXpect.Results.AndOrResult<TMember, aweXpect.Core.IThat<TMember>> IsObsolete<TMember>(this aweXpect.Core.IThat<TMember> subject)
             where TMember : System.Reflection.MemberInfo? { }
         public static aweXpect.Results.AndOrResult<TMember, aweXpect.Core.IThat<TMember>> IsPrivate<TMember>(this aweXpect.Core.IThat<TMember> subject)
             where TMember : System.Reflection.MemberInfo? { }
@@ -1375,6 +1393,7 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreNotInterfaces(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreNotInternal(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreNotNested(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
+        public static aweXpect.Reflection.Collections.Filtered.Types WhichAreNotObsolete(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreNotPrivate(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreNotPrivateProtected(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreNotProtected(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
@@ -1387,6 +1406,7 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreNotSealed(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreNotStatic(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreNotStructs(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
+        public static aweXpect.Reflection.Collections.Filtered.Types WhichAreObsolete(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichArePrivate(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichArePrivateProtected(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreProtected(this aweXpect.Reflection.Collections.Filtered.Types @this) { }

--- a/Tests/aweXpect.Reflection.Tests/Filters/ConstructorFilters.WhichAreNotObsolete.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/ConstructorFilters.WhichAreNotObsolete.Tests.cs
@@ -1,0 +1,26 @@
+using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Tests.TestHelpers;
+using aweXpect.Reflection.Tests.TestHelpers.Types;
+
+namespace aweXpect.Reflection.Tests.Filters;
+
+public sealed partial class ConstructorFilters
+{
+	public sealed class WhichAreNotObsolete
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task ShouldAllowFilteringForNonObsoleteConstructors()
+			{
+				Filtered.Constructors constructors = In.AssemblyContaining<ClassWithObsoleteMembers>()
+					.Types().Constructors().WhichAreNotObsolete();
+
+				await That(constructors).All().Satisfy(x => !Attribute.IsDefined(x, typeof(ObsoleteAttribute)))
+					.And.IsNotEmpty();
+				await That(constructors.GetDescription())
+					.IsEqualTo("non-obsolete constructors in types in assembly").AsPrefix();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/Filters/ConstructorFilters.WhichAreObsolete.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/ConstructorFilters.WhichAreObsolete.Tests.cs
@@ -1,0 +1,26 @@
+using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Tests.TestHelpers;
+using aweXpect.Reflection.Tests.TestHelpers.Types;
+
+namespace aweXpect.Reflection.Tests.Filters;
+
+public sealed partial class ConstructorFilters
+{
+	public sealed class WhichAreObsolete
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task ShouldAllowFilteringForObsoleteConstructors()
+			{
+				Filtered.Constructors constructors = In.AssemblyContaining<ClassWithObsoleteMembers>()
+					.Types().Constructors().WhichAreObsolete();
+
+				await That(constructors).All().Satisfy(x => Attribute.IsDefined(x, typeof(ObsoleteAttribute)))
+					.And.IsNotEmpty();
+				await That(constructors.GetDescription())
+					.IsEqualTo("obsolete constructors in types in assembly").AsPrefix();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/Filters/EventFilters.WhichAreNotObsolete.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/EventFilters.WhichAreNotObsolete.Tests.cs
@@ -1,0 +1,26 @@
+using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Tests.TestHelpers;
+using aweXpect.Reflection.Tests.TestHelpers.Types;
+
+namespace aweXpect.Reflection.Tests.Filters;
+
+public sealed partial class EventFilters
+{
+	public sealed class WhichAreNotObsolete
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task ShouldAllowFilteringForNonObsoleteEvents()
+			{
+				Filtered.Events events = In.AssemblyContaining<ClassWithObsoleteMembers>()
+					.Types().Events().WhichAreNotObsolete();
+
+				await That(events).All().Satisfy(x => !Attribute.IsDefined(x, typeof(ObsoleteAttribute)))
+					.And.IsNotEmpty();
+				await That(events.GetDescription())
+					.IsEqualTo("non-obsolete events in types in assembly").AsPrefix();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/Filters/EventFilters.WhichAreObsolete.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/EventFilters.WhichAreObsolete.Tests.cs
@@ -1,0 +1,26 @@
+using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Tests.TestHelpers;
+using aweXpect.Reflection.Tests.TestHelpers.Types;
+
+namespace aweXpect.Reflection.Tests.Filters;
+
+public sealed partial class EventFilters
+{
+	public sealed class WhichAreObsolete
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task ShouldAllowFilteringForObsoleteEvents()
+			{
+				Filtered.Events events = In.AssemblyContaining<ClassWithObsoleteMembers>()
+					.Types().Events().WhichAreObsolete();
+
+				await That(events).All().Satisfy(x => Attribute.IsDefined(x, typeof(ObsoleteAttribute)))
+					.And.IsNotEmpty();
+				await That(events.GetDescription())
+					.IsEqualTo("obsolete events in types in assembly").AsPrefix();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/Filters/FieldFilters.WhichAreNotObsolete.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/FieldFilters.WhichAreNotObsolete.Tests.cs
@@ -1,0 +1,26 @@
+using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Tests.TestHelpers;
+using aweXpect.Reflection.Tests.TestHelpers.Types;
+
+namespace aweXpect.Reflection.Tests.Filters;
+
+public sealed partial class FieldFilters
+{
+	public sealed class WhichAreNotObsolete
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task ShouldAllowFilteringForNonObsoleteFields()
+			{
+				Filtered.Fields fields = In.AssemblyContaining<ClassWithObsoleteMembers>()
+					.Types().Fields().WhichAreNotObsolete();
+
+				await That(fields).All().Satisfy(x => !Attribute.IsDefined(x, typeof(ObsoleteAttribute)))
+					.And.IsNotEmpty();
+				await That(fields.GetDescription())
+					.IsEqualTo("non-obsolete fields in types in assembly").AsPrefix();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/Filters/FieldFilters.WhichAreObsolete.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/FieldFilters.WhichAreObsolete.Tests.cs
@@ -1,0 +1,26 @@
+using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Tests.TestHelpers;
+using aweXpect.Reflection.Tests.TestHelpers.Types;
+
+namespace aweXpect.Reflection.Tests.Filters;
+
+public sealed partial class FieldFilters
+{
+	public sealed class WhichAreObsolete
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task ShouldAllowFilteringForObsoleteFields()
+			{
+				Filtered.Fields fields = In.AssemblyContaining<ClassWithObsoleteMembers>()
+					.Types().Fields().WhichAreObsolete();
+
+				await That(fields).All().Satisfy(x => Attribute.IsDefined(x, typeof(ObsoleteAttribute)))
+					.And.IsNotEmpty();
+				await That(fields.GetDescription())
+					.IsEqualTo("obsolete fields in types in assembly").AsPrefix();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WhichAreNotObsolete.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WhichAreNotObsolete.Tests.cs
@@ -1,0 +1,26 @@
+using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Tests.TestHelpers;
+using aweXpect.Reflection.Tests.TestHelpers.Types;
+
+namespace aweXpect.Reflection.Tests.Filters;
+
+public sealed partial class MethodFilters
+{
+	public sealed class WhichAreNotObsolete
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task ShouldAllowFilteringForNonObsoleteMethods()
+			{
+				Filtered.Methods methods = In.AssemblyContaining<ClassWithObsoleteMembers>()
+					.Types().Methods().WhichAreNotObsolete();
+
+				await That(methods).All().Satisfy(x => !Attribute.IsDefined(x, typeof(ObsoleteAttribute)))
+					.And.IsNotEmpty();
+				await That(methods.GetDescription())
+					.IsEqualTo("non-obsolete methods in types in assembly").AsPrefix();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WhichAreObsolete.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WhichAreObsolete.Tests.cs
@@ -1,0 +1,26 @@
+using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Tests.TestHelpers;
+using aweXpect.Reflection.Tests.TestHelpers.Types;
+
+namespace aweXpect.Reflection.Tests.Filters;
+
+public sealed partial class MethodFilters
+{
+	public sealed class WhichAreObsolete
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task ShouldAllowFilteringForObsoleteMethods()
+			{
+				Filtered.Methods methods = In.AssemblyContaining<ClassWithObsoleteMembers>()
+					.Types().Methods().WhichAreObsolete();
+
+				await That(methods).All().Satisfy(x => Attribute.IsDefined(x, typeof(ObsoleteAttribute)))
+					.And.IsNotEmpty();
+				await That(methods.GetDescription())
+					.IsEqualTo("obsolete methods in types in assembly").AsPrefix();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/Filters/PropertyFilters.WhichAreNotObsolete.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/PropertyFilters.WhichAreNotObsolete.Tests.cs
@@ -1,0 +1,26 @@
+using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Tests.TestHelpers;
+using aweXpect.Reflection.Tests.TestHelpers.Types;
+
+namespace aweXpect.Reflection.Tests.Filters;
+
+public sealed partial class PropertyFilters
+{
+	public sealed class WhichAreNotObsolete
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task ShouldAllowFilteringForNonObsoleteProperties()
+			{
+				Filtered.Properties properties = In.AssemblyContaining<ClassWithObsoleteMembers>()
+					.Types().Properties().WhichAreNotObsolete();
+
+				await That(properties).All().Satisfy(x => !Attribute.IsDefined(x, typeof(ObsoleteAttribute)))
+					.And.IsNotEmpty();
+				await That(properties.GetDescription())
+					.IsEqualTo("non-obsolete properties in types in assembly").AsPrefix();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/Filters/PropertyFilters.WhichAreObsolete.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/PropertyFilters.WhichAreObsolete.Tests.cs
@@ -1,0 +1,26 @@
+using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Tests.TestHelpers;
+using aweXpect.Reflection.Tests.TestHelpers.Types;
+
+namespace aweXpect.Reflection.Tests.Filters;
+
+public sealed partial class PropertyFilters
+{
+	public sealed class WhichAreObsolete
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task ShouldAllowFilteringForObsoleteProperties()
+			{
+				Filtered.Properties properties = In.AssemblyContaining<ClassWithObsoleteMembers>()
+					.Types().Properties().WhichAreObsolete();
+
+				await That(properties).All().Satisfy(x => Attribute.IsDefined(x, typeof(ObsoleteAttribute)))
+					.And.IsNotEmpty();
+				await That(properties.GetDescription())
+					.IsEqualTo("obsolete properties in types in assembly").AsPrefix();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreNotObsolete.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreNotObsolete.Tests.cs
@@ -1,0 +1,26 @@
+using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Tests.TestHelpers;
+using aweXpect.Reflection.Tests.TestHelpers.Types;
+
+namespace aweXpect.Reflection.Tests.Filters;
+
+public sealed partial class TypeFilters
+{
+	public sealed class WhichAreNotObsolete
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task ShouldAllowFilteringForNonObsoleteTypes()
+			{
+				Filtered.Types types = In.AssemblyContaining<ClassWithObsoleteMembers>()
+					.Types().WhichAreNotObsolete();
+
+				await That(types).All().Satisfy(x => !Attribute.IsDefined(x, typeof(ObsoleteAttribute)))
+					.And.IsNotEmpty();
+				await That(types.GetDescription())
+					.IsEqualTo("non-obsolete types in assembly").AsPrefix();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreObsolete.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreObsolete.Tests.cs
@@ -1,0 +1,26 @@
+using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Tests.TestHelpers;
+using aweXpect.Reflection.Tests.TestHelpers.Types;
+
+namespace aweXpect.Reflection.Tests.Filters;
+
+public sealed partial class TypeFilters
+{
+	public sealed class WhichAreObsolete
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task ShouldAllowFilteringForObsoleteTypes()
+			{
+				Filtered.Types types = In.AssemblyContaining<ClassWithObsoleteMembers>()
+					.Types().WhichAreObsolete();
+
+				await That(types).All().Satisfy(x => Attribute.IsDefined(x, typeof(ObsoleteAttribute)))
+					.And.IsNotEmpty();
+				await That(types.GetDescription())
+					.IsEqualTo("obsolete types in assembly").AsPrefix();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/ClassWithObsoleteMembers.cs
+++ b/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/ClassWithObsoleteMembers.cs
@@ -1,0 +1,44 @@
+using System;
+
+namespace aweXpect.Reflection.Tests.TestHelpers.Types;
+
+public class ClassWithObsoleteMembers
+{
+	[Obsolete]
+	public int ObsoleteField;
+
+	public int NonObsoleteField;
+
+#pragma warning disable CS0067 // Event is never used
+	[Obsolete]
+	public event EventHandler? ObsoleteEvent;
+
+	public event EventHandler? NonObsoleteEvent;
+#pragma warning restore CS0067
+
+	[Obsolete]
+	public ClassWithObsoleteMembers()
+	{
+	}
+
+	public ClassWithObsoleteMembers(int value)
+	{
+		NonObsoleteField = value;
+	}
+
+	[Obsolete]
+	public int ObsoleteProperty { get; set; }
+
+	public int NonObsoleteProperty { get; set; }
+
+#pragma warning disable CA1822 // Mark members as static
+	[Obsolete]
+	public void ObsoleteMethod()
+	{
+	}
+
+	public void NonObsoleteMethod()
+	{
+	}
+#pragma warning restore CA1822
+}

--- a/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/ObsoleteClass.cs
+++ b/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/ObsoleteClass.cs
@@ -1,0 +1,8 @@
+using System;
+
+namespace aweXpect.Reflection.Tests.TestHelpers.Types;
+
+[Obsolete]
+public class ObsoleteClass
+{
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatConstructor.IsNotObsolete.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatConstructor.IsNotObsolete.Tests.cs
@@ -1,0 +1,101 @@
+using System.Reflection;
+using aweXpect.Reflection.Tests.TestHelpers.Types;
+using Xunit.Sdk;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatConstructor
+{
+	public sealed class IsNotObsolete
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenConstructorIsNotObsolete_ShouldSucceed()
+			{
+				ConstructorInfo subject =
+					typeof(ClassWithObsoleteMembers).GetConstructor(new[] { typeof(int) })!;
+
+				async Task Act()
+				{
+					await That(subject).IsNotObsolete();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenConstructorIsObsolete_ShouldFail()
+			{
+				ConstructorInfo subject =
+					typeof(ClassWithObsoleteMembers).GetConstructor(Type.EmptyTypes)!;
+
+				async Task Act()
+				{
+					await That(subject).IsNotObsolete();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage($"""
+					              Expected that subject
+					              is not obsolete,
+					              but it was obsolete {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenConstructorIsNull_ShouldFail()
+			{
+				ConstructorInfo? subject = null;
+
+				async Task Act()
+				{
+					await That(subject).IsNotObsolete();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             is not obsolete,
+					             but it was <null>
+					             """);
+			}
+		}
+
+		public sealed class NegatedTests
+		{
+			[Fact]
+			public async Task WhenConstructorIsNotObsolete_ShouldFail()
+			{
+				ConstructorInfo subject =
+					typeof(ClassWithObsoleteMembers).GetConstructor(new[] { typeof(int) })!;
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(it => it.IsNotObsolete());
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is obsolete,
+					              but it was non-obsolete {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenConstructorIsObsolete_ShouldSucceed()
+			{
+				ConstructorInfo subject =
+					typeof(ClassWithObsoleteMembers).GetConstructor(Type.EmptyTypes)!;
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(it => it.IsNotObsolete());
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatConstructor.IsObsolete.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatConstructor.IsObsolete.Tests.cs
@@ -1,0 +1,101 @@
+using System.Reflection;
+using aweXpect.Reflection.Tests.TestHelpers.Types;
+using Xunit.Sdk;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatConstructor
+{
+	public sealed class IsObsolete
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenConstructorIsObsolete_ShouldSucceed()
+			{
+				ConstructorInfo subject =
+					typeof(ClassWithObsoleteMembers).GetConstructor(Type.EmptyTypes)!;
+
+				async Task Act()
+				{
+					await That(subject).IsObsolete();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenConstructorIsNotObsolete_ShouldFail()
+			{
+				ConstructorInfo subject =
+					typeof(ClassWithObsoleteMembers).GetConstructor(new[] { typeof(int) })!;
+
+				async Task Act()
+				{
+					await That(subject).IsObsolete();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage($"""
+					              Expected that subject
+					              is obsolete,
+					              but it was non-obsolete {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenConstructorIsNull_ShouldFail()
+			{
+				ConstructorInfo? subject = null;
+
+				async Task Act()
+				{
+					await That(subject).IsObsolete();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             is obsolete,
+					             but it was <null>
+					             """);
+			}
+		}
+
+		public sealed class NegatedTests
+		{
+			[Fact]
+			public async Task WhenConstructorIsObsolete_ShouldFail()
+			{
+				ConstructorInfo subject =
+					typeof(ClassWithObsoleteMembers).GetConstructor(Type.EmptyTypes)!;
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(it => it.IsObsolete());
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is not obsolete,
+					              but it was obsolete {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenConstructorIsNotObsolete_ShouldSucceed()
+			{
+				ConstructorInfo subject =
+					typeof(ClassWithObsoleteMembers).GetConstructor(new[] { typeof(int) })!;
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(it => it.IsObsolete());
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatConstructors.AreNotObsolete.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatConstructors.AreNotObsolete.Tests.cs
@@ -1,0 +1,169 @@
+using System.Collections.Generic;
+using System.Reflection;
+using aweXpect.Reflection.Tests.TestHelpers;
+using aweXpect.Reflection.Tests.TestHelpers.Types;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatConstructors
+{
+	public sealed class AreNotObsolete
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenAllConstructorsAreNotObsolete_ShouldSucceed()
+			{
+				IEnumerable<ConstructorInfo> subject =
+				[
+					typeof(ClassWithObsoleteMembers).GetConstructor(new[] { typeof(int) })!,
+				];
+
+				async Task Act()
+				{
+					await That(subject).AreNotObsolete();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenConstructorsContainObsoleteConstructors_ShouldFail()
+			{
+				IEnumerable<ConstructorInfo> subject =
+				[
+					typeof(ClassWithObsoleteMembers).GetConstructor(Type.EmptyTypes)!,
+					typeof(ClassWithObsoleteMembers).GetConstructor(new[] { typeof(int) })!,
+				];
+
+				async Task Act()
+				{
+					await That(subject).AreNotObsolete();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             are all not obsolete,
+					             but it contained obsolete items [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+		}
+
+		public sealed class NegatedTests
+		{
+			[Fact]
+			public async Task WhenAllConstructorsAreNotObsolete_ShouldFail()
+			{
+				IEnumerable<ConstructorInfo> subject =
+				[
+					typeof(ClassWithObsoleteMembers).GetConstructor(new[] { typeof(int) })!,
+				];
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(they => they.AreNotObsolete());
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             also contain an obsolete item,
+					             but it only contained non-obsolete items [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenConstructorsContainObsoleteConstructors_ShouldSucceed()
+			{
+				IEnumerable<ConstructorInfo> subject =
+				[
+					typeof(ClassWithObsoleteMembers).GetConstructor(Type.EmptyTypes)!,
+					typeof(ClassWithObsoleteMembers).GetConstructor(new[] { typeof(int) })!,
+				];
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(they => they.AreNotObsolete());
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+#if NET8_0_OR_GREATER
+		public sealed class AsyncEnumerableTests
+		{
+			[Fact]
+			public async Task WhenAllConstructorsAreNotObsolete_ShouldSucceed()
+			{
+				IAsyncEnumerable<ConstructorInfo?> subject = new[]
+					{
+						typeof(ClassWithObsoleteMembers).GetConstructor(new[] { typeof(int) })!,
+					}
+					.ToTestAsyncEnumerable<ConstructorInfo?>();
+
+				async Task Act()
+				{
+					await That(subject).AreNotObsolete();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenConstructorsContainObsoleteConstructors_ShouldFail()
+			{
+				IAsyncEnumerable<ConstructorInfo?> subject = new[]
+					{
+						typeof(ClassWithObsoleteMembers).GetConstructor(Type.EmptyTypes)!,
+						typeof(ClassWithObsoleteMembers).GetConstructor(new[] { typeof(int) })!,
+					}
+					.ToTestAsyncEnumerable<ConstructorInfo?>();
+
+				async Task Act()
+				{
+					await That(subject).AreNotObsolete();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             are all not obsolete,
+					             but it contained obsolete items [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenAllConstructorsAreNotObsolete_Negated_ShouldFail()
+			{
+				IAsyncEnumerable<ConstructorInfo?> subject = new[]
+					{
+						typeof(ClassWithObsoleteMembers).GetConstructor(new[] { typeof(int) })!,
+					}
+					.ToTestAsyncEnumerable<ConstructorInfo?>();
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(they => they.AreNotObsolete());
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             also contain an obsolete item,
+					             but it only contained non-obsolete items [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+		}
+#endif
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatConstructors.AreObsolete.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatConstructors.AreObsolete.Tests.cs
@@ -1,0 +1,169 @@
+using System.Collections.Generic;
+using System.Reflection;
+using aweXpect.Reflection.Tests.TestHelpers;
+using aweXpect.Reflection.Tests.TestHelpers.Types;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatConstructors
+{
+	public sealed class AreObsolete
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenAllConstructorsAreObsolete_ShouldSucceed()
+			{
+				IEnumerable<ConstructorInfo> subject =
+				[
+					typeof(ClassWithObsoleteMembers).GetConstructor(Type.EmptyTypes)!,
+				];
+
+				async Task Act()
+				{
+					await That(subject).AreObsolete();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenConstructorsContainNonObsoleteConstructors_ShouldFail()
+			{
+				IEnumerable<ConstructorInfo> subject =
+				[
+					typeof(ClassWithObsoleteMembers).GetConstructor(Type.EmptyTypes)!,
+					typeof(ClassWithObsoleteMembers).GetConstructor(new[] { typeof(int) })!,
+				];
+
+				async Task Act()
+				{
+					await That(subject).AreObsolete();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             are all obsolete,
+					             but it contained non-obsolete items [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+		}
+
+		public sealed class NegatedTests
+		{
+			[Fact]
+			public async Task WhenAllConstructorsAreObsolete_ShouldFail()
+			{
+				IEnumerable<ConstructorInfo> subject =
+				[
+					typeof(ClassWithObsoleteMembers).GetConstructor(Type.EmptyTypes)!,
+				];
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(they => they.AreObsolete());
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             are not all obsolete,
+					             but it only contained obsolete items [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenConstructorsContainNonObsoleteConstructors_ShouldSucceed()
+			{
+				IEnumerable<ConstructorInfo> subject =
+				[
+					typeof(ClassWithObsoleteMembers).GetConstructor(Type.EmptyTypes)!,
+					typeof(ClassWithObsoleteMembers).GetConstructor(new[] { typeof(int) })!,
+				];
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(they => they.AreObsolete());
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+#if NET8_0_OR_GREATER
+		public sealed class AsyncEnumerableTests
+		{
+			[Fact]
+			public async Task WhenAllConstructorsAreObsolete_ShouldSucceed()
+			{
+				IAsyncEnumerable<ConstructorInfo?> subject = new[]
+					{
+						typeof(ClassWithObsoleteMembers).GetConstructor(Type.EmptyTypes)!,
+					}
+					.ToTestAsyncEnumerable<ConstructorInfo?>();
+
+				async Task Act()
+				{
+					await That(subject).AreObsolete();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenConstructorsContainNonObsoleteConstructors_ShouldFail()
+			{
+				IAsyncEnumerable<ConstructorInfo?> subject = new[]
+					{
+						typeof(ClassWithObsoleteMembers).GetConstructor(Type.EmptyTypes)!,
+						typeof(ClassWithObsoleteMembers).GetConstructor(new[] { typeof(int) })!,
+					}
+					.ToTestAsyncEnumerable<ConstructorInfo?>();
+
+				async Task Act()
+				{
+					await That(subject).AreObsolete();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             are all obsolete,
+					             but it contained non-obsolete items [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenAllConstructorsAreObsolete_Negated_ShouldFail()
+			{
+				IAsyncEnumerable<ConstructorInfo?> subject = new[]
+					{
+						typeof(ClassWithObsoleteMembers).GetConstructor(Type.EmptyTypes)!,
+					}
+					.ToTestAsyncEnumerable<ConstructorInfo?>();
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(they => they.AreObsolete());
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             are not all obsolete,
+					             but it only contained obsolete items [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+		}
+#endif
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatEvent.IsNotObsolete.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatEvent.IsNotObsolete.Tests.cs
@@ -1,0 +1,101 @@
+using System.Reflection;
+using aweXpect.Reflection.Tests.TestHelpers.Types;
+using Xunit.Sdk;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatEvent
+{
+	public sealed class IsNotObsolete
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenEventIsNotObsolete_ShouldSucceed()
+			{
+				EventInfo subject =
+					typeof(ClassWithObsoleteMembers).GetEvent(nameof(ClassWithObsoleteMembers.NonObsoleteEvent))!;
+
+				async Task Act()
+				{
+					await That(subject).IsNotObsolete();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenEventIsObsolete_ShouldFail()
+			{
+				EventInfo subject =
+					typeof(ClassWithObsoleteMembers).GetEvent(nameof(ClassWithObsoleteMembers.ObsoleteEvent))!;
+
+				async Task Act()
+				{
+					await That(subject).IsNotObsolete();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage($"""
+					              Expected that subject
+					              is not obsolete,
+					              but it was obsolete {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenEventIsNull_ShouldFail()
+			{
+				EventInfo? subject = null;
+
+				async Task Act()
+				{
+					await That(subject).IsNotObsolete();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             is not obsolete,
+					             but it was <null>
+					             """);
+			}
+		}
+
+		public sealed class NegatedTests
+		{
+			[Fact]
+			public async Task WhenEventIsNotObsolete_ShouldFail()
+			{
+				EventInfo subject =
+					typeof(ClassWithObsoleteMembers).GetEvent(nameof(ClassWithObsoleteMembers.NonObsoleteEvent))!;
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(it => it.IsNotObsolete());
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is obsolete,
+					              but it was non-obsolete {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenEventIsObsolete_ShouldSucceed()
+			{
+				EventInfo subject =
+					typeof(ClassWithObsoleteMembers).GetEvent(nameof(ClassWithObsoleteMembers.ObsoleteEvent))!;
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(it => it.IsNotObsolete());
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatEvent.IsObsolete.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatEvent.IsObsolete.Tests.cs
@@ -1,0 +1,101 @@
+using System.Reflection;
+using aweXpect.Reflection.Tests.TestHelpers.Types;
+using Xunit.Sdk;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatEvent
+{
+	public sealed class IsObsolete
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenEventIsObsolete_ShouldSucceed()
+			{
+				EventInfo subject =
+					typeof(ClassWithObsoleteMembers).GetEvent(nameof(ClassWithObsoleteMembers.ObsoleteEvent))!;
+
+				async Task Act()
+				{
+					await That(subject).IsObsolete();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenEventIsNotObsolete_ShouldFail()
+			{
+				EventInfo subject =
+					typeof(ClassWithObsoleteMembers).GetEvent(nameof(ClassWithObsoleteMembers.NonObsoleteEvent))!;
+
+				async Task Act()
+				{
+					await That(subject).IsObsolete();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage($"""
+					              Expected that subject
+					              is obsolete,
+					              but it was non-obsolete {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenEventIsNull_ShouldFail()
+			{
+				EventInfo? subject = null;
+
+				async Task Act()
+				{
+					await That(subject).IsObsolete();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             is obsolete,
+					             but it was <null>
+					             """);
+			}
+		}
+
+		public sealed class NegatedTests
+		{
+			[Fact]
+			public async Task WhenEventIsObsolete_ShouldFail()
+			{
+				EventInfo subject =
+					typeof(ClassWithObsoleteMembers).GetEvent(nameof(ClassWithObsoleteMembers.ObsoleteEvent))!;
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(it => it.IsObsolete());
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is not obsolete,
+					              but it was obsolete {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenEventIsNotObsolete_ShouldSucceed()
+			{
+				EventInfo subject =
+					typeof(ClassWithObsoleteMembers).GetEvent(nameof(ClassWithObsoleteMembers.NonObsoleteEvent))!;
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(it => it.IsObsolete());
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatEvents.AreNotObsolete.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatEvents.AreNotObsolete.Tests.cs
@@ -1,0 +1,169 @@
+using System.Collections.Generic;
+using System.Reflection;
+using aweXpect.Reflection.Tests.TestHelpers;
+using aweXpect.Reflection.Tests.TestHelpers.Types;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatEvents
+{
+	public sealed class AreNotObsolete
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenAllEventsAreNotObsolete_ShouldSucceed()
+			{
+				IEnumerable<EventInfo> subject =
+				[
+					typeof(ClassWithObsoleteMembers).GetEvent(nameof(ClassWithObsoleteMembers.NonObsoleteEvent))!,
+				];
+
+				async Task Act()
+				{
+					await That(subject).AreNotObsolete();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenEventsContainObsoleteEvents_ShouldFail()
+			{
+				IEnumerable<EventInfo> subject =
+				[
+					typeof(ClassWithObsoleteMembers).GetEvent(nameof(ClassWithObsoleteMembers.ObsoleteEvent))!,
+					typeof(ClassWithObsoleteMembers).GetEvent(nameof(ClassWithObsoleteMembers.NonObsoleteEvent))!,
+				];
+
+				async Task Act()
+				{
+					await That(subject).AreNotObsolete();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             are all not obsolete,
+					             but it contained obsolete items [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+		}
+
+		public sealed class NegatedTests
+		{
+			[Fact]
+			public async Task WhenAllEventsAreNotObsolete_ShouldFail()
+			{
+				IEnumerable<EventInfo> subject =
+				[
+					typeof(ClassWithObsoleteMembers).GetEvent(nameof(ClassWithObsoleteMembers.NonObsoleteEvent))!,
+				];
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(they => they.AreNotObsolete());
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             also contain an obsolete item,
+					             but it only contained non-obsolete items [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenEventsContainObsoleteEvents_ShouldSucceed()
+			{
+				IEnumerable<EventInfo> subject =
+				[
+					typeof(ClassWithObsoleteMembers).GetEvent(nameof(ClassWithObsoleteMembers.ObsoleteEvent))!,
+					typeof(ClassWithObsoleteMembers).GetEvent(nameof(ClassWithObsoleteMembers.NonObsoleteEvent))!,
+				];
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(they => they.AreNotObsolete());
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+#if NET8_0_OR_GREATER
+		public sealed class AsyncEnumerableTests
+		{
+			[Fact]
+			public async Task WhenAllEventsAreNotObsolete_ShouldSucceed()
+			{
+				IAsyncEnumerable<EventInfo?> subject = new[]
+					{
+						typeof(ClassWithObsoleteMembers).GetEvent(nameof(ClassWithObsoleteMembers.NonObsoleteEvent))!,
+					}
+					.ToTestAsyncEnumerable<EventInfo?>();
+
+				async Task Act()
+				{
+					await That(subject).AreNotObsolete();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenEventsContainObsoleteEvents_ShouldFail()
+			{
+				IAsyncEnumerable<EventInfo?> subject = new[]
+					{
+						typeof(ClassWithObsoleteMembers).GetEvent(nameof(ClassWithObsoleteMembers.ObsoleteEvent))!,
+						typeof(ClassWithObsoleteMembers).GetEvent(nameof(ClassWithObsoleteMembers.NonObsoleteEvent))!,
+					}
+					.ToTestAsyncEnumerable<EventInfo?>();
+
+				async Task Act()
+				{
+					await That(subject).AreNotObsolete();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             are all not obsolete,
+					             but it contained obsolete items [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenAllEventsAreNotObsolete_Negated_ShouldFail()
+			{
+				IAsyncEnumerable<EventInfo?> subject = new[]
+					{
+						typeof(ClassWithObsoleteMembers).GetEvent(nameof(ClassWithObsoleteMembers.NonObsoleteEvent))!,
+					}
+					.ToTestAsyncEnumerable<EventInfo?>();
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(they => they.AreNotObsolete());
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             also contain an obsolete item,
+					             but it only contained non-obsolete items [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+		}
+#endif
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatEvents.AreObsolete.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatEvents.AreObsolete.Tests.cs
@@ -1,0 +1,169 @@
+using System.Collections.Generic;
+using System.Reflection;
+using aweXpect.Reflection.Tests.TestHelpers;
+using aweXpect.Reflection.Tests.TestHelpers.Types;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatEvents
+{
+	public sealed class AreObsolete
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenAllEventsAreObsolete_ShouldSucceed()
+			{
+				IEnumerable<EventInfo> subject =
+				[
+					typeof(ClassWithObsoleteMembers).GetEvent(nameof(ClassWithObsoleteMembers.ObsoleteEvent))!,
+				];
+
+				async Task Act()
+				{
+					await That(subject).AreObsolete();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenEventsContainNonObsoleteEvents_ShouldFail()
+			{
+				IEnumerable<EventInfo> subject =
+				[
+					typeof(ClassWithObsoleteMembers).GetEvent(nameof(ClassWithObsoleteMembers.ObsoleteEvent))!,
+					typeof(ClassWithObsoleteMembers).GetEvent(nameof(ClassWithObsoleteMembers.NonObsoleteEvent))!,
+				];
+
+				async Task Act()
+				{
+					await That(subject).AreObsolete();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             are all obsolete,
+					             but it contained non-obsolete items [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+		}
+
+		public sealed class NegatedTests
+		{
+			[Fact]
+			public async Task WhenAllEventsAreObsolete_ShouldFail()
+			{
+				IEnumerable<EventInfo> subject =
+				[
+					typeof(ClassWithObsoleteMembers).GetEvent(nameof(ClassWithObsoleteMembers.ObsoleteEvent))!,
+				];
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(they => they.AreObsolete());
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             are not all obsolete,
+					             but it only contained obsolete items [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenEventsContainNonObsoleteEvents_ShouldSucceed()
+			{
+				IEnumerable<EventInfo> subject =
+				[
+					typeof(ClassWithObsoleteMembers).GetEvent(nameof(ClassWithObsoleteMembers.ObsoleteEvent))!,
+					typeof(ClassWithObsoleteMembers).GetEvent(nameof(ClassWithObsoleteMembers.NonObsoleteEvent))!,
+				];
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(they => they.AreObsolete());
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+#if NET8_0_OR_GREATER
+		public sealed class AsyncEnumerableTests
+		{
+			[Fact]
+			public async Task WhenAllEventsAreObsolete_ShouldSucceed()
+			{
+				IAsyncEnumerable<EventInfo?> subject = new[]
+					{
+						typeof(ClassWithObsoleteMembers).GetEvent(nameof(ClassWithObsoleteMembers.ObsoleteEvent))!,
+					}
+					.ToTestAsyncEnumerable<EventInfo?>();
+
+				async Task Act()
+				{
+					await That(subject).AreObsolete();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenEventsContainNonObsoleteEvents_ShouldFail()
+			{
+				IAsyncEnumerable<EventInfo?> subject = new[]
+					{
+						typeof(ClassWithObsoleteMembers).GetEvent(nameof(ClassWithObsoleteMembers.ObsoleteEvent))!,
+						typeof(ClassWithObsoleteMembers).GetEvent(nameof(ClassWithObsoleteMembers.NonObsoleteEvent))!,
+					}
+					.ToTestAsyncEnumerable<EventInfo?>();
+
+				async Task Act()
+				{
+					await That(subject).AreObsolete();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             are all obsolete,
+					             but it contained non-obsolete items [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenAllEventsAreObsolete_Negated_ShouldFail()
+			{
+				IAsyncEnumerable<EventInfo?> subject = new[]
+					{
+						typeof(ClassWithObsoleteMembers).GetEvent(nameof(ClassWithObsoleteMembers.ObsoleteEvent))!,
+					}
+					.ToTestAsyncEnumerable<EventInfo?>();
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(they => they.AreObsolete());
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             are not all obsolete,
+					             but it only contained obsolete items [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+		}
+#endif
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatField.IsNotObsolete.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatField.IsNotObsolete.Tests.cs
@@ -1,0 +1,102 @@
+using System.Reflection;
+using aweXpect.Reflection.Tests.TestHelpers.Types;
+using Xunit.Sdk;
+
+namespace aweXpect.Reflection.Tests;
+
+#pragma warning disable CS0612 // Intentional reference to an obsolete test fixture member
+public sealed partial class ThatField
+{
+	public sealed class IsNotObsolete
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenFieldIsNotObsolete_ShouldSucceed()
+			{
+				FieldInfo subject =
+					typeof(ClassWithObsoleteMembers).GetField(nameof(ClassWithObsoleteMembers.NonObsoleteField))!;
+
+				async Task Act()
+				{
+					await That(subject).IsNotObsolete();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenFieldIsObsolete_ShouldFail()
+			{
+				FieldInfo subject =
+					typeof(ClassWithObsoleteMembers).GetField(nameof(ClassWithObsoleteMembers.ObsoleteField))!;
+
+				async Task Act()
+				{
+					await That(subject).IsNotObsolete();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage($"""
+					              Expected that subject
+					              is not obsolete,
+					              but it was obsolete {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenFieldIsNull_ShouldFail()
+			{
+				FieldInfo? subject = null;
+
+				async Task Act()
+				{
+					await That(subject).IsNotObsolete();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             is not obsolete,
+					             but it was <null>
+					             """);
+			}
+		}
+
+		public sealed class NegatedTests
+		{
+			[Fact]
+			public async Task WhenFieldIsNotObsolete_ShouldFail()
+			{
+				FieldInfo subject =
+					typeof(ClassWithObsoleteMembers).GetField(nameof(ClassWithObsoleteMembers.NonObsoleteField))!;
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(it => it.IsNotObsolete());
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is obsolete,
+					              but it was non-obsolete {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenFieldIsObsolete_ShouldSucceed()
+			{
+				FieldInfo subject =
+					typeof(ClassWithObsoleteMembers).GetField(nameof(ClassWithObsoleteMembers.ObsoleteField))!;
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(it => it.IsNotObsolete());
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatField.IsObsolete.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatField.IsObsolete.Tests.cs
@@ -1,0 +1,102 @@
+using System.Reflection;
+using aweXpect.Reflection.Tests.TestHelpers.Types;
+using Xunit.Sdk;
+
+namespace aweXpect.Reflection.Tests;
+
+#pragma warning disable CS0612 // Intentional reference to an obsolete test fixture member
+public sealed partial class ThatField
+{
+	public sealed class IsObsolete
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenFieldIsObsolete_ShouldSucceed()
+			{
+				FieldInfo subject =
+					typeof(ClassWithObsoleteMembers).GetField(nameof(ClassWithObsoleteMembers.ObsoleteField))!;
+
+				async Task Act()
+				{
+					await That(subject).IsObsolete();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenFieldIsNotObsolete_ShouldFail()
+			{
+				FieldInfo subject =
+					typeof(ClassWithObsoleteMembers).GetField(nameof(ClassWithObsoleteMembers.NonObsoleteField))!;
+
+				async Task Act()
+				{
+					await That(subject).IsObsolete();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage($"""
+					              Expected that subject
+					              is obsolete,
+					              but it was non-obsolete {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenFieldIsNull_ShouldFail()
+			{
+				FieldInfo? subject = null;
+
+				async Task Act()
+				{
+					await That(subject).IsObsolete();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             is obsolete,
+					             but it was <null>
+					             """);
+			}
+		}
+
+		public sealed class NegatedTests
+		{
+			[Fact]
+			public async Task WhenFieldIsObsolete_ShouldFail()
+			{
+				FieldInfo subject =
+					typeof(ClassWithObsoleteMembers).GetField(nameof(ClassWithObsoleteMembers.ObsoleteField))!;
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(it => it.IsObsolete());
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is not obsolete,
+					              but it was obsolete {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenFieldIsNotObsolete_ShouldSucceed()
+			{
+				FieldInfo subject =
+					typeof(ClassWithObsoleteMembers).GetField(nameof(ClassWithObsoleteMembers.NonObsoleteField))!;
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(it => it.IsObsolete());
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatFields.AreNotObsolete.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatFields.AreNotObsolete.Tests.cs
@@ -1,0 +1,170 @@
+using System.Collections.Generic;
+using System.Reflection;
+using aweXpect.Reflection.Tests.TestHelpers;
+using aweXpect.Reflection.Tests.TestHelpers.Types;
+
+namespace aweXpect.Reflection.Tests;
+
+#pragma warning disable CS0612 // Intentional reference to an obsolete test fixture member
+public sealed partial class ThatFields
+{
+	public sealed class AreNotObsolete
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenAllFieldsAreNotObsolete_ShouldSucceed()
+			{
+				IEnumerable<FieldInfo> subject =
+				[
+					typeof(ClassWithObsoleteMembers).GetField(nameof(ClassWithObsoleteMembers.NonObsoleteField))!,
+				];
+
+				async Task Act()
+				{
+					await That(subject).AreNotObsolete();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenFieldsContainObsoleteFields_ShouldFail()
+			{
+				IEnumerable<FieldInfo> subject =
+				[
+					typeof(ClassWithObsoleteMembers).GetField(nameof(ClassWithObsoleteMembers.ObsoleteField))!,
+					typeof(ClassWithObsoleteMembers).GetField(nameof(ClassWithObsoleteMembers.NonObsoleteField))!,
+				];
+
+				async Task Act()
+				{
+					await That(subject).AreNotObsolete();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             are all not obsolete,
+					             but it contained obsolete items [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+		}
+
+		public sealed class NegatedTests
+		{
+			[Fact]
+			public async Task WhenAllFieldsAreNotObsolete_ShouldFail()
+			{
+				IEnumerable<FieldInfo> subject =
+				[
+					typeof(ClassWithObsoleteMembers).GetField(nameof(ClassWithObsoleteMembers.NonObsoleteField))!,
+				];
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(they => they.AreNotObsolete());
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             also contain an obsolete item,
+					             but it only contained non-obsolete items [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenFieldsContainObsoleteFields_ShouldSucceed()
+			{
+				IEnumerable<FieldInfo> subject =
+				[
+					typeof(ClassWithObsoleteMembers).GetField(nameof(ClassWithObsoleteMembers.ObsoleteField))!,
+					typeof(ClassWithObsoleteMembers).GetField(nameof(ClassWithObsoleteMembers.NonObsoleteField))!,
+				];
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(they => they.AreNotObsolete());
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+#if NET8_0_OR_GREATER
+		public sealed class AsyncEnumerableTests
+		{
+			[Fact]
+			public async Task WhenAllFieldsAreNotObsolete_ShouldSucceed()
+			{
+				IAsyncEnumerable<FieldInfo?> subject = new[]
+					{
+						typeof(ClassWithObsoleteMembers).GetField(nameof(ClassWithObsoleteMembers.NonObsoleteField))!,
+					}
+					.ToTestAsyncEnumerable<FieldInfo?>();
+
+				async Task Act()
+				{
+					await That(subject).AreNotObsolete();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenFieldsContainObsoleteFields_ShouldFail()
+			{
+				IAsyncEnumerable<FieldInfo?> subject = new[]
+					{
+						typeof(ClassWithObsoleteMembers).GetField(nameof(ClassWithObsoleteMembers.ObsoleteField))!,
+						typeof(ClassWithObsoleteMembers).GetField(nameof(ClassWithObsoleteMembers.NonObsoleteField))!,
+					}
+					.ToTestAsyncEnumerable<FieldInfo?>();
+
+				async Task Act()
+				{
+					await That(subject).AreNotObsolete();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             are all not obsolete,
+					             but it contained obsolete items [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenAllFieldsAreNotObsolete_Negated_ShouldFail()
+			{
+				IAsyncEnumerable<FieldInfo?> subject = new[]
+					{
+						typeof(ClassWithObsoleteMembers).GetField(nameof(ClassWithObsoleteMembers.NonObsoleteField))!,
+					}
+					.ToTestAsyncEnumerable<FieldInfo?>();
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(they => they.AreNotObsolete());
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             also contain an obsolete item,
+					             but it only contained non-obsolete items [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+		}
+#endif
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatFields.AreObsolete.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatFields.AreObsolete.Tests.cs
@@ -1,0 +1,170 @@
+using System.Collections.Generic;
+using System.Reflection;
+using aweXpect.Reflection.Tests.TestHelpers;
+using aweXpect.Reflection.Tests.TestHelpers.Types;
+
+namespace aweXpect.Reflection.Tests;
+
+#pragma warning disable CS0612 // Intentional reference to an obsolete test fixture member
+public sealed partial class ThatFields
+{
+	public sealed class AreObsolete
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenAllFieldsAreObsolete_ShouldSucceed()
+			{
+				IEnumerable<FieldInfo> subject =
+				[
+					typeof(ClassWithObsoleteMembers).GetField(nameof(ClassWithObsoleteMembers.ObsoleteField))!,
+				];
+
+				async Task Act()
+				{
+					await That(subject).AreObsolete();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenFieldsContainNonObsoleteFields_ShouldFail()
+			{
+				IEnumerable<FieldInfo> subject =
+				[
+					typeof(ClassWithObsoleteMembers).GetField(nameof(ClassWithObsoleteMembers.ObsoleteField))!,
+					typeof(ClassWithObsoleteMembers).GetField(nameof(ClassWithObsoleteMembers.NonObsoleteField))!,
+				];
+
+				async Task Act()
+				{
+					await That(subject).AreObsolete();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             are all obsolete,
+					             but it contained non-obsolete items [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+		}
+
+		public sealed class NegatedTests
+		{
+			[Fact]
+			public async Task WhenAllFieldsAreObsolete_ShouldFail()
+			{
+				IEnumerable<FieldInfo> subject =
+				[
+					typeof(ClassWithObsoleteMembers).GetField(nameof(ClassWithObsoleteMembers.ObsoleteField))!,
+				];
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(they => they.AreObsolete());
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             are not all obsolete,
+					             but it only contained obsolete items [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenFieldsContainNonObsoleteFields_ShouldSucceed()
+			{
+				IEnumerable<FieldInfo> subject =
+				[
+					typeof(ClassWithObsoleteMembers).GetField(nameof(ClassWithObsoleteMembers.ObsoleteField))!,
+					typeof(ClassWithObsoleteMembers).GetField(nameof(ClassWithObsoleteMembers.NonObsoleteField))!,
+				];
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(they => they.AreObsolete());
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+#if NET8_0_OR_GREATER
+		public sealed class AsyncEnumerableTests
+		{
+			[Fact]
+			public async Task WhenAllFieldsAreObsolete_ShouldSucceed()
+			{
+				IAsyncEnumerable<FieldInfo?> subject = new[]
+					{
+						typeof(ClassWithObsoleteMembers).GetField(nameof(ClassWithObsoleteMembers.ObsoleteField))!,
+					}
+					.ToTestAsyncEnumerable<FieldInfo?>();
+
+				async Task Act()
+				{
+					await That(subject).AreObsolete();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenFieldsContainNonObsoleteFields_ShouldFail()
+			{
+				IAsyncEnumerable<FieldInfo?> subject = new[]
+					{
+						typeof(ClassWithObsoleteMembers).GetField(nameof(ClassWithObsoleteMembers.ObsoleteField))!,
+						typeof(ClassWithObsoleteMembers).GetField(nameof(ClassWithObsoleteMembers.NonObsoleteField))!,
+					}
+					.ToTestAsyncEnumerable<FieldInfo?>();
+
+				async Task Act()
+				{
+					await That(subject).AreObsolete();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             are all obsolete,
+					             but it contained non-obsolete items [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenAllFieldsAreObsolete_Negated_ShouldFail()
+			{
+				IAsyncEnumerable<FieldInfo?> subject = new[]
+					{
+						typeof(ClassWithObsoleteMembers).GetField(nameof(ClassWithObsoleteMembers.ObsoleteField))!,
+					}
+					.ToTestAsyncEnumerable<FieldInfo?>();
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(they => they.AreObsolete());
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             are not all obsolete,
+					             but it only contained obsolete items [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+		}
+#endif
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatMethod.IsNotObsolete.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethod.IsNotObsolete.Tests.cs
@@ -1,0 +1,101 @@
+using System.Reflection;
+using aweXpect.Reflection.Tests.TestHelpers.Types;
+using Xunit.Sdk;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatMethod
+{
+	public sealed class IsNotObsolete
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenMethodIsNotObsolete_ShouldSucceed()
+			{
+				MethodInfo subject =
+					typeof(ClassWithObsoleteMembers).GetMethod(nameof(ClassWithObsoleteMembers.NonObsoleteMethod))!;
+
+				async Task Act()
+				{
+					await That(subject).IsNotObsolete();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenMethodIsObsolete_ShouldFail()
+			{
+				MethodInfo subject =
+					typeof(ClassWithObsoleteMembers).GetMethod(nameof(ClassWithObsoleteMembers.ObsoleteMethod))!;
+
+				async Task Act()
+				{
+					await That(subject).IsNotObsolete();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage($"""
+					              Expected that subject
+					              is not obsolete,
+					              but it was obsolete {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenMethodIsNull_ShouldFail()
+			{
+				MethodInfo? subject = null;
+
+				async Task Act()
+				{
+					await That(subject).IsNotObsolete();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             is not obsolete,
+					             but it was <null>
+					             """);
+			}
+		}
+
+		public sealed class NegatedTests
+		{
+			[Fact]
+			public async Task WhenMethodIsNotObsolete_ShouldFail()
+			{
+				MethodInfo subject =
+					typeof(ClassWithObsoleteMembers).GetMethod(nameof(ClassWithObsoleteMembers.NonObsoleteMethod))!;
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(it => it.IsNotObsolete());
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is obsolete,
+					              but it was non-obsolete {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenMethodIsObsolete_ShouldSucceed()
+			{
+				MethodInfo subject =
+					typeof(ClassWithObsoleteMembers).GetMethod(nameof(ClassWithObsoleteMembers.ObsoleteMethod))!;
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(it => it.IsNotObsolete());
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatMethod.IsObsolete.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethod.IsObsolete.Tests.cs
@@ -1,0 +1,101 @@
+using System.Reflection;
+using aweXpect.Reflection.Tests.TestHelpers.Types;
+using Xunit.Sdk;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatMethod
+{
+	public sealed class IsObsolete
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenMethodIsObsolete_ShouldSucceed()
+			{
+				MethodInfo subject =
+					typeof(ClassWithObsoleteMembers).GetMethod(nameof(ClassWithObsoleteMembers.ObsoleteMethod))!;
+
+				async Task Act()
+				{
+					await That(subject).IsObsolete();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenMethodIsNotObsolete_ShouldFail()
+			{
+				MethodInfo subject =
+					typeof(ClassWithObsoleteMembers).GetMethod(nameof(ClassWithObsoleteMembers.NonObsoleteMethod))!;
+
+				async Task Act()
+				{
+					await That(subject).IsObsolete();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage($"""
+					              Expected that subject
+					              is obsolete,
+					              but it was non-obsolete {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenMethodIsNull_ShouldFail()
+			{
+				MethodInfo? subject = null;
+
+				async Task Act()
+				{
+					await That(subject).IsObsolete();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             is obsolete,
+					             but it was <null>
+					             """);
+			}
+		}
+
+		public sealed class NegatedTests
+		{
+			[Fact]
+			public async Task WhenMethodIsObsolete_ShouldFail()
+			{
+				MethodInfo subject =
+					typeof(ClassWithObsoleteMembers).GetMethod(nameof(ClassWithObsoleteMembers.ObsoleteMethod))!;
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(it => it.IsObsolete());
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is not obsolete,
+					              but it was obsolete {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenMethodIsNotObsolete_ShouldSucceed()
+			{
+				MethodInfo subject =
+					typeof(ClassWithObsoleteMembers).GetMethod(nameof(ClassWithObsoleteMembers.NonObsoleteMethod))!;
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(it => it.IsObsolete());
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatMethods.AreNotObsolete.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethods.AreNotObsolete.Tests.cs
@@ -1,0 +1,169 @@
+using System.Collections.Generic;
+using System.Reflection;
+using aweXpect.Reflection.Tests.TestHelpers;
+using aweXpect.Reflection.Tests.TestHelpers.Types;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatMethods
+{
+	public sealed class AreNotObsolete
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenAllMethodsAreNotObsolete_ShouldSucceed()
+			{
+				IEnumerable<MethodInfo> subject =
+				[
+					typeof(ClassWithObsoleteMembers).GetMethod(nameof(ClassWithObsoleteMembers.NonObsoleteMethod))!,
+				];
+
+				async Task Act()
+				{
+					await That(subject).AreNotObsolete();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenMethodsContainObsoleteMethods_ShouldFail()
+			{
+				IEnumerable<MethodInfo> subject =
+				[
+					typeof(ClassWithObsoleteMembers).GetMethod(nameof(ClassWithObsoleteMembers.ObsoleteMethod))!,
+					typeof(ClassWithObsoleteMembers).GetMethod(nameof(ClassWithObsoleteMembers.NonObsoleteMethod))!,
+				];
+
+				async Task Act()
+				{
+					await That(subject).AreNotObsolete();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             are all not obsolete,
+					             but it contained obsolete items [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+		}
+
+		public sealed class NegatedTests
+		{
+			[Fact]
+			public async Task WhenAllMethodsAreNotObsolete_ShouldFail()
+			{
+				IEnumerable<MethodInfo> subject =
+				[
+					typeof(ClassWithObsoleteMembers).GetMethod(nameof(ClassWithObsoleteMembers.NonObsoleteMethod))!,
+				];
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(they => they.AreNotObsolete());
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             also contain an obsolete item,
+					             but it only contained non-obsolete items [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenMethodsContainObsoleteMethods_ShouldSucceed()
+			{
+				IEnumerable<MethodInfo> subject =
+				[
+					typeof(ClassWithObsoleteMembers).GetMethod(nameof(ClassWithObsoleteMembers.ObsoleteMethod))!,
+					typeof(ClassWithObsoleteMembers).GetMethod(nameof(ClassWithObsoleteMembers.NonObsoleteMethod))!,
+				];
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(they => they.AreNotObsolete());
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+#if NET8_0_OR_GREATER
+		public sealed class AsyncEnumerableTests
+		{
+			[Fact]
+			public async Task WhenAllMethodsAreNotObsolete_ShouldSucceed()
+			{
+				IAsyncEnumerable<MethodInfo?> subject = new[]
+					{
+						typeof(ClassWithObsoleteMembers).GetMethod(nameof(ClassWithObsoleteMembers.NonObsoleteMethod))!,
+					}
+					.ToTestAsyncEnumerable<MethodInfo?>();
+
+				async Task Act()
+				{
+					await That(subject).AreNotObsolete();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenMethodsContainObsoleteMethods_ShouldFail()
+			{
+				IAsyncEnumerable<MethodInfo?> subject = new[]
+					{
+						typeof(ClassWithObsoleteMembers).GetMethod(nameof(ClassWithObsoleteMembers.ObsoleteMethod))!,
+						typeof(ClassWithObsoleteMembers).GetMethod(nameof(ClassWithObsoleteMembers.NonObsoleteMethod))!,
+					}
+					.ToTestAsyncEnumerable<MethodInfo?>();
+
+				async Task Act()
+				{
+					await That(subject).AreNotObsolete();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             are all not obsolete,
+					             but it contained obsolete items [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenAllMethodsAreNotObsolete_Negated_ShouldFail()
+			{
+				IAsyncEnumerable<MethodInfo?> subject = new[]
+					{
+						typeof(ClassWithObsoleteMembers).GetMethod(nameof(ClassWithObsoleteMembers.NonObsoleteMethod))!,
+					}
+					.ToTestAsyncEnumerable<MethodInfo?>();
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(they => they.AreNotObsolete());
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             also contain an obsolete item,
+					             but it only contained non-obsolete items [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+		}
+#endif
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatMethods.AreObsolete.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethods.AreObsolete.Tests.cs
@@ -1,0 +1,169 @@
+using System.Collections.Generic;
+using System.Reflection;
+using aweXpect.Reflection.Tests.TestHelpers;
+using aweXpect.Reflection.Tests.TestHelpers.Types;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatMethods
+{
+	public sealed class AreObsolete
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenAllMethodsAreObsolete_ShouldSucceed()
+			{
+				IEnumerable<MethodInfo> subject =
+				[
+					typeof(ClassWithObsoleteMembers).GetMethod(nameof(ClassWithObsoleteMembers.ObsoleteMethod))!,
+				];
+
+				async Task Act()
+				{
+					await That(subject).AreObsolete();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenMethodsContainNonObsoleteMethods_ShouldFail()
+			{
+				IEnumerable<MethodInfo> subject =
+				[
+					typeof(ClassWithObsoleteMembers).GetMethod(nameof(ClassWithObsoleteMembers.ObsoleteMethod))!,
+					typeof(ClassWithObsoleteMembers).GetMethod(nameof(ClassWithObsoleteMembers.NonObsoleteMethod))!,
+				];
+
+				async Task Act()
+				{
+					await That(subject).AreObsolete();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             are all obsolete,
+					             but it contained non-obsolete items [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+		}
+
+		public sealed class NegatedTests
+		{
+			[Fact]
+			public async Task WhenAllMethodsAreObsolete_ShouldFail()
+			{
+				IEnumerable<MethodInfo> subject =
+				[
+					typeof(ClassWithObsoleteMembers).GetMethod(nameof(ClassWithObsoleteMembers.ObsoleteMethod))!,
+				];
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(they => they.AreObsolete());
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             are not all obsolete,
+					             but it only contained obsolete items [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenMethodsContainNonObsoleteMethods_ShouldSucceed()
+			{
+				IEnumerable<MethodInfo> subject =
+				[
+					typeof(ClassWithObsoleteMembers).GetMethod(nameof(ClassWithObsoleteMembers.ObsoleteMethod))!,
+					typeof(ClassWithObsoleteMembers).GetMethod(nameof(ClassWithObsoleteMembers.NonObsoleteMethod))!,
+				];
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(they => they.AreObsolete());
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+#if NET8_0_OR_GREATER
+		public sealed class AsyncEnumerableTests
+		{
+			[Fact]
+			public async Task WhenAllMethodsAreObsolete_ShouldSucceed()
+			{
+				IAsyncEnumerable<MethodInfo?> subject = new[]
+					{
+						typeof(ClassWithObsoleteMembers).GetMethod(nameof(ClassWithObsoleteMembers.ObsoleteMethod))!,
+					}
+					.ToTestAsyncEnumerable<MethodInfo?>();
+
+				async Task Act()
+				{
+					await That(subject).AreObsolete();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenMethodsContainNonObsoleteMethods_ShouldFail()
+			{
+				IAsyncEnumerable<MethodInfo?> subject = new[]
+					{
+						typeof(ClassWithObsoleteMembers).GetMethod(nameof(ClassWithObsoleteMembers.ObsoleteMethod))!,
+						typeof(ClassWithObsoleteMembers).GetMethod(nameof(ClassWithObsoleteMembers.NonObsoleteMethod))!,
+					}
+					.ToTestAsyncEnumerable<MethodInfo?>();
+
+				async Task Act()
+				{
+					await That(subject).AreObsolete();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             are all obsolete,
+					             but it contained non-obsolete items [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenAllMethodsAreObsolete_Negated_ShouldFail()
+			{
+				IAsyncEnumerable<MethodInfo?> subject = new[]
+					{
+						typeof(ClassWithObsoleteMembers).GetMethod(nameof(ClassWithObsoleteMembers.ObsoleteMethod))!,
+					}
+					.ToTestAsyncEnumerable<MethodInfo?>();
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(they => they.AreObsolete());
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             are not all obsolete,
+					             but it only contained obsolete items [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+		}
+#endif
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatProperties.AreNotObsolete.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatProperties.AreNotObsolete.Tests.cs
@@ -1,0 +1,170 @@
+using System.Collections.Generic;
+using System.Reflection;
+using aweXpect.Reflection.Tests.TestHelpers;
+using aweXpect.Reflection.Tests.TestHelpers.Types;
+
+namespace aweXpect.Reflection.Tests;
+
+#pragma warning disable CS0612 // Intentional reference to an obsolete test fixture member
+public sealed partial class ThatProperties
+{
+	public sealed class AreNotObsolete
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenAllPropertiesAreNotObsolete_ShouldSucceed()
+			{
+				IEnumerable<PropertyInfo> subject =
+				[
+					typeof(ClassWithObsoleteMembers).GetProperty(nameof(ClassWithObsoleteMembers.NonObsoleteProperty))!,
+				];
+
+				async Task Act()
+				{
+					await That(subject).AreNotObsolete();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenPropertiesContainObsoleteProperties_ShouldFail()
+			{
+				IEnumerable<PropertyInfo> subject =
+				[
+					typeof(ClassWithObsoleteMembers).GetProperty(nameof(ClassWithObsoleteMembers.ObsoleteProperty))!,
+					typeof(ClassWithObsoleteMembers).GetProperty(nameof(ClassWithObsoleteMembers.NonObsoleteProperty))!,
+				];
+
+				async Task Act()
+				{
+					await That(subject).AreNotObsolete();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             are all not obsolete,
+					             but it contained obsolete items [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+		}
+
+		public sealed class NegatedTests
+		{
+			[Fact]
+			public async Task WhenAllPropertiesAreNotObsolete_ShouldFail()
+			{
+				IEnumerable<PropertyInfo> subject =
+				[
+					typeof(ClassWithObsoleteMembers).GetProperty(nameof(ClassWithObsoleteMembers.NonObsoleteProperty))!,
+				];
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(they => they.AreNotObsolete());
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             also contain an obsolete item,
+					             but it only contained non-obsolete items [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenPropertiesContainObsoleteProperties_ShouldSucceed()
+			{
+				IEnumerable<PropertyInfo> subject =
+				[
+					typeof(ClassWithObsoleteMembers).GetProperty(nameof(ClassWithObsoleteMembers.ObsoleteProperty))!,
+					typeof(ClassWithObsoleteMembers).GetProperty(nameof(ClassWithObsoleteMembers.NonObsoleteProperty))!,
+				];
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(they => they.AreNotObsolete());
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+#if NET8_0_OR_GREATER
+		public sealed class AsyncEnumerableTests
+		{
+			[Fact]
+			public async Task WhenAllPropertiesAreNotObsolete_ShouldSucceed()
+			{
+				IAsyncEnumerable<PropertyInfo?> subject = new[]
+					{
+						typeof(ClassWithObsoleteMembers).GetProperty(nameof(ClassWithObsoleteMembers.NonObsoleteProperty))!,
+					}
+					.ToTestAsyncEnumerable<PropertyInfo?>();
+
+				async Task Act()
+				{
+					await That(subject).AreNotObsolete();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenPropertiesContainObsoleteProperties_ShouldFail()
+			{
+				IAsyncEnumerable<PropertyInfo?> subject = new[]
+					{
+						typeof(ClassWithObsoleteMembers).GetProperty(nameof(ClassWithObsoleteMembers.ObsoleteProperty))!,
+						typeof(ClassWithObsoleteMembers).GetProperty(nameof(ClassWithObsoleteMembers.NonObsoleteProperty))!,
+					}
+					.ToTestAsyncEnumerable<PropertyInfo?>();
+
+				async Task Act()
+				{
+					await That(subject).AreNotObsolete();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             are all not obsolete,
+					             but it contained obsolete items [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenAllPropertiesAreNotObsolete_Negated_ShouldFail()
+			{
+				IAsyncEnumerable<PropertyInfo?> subject = new[]
+					{
+						typeof(ClassWithObsoleteMembers).GetProperty(nameof(ClassWithObsoleteMembers.NonObsoleteProperty))!,
+					}
+					.ToTestAsyncEnumerable<PropertyInfo?>();
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(they => they.AreNotObsolete());
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             also contain an obsolete item,
+					             but it only contained non-obsolete items [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+		}
+#endif
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatProperties.AreObsolete.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatProperties.AreObsolete.Tests.cs
@@ -1,0 +1,170 @@
+using System.Collections.Generic;
+using System.Reflection;
+using aweXpect.Reflection.Tests.TestHelpers;
+using aweXpect.Reflection.Tests.TestHelpers.Types;
+
+namespace aweXpect.Reflection.Tests;
+
+#pragma warning disable CS0612 // Intentional reference to an obsolete test fixture member
+public sealed partial class ThatProperties
+{
+	public sealed class AreObsolete
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenAllPropertiesAreObsolete_ShouldSucceed()
+			{
+				IEnumerable<PropertyInfo> subject =
+				[
+					typeof(ClassWithObsoleteMembers).GetProperty(nameof(ClassWithObsoleteMembers.ObsoleteProperty))!,
+				];
+
+				async Task Act()
+				{
+					await That(subject).AreObsolete();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenPropertiesContainNonObsoleteProperties_ShouldFail()
+			{
+				IEnumerable<PropertyInfo> subject =
+				[
+					typeof(ClassWithObsoleteMembers).GetProperty(nameof(ClassWithObsoleteMembers.ObsoleteProperty))!,
+					typeof(ClassWithObsoleteMembers).GetProperty(nameof(ClassWithObsoleteMembers.NonObsoleteProperty))!,
+				];
+
+				async Task Act()
+				{
+					await That(subject).AreObsolete();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             are all obsolete,
+					             but it contained non-obsolete items [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+		}
+
+		public sealed class NegatedTests
+		{
+			[Fact]
+			public async Task WhenAllPropertiesAreObsolete_ShouldFail()
+			{
+				IEnumerable<PropertyInfo> subject =
+				[
+					typeof(ClassWithObsoleteMembers).GetProperty(nameof(ClassWithObsoleteMembers.ObsoleteProperty))!,
+				];
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(they => they.AreObsolete());
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             are not all obsolete,
+					             but it only contained obsolete items [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenPropertiesContainNonObsoleteProperties_ShouldSucceed()
+			{
+				IEnumerable<PropertyInfo> subject =
+				[
+					typeof(ClassWithObsoleteMembers).GetProperty(nameof(ClassWithObsoleteMembers.ObsoleteProperty))!,
+					typeof(ClassWithObsoleteMembers).GetProperty(nameof(ClassWithObsoleteMembers.NonObsoleteProperty))!,
+				];
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(they => they.AreObsolete());
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+#if NET8_0_OR_GREATER
+		public sealed class AsyncEnumerableTests
+		{
+			[Fact]
+			public async Task WhenAllPropertiesAreObsolete_ShouldSucceed()
+			{
+				IAsyncEnumerable<PropertyInfo?> subject = new[]
+					{
+						typeof(ClassWithObsoleteMembers).GetProperty(nameof(ClassWithObsoleteMembers.ObsoleteProperty))!,
+					}
+					.ToTestAsyncEnumerable<PropertyInfo?>();
+
+				async Task Act()
+				{
+					await That(subject).AreObsolete();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenPropertiesContainNonObsoleteProperties_ShouldFail()
+			{
+				IAsyncEnumerable<PropertyInfo?> subject = new[]
+					{
+						typeof(ClassWithObsoleteMembers).GetProperty(nameof(ClassWithObsoleteMembers.ObsoleteProperty))!,
+						typeof(ClassWithObsoleteMembers).GetProperty(nameof(ClassWithObsoleteMembers.NonObsoleteProperty))!,
+					}
+					.ToTestAsyncEnumerable<PropertyInfo?>();
+
+				async Task Act()
+				{
+					await That(subject).AreObsolete();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             are all obsolete,
+					             but it contained non-obsolete items [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenAllPropertiesAreObsolete_Negated_ShouldFail()
+			{
+				IAsyncEnumerable<PropertyInfo?> subject = new[]
+					{
+						typeof(ClassWithObsoleteMembers).GetProperty(nameof(ClassWithObsoleteMembers.ObsoleteProperty))!,
+					}
+					.ToTestAsyncEnumerable<PropertyInfo?>();
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(they => they.AreObsolete());
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             are not all obsolete,
+					             but it only contained obsolete items [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+		}
+#endif
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatProperty.IsNotObsolete.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatProperty.IsNotObsolete.Tests.cs
@@ -1,0 +1,102 @@
+using System.Reflection;
+using aweXpect.Reflection.Tests.TestHelpers.Types;
+using Xunit.Sdk;
+
+namespace aweXpect.Reflection.Tests;
+
+#pragma warning disable CS0612 // Intentional reference to an obsolete test fixture member
+public sealed partial class ThatProperty
+{
+	public sealed class IsNotObsolete
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenPropertyIsNotObsolete_ShouldSucceed()
+			{
+				PropertyInfo subject =
+					typeof(ClassWithObsoleteMembers).GetProperty(nameof(ClassWithObsoleteMembers.NonObsoleteProperty))!;
+
+				async Task Act()
+				{
+					await That(subject).IsNotObsolete();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenPropertyIsObsolete_ShouldFail()
+			{
+				PropertyInfo subject =
+					typeof(ClassWithObsoleteMembers).GetProperty(nameof(ClassWithObsoleteMembers.ObsoleteProperty))!;
+
+				async Task Act()
+				{
+					await That(subject).IsNotObsolete();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage($"""
+					              Expected that subject
+					              is not obsolete,
+					              but it was obsolete {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenPropertyIsNull_ShouldFail()
+			{
+				PropertyInfo? subject = null;
+
+				async Task Act()
+				{
+					await That(subject).IsNotObsolete();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             is not obsolete,
+					             but it was <null>
+					             """);
+			}
+		}
+
+		public sealed class NegatedTests
+		{
+			[Fact]
+			public async Task WhenPropertyIsNotObsolete_ShouldFail()
+			{
+				PropertyInfo subject =
+					typeof(ClassWithObsoleteMembers).GetProperty(nameof(ClassWithObsoleteMembers.NonObsoleteProperty))!;
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(it => it.IsNotObsolete());
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is obsolete,
+					              but it was non-obsolete {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenPropertyIsObsolete_ShouldSucceed()
+			{
+				PropertyInfo subject =
+					typeof(ClassWithObsoleteMembers).GetProperty(nameof(ClassWithObsoleteMembers.ObsoleteProperty))!;
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(it => it.IsNotObsolete());
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatProperty.IsObsolete.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatProperty.IsObsolete.Tests.cs
@@ -1,0 +1,102 @@
+using System.Reflection;
+using aweXpect.Reflection.Tests.TestHelpers.Types;
+using Xunit.Sdk;
+
+namespace aweXpect.Reflection.Tests;
+
+#pragma warning disable CS0612 // Intentional reference to an obsolete test fixture member
+public sealed partial class ThatProperty
+{
+	public sealed class IsObsolete
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenPropertyIsObsolete_ShouldSucceed()
+			{
+				PropertyInfo subject =
+					typeof(ClassWithObsoleteMembers).GetProperty(nameof(ClassWithObsoleteMembers.ObsoleteProperty))!;
+
+				async Task Act()
+				{
+					await That(subject).IsObsolete();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenPropertyIsNotObsolete_ShouldFail()
+			{
+				PropertyInfo subject =
+					typeof(ClassWithObsoleteMembers).GetProperty(nameof(ClassWithObsoleteMembers.NonObsoleteProperty))!;
+
+				async Task Act()
+				{
+					await That(subject).IsObsolete();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage($"""
+					              Expected that subject
+					              is obsolete,
+					              but it was non-obsolete {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenPropertyIsNull_ShouldFail()
+			{
+				PropertyInfo? subject = null;
+
+				async Task Act()
+				{
+					await That(subject).IsObsolete();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             is obsolete,
+					             but it was <null>
+					             """);
+			}
+		}
+
+		public sealed class NegatedTests
+		{
+			[Fact]
+			public async Task WhenPropertyIsObsolete_ShouldFail()
+			{
+				PropertyInfo subject =
+					typeof(ClassWithObsoleteMembers).GetProperty(nameof(ClassWithObsoleteMembers.ObsoleteProperty))!;
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(it => it.IsObsolete());
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is not obsolete,
+					              but it was obsolete {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenPropertyIsNotObsolete_ShouldSucceed()
+			{
+				PropertyInfo subject =
+					typeof(ClassWithObsoleteMembers).GetProperty(nameof(ClassWithObsoleteMembers.NonObsoleteProperty))!;
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(it => it.IsObsolete());
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatType.IsNotObsolete.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatType.IsNotObsolete.Tests.cs
@@ -1,0 +1,100 @@
+using aweXpect.Reflection.Tests.TestHelpers.Types;
+using Xunit.Sdk;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatType
+{
+	public sealed class IsNotObsolete
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenTypeIsNotObsolete_ShouldSucceed()
+			{
+				Type subject = typeof(ClassWithObsoleteMembers);
+
+				async Task Act()
+				{
+					await That(subject).IsNotObsolete();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenTypeIsObsolete_ShouldFail()
+			{
+#pragma warning disable CS0612
+				Type subject = typeof(ObsoleteClass);
+#pragma warning restore CS0612
+
+				async Task Act()
+				{
+					await That(subject).IsNotObsolete();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage($"""
+					              Expected that subject
+					              is not obsolete,
+					              but it was obsolete {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenTypeIsNull_ShouldFail()
+			{
+				Type? subject = null;
+
+				async Task Act()
+				{
+					await That(subject).IsNotObsolete();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             is not obsolete,
+					             but it was <null>
+					             """);
+			}
+		}
+
+		public sealed class NegatedTests
+		{
+			[Fact]
+			public async Task WhenTypeIsNotObsolete_ShouldFail()
+			{
+				Type subject = typeof(ClassWithObsoleteMembers);
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(it => it.IsNotObsolete());
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is obsolete,
+					              but it was non-obsolete {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenTypeIsObsolete_ShouldSucceed()
+			{
+#pragma warning disable CS0612
+				Type subject = typeof(ObsoleteClass);
+#pragma warning restore CS0612
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(it => it.IsNotObsolete());
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatType.IsObsolete.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatType.IsObsolete.Tests.cs
@@ -1,0 +1,100 @@
+using aweXpect.Reflection.Tests.TestHelpers.Types;
+using Xunit.Sdk;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatType
+{
+	public sealed class IsObsolete
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenTypeIsObsolete_ShouldSucceed()
+			{
+#pragma warning disable CS0612
+				Type subject = typeof(ObsoleteClass);
+#pragma warning restore CS0612
+
+				async Task Act()
+				{
+					await That(subject).IsObsolete();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenTypeIsNotObsolete_ShouldFail()
+			{
+				Type subject = typeof(ClassWithObsoleteMembers);
+
+				async Task Act()
+				{
+					await That(subject).IsObsolete();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage($"""
+					              Expected that subject
+					              is obsolete,
+					              but it was non-obsolete {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenTypeIsNull_ShouldFail()
+			{
+				Type? subject = null;
+
+				async Task Act()
+				{
+					await That(subject).IsObsolete();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             is obsolete,
+					             but it was <null>
+					             """);
+			}
+		}
+
+		public sealed class NegatedTests
+		{
+			[Fact]
+			public async Task WhenTypeIsObsolete_ShouldFail()
+			{
+#pragma warning disable CS0612
+				Type subject = typeof(ObsoleteClass);
+#pragma warning restore CS0612
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(it => it.IsObsolete());
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is not obsolete,
+					              but it was obsolete {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenTypeIsNotObsolete_ShouldSucceed()
+			{
+				Type subject = typeof(ClassWithObsoleteMembers);
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(it => it.IsObsolete());
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.AreNotObsolete.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.AreNotObsolete.Tests.cs
@@ -1,0 +1,174 @@
+using System.Collections.Generic;
+using aweXpect.Reflection.Tests.TestHelpers;
+using aweXpect.Reflection.Tests.TestHelpers.Types;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatTypes
+{
+	public sealed class AreNotObsolete
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenAllTypesAreNotObsolete_ShouldSucceed()
+			{
+				IEnumerable<Type> subject =
+				[
+					typeof(ClassWithObsoleteMembers),
+				];
+
+				async Task Act()
+				{
+					await That(subject).AreNotObsolete();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenTypesContainObsoleteTypes_ShouldFail()
+			{
+#pragma warning disable CS0612
+				IEnumerable<Type> subject =
+				[
+					typeof(ObsoleteClass),
+					typeof(ClassWithObsoleteMembers),
+				];
+#pragma warning restore CS0612
+
+				async Task Act()
+				{
+					await That(subject).AreNotObsolete();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             are all not obsolete,
+					             but it contained obsolete items [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+		}
+
+		public sealed class NegatedTests
+		{
+			[Fact]
+			public async Task WhenAllTypesAreNotObsolete_ShouldFail()
+			{
+				IEnumerable<Type> subject =
+				[
+					typeof(ClassWithObsoleteMembers),
+				];
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(they => they.AreNotObsolete());
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             also contain an obsolete item,
+					             but it only contained non-obsolete items [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenTypesContainObsoleteTypes_ShouldSucceed()
+			{
+#pragma warning disable CS0612
+				IEnumerable<Type> subject =
+				[
+					typeof(ObsoleteClass),
+					typeof(ClassWithObsoleteMembers),
+				];
+#pragma warning restore CS0612
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(they => they.AreNotObsolete());
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+#if NET8_0_OR_GREATER
+		public sealed class AsyncEnumerableTests
+		{
+			[Fact]
+			public async Task WhenAllTypesAreNotObsolete_ShouldSucceed()
+			{
+				IAsyncEnumerable<Type?> subject = new[]
+					{
+						typeof(ClassWithObsoleteMembers),
+					}
+					.ToTestAsyncEnumerable<Type?>();
+
+				async Task Act()
+				{
+					await That(subject).AreNotObsolete();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenTypesContainObsoleteTypes_ShouldFail()
+			{
+#pragma warning disable CS0612
+				IAsyncEnumerable<Type?> subject = new[]
+					{
+						typeof(ObsoleteClass),
+						typeof(ClassWithObsoleteMembers),
+					}
+					.ToTestAsyncEnumerable<Type?>();
+#pragma warning restore CS0612
+
+				async Task Act()
+				{
+					await That(subject).AreNotObsolete();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             are all not obsolete,
+					             but it contained obsolete items [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenAllTypesAreNotObsolete_Negated_ShouldFail()
+			{
+				IAsyncEnumerable<Type?> subject = new[]
+					{
+						typeof(ClassWithObsoleteMembers),
+					}
+					.ToTestAsyncEnumerable<Type?>();
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(they => they.AreNotObsolete());
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             also contain an obsolete item,
+					             but it only contained non-obsolete items [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+		}
+#endif
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.AreObsolete.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.AreObsolete.Tests.cs
@@ -1,0 +1,182 @@
+using System.Collections.Generic;
+using aweXpect.Reflection.Tests.TestHelpers;
+using aweXpect.Reflection.Tests.TestHelpers.Types;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatTypes
+{
+	public sealed class AreObsolete
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenAllTypesAreObsolete_ShouldSucceed()
+			{
+#pragma warning disable CS0612
+				IEnumerable<Type> subject =
+				[
+					typeof(ObsoleteClass),
+				];
+#pragma warning restore CS0612
+
+				async Task Act()
+				{
+					await That(subject).AreObsolete();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenTypesContainNonObsoleteTypes_ShouldFail()
+			{
+#pragma warning disable CS0612
+				IEnumerable<Type> subject =
+				[
+					typeof(ObsoleteClass),
+					typeof(ClassWithObsoleteMembers),
+				];
+#pragma warning restore CS0612
+
+				async Task Act()
+				{
+					await That(subject).AreObsolete();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             are all obsolete,
+					             but it contained non-obsolete items [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+		}
+
+		public sealed class NegatedTests
+		{
+			[Fact]
+			public async Task WhenAllTypesAreObsolete_ShouldFail()
+			{
+#pragma warning disable CS0612
+				IEnumerable<Type> subject =
+				[
+					typeof(ObsoleteClass),
+				];
+#pragma warning restore CS0612
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(they => they.AreObsolete());
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             are not all obsolete,
+					             but it only contained obsolete items [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenTypesContainNonObsoleteTypes_ShouldSucceed()
+			{
+#pragma warning disable CS0612
+				IEnumerable<Type> subject =
+				[
+					typeof(ObsoleteClass),
+					typeof(ClassWithObsoleteMembers),
+				];
+#pragma warning restore CS0612
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(they => they.AreObsolete());
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+#if NET8_0_OR_GREATER
+		public sealed class AsyncEnumerableTests
+		{
+			[Fact]
+			public async Task WhenAllTypesAreObsolete_ShouldSucceed()
+			{
+#pragma warning disable CS0612
+				IAsyncEnumerable<Type?> subject = new[]
+					{
+						typeof(ObsoleteClass),
+					}
+					.ToTestAsyncEnumerable<Type?>();
+#pragma warning restore CS0612
+
+				async Task Act()
+				{
+					await That(subject).AreObsolete();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenTypesContainNonObsoleteTypes_ShouldFail()
+			{
+#pragma warning disable CS0612
+				IAsyncEnumerable<Type?> subject = new[]
+					{
+						typeof(ObsoleteClass),
+						typeof(ClassWithObsoleteMembers),
+					}
+					.ToTestAsyncEnumerable<Type?>();
+#pragma warning restore CS0612
+
+				async Task Act()
+				{
+					await That(subject).AreObsolete();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             are all obsolete,
+					             but it contained non-obsolete items [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenAllTypesAreObsolete_Negated_ShouldFail()
+			{
+#pragma warning disable CS0612
+				IAsyncEnumerable<Type?> subject = new[]
+					{
+						typeof(ObsoleteClass),
+					}
+					.ToTestAsyncEnumerable<Type?>();
+#pragma warning restore CS0612
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(they => they.AreObsolete());
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             are not all obsolete,
+					             but it only contained obsolete items [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+		}
+#endif
+	}
+}


### PR DESCRIPTION
Adds a self-documenting shorthand for the ObsoleteAttribute across all member kinds (types, methods, properties, fields, events and constructors):

- Filters: WhichAreObsolete()/WhichAreNotObsolete() for types, methods, properties, fields, events and constructors
- Single assertions: IsObsolete()/IsNotObsolete() on any MemberInfo
- Collection assertions: AreObsolete()/AreNotObsolete() (incl. IAsyncEnumerable on net8.0+)

Assemblies are intentionally excluded because ObsoleteAttribute cannot target an assembly.

---

- *Fixes #227*