### PR TITLE
refactor: make filtered collections immutable value objects

### DIFF
--- a/Source/aweXpect.Reflection/Collections/Filtered.Assemblies.cs
+++ b/Source/aweXpect.Reflection/Collections/Filtered.Assemblies.cs
@@ -50,10 +50,18 @@ public static partial class Filtered
 		/// <summary>
 		///     Container for a filterable collection of <see cref="Assembly" />.
 		/// </summary>
-		protected Assemblies(Assemblies inner) : base(inner, inner.Filters)
+		protected Assemblies(Assemblies inner) : this(inner, inner.Filters)
+		{
+		}
+
+		private Assemblies(Assemblies inner, List<IFilter<Assembly>> filters) : base(inner, filters)
 		{
 			_description = inner._description;
 		}
+
+		/// <inheritdoc />
+		private protected override Assemblies CloneWith(List<IFilter<Assembly>> filters)
+			=> new(this, filters);
 
 		/// <summary>
 		///     Filters for public types.

--- a/Source/aweXpect.Reflection/Collections/Filtered.Constructors.cs
+++ b/Source/aweXpect.Reflection/Collections/Filtered.Constructors.cs
@@ -40,11 +40,19 @@ public static partial class Filtered
 		/// <summary>
 		///     Container for a filterable collection of <see cref="ConstructorInfo" />.
 		/// </summary>
-		protected Constructors(Constructors inner) : base(inner, inner.Filters)
+		protected Constructors(Constructors inner) : this(inner, inner.Filters)
+		{
+		}
+
+		private Constructors(Constructors inner, List<IFilter<ConstructorInfo>> filters) : base(inner, filters)
 		{
 			_description = inner._description;
 			_types = inner._types;
 		}
+
+		/// <inheritdoc />
+		private protected override Constructors CloneWith(List<IFilter<ConstructorInfo>> filters)
+			=> new(this, filters);
 
 		/// <inheritdoc />
 		public string GetDescription()

--- a/Source/aweXpect.Reflection/Collections/Filtered.Events.cs
+++ b/Source/aweXpect.Reflection/Collections/Filtered.Events.cs
@@ -43,11 +43,19 @@ public static partial class Filtered
 		/// <summary>
 		///     Container for a filterable collection of <see cref="EventInfo" />.
 		/// </summary>
-		protected Events(Events inner) : base(inner, inner.Filters)
+		protected Events(Events inner) : this(inner, inner.Filters)
+		{
+		}
+
+		private Events(Events inner, List<IFilter<EventInfo>> filters) : base(inner, filters)
 		{
 			_description = inner._description;
 			_types = inner._types;
 		}
+
+		/// <inheritdoc />
+		private protected override Events CloneWith(List<IFilter<EventInfo>> filters)
+			=> new(this, filters);
 
 		/// <inheritdoc />
 		public string GetDescription()

--- a/Source/aweXpect.Reflection/Collections/Filtered.Fields.cs
+++ b/Source/aweXpect.Reflection/Collections/Filtered.Fields.cs
@@ -43,11 +43,19 @@ public static partial class Filtered
 		/// <summary>
 		///     Container for a filterable collection of <see cref="FieldInfo" />.
 		/// </summary>
-		protected Fields(Fields inner) : base(inner, inner.Filters)
+		protected Fields(Fields inner) : this(inner, inner.Filters)
+		{
+		}
+
+		private Fields(Fields inner, List<IFilter<FieldInfo>> filters) : base(inner, filters)
 		{
 			_description = inner._description;
 			_types = inner._types;
 		}
+
+		/// <inheritdoc />
+		private protected override Fields CloneWith(List<IFilter<FieldInfo>> filters)
+			=> new(this, filters);
 
 		/// <inheritdoc />
 		public string GetDescription()

--- a/Source/aweXpect.Reflection/Collections/Filtered.Methods.cs
+++ b/Source/aweXpect.Reflection/Collections/Filtered.Methods.cs
@@ -52,13 +52,21 @@ public static partial class Filtered
 		/// <summary>
 		///     Container for a filterable collection of <see cref="MethodInfo" />.
 		/// </summary>
