### PR TITLE
refactor!: merge `In.Assemblies` overloads into single `params IEnumerable<Assembly?>` overload

### DIFF
--- a/Source/aweXpect.Reflection/In.cs
+++ b/Source/aweXpect.Reflection/In.cs
@@ -35,13 +35,7 @@ public static class In
 	/// <summary>
 	///     Defines expectations on the given <paramref name="assemblies" />.
 	/// </summary>
-	public static Filtered.Assemblies Assemblies(params Assembly?[] assemblies)
-		=> new(assemblies, $"in the assemblies {Formatter.Format(assemblies)}");
-
-	/// <summary>
-	///     Defines expectations on the given <paramref name="assemblies" />.
-	/// </summary>
-	public static Filtered.Assemblies Assemblies(IEnumerable<Assembly> assemblies)
+	public static Filtered.Assemblies Assemblies(params IEnumerable<Assembly?> assemblies)
 		=> new(assemblies, $"in the assemblies {Formatter.Format(assemblies)}");
 
 	/// <summary>

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net10.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net10.0.txt
@@ -320,8 +320,7 @@ namespace aweXpect.Reflection
     public static class In
     {
         public static aweXpect.Reflection.Collections.Filtered.Assemblies AllLoadedAssemblies() { }
-        public static aweXpect.Reflection.Collections.Filtered.Assemblies Assemblies(System.Collections.Generic.IEnumerable<System.Reflection.Assembly> assemblies) { }
-        public static aweXpect.Reflection.Collections.Filtered.Assemblies Assemblies(params System.Reflection.Assembly?[] assemblies) { }
+        public static aweXpect.Reflection.Collections.Filtered.Assemblies Assemblies(System.Collections.Generic.IEnumerable<System.Reflection.Assembly?> assemblies) { }
         public static aweXpect.Reflection.Collections.Filtered.Assemblies AssemblyContaining(System.Type type) { }
         public static aweXpect.Reflection.Collections.Filtered.Assemblies AssemblyContaining<TType>() { }
         public static aweXpect.Reflection.Collections.Filtered.Constructors Constructors(System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo> constructors) { }

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net8.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net8.0.txt
@@ -320,8 +320,7 @@ namespace aweXpect.Reflection
     public static class In
     {
         public static aweXpect.Reflection.Collections.Filtered.Assemblies AllLoadedAssemblies() { }
-        public static aweXpect.Reflection.Collections.Filtered.Assemblies Assemblies(System.Collections.Generic.IEnumerable<System.Reflection.Assembly> assemblies) { }
-        public static aweXpect.Reflection.Collections.Filtered.Assemblies Assemblies(params System.Reflection.Assembly?[] assemblies) { }
+        public static aweXpect.Reflection.Collections.Filtered.Assemblies Assemblies(System.Collections.Generic.IEnumerable<System.Reflection.Assembly?> assemblies) { }
         public static aweXpect.Reflection.Collections.Filtered.Assemblies AssemblyContaining(System.Type type) { }
         public static aweXpect.Reflection.Collections.Filtered.Assemblies AssemblyContaining<TType>() { }
         public static aweXpect.Reflection.Collections.Filtered.Constructors Constructors(System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo> constructors) { }

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_netstandard2.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_netstandard2.0.txt
@@ -320,8 +320,7 @@ namespace aweXpect.Reflection
     public static class In
     {
         public static aweXpect.Reflection.Collections.Filtered.Assemblies AllLoadedAssemblies() { }
-        public static aweXpect.Reflection.Collections.Filtered.Assemblies Assemblies(System.Collections.Generic.IEnumerable<System.Reflection.Assembly> assemblies) { }
-        public static aweXpect.Reflection.Collections.Filtered.Assemblies Assemblies(params System.Reflection.Assembly?[] assemblies) { }
+        public static aweXpect.Reflection.Collections.Filtered.Assemblies Assemblies(System.Collections.Generic.IEnumerable<System.Reflection.Assembly?> assemblies) { }
         public static aweXpect.Reflection.Collections.Filtered.Assemblies AssemblyContaining(System.Type type) { }
         public static aweXpect.Reflection.Collections.Filtered.Assemblies AssemblyContaining<TType>() { }
         public static aweXpect.Reflection.Collections.Filtered.Constructors Constructors(System.Collections.Generic.IEnumerable<System.Reflection.ConstructorInfo> constructors) { }


### PR DESCRIPTION
Replaces the `params Assembly?[]` and `IEnumerable<Assembly>` overloads with a single `params IEnumerable<Assembly?>` overload (C# 13 params collections) and updates the expected API surface accordingly.