### PR TITLE
refactor: suppress CS0618 for obsolete fixture members with messages

### DIFF
--- a/Tests/aweXpect.Reflection.Tests/ThatField.IsNotObsolete.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatField.IsNotObsolete.Tests.cs
@@ -4,7 +4,7 @@ using Xunit.Sdk;
 
 namespace aweXpect.Reflection.Tests;
 
-#pragma warning disable CS0612 // Intentional reference to an obsolete test fixture member
+#pragma warning disable CS0612, CS0618 // Intentional reference to an obsolete test fixture member
 public sealed partial class ThatField
 {
 	public sealed class IsNotObsolete

--- a/Tests/aweXpect.Reflection.Tests/ThatField.IsObsolete.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatField.IsObsolete.Tests.cs
@@ -4,7 +4,7 @@ using Xunit.Sdk;
 
 namespace aweXpect.Reflection.Tests;
 
-#pragma warning disable CS0612 // Intentional reference to an obsolete test fixture member
+#pragma warning disable CS0612, CS0618 // Intentional reference to an obsolete test fixture member
 public sealed partial class ThatField
 {
 	public sealed class IsObsolete

--- a/Tests/aweXpect.Reflection.Tests/ThatFields.AreNotObsolete.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatFields.AreNotObsolete.Tests.cs
@@ -5,7 +5,7 @@ using aweXpect.Reflection.Tests.TestHelpers.Types;
 
 namespace aweXpect.Reflection.Tests;
 
-#pragma warning disable CS0612 // Intentional reference to an obsolete test fixture member
+#pragma warning disable CS0612, CS0618 // Intentional reference to an obsolete test fixture member
 public sealed partial class ThatFields
 {
 	public sealed class AreNotObsolete

--- a/Tests/aweXpect.Reflection.Tests/ThatFields.AreObsolete.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatFields.AreObsolete.Tests.cs
@@ -5,7 +5,7 @@ using aweXpect.Reflection.Tests.TestHelpers.Types;
 
 namespace aweXpect.Reflection.Tests;
 
-#pragma warning disable CS0612 // Intentional reference to an obsolete test fixture member
+#pragma warning disable CS0612, CS0618 // Intentional reference to an obsolete test fixture member
 public sealed partial class ThatFields
 {
 	public sealed class AreObsolete

--- a/Tests/aweXpect.Reflection.Tests/ThatProperties.AreNotObsolete.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatProperties.AreNotObsolete.Tests.cs
@@ -5,7 +5,7 @@ using aweXpect.Reflection.Tests.TestHelpers.Types;
 
 namespace aweXpect.Reflection.Tests;
 
-#pragma warning disable CS0612 // Intentional reference to an obsolete test fixture member
+#pragma warning disable CS0612, CS0618 // Intentional reference to an obsolete test fixture member
 public sealed partial class ThatProperties
 {
 	public sealed class AreNotObsolete

--- a/Tests/aweXpect.Reflection.Tests/ThatProperties.AreObsolete.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatProperties.AreObsolete.Tests.cs
@@ -5,7 +5,7 @@ using aweXpect.Reflection.Tests.TestHelpers.Types;
 
 namespace aweXpect.Reflection.Tests;
 
-#pragma warning disable CS0612 // Intentional reference to an obsolete test fixture member
+#pragma warning disable CS0612, CS0618 // Intentional reference to an obsolete test fixture member
 public sealed partial class ThatProperties
 {
 	public sealed class AreObsolete

--- a/Tests/aweXpect.Reflection.Tests/ThatProperty.IsNotObsolete.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatProperty.IsNotObsolete.Tests.cs
@@ -4,7 +4,7 @@ using Xunit.Sdk;
 
 namespace aweXpect.Reflection.Tests;
 
-#pragma warning disable CS0612 // Intentional reference to an obsolete test fixture member
+#pragma warning disable CS0612, CS0618 // Intentional reference to an obsolete test fixture member
 public sealed partial class ThatProperty
 {
 	public sealed class IsNotObsolete

--- a/Tests/aweXpect.Reflection.Tests/ThatProperty.IsObsolete.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatProperty.IsObsolete.Tests.cs
@@ -4,7 +4,7 @@ using Xunit.Sdk;
 
 namespace aweXpect.Reflection.Tests;
 
-#pragma warning disable CS0612 // Intentional reference to an obsolete test fixture member
+#pragma warning disable CS0612, CS0618 // Intentional reference to an obsolete test fixture member
 public sealed partial class ThatProperty
 {
 	public sealed class IsObsolete

--- a/Tests/aweXpect.Reflection.Tests/ThatType.IsNotObsolete.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatType.IsNotObsolete.Tests.cs
@@ -25,9 +25,9 @@ public sealed partial class ThatType
 			[Fact]
 			public async Task WhenTypeIsObsolete_ShouldFail()
 			{
-#pragma warning disable CS0612
+#pragma warning disable CS0612, CS0618
 				Type subject = typeof(ObsoleteClass);
-#pragma warning restore CS0612
+#pragma warning restore CS0612, CS0618
 
 				async Task Act()
 				{
@@ -84,9 +84,9 @@ public sealed partial class ThatType
 			[Fact]
 			public async Task WhenTypeIsObsolete_ShouldSucceed()
 			{
-#pragma warning disable CS0612
+#pragma warning disable CS0612, CS0618
 				Type subject = typeof(ObsoleteClass);
-#pragma warning restore CS0612
+#pragma warning restore CS0612, CS0618
 
 				async Task Act()
 				{

--- a/Tests/aweXpect.Reflection.Tests/ThatType.IsObsolete.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatType.IsObsolete.Tests.cs
@@ -12,9 +12,9 @@ public sealed partial class ThatType
 			[Fact]
 			public async Task WhenTypeIsObsolete_ShouldSucceed()
 			{
-#pragma warning disable CS0612
+#pragma warning disable CS0612, CS0618
 				Type subject = typeof(ObsoleteClass);
-#pragma warning restore CS0612
+#pragma warning restore CS0612, CS0618
 
 				async Task Act()
 				{
@@ -66,9 +66,9 @@ public sealed partial class ThatType
 			[Fact]
 			public async Task WhenTypeIsObsolete_ShouldFail()
 			{
-#pragma warning disable CS0612
+#pragma warning disable CS0612, CS0618
 				Type subject = typeof(ObsoleteClass);
-#pragma warning restore CS0612
+#pragma warning restore CS0612, CS0618
 
 				async Task Act()
 				{

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.AreNotObsolete.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.AreNotObsolete.Tests.cs
@@ -29,13 +29,13 @@ public sealed partial class ThatTypes
 			[Fact]
 			public async Task WhenTypesContainObsoleteTypes_ShouldFail()
 			{
-#pragma warning disable CS0612
+#pragma warning disable CS0612, CS0618
 				IEnumerable<Type> subject =
 				[
 					typeof(ObsoleteClass),
 					typeof(ClassWithObsoleteMembers),
 				];
-#pragma warning restore CS0612
+#pragma warning restore CS0612, CS0618
 
 				async Task Act()
 				{
@@ -81,13 +81,13 @@ public sealed partial class ThatTypes
 			[Fact]
 			public async Task WhenTypesContainObsoleteTypes_ShouldSucceed()
 			{
-#pragma warning disable CS0612
+#pragma warning disable CS0612, CS0618
 				IEnumerable<Type> subject =
 				[
 					typeof(ObsoleteClass),
 					typeof(ClassWithObsoleteMembers),
 				];
-#pragma warning restore CS0612
+#pragma warning restore CS0612, CS0618
 
 				async Task Act()
 				{
@@ -121,14 +121,14 @@ public sealed partial class ThatTypes
 			[Fact]
 			public async Task WhenTypesContainObsoleteTypes_ShouldFail()
 			{
-#pragma warning disable CS0612
+#pragma warning disable CS0612, CS0618
 				IAsyncEnumerable<Type?> subject = new[]
 					{
 						typeof(ObsoleteClass),
 						typeof(ClassWithObsoleteMembers),
 					}
 					.ToTestAsyncEnumerable<Type?>();
-#pragma warning restore CS0612
+#pragma warning restore CS0612, CS0618
 
 				async Task Act()
 				{

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.AreObsolete.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.AreObsolete.Tests.cs
@@ -13,12 +13,12 @@ public sealed partial class ThatTypes
 			[Fact]
 			public async Task WhenAllTypesAreObsolete_ShouldSucceed()
 			{
-#pragma warning disable CS0612
+#pragma warning disable CS0612, CS0618
 				IEnumerable<Type> subject =
 				[
 					typeof(ObsoleteClass),
 				];
-#pragma warning restore CS0612
+#pragma warning restore CS0612, CS0618
 
 				async Task Act()
 				{
@@ -31,13 +31,13 @@ public sealed partial class ThatTypes
 			[Fact]
 			public async Task WhenTypesContainNonObsoleteTypes_ShouldFail()
 			{
-#pragma warning disable CS0612
+#pragma warning disable CS0612, CS0618
 				IEnumerable<Type> subject =
 				[
 					typeof(ObsoleteClass),
 					typeof(ClassWithObsoleteMembers),
 				];
-#pragma warning restore CS0612
+#pragma warning restore CS0612, CS0618
 
 				async Task Act()
 				{
@@ -60,12 +60,12 @@ public sealed partial class ThatTypes
 			[Fact]
 			public async Task WhenAllTypesAreObsolete_ShouldFail()
 			{
-#pragma warning disable CS0612
+#pragma warning disable CS0612, CS0618
 				IEnumerable<Type> subject =
 				[
 					typeof(ObsoleteClass),
 				];
-#pragma warning restore CS0612
+#pragma warning restore CS0612, CS0618
 
 				async Task Act()
 				{
@@ -85,13 +85,13 @@ public sealed partial class ThatTypes
 			[Fact]
 			public async Task WhenTypesContainNonObsoleteTypes_ShouldSucceed()
 			{
-#pragma warning disable CS0612
+#pragma warning disable CS0612, CS0618
 				IEnumerable<Type> subject =
 				[
 					typeof(ObsoleteClass),
 					typeof(ClassWithObsoleteMembers),
 				];
-#pragma warning restore CS0612
+#pragma warning restore CS0612, CS0618
 
 				async Task Act()
 				{
@@ -108,13 +108,13 @@ public sealed partial class ThatTypes
 			[Fact]
 			public async Task WhenAllTypesAreObsolete_ShouldSucceed()
 			{
-#pragma warning disable CS0612
+#pragma warning disable CS0612, CS0618
 				IAsyncEnumerable<Type?> subject = new[]
 					{
 						typeof(ObsoleteClass),
 					}
 					.ToTestAsyncEnumerable<Type?>();
-#pragma warning restore CS0612
+#pragma warning restore CS0612, CS0618
 
 				async Task Act()
 				{
@@ -127,14 +127,14 @@ public sealed partial class ThatTypes
 			[Fact]
 			public async Task WhenTypesContainNonObsoleteTypes_ShouldFail()
 			{
-#pragma warning disable CS0612
+#pragma warning disable CS0612, CS0618
 				IAsyncEnumerable<Type?> subject = new[]
 					{
 						typeof(ObsoleteClass),
 						typeof(ClassWithObsoleteMembers),
 					}
 					.ToTestAsyncEnumerable<Type?>();
-#pragma warning restore CS0612
+#pragma warning restore CS0612, CS0618
 
 				async Task Act()
 				{
@@ -154,13 +154,13 @@ public sealed partial class ThatTypes
 			[Fact]
 			public async Task WhenAllTypesAreObsolete_Negated_ShouldFail()
 			{
-#pragma warning disable CS0612
+#pragma warning disable CS0612, CS0618
 				IAsyncEnumerable<Type?> subject = new[]
 					{
 						typeof(ObsoleteClass),
 					}
 					.ToTestAsyncEnumerable<Type?>();
-#pragma warning restore CS0612
+#pragma warning restore CS0612, CS0618
 
 				async Task Act()
 				{


### PR DESCRIPTION
Adding messages to the ObsoleteAttribute on the test fixtures changed the diagnostic from CS0612 to CS0618 at the reference sites. The existing pragmas only suppressed CS0612, so the new CS0618 warnings surfaced as Sonar code smells. Extend each pragma to cover both ids.