### PR TITLE
refactor: add messages to ObsoleteAttribute on test fixtures

### DIFF
--- a/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/ClassWithObsoleteMembers.cs
+++ b/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/ClassWithObsoleteMembers.cs
@@ -4,19 +4,19 @@ namespace aweXpect.Reflection.Tests.TestHelpers.Types;
 
 public class ClassWithObsoleteMembers
 {
-	[Obsolete]
+	[Obsolete("This field is obsolete.")]
 	public int ObsoleteField;
 
 	public int NonObsoleteField;
 
 #pragma warning disable CS0067 // Event is never used
-	[Obsolete]
+	[Obsolete("This event is obsolete.")]
 	public event EventHandler? ObsoleteEvent;
 
 	public event EventHandler? NonObsoleteEvent;
 #pragma warning restore CS0067
 
-	[Obsolete]
+	[Obsolete("This constructor is obsolete.")]
 	public ClassWithObsoleteMembers()
 	{
 	}
@@ -26,13 +26,13 @@ public class ClassWithObsoleteMembers
 		NonObsoleteField = value;
 	}
 
-	[Obsolete]
+	[Obsolete("This property is obsolete.")]
 	public int ObsoleteProperty { get; set; }
 
 	public int NonObsoleteProperty { get; set; }
 
 #pragma warning disable CA1822 // Mark members as static
-	[Obsolete]
+	[Obsolete("This method is obsolete.")]
 	public void ObsoleteMethod()
 	{
 	}

--- a/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/ObsoleteClass.cs
+++ b/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/ObsoleteClass.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace aweXpect.Reflection.Tests.TestHelpers.Types;
 
-[Obsolete]
+[Obsolete("This class is obsolete.")]
 public class ObsoleteClass
 {
 }


### PR DESCRIPTION
Resolves the Sonar 'Provide a message for the ObsoleteAttribute' code smells on the obsolete test-helper types.