-		protected Methods(Methods inner) : base(inner, inner.Filters)
+		protected Methods(Methods inner) : this(inner, inner.Filters)
+		{
+		}
+
+		private Methods(Methods inner, List<IFilter<MethodInfo>> filters) : base(inner, filters)
 		{
 			_description = inner._description;
 			_types = inner._types;
 			_memberScope = inner._memberScope;
 			_includeOperators = inner._includeOperators;
 		}
+
+		/// <inheritdoc />
+		private protected override Methods CloneWith(List<IFilter<MethodInfo>> filters)
+			=> new(this, filters);
 
 		/// <inheritdoc />
 		public string GetDescription()
@@ -95,12 +103,7 @@ public static partial class Filtered
 			}
 
 			Methods rebuilt = new(_types, _description, _memberScope, includeOperators: true);
-			foreach (IFilter<MethodInfo> filter in Filters)
-			{
-				rebuilt.Which(filter);
-			}
-
-			return rebuilt;
+			return rebuilt.CloneWith([.. Filters,]);
 		}
 
 		/// <summary>

--- a/Source/aweXpect.Reflection/Collections/Filtered.Properties.cs
+++ b/Source/aweXpect.Reflection/Collections/Filtered.Properties.cs
@@ -43,11 +43,19 @@ public static partial class Filtered
 		/// <summary>
 		///     Container for a filterable collection of <see cref="PropertyInfo" />.
 		/// </summary>
-		protected Properties(Properties inner) : base(inner, inner.Filters)
+		protected Properties(Properties inner) : this(inner, inner.Filters)
+		{
+		}
+
+		private Properties(Properties inner, List<IFilter<PropertyInfo>> filters) : base(inner, filters)
 		{
 			_description = inner._description;
 			_types = inner._types;
 		}
+
+		/// <inheritdoc />
+		private protected override Properties CloneWith(List<IFilter<PropertyInfo>> filters)
+			=> new(this, filters);
 
 		/// <inheritdoc />
 		public string GetDescription()

--- a/Source/aweXpect.Reflection/Collections/Filtered.Types.cs
+++ b/Source/aweXpect.Reflection/Collections/Filtered.Types.cs
@@ -105,11 +105,19 @@ public static partial class Filtered
 		/// <summary>
 		///     Container for a filterable collection of <see cref="Type" />.
 		/// </summary>
-		protected Types(Types inner) : base(inner, inner.Filters)
+		protected Types(Types inner) : this(inner, inner.Filters)
+		{
+		}
+
+		private Types(Types inner, List<IFilter<Type>> filters) : base(inner, filters)
 		{
 			_description = inner._description;
 			_assemblies = inner._assemblies;
 		}
+
+		/// <inheritdoc />
+		private protected override Types CloneWith(List<IFilter<Type>> filters)
+			=> new(this, filters);
 
 		/// <summary>
 		///     Filters for public members.

--- a/Source/aweXpect.Reflection/Collections/Filtered.cs
+++ b/Source/aweXpect.Reflection/Collections/Filtered.cs
@@ -1,4 +1,4 @@
-﻿#if NET8_0_OR_GREATER
+#if NET8_0_OR_GREATER
 using System.Threading;
 using System.Threading.Tasks;
 #else
@@ -17,25 +17,59 @@ public static partial class Filtered;
 /// <summary>
 ///     Base class for filtered collections of <typeparamref name="T" />.
 /// </summary>
+/// <remarks>
+///     Filtered collections are immutable value objects: the underlying <c>source</c> and the <see cref="Filters" />
+///     captured at construction are never mutated afterwards. Every filtering operation (<see cref="Which" /> and the
+///     <c>WhichAre*</c> / <c>With*</c> / <c>Without*</c> extensions that funnel through it) returns a NEW instance via
+///     <c>CloneWith</c>, so deriving multiple filtered views from the same base collection cannot corrupt each other.
+///     <para />
+///     Scope boundary: the immutability guarantee covers the collection/filter level. The nested
+///     <c>StringEqualityResult</c> / <c>StringEqualityResultType</c> refinement classes still refine their
+///     <c>StringEqualityOptions</c> via in-place mutation; that options object originates from the aweXpect core library
+///     (<c>aweXpect.Options</c>), is mutable by design, and is intentionally left as-is.
+/// </remarks>
 #if NET8_0_OR_GREATER
