### PR TITLE
feat: add In.Namespace source

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ evaluated collection that you can navigate and filter further.
 | `In.ExecutingAssembly()`                                                                      | the executing assembly                                                               |
 | `In.Type<T>()` / `In.Type(typeof(T))`                                                         | a single type                                                                        |
 | `In.Types<T1, T2>()` / `In.Types<T1, T2, T3>()` / `In.Types(t1, t2, …)`                       | the given types                                                                      |
+| `In.Namespace("ns")`                                                                          | all types within a namespace and its sub-namespaces (across loaded assemblies)       |
 | `In.Constructors(…)` / `In.Events(…)` / `In.Fields(…)` / `In.Methods(…)` / `In.Properties(…)` | the given members                                                                    |
 
 ## Navigating to members

--- a/Source/aweXpect.Reflection/In.cs
+++ b/Source/aweXpect.Reflection/In.cs
@@ -64,6 +64,18 @@ public static class In
 		=> new(Assembly.GetExecutingAssembly(), "in executing assembly");
 
 	/// <summary>
+	///     Defines expectations on all types within the <paramref name="namespace" /> (including sub-namespaces)
+	///     from all loaded assemblies of the current <see cref="System.AppDomain.CurrentDomain" />.
+	/// </summary>
+	/// <remarks>
+	///     This matches the <paramref name="namespace" /> and its sub-namespaces, but not namespaces that merely start
+	///     with the same text (e.g. <c>Foo.Bar</c> does not include <c>Foo.BarBaz</c>). The comparison is exact and
+	///     case-sensitive.
+	/// </remarks>
+	public static Filtered.Types Namespace(string @namespace)
+		=> AllLoadedAssemblies().Types().WithinNamespace(@namespace);
+
+	/// <summary>
 	///     Defines expectations on the type <typeparamref name="TType" />.
 	/// </summary>
 	public static Filtered.Types Type<TType>()

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net10.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net10.0.txt
@@ -324,6 +324,7 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Collections.Filtered.Assemblies ExecutingAssembly() { }
         public static aweXpect.Reflection.Collections.Filtered.Fields Fields(System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo> fields) { }
         public static aweXpect.Reflection.Collections.Filtered.Methods Methods(System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo> methods) { }
+        public static aweXpect.Reflection.Collections.Filtered.Types Namespace(string @namespace) { }
         public static aweXpect.Reflection.Collections.Filtered.Properties Properties(System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo> properties) { }
         public static aweXpect.Reflection.Collections.Filtered.Types Type(System.Type type) { }
         public static aweXpect.Reflection.Collections.Filtered.Types Type<TType>() { }

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net8.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net8.0.txt
@@ -324,6 +324,7 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Collections.Filtered.Assemblies ExecutingAssembly() { }
         public static aweXpect.Reflection.Collections.Filtered.Fields Fields(System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo> fields) { }
         public static aweXpect.Reflection.Collections.Filtered.Methods Methods(System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo> methods) { }
+        public static aweXpect.Reflection.Collections.Filtered.Types Namespace(string @namespace) { }
         public static aweXpect.Reflection.Collections.Filtered.Properties Properties(System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo> properties) { }
         public static aweXpect.Reflection.Collections.Filtered.Types Type(System.Type type) { }
         public static aweXpect.Reflection.Collections.Filtered.Types Type<TType>() { }

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_netstandard2.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_netstandard2.0.txt
@@ -324,6 +324,7 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Collections.Filtered.Assemblies ExecutingAssembly() { }
         public static aweXpect.Reflection.Collections.Filtered.Fields Fields(System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo> fields) { }
         public static aweXpect.Reflection.Collections.Filtered.Methods Methods(System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo> methods) { }
+        public static aweXpect.Reflection.Collections.Filtered.Types Namespace(string @namespace) { }
         public static aweXpect.Reflection.Collections.Filtered.Properties Properties(System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo> properties) { }
         public static aweXpect.Reflection.Collections.Filtered.Types Type(System.Type type) { }
         public static aweXpect.Reflection.Collections.Filtered.Types Type<TType>() { }

--- a/Tests/aweXpect.Reflection.Tests/InTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/InTests.cs
@@ -2,6 +2,10 @@
 using System.Reflection;
 using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
+using aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope;
+using aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope.Nested;
+using aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScopeSibling;
+using Xunit.Sdk;
 
 namespace aweXpect.Reflection.Tests;
 
@@ -157,6 +161,79 @@ public sealed class InTests
 		Filtered.Methods sut = In.Methods(method);
 
 		await That(sut).HasSingle().Which.IsEqualTo(method);
+	}
+
+	[Fact]
+	public async Task Namespace_ShouldContainTypesWithinNamespaceIncludingSubNamespaces()
+	{
+		Filtered.Types sut = In.Namespace("aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope");
+
+		await That(sut).Contains(typeof(ClassInNamespaceScope));
+		await That(sut).Contains(typeof(ClassInNestedNamespaceScope));
+		await That(sut).DoesNotContain(typeof(ClassInSiblingNamespaceScope));
+		await That(sut.GetDescription())
+			.IsEqualTo(
+				"types within namespace \"aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope\" in all loaded assemblies");
+	}
+
+	[Fact]
+	public async Task Namespace_ShouldSelectTypesThatCanBeAsserted()
+	{
+		Filtered.Types sut = In.Namespace("aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope");
+
+		async Task Act()
+			=> await That(sut)
+				.AreWithinNamespace("aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope");
+
+		await That(Act).DoesNotThrow();
+	}
+
+	[Fact]
+	public async Task Namespace_WhenAssertionFails_ShouldReportFullMessage()
+	{
+		Filtered.Types sut = In.Namespace("aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope");
+
+		async Task Act()
+			=> await That(sut)
+				.AreWithinNamespace("aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScopeSibling");
+
+		await That(Act).Throws<XunitException>()
+			.WithMessage("""
+			             Expected that types within namespace "aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope" in all loaded assemblies
+			             are all within namespace "aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScopeSibling",
+			             but it contained not matching types [
+			               *
+			             ]
+			             """).AsWildcard();
+	}
+
+	[Fact]
+	public async Task Namespace_WhenNegatingMatchingAssertion_ShouldReportFullMessage()
+	{
+		Filtered.Types sut = In.Namespace("aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope");
+
+		async Task Act()
+			=> await That(sut).DoesNotComplyWith(they
+				=> they.AreWithinNamespace("aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope"));
+
+		await That(Act).Throws<XunitException>()
+			.WithMessage("""
+			             Expected that types within namespace "aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope" in all loaded assemblies
+			             are not all within namespace "aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope",
+			             but it only contained matching types [
+			               *
+			             ]
+			             """).AsWildcard();
+	}
+
+	[Fact]
+	public async Task Namespace_WhenNoTypesAreInNamespace_ShouldBeEmpty()
+	{
+		Filtered.Types sut = In.Namespace("Non.Existent.Namespace");
+
+		await That(sut).IsEmpty();
+		await That(sut.GetDescription())
+			.IsEqualTo("types within namespace \"Non.Existent.Namespace\" in all loaded assemblies");
 	}
 
 	[Fact]


### PR DESCRIPTION
Add a first-class In.Namespace(string) source that selects all types within a namespace (including sub-namespaces) across all loaded assemblies, reusing the existing WithinNamespace filter. Update the public API approval snapshots and the README source table.

---

- *Fixes #318*