### PR TITLE
feat: support C# extension block syntax for extension method assertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,6 +409,11 @@ The `ref` / `out` / `in` / `params` / optional parameter filters and assertions 
 each also has `<T>()`, `(Type)`, `<T>("name")` and `…Exactly<T>()` overloads to constrain the parameter's type
 and name (e.g. `.WithRefParameter<int>("count")`, `.HasOutParameterExactly<string>()`).
 
+`WhichAreExtensionMethods()`, `IsAnExtensionMethod()` and `AreExtensionMethods()` match both classic `this`-parameter
+extension methods and extension methods declared with the C# extension block syntax (`extension(...) { … }`), including
+static extension methods. The compiler-generated grouping types backing the extension block syntax are excluded from the
+reflected members.
+
 ```csharp
 In.AllLoadedAssemblies().Methods()
     .WhichArePublic()

--- a/Source/aweXpect.Reflection/Helpers/MethodInfoHelpers.cs
+++ b/Source/aweXpect.Reflection/Helpers/MethodInfoHelpers.cs
@@ -201,6 +201,14 @@ internal static class MethodInfoHelpers
 	/// </summary>
 	private static bool IsStaticExtensionMethod(this MethodInfo methodInfo)
 	{
+		// The public implementation of a static extension method is itself a static method without the
+		// [Extension] attribute; instance (and classic) extension methods always carry the attribute and are
+		// handled before reaching this point. Anything non-static therefore cannot be a static extension method.
+		if (!methodInfo.IsStatic)
+		{
+			return false;
+		}
+
 		Type? declaringType = methodInfo.DeclaringType;
 		if (declaringType?.IsDefined(typeof(ExtensionAttribute), false) != true)
 		{
@@ -214,6 +222,7 @@ internal static class MethodInfoHelpers
 				continue;
 			}
 
+			int extensionArity = nestedType.GetGenericArguments().Length;
 			foreach (MethodInfo skeleton in nestedType.GetMethods(BindingFlags.Public |
 			                                                      BindingFlags.NonPublic |
 			                                                      BindingFlags.Static |
@@ -221,7 +230,7 @@ internal static class MethodInfoHelpers
 			{
 				if (!skeleton.IsSpecialName &&
 				    string.Equals(skeleton.Name, methodInfo.Name, StringComparison.Ordinal) &&
-				    ParametersMatch(skeleton, methodInfo))
+				    ParametersMatch(skeleton, methodInfo, extensionArity))
 				{
 					return true;
 				}
@@ -231,7 +240,7 @@ internal static class MethodInfoHelpers
 		return false;
 	}
 
-	private static bool ParametersMatch(MethodInfo skeleton, MethodInfo implementation)
+	private static bool ParametersMatch(MethodInfo skeleton, MethodInfo implementation, int extensionArity)
 	{
 		ParameterInfo[] skeletonParameters = skeleton.GetParameters();
 		ParameterInfo[] implementationParameters = implementation.GetParameters();
@@ -242,8 +251,11 @@ internal static class MethodInfoHelpers
 
 		for (int i = 0; i < skeletonParameters.Length; i++)
 		{
-			if (!string.Equals(ParameterTypeKey(skeletonParameters[i].ParameterType),
-				    ParameterTypeKey(implementationParameters[i].ParameterType), StringComparison.Ordinal))
+			// On the skeleton the extension's type parameters are declared on the grouping type, while the
+			// implementation merges them (ahead of the method's own type parameters) into the method itself.
+			// Offsetting the skeleton's method-level type parameters by the extension arity re-aligns the two.
+			if (!string.Equals(ParameterTypeKey(skeletonParameters[i].ParameterType, extensionArity),
+				    ParameterTypeKey(implementationParameters[i].ParameterType, 0), StringComparison.Ordinal))
 			{
 				return false;
 			}
@@ -258,13 +270,38 @@ internal static class MethodInfoHelpers
 	/// </summary>
 	/// <remarks>
 	///     Generic type parameters are named differently on the grouping type (<c>$T0</c>, <c>$T1</c>, …) than on the
-	///     public implementation (the source names), so they are keyed by their position. All other types are keyed by
-	///     their full name (avoiding false matches between unrelated types that share a simple name), falling back to the
-	///     simple name when the full name is unavailable (e.g. for a constructed generic type such as
-	///     <c>List&lt;T&gt;</c>).
+	///     public implementation (the source names), so they are keyed by their position within a single merged
+	///     numbering: parameters declared on the grouping type keep their position, while those declared on the method
+	///     are shifted past the extension's type parameters (<paramref name="methodGenericOffset" />) which the
+	///     implementation hoists ahead of its own. Constructed generic types, arrays and by-ref/pointer types are keyed
+	///     recursively so their generic arguments and element types are compared too. All other types are keyed by their
+	///     full name (avoiding false matches between unrelated types that share a simple name), falling back to the
+	///     simple name when the full name is unavailable.
 	/// </remarks>
-	private static string ParameterTypeKey(Type type)
-		=> type.IsGenericParameter
-			? "!" + type.GenericParameterPosition.ToString(CultureInfo.InvariantCulture)
-			: type.FullName ?? type.Name;
+	private static string ParameterTypeKey(Type type, int methodGenericOffset)
+	{
+		if (type.IsByRef || type.IsArray || type.IsPointer)
+		{
+			string suffix = type.IsByRef ? "&" : type.IsPointer ? "*" : "[]";
+			return ParameterTypeKey(type.GetElementType()!, methodGenericOffset) + suffix;
+		}
+
+		if (type.IsGenericParameter)
+		{
+			int position = type.DeclaringMethod is null
+				? type.GenericParameterPosition
+				: type.GenericParameterPosition + methodGenericOffset;
+			return "!" + position.ToString(CultureInfo.InvariantCulture);
+		}
+
+		if (type.IsGenericType)
+		{
+			Type definition = type.GetGenericTypeDefinition();
+			return (definition.FullName ?? definition.Name) + "[" +
+			       string.Join(",", type.GetGenericArguments()
+				       .Select(argument => ParameterTypeKey(argument, methodGenericOffset))) + "]";
+		}
+
+		return type.FullName ?? type.Name;
+	}
 }

--- a/Source/aweXpect.Reflection/Helpers/MethodInfoHelpers.cs
+++ b/Source/aweXpect.Reflection/Helpers/MethodInfoHelpers.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
@@ -162,12 +163,22 @@ internal static class MethodInfoHelpers
 	///     Gets a value indicating whether the <see cref="MethodInfo" /> is an extension method.
 	/// </summary>
 	/// <remarks>
-	///     Detection is based on the <see cref="ExtensionAttribute" /> which the compiler emits for methods whose first
-	///     parameter is declared with the <see langword="this" /> modifier.
+	///     Classic extension methods and instance extension methods declared with the C# extension block syntax are
+	///     marked with the <see cref="ExtensionAttribute" /> on their public implementation. Static extension methods
+	///     declared with the extension block syntax are not, so they are detected by correlating the implementation with
+	///     the <c>&lt;G&gt;$…</c> grouping type that the compiler emits for the extension block.
 	/// </remarks>
 	/// <param name="methodInfo">The <see cref="MethodInfo" />.</param>
 	public static bool IsExtensionMethod(this MethodInfo? methodInfo)
-		=> methodInfo?.IsDefined(typeof(ExtensionAttribute), false) == true;
+	{
+		if (methodInfo is null)
+		{
+			return false;
+		}
+
+		return methodInfo.IsDefined(typeof(ExtensionAttribute), false) ||
+		       methodInfo.IsStaticExtensionMethod();
+	}
 
 	/// <summary>
 	///     Gets a value indicating whether the <see cref="MethodInfo" /> is an operator (e.g. <c>op_Addition</c>,
@@ -181,4 +192,79 @@ internal static class MethodInfoHelpers
 	public static bool IsOperator(this MethodInfo? methodInfo)
 		=> methodInfo is { IsSpecialName: true, }
 		   && methodInfo.Name.StartsWith("op_", StringComparison.Ordinal);
+
+	/// <summary>
+	///     Detects static extension methods declared with the C# extension block syntax. Unlike instance extension
+	///     methods, their public implementation is not marked with the <see cref="ExtensionAttribute" />, so the
+	///     implementation is correlated with the matching skeleton in the <c>&lt;G&gt;$…</c> grouping type that the
+	///     compiler emits for the surrounding extension block.
+	/// </summary>
+	private static bool IsStaticExtensionMethod(this MethodInfo methodInfo)
+	{
+		Type? declaringType = methodInfo.DeclaringType;
+		if (declaringType?.IsDefined(typeof(ExtensionAttribute), false) != true)
+		{
+			return false;
+		}
+
+		foreach (Type nestedType in declaringType.GetNestedTypes(BindingFlags.Public | BindingFlags.NonPublic))
+		{
+			if (!nestedType.IsExtensionGroupingType())
+			{
+				continue;
+			}
+
+			foreach (MethodInfo skeleton in nestedType.GetMethods(BindingFlags.Public |
+			                                                      BindingFlags.NonPublic |
+			                                                      BindingFlags.Static |
+			                                                      BindingFlags.DeclaredOnly))
+			{
+				if (!skeleton.IsSpecialName &&
+				    string.Equals(skeleton.Name, methodInfo.Name, StringComparison.Ordinal) &&
+				    ParametersMatch(skeleton, methodInfo))
+				{
+					return true;
+				}
+			}
+		}
+
+		return false;
+	}
+
+	private static bool ParametersMatch(MethodInfo skeleton, MethodInfo implementation)
+	{
+		ParameterInfo[] skeletonParameters = skeleton.GetParameters();
+		ParameterInfo[] implementationParameters = implementation.GetParameters();
+		if (skeletonParameters.Length != implementationParameters.Length)
+		{
+			return false;
+		}
+
+		for (int i = 0; i < skeletonParameters.Length; i++)
+		{
+			if (!string.Equals(ParameterTypeKey(skeletonParameters[i].ParameterType),
+				    ParameterTypeKey(implementationParameters[i].ParameterType), StringComparison.Ordinal))
+			{
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/// <summary>
+	///     Builds the comparison key for a parameter type when correlating a public implementation with its
+	///     grouping-type skeleton.
+	/// </summary>
+	/// <remarks>
+	///     Generic type parameters are named differently on the grouping type (<c>$T0</c>, <c>$T1</c>, …) than on the
+	///     public implementation (the source names), so they are keyed by their position. All other types are keyed by
+	///     their full name (avoiding false matches between unrelated types that share a simple name), falling back to the
+	///     simple name when the full name is unavailable (e.g. for a constructed generic type such as
+	///     <c>List&lt;T&gt;</c>).
+	/// </remarks>
+	private static string ParameterTypeKey(Type type)
+		=> type.IsGenericParameter
+			? "!" + type.GenericParameterPosition.ToString(CultureInfo.InvariantCulture)
+			: type.FullName ?? type.Name;
 }

--- a/Source/aweXpect.Reflection/Helpers/MethodInfoHelpers.cs
+++ b/Source/aweXpect.Reflection/Helpers/MethodInfoHelpers.cs
@@ -282,7 +282,12 @@ internal static class MethodInfoHelpers
 	{
 		if (type.IsByRef || type.IsArray || type.IsPointer)
 		{
-			string suffix = type.IsByRef ? "&" : type.IsPointer ? "*" : "[]";
+			string suffix = type switch
+			{
+				{ IsByRef: true, } => "&",
+				{ IsPointer: true, } => "*",
+				_ => "[]",
+			};
 			return ParameterTypeKey(type.GetElementType()!, methodGenericOffset) + suffix;
 		}
 

--- a/Source/aweXpect.Reflection/Helpers/TypeHelpers.cs
+++ b/Source/aweXpect.Reflection/Helpers/TypeHelpers.cs
@@ -272,7 +272,8 @@ internal static class TypeHelpers
 		     type is not null;
 		     type = type.DeclaringType)
 		{
-			if (type.IsDefined(typeof(CompilerGeneratedAttribute), false))
+			if (type.IsDefined(typeof(CompilerGeneratedAttribute), false) ||
+			    type.IsExtensionGroupingType())
 			{
 				return true;
 			}
@@ -280,6 +281,18 @@ internal static class TypeHelpers
 
 		return member.IsDefined(typeof(CompilerGeneratedAttribute), false);
 	}
+
+	/// <summary>
+	///     Determines whether the <paramref name="type" /> is a compiler-generated grouping type that backs the C#
+	///     extension block syntax (the unspeakable <c>&lt;G&gt;$…</c> container emitted for the new extension members).
+	/// </summary>
+	/// <remarks>
+	///     These types are not marked with <see cref="CompilerGeneratedAttribute" />, but they always carry the
+	///     <see cref="ExtensionAttribute" /> and have an unspeakable name (which a source identifier can never have).
+	/// </remarks>
+	internal static bool IsExtensionGroupingType(this Type type)
+		=> type.Name.StartsWith("<", StringComparison.Ordinal) &&
+		   type.IsDefined(typeof(ExtensionAttribute), false);
 
 	private static bool IncludeMethod(
 		MethodInfo method,

--- a/Tests/aweXpect.Reflection.Tests/ExtensionGroupingTypeFilteringTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ExtensionGroupingTypeFilteringTests.cs
@@ -1,0 +1,72 @@
+#if NET10_0_OR_GREATER
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using aweXpect.Customization;
+using aweXpect.Reflection.Tests.TestHelpers.Types;
+
+namespace aweXpect.Reflection.Tests;
+
+/// <summary>
+///     The C# extension block syntax emits hidden <c>&lt;G&gt;$…</c> grouping types (and skeleton members) that are not
+///     marked with <c>[CompilerGenerated]</c>. They must be excluded from discovery so they do not pollute the results.
+/// </summary>
+public sealed class ExtensionGroupingTypeFilteringTests
+{
+	private const string ExtensionMarkerAttributeName = "ExtensionMarkerAttribute";
+
+	[Fact]
+	public async Task Types_ShouldExcludeExtensionGroupingTypesByDefault()
+	{
+		IReadOnlyList<Type> types = await GetTypes();
+
+		await That(types).None().Satisfy(t => t.DeclaringType == typeof(StaticClassWithNewExtensionMethods) &&
+		                                      t.Name.StartsWith("<", StringComparison.Ordinal));
+		await That(types).Contains(t => t == typeof(StaticClassWithNewExtensionMethods));
+	}
+
+	[Fact]
+	public async Task Types_WhenIncludingCompilerGenerated_ShouldContainExtensionGroupingTypes()
+	{
+		using (Customize.aweXpect.Reflection().IncludedCompilerGeneratedMembers()
+			       .Set(CompilerGeneratedMembers.Types))
+		{
+			IReadOnlyList<Type> types = await GetTypes();
+
+			await That(types).Contains(t => t.DeclaringType == typeof(StaticClassWithNewExtensionMethods) &&
+			                                t.Name.StartsWith("<", StringComparison.Ordinal));
+		}
+	}
+
+	[Fact]
+	public async Task Methods_ShouldExcludeExtensionGroupingSkeletonsByDefault()
+	{
+		IReadOnlyList<MethodInfo> methods = await GetMethods();
+
+		await That(methods).None().Satisfy(m => m.GetCustomAttributesData()
+			.Any(a => a.AttributeType.Name == ExtensionMarkerAttributeName));
+		await That(methods).Contains(m => m.DeclaringType == typeof(StaticClassWithNewExtensionMethods) &&
+		                                  m.Name == nameof(StaticClassWithNewExtensionMethods.Create) &&
+		                                  m.GetParameters().Length == 0);
+	}
+
+	private static async Task<IReadOnlyList<Type>> GetTypes()
+		=> await ToList(In.AssemblyContaining<ExtensionGroupingTypeFilteringTests>().Types());
+
+	private static async Task<IReadOnlyList<MethodInfo>> GetMethods()
+		=> await ToList(In.AssemblyContaining<ExtensionGroupingTypeFilteringTests>().Types().Methods());
+
+	private static async Task<List<T>> ToList<T>(IAsyncEnumerable<T> source)
+	{
+		List<T> result = new();
+		await foreach (T item in source)
+		{
+			result.Add(item);
+		}
+
+		return result;
+	}
+}
+#endif

--- a/Tests/aweXpect.Reflection.Tests/ExtensionGroupingTypeFilteringTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ExtensionGroupingTypeFilteringTests.cs
@@ -23,7 +23,7 @@ public sealed class ExtensionGroupingTypeFilteringTests
 		IReadOnlyList<Type> types = await GetTypes();
 
 		await That(types).None().Satisfy(t => t.DeclaringType == typeof(StaticClassWithNewExtensionMethods) &&
-		                                      t.Name.StartsWith("<", StringComparison.Ordinal));
+		                                      t.Name.StartsWith('<'));
 		await That(types).Contains(t => t == typeof(StaticClassWithNewExtensionMethods));
 	}
 
@@ -36,7 +36,7 @@ public sealed class ExtensionGroupingTypeFilteringTests
 			IReadOnlyList<Type> types = await GetTypes();
 
 			await That(types).Contains(t => t.DeclaringType == typeof(StaticClassWithNewExtensionMethods) &&
-			                                t.Name.StartsWith("<", StringComparison.Ordinal));
+			                                t.Name.StartsWith('<'));
 		}
 	}
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WhichAreExtensionMethods.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WhichAreExtensionMethods.Tests.cs
@@ -1,5 +1,8 @@
 using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Tests.TestHelpers;
+#if NET10_0_OR_GREATER
+using aweXpect.Reflection.Tests.TestHelpers.Types;
+#endif
 
 namespace aweXpect.Reflection.Tests.Filters;
 
@@ -20,5 +23,22 @@ public sealed partial class MethodFilters
 					.IsEqualTo("extension methods in types in assembly").AsPrefix();
 			}
 		}
+
+#if NET10_0_OR_GREATER
+		public sealed class NewSyntaxTests
+		{
+			[Fact]
+			public async Task ShouldIncludeStaticExtensionMethods()
+			{
+				Filtered.Methods methods = In.AssemblyContaining<MethodFilters>()
+					.Types().Methods().WhichAreExtensionMethods()
+					.WithName(nameof(StaticClassWithNewExtensionMethods.Create));
+
+				await That(methods).All().Satisfy(x =>
+						x.IsStatic && x.DeclaringType == typeof(StaticClassWithNewExtensionMethods))
+					.And.IsNotEmpty();
+			}
+		}
+#endif
 	}
 }

--- a/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WhichAreNotExtensionMethods.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WhichAreNotExtensionMethods.Tests.cs
@@ -1,5 +1,8 @@
 using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Tests.TestHelpers;
+#if NET10_0_OR_GREATER
+using aweXpect.Reflection.Tests.TestHelpers.Types;
+#endif
 
 namespace aweXpect.Reflection.Tests.Filters;
 
@@ -20,5 +23,25 @@ public sealed partial class MethodFilters
 					.IsEqualTo("non-extension methods in types in assembly").AsPrefix();
 			}
 		}
+
+#if NET10_0_OR_GREATER
+		public sealed class NewSyntaxTests
+		{
+			[Fact]
+			public async Task ShouldExcludeStaticExtensionMethods()
+			{
+				Filtered.Methods methods = In.AssemblyContaining<MethodFilters>()
+					.Types().Methods().WhichAreNotExtensionMethods()
+					.WithName(nameof(StaticClassWithNewExtensionMethods.Create));
+
+				// The static extension method Create() must be excluded; only the regular Create(int) overload
+				// of the extension-bearing class may remain.
+				await That(methods).All().Satisfy(x =>
+						x.DeclaringType != typeof(StaticClassWithNewExtensionMethods) ||
+						x.GetParameters().Length > 0)
+					.And.IsNotEmpty();
+			}
+		}
+#endif
 	}
 }

--- a/Tests/aweXpect.Reflection.Tests/TestHelpers/MethodInfoExtensions.cs
+++ b/Tests/aweXpect.Reflection.Tests/TestHelpers/MethodInfoExtensions.cs
@@ -90,7 +90,12 @@ public static class MethodInfoExtensions
 	{
 		if (type.IsByRef || type.IsArray || type.IsPointer)
 		{
-			string suffix = type.IsByRef ? "&" : type.IsPointer ? "*" : "[]";
+			string suffix = type switch
+			{
+				{ IsByRef: true, } => "&",
+				{ IsPointer: true, } => "*",
+				_ => "[]",
+			};
 			return ParameterTypeKey(type.GetElementType()!, methodGenericOffset) + suffix;
 		}
 

--- a/Tests/aweXpect.Reflection.Tests/TestHelpers/MethodInfoExtensions.cs
+++ b/Tests/aweXpect.Reflection.Tests/TestHelpers/MethodInfoExtensions.cs
@@ -19,7 +19,10 @@ public static class MethodInfoExtensions
 	///     declared with the C# extension block syntax).
 	/// </summary>
 	/// <remarks>
-	///     This is an independent re-implementation used to validate the production detection, so it must not call into it.
+	///     This is a parallel reference implementation used to derive the expected method set in the filter and collection
+	///     tests, so it must not call into the production code. It mirrors the same detection heuristic and therefore
+	///     shares its limitations; it is not an independent oracle. The behaviour of individual methods is pinned by the
+	///     hard-coded assertions in <c>ThatMethod.IsAnExtensionMethod</c>.
 	/// </remarks>
 	/// <param name="methodInfo">The <see cref="MethodInfo" /> to check.</param>
 	public static bool IsReallyExtensionMethod(this MethodInfo? methodInfo)
@@ -34,7 +37,13 @@ public static class MethodInfoExtensions
 			return true;
 		}
 
-#if NET10_0_OR_GREATER
+		// The public implementation of a static extension method is itself a static method without the
+		// [Extension] attribute; instance (and classic) extension methods always carry the attribute.
+		if (!methodInfo.IsStatic)
+		{
+			return false;
+		}
+
 		Type? declaringType = methodInfo.DeclaringType;
 		if (declaringType?.IsDefined(typeof(ExtensionAttribute), false) != true)
 		{
@@ -45,18 +54,15 @@ public static class MethodInfoExtensions
 			.GetNestedTypes(BindingFlags.Public | BindingFlags.NonPublic)
 			.Where(nestedType => nestedType.Name.StartsWith("<", StringComparison.Ordinal) &&
 			                     nestedType.IsDefined(typeof(ExtensionAttribute), false))
-			.SelectMany(groupingType => groupingType.GetMethods(BindingFlags.Public | BindingFlags.NonPublic |
-			                                                    BindingFlags.Static | BindingFlags.DeclaredOnly))
-			.Any(skeleton => !skeleton.IsSpecialName &&
-			                 string.Equals(skeleton.Name, methodInfo.Name, StringComparison.Ordinal) &&
-			                 ParametersMatch(skeleton, methodInfo));
-#else
-		return false;
-#endif
+			.Any(groupingType => groupingType
+				.GetMethods(BindingFlags.Public | BindingFlags.NonPublic |
+				            BindingFlags.Static | BindingFlags.DeclaredOnly)
+				.Any(skeleton => !skeleton.IsSpecialName &&
+				                 string.Equals(skeleton.Name, methodInfo.Name, StringComparison.Ordinal) &&
+				                 ParametersMatch(skeleton, methodInfo, groupingType.GetGenericArguments().Length)));
 	}
 
-#if NET10_0_OR_GREATER
-	private static bool ParametersMatch(MethodInfo skeleton, MethodInfo implementation)
+	private static bool ParametersMatch(MethodInfo skeleton, MethodInfo implementation, int extensionArity)
 	{
 		ParameterInfo[] skeletonParameters = skeleton.GetParameters();
 		ParameterInfo[] implementationParameters = implementation.GetParameters();
@@ -67,17 +73,11 @@ public static class MethodInfoExtensions
 
 		for (int i = 0; i < skeletonParameters.Length; i++)
 		{
-			Type skeletonType = skeletonParameters[i].ParameterType;
-			Type implementationType = implementationParameters[i].ParameterType;
-
-			// Generic parameters are named differently on the grouping type ($T0, …) than on the implementation, so
-			// compare them by position; compare other types by their full name (falling back to the simple name).
-			bool matches = skeletonType.IsGenericParameter || implementationType.IsGenericParameter
-				? skeletonType.IsGenericParameter && implementationType.IsGenericParameter &&
-				  skeletonType.GenericParameterPosition == implementationType.GenericParameterPosition
-				: string.Equals(skeletonType.FullName ?? skeletonType.Name,
-					implementationType.FullName ?? implementationType.Name, StringComparison.Ordinal);
-			if (!matches)
+			// The extension's type parameters are declared on the grouping type for the skeleton, but merged
+			// (ahead of the method's own) into the method for the implementation, so offset the skeleton's
+			// method-level type parameters by the extension arity to re-align the two numberings.
+			if (!string.Equals(ParameterTypeKey(skeletonParameters[i].ParameterType, extensionArity),
+				    ParameterTypeKey(implementationParameters[i].ParameterType, 0), StringComparison.Ordinal))
 			{
 				return false;
 			}
@@ -85,7 +85,33 @@ public static class MethodInfoExtensions
 
 		return true;
 	}
-#endif
+
+	private static string ParameterTypeKey(Type type, int methodGenericOffset)
+	{
+		if (type.IsByRef || type.IsArray || type.IsPointer)
+		{
+			string suffix = type.IsByRef ? "&" : type.IsPointer ? "*" : "[]";
+			return ParameterTypeKey(type.GetElementType()!, methodGenericOffset) + suffix;
+		}
+
+		if (type.IsGenericParameter)
+		{
+			int position = type.DeclaringMethod is null
+				? type.GenericParameterPosition
+				: type.GenericParameterPosition + methodGenericOffset;
+			return "!" + position.ToString(System.Globalization.CultureInfo.InvariantCulture);
+		}
+
+		if (type.IsGenericType)
+		{
+			Type definition = type.GetGenericTypeDefinition();
+			return (definition.FullName ?? definition.Name) + "[" +
+			       string.Join(",", type.GetGenericArguments()
+				       .Select(argument => ParameterTypeKey(argument, methodGenericOffset))) + "]";
+		}
+
+		return type.FullName ?? type.Name;
+	}
 
 	/// <summary>
 	///     Checks if the <paramref name="methodInfo" /> is an operator (e.g. <c>op_Addition</c>, <c>op_Equality</c>, …).

--- a/Tests/aweXpect.Reflection.Tests/TestHelpers/MethodInfoExtensions.cs
+++ b/Tests/aweXpect.Reflection.Tests/TestHelpers/MethodInfoExtensions.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
@@ -13,12 +15,77 @@ public static class MethodInfoExtensions
 		=> methodInfo?.GetCustomAttribute<AsyncStateMachineAttribute>() is not null;
 
 	/// <summary>
-	///     Checks if the <paramref name="methodInfo" /> is an extension method (whose first parameter is declared with the
-	///     <see langword="this" /> modifier).
+	///     Checks if the <paramref name="methodInfo" /> is an extension method (classic <see langword="this" /> parameter or
+	///     declared with the C# extension block syntax).
 	/// </summary>
+	/// <remarks>
+	///     This is an independent re-implementation used to validate the production detection, so it must not call into it.
+	/// </remarks>
 	/// <param name="methodInfo">The <see cref="MethodInfo" /> to check.</param>
 	public static bool IsReallyExtensionMethod(this MethodInfo? methodInfo)
-		=> methodInfo?.IsDefined(typeof(ExtensionAttribute), false) == true;
+	{
+		if (methodInfo is null)
+		{
+			return false;
+		}
+
+		if (methodInfo.IsDefined(typeof(ExtensionAttribute), false))
+		{
+			return true;
+		}
+
+#if NET10_0_OR_GREATER
+		Type? declaringType = methodInfo.DeclaringType;
+		if (declaringType?.IsDefined(typeof(ExtensionAttribute), false) != true)
+		{
+			return false;
+		}
+
+		return declaringType
+			.GetNestedTypes(BindingFlags.Public | BindingFlags.NonPublic)
+			.Where(nestedType => nestedType.Name.StartsWith("<", StringComparison.Ordinal) &&
+			                     nestedType.IsDefined(typeof(ExtensionAttribute), false))
+			.SelectMany(groupingType => groupingType.GetMethods(BindingFlags.Public | BindingFlags.NonPublic |
+			                                                    BindingFlags.Static | BindingFlags.DeclaredOnly))
+			.Any(skeleton => !skeleton.IsSpecialName &&
+			                 string.Equals(skeleton.Name, methodInfo.Name, StringComparison.Ordinal) &&
+			                 ParametersMatch(skeleton, methodInfo));
+#else
+		return false;
+#endif
+	}
+
+#if NET10_0_OR_GREATER
+	private static bool ParametersMatch(MethodInfo skeleton, MethodInfo implementation)
+	{
+		ParameterInfo[] skeletonParameters = skeleton.GetParameters();
+		ParameterInfo[] implementationParameters = implementation.GetParameters();
+		if (skeletonParameters.Length != implementationParameters.Length)
+		{
+			return false;
+		}
+
+		for (int i = 0; i < skeletonParameters.Length; i++)
+		{
+			Type skeletonType = skeletonParameters[i].ParameterType;
+			Type implementationType = implementationParameters[i].ParameterType;
+
+			// Generic parameters are named differently on the grouping type ($T0, …) than on the implementation, so
+			// compare them by position; compare other types by their full name (falling back to the simple name).
+			bool matches = skeletonType.IsGenericParameter || implementationType.IsGenericParameter
+				? skeletonType.IsGenericParameter && implementationType.IsGenericParameter &&
+				  skeletonType.GenericParameterPosition == implementationType.GenericParameterPosition
+				: string.Equals(skeletonType.FullName ?? skeletonType.Name,
+					implementationType.FullName ?? implementationType.Name, StringComparison.Ordinal);
+			if (!matches)
+			{
+				return false;
+			}
+		}
+
+		return true;
+	}
+#endif
 
 	/// <summary>
 	///     Checks if the <paramref name="methodInfo" /> is an operator (e.g. <c>op_Addition</c>, <c>op_Equality</c>, …).

--- a/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/GenericClassWithNewExtensionMethods.cs
+++ b/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/GenericClassWithNewExtensionMethods.cs
@@ -25,6 +25,11 @@ public static class GenericClassWithNewExtensionMethods
 
 		// Generic static extension method whose parameter is a constructed generic type (FullName is null).
 		public static T First(List<T> values) => values[0];
+
+		// Generic static extension method that declares its OWN method-level type parameter in addition to the
+		// extension's type parameter. The implementation merges both into the method (extension parameter first),
+		// shifting the positions relative to the grouping-type skeleton.
+		public static TValue Convert<TValue>(TValue value, T element) => value;
 	}
 }
 #endif

--- a/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/GenericClassWithNewExtensionMethods.cs
+++ b/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/GenericClassWithNewExtensionMethods.cs
@@ -1,0 +1,30 @@
+#if NET10_0_OR_GREATER
+using System.Collections.Generic;
+
+namespace aweXpect.Reflection.Tests.TestHelpers.Types;
+
+/// <summary>
+///     Uses generic C# extension blocks (<c>extension&lt;T&gt;(...)</c>) to exercise detection of generic extension
+///     methods, where parameter types are generic type parameters (whose <c>FullName</c> is <see langword="null" />).
+/// </summary>
+public static class GenericClassWithNewExtensionMethods
+{
+	extension<T>(T source) where T : class
+	{
+		// Generic instance extension method - its public implementation carries the [Extension] attribute.
+		public bool IsNotNullValue() => source is not null;
+	}
+
+	extension<T>(T[] array)
+	{
+		// Generic static extension method without parameters.
+		public static T[] Empty() => [];
+
+		// Generic static extension method whose parameter is a generic type parameter (FullName is null).
+		public static T Identity(T value) => value;
+
+		// Generic static extension method whose parameter is a constructed generic type (FullName is null).
+		public static T First(List<T> values) => values[0];
+	}
+}
+#endif

--- a/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/StaticClassWithNewExtensionMethods.cs
+++ b/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/StaticClassWithNewExtensionMethods.cs
@@ -1,0 +1,51 @@
+#if NET10_0_OR_GREATER
+using System;
+
+namespace aweXpect.Reflection.Tests.TestHelpers.Types;
+
+/// <summary>
+///     Uses the C# extension block syntax (C# 14 / .NET 10) to exercise detection of new-syntax extension members.
+/// </summary>
+public static class StaticClassWithNewExtensionMethods
+{
+	extension(string text)
+	{
+		// Instance extension method (new syntax) - the public implementation carries the [Extension] attribute.
+		public bool IsLongText() => text.Length > 10;
+
+		// Instance extension property - only reachable via a (special-name) accessor.
+		public bool IsEmptyText => text.Length == 0;
+	}
+
+	extension(string)
+	{
+		// Static extension methods (new syntax) - the public implementation has no [Extension] attribute.
+		public static string Create() => "created";
+
+		public static string Combine(int count) => count.ToString();
+
+		// Static extension property - emitted as a (special-name) accessor in the grouping type.
+		public static string DefaultValue => "default";
+	}
+
+	// Regular static method whose name matches a static extension method but with a different parameter count.
+	public static string Create(int unused) => unused.ToString();
+
+	// Regular static method whose name matches a static extension method but with a different parameter type.
+	public static string Combine(string value) => value;
+
+	// Regular static method in an extension-bearing class - not an extension method.
+	public static void RegularStaticMethod() { }
+
+	// Contains a lambda, so the class also owns a compiler-generated <>c nested type which must be
+	// distinguished from the (also unspeakably named) extension grouping types.
+	public static int WithClosure()
+	{
+		Func<int, int> increment = value => value + 1;
+		return increment(41);
+	}
+
+	// Non-grouping nested type, to ensure it is skipped while scanning for grouping types.
+	public sealed class NestedHelper { }
+}
+#endif

--- a/Tests/aweXpect.Reflection.Tests/ThatMethod.IsAnExtensionMethod.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethod.IsAnExtensionMethod.Tests.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Reflection;
+using System.Reflection.Emit;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 using Xunit.Sdk;
 
@@ -62,6 +64,24 @@ public sealed partial class ThatMethod
 					             but it was <null>
 					             """);
 			}
+
+			[Fact]
+			public async Task WhenMethodHasNoDeclaringType_ShouldFail()
+			{
+				MethodInfo subject = new DynamicMethod("Dynamic", typeof(void), Type.EmptyTypes);
+
+				async Task Act()
+				{
+					await That(subject).IsAnExtensionMethod();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage($"""
+					              Expected that subject
+					              is an extension method,
+					              but it was not an extension method {Formatter.Format(subject)}
+					              """);
+			}
 		}
 
 		public sealed class NegatedTests
@@ -101,5 +121,175 @@ public sealed partial class ThatMethod
 				await That(Act).DoesNotThrow();
 			}
 		}
+
+#if NET10_0_OR_GREATER
+		public sealed class NewSyntaxTests
+		{
+			[Fact]
+			public async Task WhenMethodIsANewSyntaxInstanceExtensionMethod_ShouldSucceed()
+			{
+				MethodInfo subject =
+					typeof(StaticClassWithNewExtensionMethods).GetMethod(
+						nameof(StaticClassWithNewExtensionMethods.IsLongText))!;
+
+				async Task Act()
+				{
+					await That(subject).IsAnExtensionMethod();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenMethodIsAStaticExtensionMethod_ShouldSucceed()
+			{
+				MethodInfo subject =
+					typeof(StaticClassWithNewExtensionMethods).GetMethod(
+						nameof(StaticClassWithNewExtensionMethods.Create), Type.EmptyTypes)!;
+
+				async Task Act()
+				{
+					await That(subject).IsAnExtensionMethod();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenMethodIsAStaticExtensionMethodWithParameters_ShouldSucceed()
+			{
+				MethodInfo subject =
+					typeof(StaticClassWithNewExtensionMethods).GetMethod(
+						nameof(StaticClassWithNewExtensionMethods.Combine), [typeof(int),])!;
+
+				async Task Act()
+				{
+					await That(subject).IsAnExtensionMethod();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenMethodIsARegularStaticMethodInExtensionClass_ShouldFail()
+			{
+				MethodInfo subject =
+					typeof(StaticClassWithNewExtensionMethods).GetMethod(
+						nameof(StaticClassWithNewExtensionMethods.RegularStaticMethod))!;
+
+				async Task Act()
+				{
+					await That(subject).IsAnExtensionMethod();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage($"""
+					              Expected that subject
+					              is an extension method,
+					              but it was not an extension method {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenMethodMatchesStaticExtensionByNameWithDifferentParameterCount_ShouldFail()
+			{
+				MethodInfo subject =
+					typeof(StaticClassWithNewExtensionMethods).GetMethod(
+						nameof(StaticClassWithNewExtensionMethods.Create), [typeof(int),])!;
+
+				async Task Act()
+				{
+					await That(subject).IsAnExtensionMethod();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage($"""
+					              Expected that subject
+					              is an extension method,
+					              but it was not an extension method {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenMethodMatchesStaticExtensionByNameWithDifferentParameterType_ShouldFail()
+			{
+				MethodInfo subject =
+					typeof(StaticClassWithNewExtensionMethods).GetMethod(
+						nameof(StaticClassWithNewExtensionMethods.Combine), [typeof(string),])!;
+
+				async Task Act()
+				{
+					await That(subject).IsAnExtensionMethod();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage($"""
+					              Expected that subject
+					              is an extension method,
+					              but it was not an extension method {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenMethodIsAGenericInstanceExtensionMethod_ShouldSucceed()
+			{
+				MethodInfo subject =
+					typeof(GenericClassWithNewExtensionMethods).GetMethod(
+						nameof(GenericClassWithNewExtensionMethods.IsNotNullValue))!;
+
+				async Task Act()
+				{
+					await That(subject).IsAnExtensionMethod();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenMethodIsAGenericStaticExtensionMethod_ShouldSucceed()
+			{
+				MethodInfo subject =
+					typeof(GenericClassWithNewExtensionMethods).GetMethod(
+						nameof(GenericClassWithNewExtensionMethods.Empty))!;
+
+				async Task Act()
+				{
+					await That(subject).IsAnExtensionMethod();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenMethodIsAGenericStaticExtensionMethodWithGenericParameter_ShouldSucceed()
+			{
+				MethodInfo subject =
+					typeof(GenericClassWithNewExtensionMethods).GetMethod(
+						nameof(GenericClassWithNewExtensionMethods.Identity))!;
+
+				async Task Act()
+				{
+					await That(subject).IsAnExtensionMethod();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenMethodIsAGenericStaticExtensionMethodWithConstructedGenericParameter_ShouldSucceed()
+			{
+				MethodInfo subject =
+					typeof(GenericClassWithNewExtensionMethods).GetMethod(
+						nameof(GenericClassWithNewExtensionMethods.First))!;
+
+				async Task Act()
+				{
+					await That(subject).IsAnExtensionMethod();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+#endif
 	}
 }

--- a/Tests/aweXpect.Reflection.Tests/ThatMethod.IsAnExtensionMethod.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethod.IsAnExtensionMethod.Tests.cs
@@ -289,6 +289,21 @@ public sealed partial class ThatMethod
 
 				await That(Act).DoesNotThrow();
 			}
+
+			[Fact]
+			public async Task WhenMethodIsAGenericStaticExtensionMethodWithOwnTypeParameter_ShouldSucceed()
+			{
+				MethodInfo subject =
+					typeof(GenericClassWithNewExtensionMethods).GetMethod(
+						nameof(GenericClassWithNewExtensionMethods.Convert))!;
+
+				async Task Act()
+				{
+					await That(subject).IsAnExtensionMethod();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
 		}
 #endif
 	}

--- a/Tests/aweXpect.Reflection.Tests/ThatMethod.IsNotAnExtensionMethod.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethod.IsNotAnExtensionMethod.Tests.cs
@@ -1,3 +1,6 @@
+#if NET10_0_OR_GREATER
+using System;
+#endif
 using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 using Xunit.Sdk;
@@ -101,5 +104,65 @@ public sealed partial class ThatMethod
 					              """);
 			}
 		}
+
+#if NET10_0_OR_GREATER
+		public sealed class NewSyntaxTests
+		{
+			[Fact]
+			public async Task WhenMethodIsAStaticExtensionMethod_ShouldFail()
+			{
+				MethodInfo subject =
+					typeof(StaticClassWithNewExtensionMethods).GetMethod(
+						nameof(StaticClassWithNewExtensionMethods.Create), Type.EmptyTypes)!;
+
+				async Task Act()
+				{
+					await That(subject).IsNotAnExtensionMethod();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage($"""
+					              Expected that subject
+					              is not an extension method,
+					              but it was an extension method {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenMethodIsANewSyntaxInstanceExtensionMethod_ShouldFail()
+			{
+				MethodInfo subject =
+					typeof(StaticClassWithNewExtensionMethods).GetMethod(
+						nameof(StaticClassWithNewExtensionMethods.IsLongText))!;
+
+				async Task Act()
+				{
+					await That(subject).IsNotAnExtensionMethod();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage($"""
+					              Expected that subject
+					              is not an extension method,
+					              but it was an extension method {Formatter.Format(subject)}
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenMethodIsARegularStaticMethodInExtensionClass_ShouldSucceed()
+			{
+				MethodInfo subject =
+					typeof(StaticClassWithNewExtensionMethods).GetMethod(
+						nameof(StaticClassWithNewExtensionMethods.RegularStaticMethod))!;
+
+				async Task Act()
+				{
+					await That(subject).IsNotAnExtensionMethod();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+#endif
 	}
 }

--- a/Tests/aweXpect.Reflection.Tests/ThatMethods.AreExtensionMethods.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethods.AreExtensionMethods.Tests.cs
@@ -1,3 +1,6 @@
+#if NET10_0_OR_GREATER
+using System;
+#endif
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -147,6 +150,58 @@ public sealed partial class ThatMethods
 					             Expected that subject
 					             are not all extension methods,
 					             but it only contained extension methods [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+		}
+#endif
+
+#if NET10_0_OR_GREATER
+		public sealed class NewSyntaxTests
+		{
+			[Fact]
+			public async Task WhenAllAreNewSyntaxExtensionMethods_ShouldSucceed()
+			{
+				IEnumerable<MethodInfo> subject =
+				[
+					typeof(StaticClassWithNewExtensionMethods).GetMethod(
+						nameof(StaticClassWithNewExtensionMethods.IsLongText))!,
+					typeof(StaticClassWithNewExtensionMethods).GetMethod(
+						nameof(StaticClassWithNewExtensionMethods.Create), Type.EmptyTypes)!,
+					typeof(StaticClassWithNewExtensionMethods).GetMethod(
+						nameof(StaticClassWithNewExtensionMethods.Combine), [typeof(int),])!,
+				];
+
+				async Task Act()
+				{
+					await That(subject).AreExtensionMethods();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenContainingARegularStaticMethod_ShouldFail()
+			{
+				IEnumerable<MethodInfo> subject =
+				[
+					typeof(StaticClassWithNewExtensionMethods).GetMethod(
+						nameof(StaticClassWithNewExtensionMethods.Create), Type.EmptyTypes)!,
+					typeof(StaticClassWithNewExtensionMethods).GetMethod(
+						nameof(StaticClassWithNewExtensionMethods.RegularStaticMethod))!,
+				];
+
+				async Task Act()
+				{
+					await That(subject).AreExtensionMethods();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             are all extension methods,
+					             but it contained non-extension methods [
 					               *
 					             ]
 					             """).AsWildcard();

--- a/Tests/aweXpect.Reflection.Tests/ThatMethods.AreNotExtensionMethods.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethods.AreNotExtensionMethods.Tests.cs
@@ -1,3 +1,6 @@
+#if NET10_0_OR_GREATER
+using System;
+#endif
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -147,6 +150,56 @@ public sealed partial class ThatMethods
 					             Expected that subject
 					             also contain an extension method,
 					             but it only contained non-extension methods [
+					               *
+					             ]
+					             """).AsWildcard();
+			}
+		}
+#endif
+
+#if NET10_0_OR_GREATER
+		public sealed class NewSyntaxTests
+		{
+			[Fact]
+			public async Task WhenAllAreRegularMethods_ShouldSucceed()
+			{
+				IEnumerable<MethodInfo> subject =
+				[
+					typeof(StaticClassWithNewExtensionMethods).GetMethod(
+						nameof(StaticClassWithNewExtensionMethods.RegularStaticMethod))!,
+					typeof(StaticClassWithNewExtensionMethods).GetMethod(
+						nameof(StaticClassWithNewExtensionMethods.Create), [typeof(int),])!,
+				];
+
+				async Task Act()
+				{
+					await That(subject).AreNotExtensionMethods();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenContainingAStaticExtensionMethod_ShouldFail()
+			{
+				IEnumerable<MethodInfo> subject =
+				[
+					typeof(StaticClassWithNewExtensionMethods).GetMethod(
+						nameof(StaticClassWithNewExtensionMethods.RegularStaticMethod))!,
+					typeof(StaticClassWithNewExtensionMethods).GetMethod(
+						nameof(StaticClassWithNewExtensionMethods.Create), Type.EmptyTypes)!,
+				];
+
+				async Task Act()
+				{
+					await That(subject).AreNotExtensionMethods();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             are all not extension methods,
+					             but it contained extension methods [
 					               *
 					             ]
 					             """).AsWildcard();


### PR DESCRIPTION
Make the extension method filter and assertions recognize extension methods declared with the C# 14 extension block syntax (extension(...) { ... }), so they work seamlessly alongside classic this-parameter extension methods:

- Instance extension methods already carry [Extension] on their public implementation and were already detected.
- Static extension methods are not marked with [Extension]; they are now detected by correlating the public implementation with the matching skeleton in the compiler-generated <G>$ grouping type.

Also exclude the compiler-generated extension grouping types (and their skeleton members) from type/method discovery: they are not marked with [CompilerGenerated], so they previously leaked into Types() and Methods() for any assembly using the new syntax. They are now treated as compiler-generated (excluded by default, opt-in via the existing CompilerGeneratedMembers.Types customization).

Detection of the new syntax requires .NET 10 / C# 14 to compile, but the attribute- and name-based checks work from every target framework when scanning such an assembly. Extension properties are not covered.