-public abstract class Filtered<T, TFiltered>(IAsyncEnumerable<T> source, List<IFilter<T>>? filters = null)
+public abstract class Filtered<T, TFiltered>
 	: IAsyncEnumerable<T>
 #else
-public abstract class Filtered<T, TFiltered>(IEnumerable<T> source, List<IFilter<T>>? filters = null)
+public abstract class Filtered<T, TFiltered>
 	: IEnumerable<T>
 #endif
 	where TFiltered : Filtered<T, TFiltered>
 {
+#if NET8_0_OR_GREATER
+	private readonly IAsyncEnumerable<T> _source;
+#else
+	private readonly IEnumerable<T> _source;
+#endif
+
+	/// <summary>
+	///     Base class for filtered collections of <typeparamref name="T" />.
+	/// </summary>
+#if NET8_0_OR_GREATER
+	protected Filtered(IAsyncEnumerable<T> source, List<IFilter<T>>? filters = null)
+#else
+	protected Filtered(IEnumerable<T> source, List<IFilter<T>>? filters = null)
+#endif
+	{
+		_source = source;
+		Filters = filters ?? [];
+	}
+
 	/// <summary>
 	///     The filters on the source.
 	/// </summary>
-	protected List<IFilter<T>> Filters { get; } = filters ?? [];
+	/// <remarks>
+	///     Treated as immutable: it is never modified after construction. The concrete type stays <see cref="List{T}" />
+	///     to preserve the public API surface.
+	/// </remarks>
+	protected List<IFilter<T>> Filters { get; }
 
 #if NET8_0_OR_GREATER
 	/// <inheritdoc />
 	public async IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = new())
 	{
-		await foreach (T item in source.WithCancellation(cancellationToken))
+		await foreach (T item in _source.WithCancellation(cancellationToken))
 		{
 			if (await Filters.AllAsync(filter => filter.Applies(item)))
 			{
@@ -46,7 +80,7 @@ public abstract class Filtered<T, TFiltered>(IEnumerable<T> source, List<IFilter
 #else
 	/// <inheritdoc />
 	public IEnumerator<T> GetEnumerator()
-		=> source.Where(a => Filters.All(f => f.Applies(a).GetAwaiter().GetResult())).GetEnumerator();
+		=> _source.Where(a => Filters.All(f => f.Applies(a).GetAwaiter().GetResult())).GetEnumerator();
 
 	IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 #endif
@@ -56,8 +90,25 @@ public abstract class Filtered<T, TFiltered>(IEnumerable<T> source, List<IFilter
 	/// </summary>
 	/// <param name="filter">The filter to apply on <typeparamref name="T" />.</param>
 	public TFiltered Which(IFilter<T> filter)
+		=> CloneWith([.. Filters, filter,]);
+
+	/// <summary>
+	///     Creates a clone that reuses the ORIGINAL <paramref name="original" />'s underlying source (never wrapping the
+	///     instance itself) together with a fresh <paramref name="filters" /> list, so that filters are never re-applied
+	///     on top of an already-filtered sequence.
+	/// </summary>
+	/// <remarks>
+	///     Declared after the iterator methods on purpose: it must stay out of the way of the compiler-generated async
+	///     iterator state-machine ordinal so the public API surface (which captures that generated name) is preserved.
+	/// </remarks>
+	private protected Filtered(Filtered<T, TFiltered> original, List<IFilter<T>> filters)
+		: this(original._source, filters)
 	{
-		Filters.Add(filter);
-		return (TFiltered)this;
 	}
+
+	/// <summary>
+	///     Creates a new instance of <typeparamref name="TFiltered" /> that shares this collection's original source and
+	///     metadata, but uses the given <paramref name="filters" />.
+	/// </summary>
+	private protected abstract TFiltered CloneWith(List<IFilter<T>> filters);
 }

--- a/Source/aweXpect.Reflection/Filters/MethodFilters.WhichAreGeneric.cs
+++ b/Source/aweXpect.Reflection/Filters/MethodFilters.WhichAreGeneric.cs
@@ -40,12 +40,9 @@ public static partial class MethodFilters
 		///     …with the <paramref name="expected" /> number of generic arguments.
 		/// </summary>
 		public GenericMethods WithArgumentCount(int expected)
-		{
-			Which(Filter.Suffix<MethodInfo>(
+			=> new(Which(Filter.Suffix<MethodInfo>(
 				method => method.GetGenericArguments().Length == expected,
-				() => $"with {expected} generic {(expected == 1 ? "argument" : "arguments")} "));
-			return this;
-		}
+				() => $"with {expected} generic {(expected == 1 ? "argument" : "arguments")} ")));
 
 		/// <summary>
 		///     …with a generic argument constrained to type <typeparamref name="T" />.
@@ -75,8 +72,8 @@ public static partial class MethodFilters
 				},
 				()
 					=> $"with argument {genericArgumentFilterOptions.GetDescription()}{collectionIndexOptions.Match.GetDescription()} ");
-			Which(filter);
-			return new GenericMethodsWithArgument(this, collectionIndexOptions);
+			Filtered.Methods filtered = Which(filter);
+			return new GenericMethodsWithArgument(new GenericMethods(filtered), collectionIndexOptions);
 		}
 
 		/// <summary>
@@ -111,8 +108,8 @@ public static partial class MethodFilters
 				},
 				()
 					=> $"with argument {genericArgumentFilterOptions.GetDescription()}{collectionIndexOptions.Match.GetDescription()} ");
-			Which(filter);
-			return new GenericMethodsWithNamedArgument(this, collectionIndexOptions, stringEqualityOptions);
+			Filtered.Methods filtered = Which(filter);
+			return new GenericMethodsWithNamedArgument(new GenericMethods(filtered), collectionIndexOptions, stringEqualityOptions);
 		}
 
 		/// <summary>
@@ -143,8 +140,8 @@ public static partial class MethodFilters
 				},
 				()
 					=> $"with argument {genericArgumentFilterOptions.GetDescription()}{collectionIndexOptions.Match.GetDescription()} ");
-			Which(filter);
-			return new GenericMethodsWithNamedArgument(this, collectionIndexOptions, stringEqualityOptions);
+			Filtered.Methods filtered = Which(filter);
+			return new GenericMethodsWithNamedArgument(new GenericMethods(filtered), collectionIndexOptions, stringEqualityOptions);
 		}
 	}
 

--- a/Source/aweXpect.Reflection/Filters/TypeFilters.WhichAreGeneric.cs
+++ b/Source/aweXpect.Reflection/Filters/TypeFilters.WhichAreGeneric.cs
@@ -39,12 +39,9 @@ public static partial class TypeFilters
 		///     …with the <paramref name="expected" /> number of generic arguments.
 		/// </summary>
 		public GenericTypes WithArgumentCount(int expected)
-		{
-			Which(Filter.Suffix<Type>(
+			=> new(Which(Filter.Suffix<Type>(
 				type => type.GetGenericArguments().Length == expected,
-				() => $"with {expected} generic {(expected == 1 ? "argument" : "arguments")} "));
-			return this;
-		}
+				() => $"with {expected} generic {(expected == 1 ? "argument" : "arguments")} ")));
 
 		/// <summary>
 		///     …with a generic argument constrained to type <typeparamref name="T" />.
@@ -74,8 +71,8 @@ public static partial class TypeFilters
 				},
 				()
 					=> $"with argument {genericArgumentFilterOptions.GetDescription()}{collectionIndexOptions.Match.GetDescription()} ");
-			Which(filter);
-			return new GenericTypesWithArgument(this, collectionIndexOptions);
+			Filtered.Types filtered = Which(filter);
+			return new GenericTypesWithArgument(new GenericTypes(filtered), collectionIndexOptions);
 		}
 
 		/// <summary>
@@ -110,8 +107,8 @@ public static partial class TypeFilters
 				},
 				()
 					=> $"with argument {genericArgumentFilterOptions.GetDescription()}{collectionIndexOptions.Match.GetDescription()} ");
-			Which(filter);
-			return new GenericTypesWithNamedArgument(this, collectionIndexOptions, stringEqualityOptions);
+			Filtered.Types filtered = Which(filter);
+			return new GenericTypesWithNamedArgument(new GenericTypes(filtered), collectionIndexOptions, stringEqualityOptions);
 		}
 
 		/// <summary>
@@ -142,8 +139,8 @@ public static partial class TypeFilters
 				},
 				()
 					=> $"with argument {genericArgumentFilterOptions.GetDescription()}{collectionIndexOptions.Match.GetDescription()} ");
-			Which(filter);
-			return new GenericTypesWithNamedArgument(this, collectionIndexOptions, stringEqualityOptions);
+			Filtered.Types filtered = Which(filter);
+			return new GenericTypesWithNamedArgument(new GenericTypes(filtered), collectionIndexOptions, stringEqualityOptions);
 		}
 
 		/// <summary>

--- a/Tests/aweXpect.Reflection.Tests/Collections/FilteredReuseIndependenceTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Collections/FilteredReuseIndependenceTests.cs
@@ -118,6 +118,87 @@ public sealed class FilteredReuseIndependenceTests
 		await That(@base).IsEqualTo([typeof(SampleType1), typeof(SampleType2),]).InAnyOrder();
 	}
 
+	[Fact]
+	public async Task MethodsWhichAreGenericWithArgumentCount_BranchingFromSharedBase_ShouldBeIndependent()
+	{
+		MethodFilters.GenericMethods @base = In.Type<SampleGenericMethods>().Methods()
+			.WhichAreGeneric();
+
+		Filtered.Methods view1 = @base.WithArgumentCount(1);
+		Filtered.Methods view2 = @base.WithArgumentCount(2);
+
+		await That(view1).All().Satisfy(m => m.GetGenericArguments().Length == 1);
+		await That(view1).HasCount(1);
+		await That(view2).All().Satisfy(m => m.GetGenericArguments().Length == 2);
+		await That(view2).HasCount(1);
+		await That(@base).All().Satisfy(m => m.IsGenericMethod);
+		await That(@base).HasCount(2);
+	}
+
+	[Fact]
+	public async Task MethodsWhichAreGenericWithArgument_BranchingFromSharedBase_ShouldBeIndependent()
+	{
+		MethodFilters.GenericMethods @base = In.Type<SampleGenericArgumentMethods>().Methods()
+			.WhichAreGeneric();
+
+		Filtered.Methods view1 = @base.WithArgument<BaseA>();
+		Filtered.Methods view2 = @base.WithArgument<BaseB>();
+
+		await That(view1).IsEqualTo([
+			typeof(SampleGenericArgumentMethods).GetMethod(nameof(SampleGenericArgumentMethods.ArgumentOfBaseA))!,
+		]).InAnyOrder();
+		await That(view2).IsEqualTo([
+			typeof(SampleGenericArgumentMethods).GetMethod(nameof(SampleGenericArgumentMethods.ArgumentOfBaseB))!,
+		]).InAnyOrder();
+		await That(@base).HasCount(2);
+	}
+
+	[Fact]
+	public async Task TypesWhichAreGenericWithArgumentCount_BranchingFromSharedBase_ShouldBeIndependent()
+	{
+		TypeFilters.GenericTypes @base = In.Types<SampleGenericType1<int>, SampleGenericType2<int, int>>()
+			.WhichAreGeneric();
+
+		Filtered.Types view1 = @base.WithArgumentCount(1);
+		Filtered.Types view2 = @base.WithArgumentCount(2);
+
+		await That(view1).IsEqualTo([typeof(SampleGenericType1<int>),]).InAnyOrder();
+		await That(view2).IsEqualTo([typeof(SampleGenericType2<int, int>),]).InAnyOrder();
+		await That(@base).IsEqualTo([
+			typeof(SampleGenericType1<int>), typeof(SampleGenericType2<int, int>),
+		]).InAnyOrder();
+	}
+
+	private class BaseA;
+
+	private class BaseB;
+
+	private class SampleGenericMethods
+	{
+		public static void OneArgument<T1>()
+		{
+		}
+
+		public static void TwoArguments<T1, T2>()
+		{
+		}
+	}
+
+	private class SampleGenericArgumentMethods
+	{
+		public static void ArgumentOfBaseA<T>() where T : BaseA
+		{
+		}
+
+		public static void ArgumentOfBaseB<T>() where T : BaseB
+		{
+		}
+	}
+
+	private class SampleGenericType1<T1>;
+
+	private class SampleGenericType2<T1, T2>;
+
 	private class SampleType1;
 
 	private class SampleType2;
@@ -142,11 +223,11 @@ public sealed class FilteredReuseIndependenceTests
 		public int PropA { get; set; }
 		public int PropB { get; set; }
 
-		public void DoA()
+		public static void DoA()
 		{
 		}
 
-		public void DoB()
+		public static void DoB()
 		{
 		}
 	}

--- a/Tests/aweXpect.Reflection.Tests/Collections/FilteredReuseIndependenceTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Collections/FilteredReuseIndependenceTests.cs
@@ -1,0 +1,153 @@
+using System.Reflection;
+using aweXpect.Reflection.Collections;
+
+// ReSharper disable UnusedMember.Local
+// ReSharper disable EventNeverSubscribedTo.Local
+#pragma warning disable CS0067 // Event is never used
+#pragma warning disable CS0649 // Field is never assigned to
+
+namespace aweXpect.Reflection.Tests;
+
+/// <summary>
+///     Verifies that the filtered collections behave as immutable value objects: deriving two divergent
+///     filtered views from the same base collection must not corrupt the base nor each other.
+/// </summary>
+public sealed class FilteredReuseIndependenceTests
+{
+	[Fact]
+	public async Task Assemblies_BranchingFromSharedBase_ShouldBeIndependent()
+	{
+		Assembly assembly1 = typeof(In).Assembly;
+		Assembly assembly2 = typeof(FilteredReuseIndependenceTests).Assembly;
+		Filtered.Assemblies @base = In.Assemblies(assembly1, assembly2);
+
+		Filtered.Assemblies view1 = @base.Which(a => a == assembly1);
+		Filtered.Assemblies view2 = @base.Which(a => a == assembly2);
+
+		await That(view1).IsEqualTo([assembly1,]).InAnyOrder();
+		await That(view2).IsEqualTo([assembly2,]).InAnyOrder();
+		await That(@base).IsEqualTo([assembly1, assembly2,]).InAnyOrder();
+	}
+
+	[Fact]
+	public async Task Constructors_BranchingFromSharedBase_ShouldBeIndependent()
+	{
+		Filtered.Constructors @base = In.Type<SampleWithMembers>().Constructors();
+
+		Filtered.Constructors view1 = @base.Which(c => c.GetParameters().Length == 0);
+		Filtered.Constructors view2 = @base.Which(c => c.GetParameters().Length == 1);
+
+		await That(view1).HasCount().AtLeast(1);
+		await That(view1).All().Satisfy(c => c.GetParameters().Length == 0);
+		await That(view2).HasCount().AtLeast(1);
+		await That(view2).All().Satisfy(c => c.GetParameters().Length == 1);
+		await That(@base).HasCount().AtLeast(2);
+	}
+
+	[Fact]
+	public async Task Events_BranchingFromSharedBase_ShouldBeIndependent()
+	{
+		EventInfo eventA = typeof(SampleWithMembers).GetEvent(nameof(SampleWithMembers.EventA))!;
+		EventInfo eventB = typeof(SampleWithMembers).GetEvent(nameof(SampleWithMembers.EventB))!;
+		Filtered.Events @base = In.Type<SampleWithMembers>().Events();
+
+		Filtered.Events view1 = @base.Which(e => e.Name == eventA.Name);
+		Filtered.Events view2 = @base.Which(e => e.Name == eventB.Name);
+
+		await That(view1).IsEqualTo([eventA,]).InAnyOrder();
+		await That(view2).IsEqualTo([eventB,]).InAnyOrder();
+		await That(@base).HasCount().AtLeast(2);
+	}
+
+	[Fact]
+	public async Task Fields_BranchingFromSharedBase_ShouldBeIndependent()
+	{
+		FieldInfo fieldA = typeof(SampleWithMembers).GetField(nameof(SampleWithMembers.FieldA))!;
+		FieldInfo fieldB = typeof(SampleWithMembers).GetField(nameof(SampleWithMembers.FieldB))!;
+		Filtered.Fields @base = In.Type<SampleWithMembers>().Fields();
+
+		Filtered.Fields view1 = @base.Which(f => f.Name == fieldA.Name);
+		Filtered.Fields view2 = @base.Which(f => f.Name == fieldB.Name);
+
+		await That(view1).IsEqualTo([fieldA,]).InAnyOrder();
+		await That(view2).IsEqualTo([fieldB,]).InAnyOrder();
+		await That(@base).HasCount().AtLeast(2);
+	}
+
+	[Fact]
+	public async Task Methods_BranchingFromSharedBase_ShouldBeIndependent()
+	{
+		MethodInfo methodA = typeof(SampleWithMembers).GetMethod(nameof(SampleWithMembers.DoA))!;
+		MethodInfo methodB = typeof(SampleWithMembers).GetMethod(nameof(SampleWithMembers.DoB))!;
+		Filtered.Methods @base = In.Type<SampleWithMembers>().Methods()
+			.Which(m => m.Name.StartsWith("Do"));
+
+		Filtered.Methods view1 = @base.Which(m => m.Name == methodA.Name);
+		Filtered.Methods view2 = @base.Which(m => m.Name == methodB.Name);
+
+		await That(view1).IsEqualTo([methodA,]).InAnyOrder();
+		await That(view2).IsEqualTo([methodB,]).InAnyOrder();
+		await That(@base).IsEqualTo([methodA, methodB,]).InAnyOrder();
+	}
+
+	[Fact]
+	public async Task Properties_BranchingFromSharedBase_ShouldBeIndependent()
+	{
+		PropertyInfo propertyA = typeof(SampleWithMembers).GetProperty(nameof(SampleWithMembers.PropA))!;
+		PropertyInfo propertyB = typeof(SampleWithMembers).GetProperty(nameof(SampleWithMembers.PropB))!;
+		Filtered.Properties @base = In.Type<SampleWithMembers>().Properties();
+
+		Filtered.Properties view1 = @base.Which(p => p.Name == propertyA.Name);
+		Filtered.Properties view2 = @base.Which(p => p.Name == propertyB.Name);
+
+		await That(view1).IsEqualTo([propertyA,]).InAnyOrder();
+		await That(view2).IsEqualTo([propertyB,]).InAnyOrder();
+		await That(@base).HasCount().AtLeast(2);
+	}
+
+	[Fact]
+	public async Task Types_BranchingFromSharedBase_ShouldBeIndependent()
+	{
+		Filtered.Types @base = In.Types<SampleType1, SampleType2>();
+
+		Filtered.Types view1 = @base.Which(t => t == typeof(SampleType1));
+		Filtered.Types view2 = @base.Which(t => t == typeof(SampleType2));
+
+		await That(view1).IsEqualTo([typeof(SampleType1),]).InAnyOrder();
+		await That(view2).IsEqualTo([typeof(SampleType2),]).InAnyOrder();
+		await That(@base).IsEqualTo([typeof(SampleType1), typeof(SampleType2),]).InAnyOrder();
+	}
+
+	private class SampleType1;
+
+	private class SampleType2;
+
+	private class SampleWithMembers
+	{
+		public int FieldA;
+		public int FieldB;
+
+		public SampleWithMembers()
+		{
+		}
+
+		public SampleWithMembers(int value)
+		{
+			FieldA = value;
+		}
+
+		public event EventHandler? EventA;
+		public event EventHandler? EventB;
+
+		public int PropA { get; set; }
+		public int PropB { get; set; }
+
+		public void DoA()
+		{
+		}
+
+		public void DoB()
+		{
+		}
+	}
+}


### PR DESCRIPTION
Filtering operations now return a new instance instead of mutating the receiver, so branching from a stored intermediate collection no longer corrupts it.

- Filtered<T,TFiltered>: store source in a readonly field, treat Filters as immutable, and route Which through a copy-on-write CloneWith that reuses the original source (avoiding repeated re-filtering).
- The 7 concrete collection types carry all metadata across clones.
- Methods.WithOperatorsIncluded composes with the immutable Which.
- WhichAreGeneric().WithArgument builders no longer rely on in-place mutation / shared filter-list aliasing.

New CloneWith and clone constructor use private protected accessibility and are declared after the iterator methods to keep the public API surface (incl. the generated async iterator ordinal) unchanged.

Adds a reuse-independence test per collection type.