### PR TITLE
feat!: add `Types` static entry point and remove `In.Namespace`

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 Expectations for reflection types for [aweXpect](https://github.com/Testably/aweXpect).
 
 Write architecture and convention tests as plain, readable assertions: **select** the assemblies, types
-or members you care about with `In`, then **assert** a rule on them with `Expect.That`.
+or members you care about with `In` or `Types`, then **assert** a rule on them with `Expect.That`.
 
 ## At a glance
 
@@ -98,8 +98,32 @@ evaluated collection that you can navigate and filter further.
 | `In.ExecutingAssembly()`                                                                      | the executing assembly                                                               |
 | `In.Type<T>()` / `In.Type(typeof(T))`                                                         | a single type                                                                        |
 | `In.Types<T1, T2>()` / `In.Types<T1, T2, T3>()` / `In.Types(t1, t2, …)`                       | the given types                                                                      |
-| `In.Namespace("ns")`                                                                          | all types within a namespace and its sub-namespaces (across loaded assemblies)       |
 | `In.Constructors(…)` / `In.Events(…)` / `In.Fields(…)` / `In.Methods(…)` / `In.Properties(…)` | the given members                                                                    |
+
+## Sources: the `Types` helper
+
+While `In` starts from concrete reflection objects, `Types` selects types *by criteria* — the natural entry
+point for architecture rules:
+
+| Source                                                          | Returns                                                                         |
+|-----------------------------------------------------------------|---------------------------------------------------------------------------------|
+| `Types.InNamespace("ns")`                                       | all types within a namespace and its sub-namespaces (across loaded assemblies) |
+| `Types.InAllLoadedAssemblies()`                                 | all types in all currently loaded assemblies                                   |
+| `Types.InAssemblies(a1, a2, …)`                                 | all types in the given assemblies                                              |
+| `Types.InAssemblyContaining<T>()` / `…(typeof(T))`              | all types in the assembly that declares `T`                                    |
+| `Types.InEntryAssembly()` / `Types.InExecutingAssembly()`       | all types in the entry / executing assembly                                    |
+
+`Types.InNamespace(…)` searches all loaded assemblies by default; chain one of the same `In*` methods directly
+after it to clarify the assembly source (it can only be specified once, before any further filters):
+
+```csharp
+// Defaults to all loaded assemblies
+await Expect.That(Types.InNamespace("MyApp.Domain")).AreSealed();
+
+// Clarify the assembly source
+await Expect.That(Types.InNamespace("MyApp.Domain").InAssemblyContaining<MyApp.Startup>())
+    .AreSealed();
+```
 
 ## Navigating to members
 
@@ -401,11 +425,11 @@ Layering and architecture rules over the types a type references **in its signat
 
 ```csharp
 // Presentation must not reference the data layer
-await Expect.That(In.Namespace("MyApp.Presentation"))
+await Expect.That(Types.InNamespace("MyApp.Presentation"))
     .DoNotDependOn("MyApp.Data");
 
 // The API layer may only reference the application and domain layers
-await Expect.That(In.Namespace("MyApp.Api"))
+await Expect.That(Types.InNamespace("MyApp.Api"))
     .DependOnlyOn("MyApp.Application", "MyApp.Domain");
 
 // Filter for the types that depend on a namespace
@@ -434,7 +458,7 @@ extends the built-in set). Types you write in authored signatures always do coun
 > as `new Infra.Foo()`, static calls and local variables are **not** detected. Function-pointer signatures
 > (`delegate*<…>`) are not decomposed either; the types inside them are invisible to dependency assertions.
 > Nested types are separate types with their own dependency surface: asserting on `typeof(Outer)` does not
-> include what `Outer.Inner` references. The collection-based assertions (e.g. over `In.Namespace(…)`)
+> include what `Outer.Inner` references. The collection-based assertions (e.g. over `Types.InNamespace(…)`)
 > enumerate nested types as their own items and therefore cover them. For IL/body-level accuracy, plug in
 > your own resolver via `Customize.aweXpect.Reflection().DependencyResolver()` (see
 > [Configuration](#dependency-resolver)).
@@ -445,7 +469,7 @@ can be targeted or allowed with an empty string (`""`). Each result is chainable
 
 ```csharp
 // Widen the set with .OrOn(…)
-await Expect.That(In.Namespace("MyApp.Api"))
+await Expect.That(Types.InNamespace("MyApp.Api"))
     .DependOnlyOn("MyApp.Application").OrOn("MyApp.Domain");
 
 // Opt out of sub-namespace matching for the whole expression
@@ -457,7 +481,7 @@ For `DependsOnlyOn` a type's own namespace is always allowed, and by default so 
 type's own sub-namespaces:
 
 ```csharp
-await Expect.That(In.Namespace("MyApp.Domain"))
+await Expect.That(Types.InNamespace("MyApp.Domain"))
     .DependOnlyOn("MyApp.Domain").ExcludingSubNamespaces().ExcludingOwnSubNamespaces();
 ```
 
@@ -490,7 +514,7 @@ The "slices should be free of cycles" architecture rule: assert that the namespa
 
 ```csharp
 // No dependency cycles among the namespaces under MyApp
-await Expect.That(In.Namespace("MyApp"))
+await Expect.That(Types.InNamespace("MyApp"))
     .HaveNoDependencyCycles();
 ```
 
@@ -512,7 +536,7 @@ parent/child reference becomes an edge (and can form a cycle):
 
 ```csharp
 // Treat every namespace as its own node (MyApp.Orders ↔ MyApp.Orders.Domain can now form a cycle)
-await Expect.That(In.Namespace("MyApp"))
+await Expect.That(Types.InNamespace("MyApp"))
     .HaveNoDependencyCycles().ExcludingSubNamespaces();
 ```
 
@@ -522,7 +546,7 @@ into the single slice `MyApp.Orders`:
 
 ```csharp
 // Group MyApp.Orders.* / MyApp.Billing.* / … into one slice each before looking for cycles
-await Expect.That(In.Namespace("MyApp"))
+await Expect.That(Types.InNamespace("MyApp"))
     .HaveNoDependencyCycles("MyApp");
 ```
 

--- a/Source/aweXpect.Reflection/Collections/Filtered.Types.cs
+++ b/Source/aweXpect.Reflection/Collections/Filtered.Types.cs
@@ -483,5 +483,65 @@ public static partial class Filtered
 				return new NamespaceDependencyOnlyOnFilterResult(refined, _build);
 			}
 		}
+
+		/// <summary>
+		///     A filtered collection of <see cref="System.Type" /> within a namespace, that also allows clarifying
+		///     the assembly source once (it defaults to all loaded assemblies).
+		/// </summary>
+		/// <remarks>
+		///     The clarification methods return a plain <see cref="Types" /> collection rooted at the given source,
+		///     so the source can only be specified once and must be specified before applying further filters.
+		/// </remarks>
+		public sealed class InNamespaceResult : Types
+		{
+			private readonly string _namespace;
+
+			internal InNamespaceResult(string @namespace)
+				: base(In.AllLoadedAssemblies().Types().WithinNamespace(@namespace))
+			{
+				_namespace = @namespace;
+			}
+
+			/// <summary>
+			///     Clarifies that the types within the namespace are searched in all loaded assemblies from the
+			///     current <see cref="System.AppDomain.CurrentDomain" /> (the default).
+			/// </summary>
+			public Types InAllLoadedAssemblies()
+				=> In.AllLoadedAssemblies().Types().WithinNamespace(_namespace);
+
+			/// <summary>
+			///     Clarifies that the types within the namespace are searched in the given <paramref name="assemblies" />.
+			/// </summary>
+			public Types InAssemblies(params IEnumerable<Assembly?> assemblies)
+				=> new Assemblies(assemblies, $"in the assemblies {Formatter.Format(assemblies)}").Types()
+					.WithinNamespace(_namespace);
+
+			/// <summary>
+			///     Clarifies that the types within the namespace are searched in the assembly that contains
+			///     the <typeparamref name="TType" />.
+			/// </summary>
+			public Types InAssemblyContaining<TType>()
+				=> In.AssemblyContaining<TType>().Types().WithinNamespace(_namespace);
+
+			/// <summary>
+			///     Clarifies that the types within the namespace are searched in the assembly that contains
+			///     the <paramref name="type" />.
+			/// </summary>
+			public Types InAssemblyContaining(Type type)
+				=> In.AssemblyContaining(type).Types().WithinNamespace(_namespace);
+
+			/// <summary>
+			///     Clarifies that the types within the namespace are searched in the <see cref="Assembly.GetEntryAssembly()" />.
+			/// </summary>
+			public Types InEntryAssembly()
+				=> In.EntryAssembly().Types().WithinNamespace(_namespace);
+
+			/// <summary>
+			///     Clarifies that the types within the namespace are searched in the
+			///     <see cref="Assembly.GetExecutingAssembly()" />.
+			/// </summary>
+			public Types InExecutingAssembly()
+				=> In.ExecutingAssembly().Types().WithinNamespace(_namespace);
+		}
 	}
 }

--- a/Source/aweXpect.Reflection/In.cs
+++ b/Source/aweXpect.Reflection/In.cs
@@ -63,18 +63,6 @@ public static class In
 		=> new(Assembly.GetExecutingAssembly(), "in executing assembly");
 
 	/// <summary>
-	///     Defines expectations on all types within the <paramref name="namespace" /> (including sub-namespaces)
-	///     from all loaded assemblies of the current <see cref="System.AppDomain.CurrentDomain" />.
-	/// </summary>
-	/// <remarks>
-	///     This matches the <paramref name="namespace" /> and its sub-namespaces, but not namespaces that merely start
-	///     with the same text (e.g. <c>Foo.Bar</c> does not include <c>Foo.BarBaz</c>). The comparison is exact and
-	///     case-sensitive.
-	/// </remarks>
-	public static Filtered.Types Namespace(string @namespace)
-		=> AllLoadedAssemblies().Types().WithinNamespace(@namespace);
-
-	/// <summary>
 	///     Defines expectations on the type <typeparamref name="TType" />.
 	/// </summary>
 	public static Filtered.Types Type<TType>()

--- a/Source/aweXpect.Reflection/ThatTypes.HaveNoDependencyCycles.cs
+++ b/Source/aweXpect.Reflection/ThatTypes.HaveNoDependencyCycles.cs
@@ -108,7 +108,7 @@ public static partial class ThatTypes
 
 		public ConstraintResult IsMetBy(IEnumerable<Type?> actual)
 		{
-			// Materialize once: the source (e.g. In.Namespace(...)) may be lazy and re-scan assemblies on every
+			// Materialize once: the source (e.g. Types.InNamespace(...)) may be lazy and re-scan assemblies on every
 			// enumeration, while both the cycle detection and the later result formatting read Actual.
 			List<Type?> materialized = [.. actual];
 			Actual = materialized;

--- a/Source/aweXpect.Reflection/Types.cs
+++ b/Source/aweXpect.Reflection/Types.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using aweXpect.Reflection.Collections;
+
+namespace aweXpect.Reflection;
+
+/// <summary>
+///     Static entry point for selecting types by criteria.
+/// </summary>
+public static class Types
+{
+	/// <summary>
+	///     Defines expectations on all types in all loaded assemblies from the current
+	///     <see cref="System.AppDomain.CurrentDomain" />.
+	/// </summary>
+	/// <remarks>
+	///     Assemblies whose name matches one of the <c>ExcludedAssemblyPrefixes</c> at a name-segment boundary
+	///     are skipped — the same matching the dependency assertions use, so one customization value has one
+	///     meaning everywhere.
+	/// </remarks>
+	public static Filtered.Types InAllLoadedAssemblies()
+		=> In.AllLoadedAssemblies().Types();
+
+	/// <summary>
+	///     Defines expectations on all types in the given <paramref name="assemblies" />.
+	/// </summary>
+	public static Filtered.Types InAssemblies(params IEnumerable<Assembly?> assemblies)
+		=> In.Assemblies(assemblies).Types();
+
+	/// <summary>
+	///     Defines expectations on all types in the assembly that contains the <typeparamref name="TType" />.
+	/// </summary>
+	public static Filtered.Types InAssemblyContaining<TType>()
+		=> In.AssemblyContaining<TType>().Types();
+
+	/// <summary>
+	///     Defines expectations on all types in the assembly that contains the <paramref name="type" />.
+	/// </summary>
+	public static Filtered.Types InAssemblyContaining(Type type)
+		=> In.AssemblyContaining(type).Types();
+
+	/// <summary>
+	///     Defines expectations on all types in the <see cref="Assembly.GetEntryAssembly()" />.
+	/// </summary>
+	public static Filtered.Types InEntryAssembly()
+		=> In.EntryAssembly().Types();
+
+	/// <summary>
+	///     Defines expectations on all types in the <see cref="Assembly.GetExecutingAssembly()" />.
+	/// </summary>
+	public static Filtered.Types InExecutingAssembly()
+		=> In.ExecutingAssembly().Types();
+
+	/// <summary>
+	///     Defines expectations on all types within the <paramref name="namespace" /> (including sub-namespaces).
+	/// </summary>
+	/// <remarks>
+	///     By default, the types from all loaded assemblies of the current
+	///     <see cref="System.AppDomain.CurrentDomain" /> are considered; use one of the <c>In*</c> methods on the
+	///     returned collection to clarify a different assembly source.
+	///     <para />
+	///     This matches the <paramref name="namespace" /> and its sub-namespaces, but not namespaces that merely start
+	///     with the same text (e.g. <c>Foo.Bar</c> does not include <c>Foo.BarBaz</c>). The comparison is exact and
+	///     case-sensitive.
+	/// </remarks>
+	public static Filtered.Types.InNamespaceResult InNamespace(string @namespace)
+		=> new(@namespace);
+}

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net10.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net10.0.txt
@@ -329,7 +329,6 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Collections.Filtered.Assemblies ExecutingAssembly() { }
         public static aweXpect.Reflection.Collections.Filtered.Fields Fields(System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo> fields) { }
         public static aweXpect.Reflection.Collections.Filtered.Methods Methods(System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo> methods) { }
-        public static aweXpect.Reflection.Collections.Filtered.Types Namespace(string @namespace) { }
         public static aweXpect.Reflection.Collections.Filtered.Properties Properties(System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo> properties) { }
         public static aweXpect.Reflection.Collections.Filtered.Types Type(System.Type type) { }
         public static aweXpect.Reflection.Collections.Filtered.Types Type<TType>() { }
@@ -2019,6 +2018,16 @@ namespace aweXpect.Reflection
                 where TAttribute : System.Attribute { }
         }
     }
+    public static class Types
+    {
+        public static aweXpect.Reflection.Collections.Filtered.Types InAllLoadedAssemblies() { }
+        public static aweXpect.Reflection.Collections.Filtered.Types InAssemblies(System.Collections.Generic.IEnumerable<System.Reflection.Assembly?> assemblies) { }
+        public static aweXpect.Reflection.Collections.Filtered.Types InAssemblyContaining(System.Type type) { }
+        public static aweXpect.Reflection.Collections.Filtered.Types InAssemblyContaining<TType>() { }
+        public static aweXpect.Reflection.Collections.Filtered.Types InEntryAssembly() { }
+        public static aweXpect.Reflection.Collections.Filtered.Types InExecutingAssembly() { }
+        public static aweXpect.Reflection.Collections.Filtered.Types.InNamespaceResult InNamespace(string @namespace) { }
+    }
 }
 namespace aweXpect.Reflection.Collections
 {
@@ -2186,6 +2195,15 @@ namespace aweXpect.Reflection.Collections
             public string GetDescription() { }
             public aweXpect.Reflection.Collections.Filtered.Methods Methods(aweXpect.Reflection.Collections.MemberScope memberScope = 0) { }
             public aweXpect.Reflection.Collections.Filtered.Properties Properties(aweXpect.Reflection.Collections.MemberScope memberScope = 0) { }
+            public sealed class InNamespaceResult : aweXpect.Reflection.Collections.Filtered.Types
+            {
+                public aweXpect.Reflection.Collections.Filtered.Types InAllLoadedAssemblies() { }
+                public aweXpect.Reflection.Collections.Filtered.Types InAssemblies(System.Collections.Generic.IEnumerable<System.Reflection.Assembly?> assemblies) { }
+                public aweXpect.Reflection.Collections.Filtered.Types InAssemblyContaining(System.Type type) { }
+                public aweXpect.Reflection.Collections.Filtered.Types InAssemblyContaining<TType>() { }
+                public aweXpect.Reflection.Collections.Filtered.Types InEntryAssembly() { }
+                public aweXpect.Reflection.Collections.Filtered.Types InExecutingAssembly() { }
+            }
             public sealed class NamespaceDependencyFilterResult : aweXpect.Reflection.Collections.Filtered.Types
             {
                 public aweXpect.Reflection.Collections.Filtered.Types.NamespaceDependencyFilterResult ExcludingSubNamespaces() { }

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net8.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net8.0.txt
@@ -329,7 +329,6 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Collections.Filtered.Assemblies ExecutingAssembly() { }
         public static aweXpect.Reflection.Collections.Filtered.Fields Fields(System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo> fields) { }
         public static aweXpect.Reflection.Collections.Filtered.Methods Methods(System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo> methods) { }
-        public static aweXpect.Reflection.Collections.Filtered.Types Namespace(string @namespace) { }
         public static aweXpect.Reflection.Collections.Filtered.Properties Properties(System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo> properties) { }
         public static aweXpect.Reflection.Collections.Filtered.Types Type(System.Type type) { }
         public static aweXpect.Reflection.Collections.Filtered.Types Type<TType>() { }
@@ -2019,6 +2018,16 @@ namespace aweXpect.Reflection
                 where TAttribute : System.Attribute { }
         }
     }
+    public static class Types
+    {
+        public static aweXpect.Reflection.Collections.Filtered.Types InAllLoadedAssemblies() { }
+        public static aweXpect.Reflection.Collections.Filtered.Types InAssemblies(System.Collections.Generic.IEnumerable<System.Reflection.Assembly?> assemblies) { }
+        public static aweXpect.Reflection.Collections.Filtered.Types InAssemblyContaining(System.Type type) { }
+        public static aweXpect.Reflection.Collections.Filtered.Types InAssemblyContaining<TType>() { }
+        public static aweXpect.Reflection.Collections.Filtered.Types InEntryAssembly() { }
+        public static aweXpect.Reflection.Collections.Filtered.Types InExecutingAssembly() { }
+        public static aweXpect.Reflection.Collections.Filtered.Types.InNamespaceResult InNamespace(string @namespace) { }
+    }
 }
 namespace aweXpect.Reflection.Collections
 {
@@ -2186,6 +2195,15 @@ namespace aweXpect.Reflection.Collections
             public string GetDescription() { }
             public aweXpect.Reflection.Collections.Filtered.Methods Methods(aweXpect.Reflection.Collections.MemberScope memberScope = 0) { }
             public aweXpect.Reflection.Collections.Filtered.Properties Properties(aweXpect.Reflection.Collections.MemberScope memberScope = 0) { }
+            public sealed class InNamespaceResult : aweXpect.Reflection.Collections.Filtered.Types
+            {
+                public aweXpect.Reflection.Collections.Filtered.Types InAllLoadedAssemblies() { }
+                public aweXpect.Reflection.Collections.Filtered.Types InAssemblies(System.Collections.Generic.IEnumerable<System.Reflection.Assembly?> assemblies) { }
+                public aweXpect.Reflection.Collections.Filtered.Types InAssemblyContaining(System.Type type) { }
+                public aweXpect.Reflection.Collections.Filtered.Types InAssemblyContaining<TType>() { }
+                public aweXpect.Reflection.Collections.Filtered.Types InEntryAssembly() { }
+                public aweXpect.Reflection.Collections.Filtered.Types InExecutingAssembly() { }
+            }
             public sealed class NamespaceDependencyFilterResult : aweXpect.Reflection.Collections.Filtered.Types
             {
                 public aweXpect.Reflection.Collections.Filtered.Types.NamespaceDependencyFilterResult ExcludingSubNamespaces() { }

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_netstandard2.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_netstandard2.0.txt
@@ -329,7 +329,6 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Collections.Filtered.Assemblies ExecutingAssembly() { }
         public static aweXpect.Reflection.Collections.Filtered.Fields Fields(System.Collections.Generic.IEnumerable<System.Reflection.FieldInfo> fields) { }
         public static aweXpect.Reflection.Collections.Filtered.Methods Methods(System.Collections.Generic.IEnumerable<System.Reflection.MethodInfo> methods) { }
-        public static aweXpect.Reflection.Collections.Filtered.Types Namespace(string @namespace) { }
         public static aweXpect.Reflection.Collections.Filtered.Properties Properties(System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo> properties) { }
         public static aweXpect.Reflection.Collections.Filtered.Types Type(System.Type type) { }
         public static aweXpect.Reflection.Collections.Filtered.Types Type<TType>() { }
@@ -1658,6 +1657,16 @@ namespace aweXpect.Reflection
                 where TAttribute : System.Attribute { }
         }
     }
+    public static class Types
+    {
+        public static aweXpect.Reflection.Collections.Filtered.Types InAllLoadedAssemblies() { }
+        public static aweXpect.Reflection.Collections.Filtered.Types InAssemblies(System.Collections.Generic.IEnumerable<System.Reflection.Assembly?> assemblies) { }
+        public static aweXpect.Reflection.Collections.Filtered.Types InAssemblyContaining(System.Type type) { }
+        public static aweXpect.Reflection.Collections.Filtered.Types InAssemblyContaining<TType>() { }
+        public static aweXpect.Reflection.Collections.Filtered.Types InEntryAssembly() { }
+        public static aweXpect.Reflection.Collections.Filtered.Types InExecutingAssembly() { }
+        public static aweXpect.Reflection.Collections.Filtered.Types.InNamespaceResult InNamespace(string @namespace) { }
+    }
 }
 namespace aweXpect.Reflection.Collections
 {
@@ -1825,6 +1834,15 @@ namespace aweXpect.Reflection.Collections
             public string GetDescription() { }
             public aweXpect.Reflection.Collections.Filtered.Methods Methods(aweXpect.Reflection.Collections.MemberScope memberScope = 0) { }
             public aweXpect.Reflection.Collections.Filtered.Properties Properties(aweXpect.Reflection.Collections.MemberScope memberScope = 0) { }
+            public sealed class InNamespaceResult : aweXpect.Reflection.Collections.Filtered.Types
+            {
+                public aweXpect.Reflection.Collections.Filtered.Types InAllLoadedAssemblies() { }
+                public aweXpect.Reflection.Collections.Filtered.Types InAssemblies(System.Collections.Generic.IEnumerable<System.Reflection.Assembly?> assemblies) { }
+                public aweXpect.Reflection.Collections.Filtered.Types InAssemblyContaining(System.Type type) { }
+                public aweXpect.Reflection.Collections.Filtered.Types InAssemblyContaining<TType>() { }
+                public aweXpect.Reflection.Collections.Filtered.Types InEntryAssembly() { }
+                public aweXpect.Reflection.Collections.Filtered.Types InExecutingAssembly() { }
+            }
             public sealed class NamespaceDependencyFilterResult : aweXpect.Reflection.Collections.Filtered.Types
             {
                 public aweXpect.Reflection.Collections.Filtered.Types.NamespaceDependencyFilterResult ExcludingSubNamespaces() { }

--- a/Tests/aweXpect.Reflection.Tests/Collections/FilteredReuseIndependenceTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Collections/FilteredReuseIndependenceTests.cs
@@ -161,7 +161,7 @@ public sealed class FilteredReuseIndependenceTests
 		const string layer2 = "aweXpect.Reflection.Tests.TestHelpers.Dependencies.Layer2";
 		const string consumers = "aweXpect.Reflection.Tests.TestHelpers.Dependencies.Consumers";
 
-		Filtered.Types.NamespaceDependencyFilterResult @base = In.Namespace(consumers).WhichDependOn(layer1);
+		Filtered.Types.NamespaceDependencyFilterResult @base = Types.InNamespace(consumers).WhichDependOn(layer1);
 
 		// Branch a separate view off the base, then widen the base. The branch must not see the widening.
 		Filtered.Types branch = @base.Which(_ => true);

--- a/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichDependOn.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichDependOn.Tests.cs
@@ -15,7 +15,7 @@ public sealed partial class TypeFilters
 			[Fact]
 			public async Task ShouldFilterForTypesDependingOnNamespace()
 			{
-				Filtered.Types types = In.Namespace(ConsumersNamespace).WhichDependOn(Layer1Namespace);
+				Filtered.Types types = Types.InNamespace(ConsumersNamespace).WhichDependOn(Layer1Namespace);
 
 				await That(types).Contains(typeof(ViaField));
 				await That(types).Contains(typeof(ViaSubNamespace));
@@ -25,7 +25,7 @@ public sealed partial class TypeFilters
 			[Fact]
 			public async Task WhenExcludingSubNamespaces_ShouldNotMatchSubNamespace()
 			{
-				Filtered.Types types = In.Namespace(ConsumersNamespace)
+				Filtered.Types types = Types.InNamespace(ConsumersNamespace)
 					.WhichDependOn(Layer1Namespace).ExcludingSubNamespaces();
 
 				await That(types).Contains(typeof(ViaField));
@@ -35,7 +35,7 @@ public sealed partial class TypeFilters
 			[Fact]
 			public async Task WhenWidenedWithOrOn_ShouldMatchEither()
 			{
-				Filtered.Types types = In.Namespace(ConsumersNamespace)
+				Filtered.Types types = Types.InNamespace(ConsumersNamespace)
 					.WhichDependOn("Non.Existent.Namespace").OrOn(Layer1Namespace);
 
 				await That(types).Contains(typeof(ViaField));
@@ -44,7 +44,7 @@ public sealed partial class TypeFilters
 			[Fact]
 			public async Task WhenNoNamespaceIsSpecified_ShouldThrowArgumentException()
 			{
-				void Act() => _ = In.Namespace(ConsumersNamespace).WhichDependOn();
+				void Act() => _ = Types.InNamespace(ConsumersNamespace).WhichDependOn();
 
 				await That(Act).Throws<ArgumentException>()
 					.WithMessage("At least one namespace must be specified.");

--- a/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichDependOnlyOn.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichDependOnlyOn.Tests.cs
@@ -15,7 +15,7 @@ public sealed partial class TypeFilters
 			[Fact]
 			public async Task ShouldFilterForTypesDependingOnlyOnAllowedNamespaces()
 			{
-				Filtered.Types types = In.Namespace(ConsumersNamespace).WhichDependOnlyOn(Layer1Namespace);
+				Filtered.Types types = Types.InNamespace(ConsumersNamespace).WhichDependOnlyOn(Layer1Namespace);
 
 				await That(types).Contains(typeof(OnlyLayer1));
 				await That(types).Contains(typeof(FrameworkConsumer));

--- a/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichDoNotDependOn.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichDoNotDependOn.Tests.cs
@@ -15,7 +15,7 @@ public sealed partial class TypeFilters
 			[Fact]
 			public async Task ShouldFilterForTypesNotDependingOnNamespace()
 			{
-				Filtered.Types types = In.Namespace(ConsumersNamespace).WhichDoNotDependOn(Layer1Namespace);
+				Filtered.Types types = Types.InNamespace(ConsumersNamespace).WhichDoNotDependOn(Layer1Namespace);
 
 				await That(types).Contains(typeof(FrameworkConsumer));
 				await That(types).DoesNotContain(typeof(ViaField));

--- a/Tests/aweXpect.Reflection.Tests/InTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/InTests.cs
@@ -2,10 +2,6 @@
 using System.Reflection;
 using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
-using aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope;
-using aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope.Nested;
-using aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScopeSibling;
-using Xunit.Sdk;
 
 namespace aweXpect.Reflection.Tests;
 
@@ -161,79 +157,6 @@ public sealed class InTests
 		Filtered.Methods sut = In.Methods(method);
 
 		await That(sut).HasSingle().Which.IsEqualTo(method);
-	}
-
-	[Fact]
-	public async Task Namespace_ShouldContainTypesWithinNamespaceIncludingSubNamespaces()
-	{
-		Filtered.Types sut = In.Namespace("aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope");
-
-		await That(sut).Contains(typeof(ClassInNamespaceScope));
-		await That(sut).Contains(typeof(ClassInNestedNamespaceScope));
-		await That(sut).DoesNotContain(typeof(ClassInSiblingNamespaceScope));
-		await That(sut.GetDescription())
-			.IsEqualTo(
-				"types within namespace \"aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope\" in all loaded assemblies");
-	}
-
-	[Fact]
-	public async Task Namespace_ShouldSelectTypesThatCanBeAsserted()
-	{
-		Filtered.Types sut = In.Namespace("aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope");
-
-		async Task Act()
-			=> await That(sut)
-				.AreWithinNamespace("aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope");
-
-		await That(Act).DoesNotThrow();
-	}
-
-	[Fact]
-	public async Task Namespace_WhenAssertionFails_ShouldReportFullMessage()
-	{
-		Filtered.Types sut = In.Namespace("aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope");
-
-		async Task Act()
-			=> await That(sut)
-				.AreWithinNamespace("aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScopeSibling");
-
-		await That(Act).Throws<XunitException>()
-			.WithMessage("""
-			             Expected that types within namespace "aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope" in all loaded assemblies
-			             are all within namespace "aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScopeSibling",
-			             but it contained not matching types [
-			               *
-			             ]
-			             """).AsWildcard();
-	}
-
-	[Fact]
-	public async Task Namespace_WhenNegatingMatchingAssertion_ShouldReportFullMessage()
-	{
-		Filtered.Types sut = In.Namespace("aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope");
-
-		async Task Act()
-			=> await That(sut).DoesNotComplyWith(they
-				=> they.AreWithinNamespace("aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope"));
-
-		await That(Act).Throws<XunitException>()
-			.WithMessage("""
-			             Expected that types within namespace "aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope" in all loaded assemblies
-			             are not all within namespace "aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope",
-			             but it only contained matching types [
-			               *
-			             ]
-			             """).AsWildcard();
-	}
-
-	[Fact]
-	public async Task Namespace_WhenNoTypesAreInNamespace_ShouldBeEmpty()
-	{
-		Filtered.Types sut = In.Namespace("Non.Existent.Namespace");
-
-		await That(sut).IsEmpty();
-		await That(sut.GetDescription())
-			.IsEqualTo("types within namespace \"Non.Existent.Namespace\" in all loaded assemblies");
 	}
 
 	[Fact]

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.HaveNoDependencyCycles.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.HaveNoDependencyCycles.Tests.cs
@@ -126,7 +126,7 @@ public sealed partial class ThatTypes
 			public async Task WhenUsingNamespaceSource_ShouldDetectCycle()
 			{
 				async Task Act()
-					=> await That(In.Namespace($"{Prefix}.Two")).HaveNoDependencyCycles();
+					=> await That(Types.InNamespace($"{Prefix}.Two")).HaveNoDependencyCycles();
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("*had a dependency cycle*").AsWildcard();

--- a/Tests/aweXpect.Reflection.Tests/TypesTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/TypesTests.cs
@@ -1,0 +1,229 @@
+using System.Collections.Generic;
+using System.Reflection;
+using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope;
+using aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope.Nested;
+using aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScopeSibling;
+using Xunit.Sdk;
+
+namespace aweXpect.Reflection.Tests;
+
+// ReSharper disable PossibleMultipleEnumeration
+public sealed class TypesTests
+{
+	private const string NamespaceScope = "aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope";
+
+	[Fact]
+	public async Task InAllLoadedAssemblies_ShouldContainTypesFromMultipleAssemblies()
+	{
+		Filtered.Types sut = Types.InAllLoadedAssemblies();
+
+		await That(sut).Contains(typeof(TypesTests));
+		await That(sut).Contains(typeof(In));
+		await That(sut.GetDescription()).IsEqualTo("types in all loaded assemblies");
+	}
+
+	[Fact]
+	public async Task InAssemblies_WithEnumerable_ShouldContainTypesFromProvidedAssemblies()
+	{
+		IEnumerable<Assembly?> assemblies = [typeof(TypesTests).Assembly,];
+
+		Filtered.Types sut = Types.InAssemblies(assemblies);
+
+		await That(sut).Contains(typeof(TypesTests));
+		await That(sut).DoesNotContain(typeof(In));
+	}
+
+	[Fact]
+	public async Task InAssemblies_WithMultipleAssemblies_ShouldContainTypesFromProvidedAssemblies()
+	{
+		Filtered.Types sut = Types.InAssemblies(typeof(In).Assembly, typeof(TypesTests).Assembly);
+
+		await That(sut).Contains(typeof(In));
+		await That(sut).Contains(typeof(TypesTests));
+		await That(sut.GetDescription())
+			.IsEqualTo("types in the assemblies [aweXpect.Reflection*, aweXpect.Reflection.Tests*]").AsWildcard();
+	}
+
+	[Fact]
+	public async Task InAssemblyContaining_WithGeneric_ShouldContainTypesFromAssemblyOfProvidedType()
+	{
+		Filtered.Types sut = Types.InAssemblyContaining<TypesTests>();
+
+		await That(sut).Contains(typeof(TypesTests));
+		await That(sut).DoesNotContain(typeof(In));
+		await That(sut.GetDescription()).IsEqualTo("types in assembly containing type TypesTests");
+	}
+
+	[Fact]
+	public async Task InAssemblyContaining_WithType_ShouldContainTypesFromAssemblyOfProvidedType()
+	{
+		Filtered.Types sut = Types.InAssemblyContaining(typeof(In));
+
+		await That(sut).Contains(typeof(In));
+		await That(sut).DoesNotContain(typeof(TypesTests));
+		await That(sut.GetDescription()).IsEqualTo("types in assembly containing type In");
+	}
+
+	[Fact]
+	public async Task InEntryAssembly_ShouldUseEntryAssemblyAsSource()
+	{
+		Filtered.Types sut = Types.InEntryAssembly();
+
+		await That(sut).DoesNotContain(typeof(TypesTests));
+		await That(sut.GetDescription()).IsEqualTo("types in entry assembly");
+	}
+
+	[Fact]
+	public async Task InExecutingAssembly_ShouldContainTypesFromExecutingAssembly()
+	{
+		Filtered.Types sut = Types.InExecutingAssembly();
+
+		await That(sut).Contains(typeof(In));
+		await That(sut.GetDescription()).IsEqualTo("types in executing assembly");
+	}
+
+	[Fact]
+	public async Task InNamespace_ShouldContainTypesWithinNamespaceIncludingSubNamespaces()
+	{
+		Filtered.Types sut = Types.InNamespace(NamespaceScope);
+
+		await That(sut).Contains(typeof(ClassInNamespaceScope));
+		await That(sut).Contains(typeof(ClassInNestedNamespaceScope));
+		await That(sut).DoesNotContain(typeof(ClassInSiblingNamespaceScope));
+		await That(sut.GetDescription())
+			.IsEqualTo($"types within namespace \"{NamespaceScope}\" in all loaded assemblies");
+	}
+
+	[Fact]
+	public async Task InNamespace_ShouldSelectTypesThatCanBeAsserted()
+	{
+		Filtered.Types sut = Types.InNamespace(NamespaceScope);
+
+		async Task Act()
+			=> await That(sut).AreWithinNamespace(NamespaceScope);
+
+		await That(Act).DoesNotThrow();
+	}
+
+	[Fact]
+	public async Task InNamespace_WhenAssertionFails_ShouldReportFullMessage()
+	{
+		Filtered.Types sut = Types.InNamespace(NamespaceScope);
+
+		async Task Act()
+			=> await That(sut)
+				.AreWithinNamespace("aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScopeSibling");
+
+		await That(Act).Throws<XunitException>()
+			.WithMessage("""
+			             Expected that types within namespace "aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope" in all loaded assemblies
+			             are all within namespace "aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScopeSibling",
+			             but it contained not matching types [
+			               *
+			             ]
+			             """).AsWildcard();
+	}
+
+	[Fact]
+	public async Task InNamespace_WhenNegatingMatchingAssertion_ShouldReportFullMessage()
+	{
+		Filtered.Types sut = Types.InNamespace(NamespaceScope);
+
+		async Task Act()
+			=> await That(sut).DoesNotComplyWith(they
+				=> they.AreWithinNamespace(NamespaceScope));
+
+		await That(Act).Throws<XunitException>()
+			.WithMessage("""
+			             Expected that types within namespace "aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope" in all loaded assemblies
+			             are not all within namespace "aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope",
+			             but it only contained matching types [
+			               *
+			             ]
+			             """).AsWildcard();
+	}
+
+	[Fact]
+	public async Task InNamespace_WhenNoTypesAreInNamespace_ShouldBeEmpty()
+	{
+		Filtered.Types sut = Types.InNamespace("Non.Existent.Namespace");
+
+		await That(sut).IsEmpty();
+		await That(sut.GetDescription())
+			.IsEqualTo("types within namespace \"Non.Existent.Namespace\" in all loaded assemblies");
+	}
+
+	[Fact]
+	public async Task InNamespace_InAllLoadedAssemblies_ShouldMatchDefaultSource()
+	{
+		Filtered.Types sut = Types.InNamespace(NamespaceScope).InAllLoadedAssemblies();
+
+		await That(sut).Contains(typeof(ClassInNamespaceScope));
+		await That(sut.GetDescription())
+			.IsEqualTo($"types within namespace \"{NamespaceScope}\" in all loaded assemblies");
+	}
+
+	[Fact]
+	public async Task InNamespace_InAssemblies_ShouldLimitSourceToProvidedAssemblies()
+	{
+		Filtered.Types sut = Types.InNamespace(NamespaceScope).InAssemblies(typeof(TypesTests).Assembly);
+
+		await That(sut).Contains(typeof(ClassInNamespaceScope));
+		await That(sut.GetDescription())
+			.IsEqualTo($"types within namespace \"{NamespaceScope}\" in the assemblies [aweXpect.Reflection.Tests*]")
+			.AsWildcard();
+	}
+
+	[Fact]
+	public async Task InNamespace_InAssemblyContaining_WithGeneric_ShouldLimitSourceToAssemblyOfProvidedType()
+	{
+		Filtered.Types sut = Types.InNamespace(NamespaceScope).InAssemblyContaining<ClassInNamespaceScope>();
+
+		await That(sut).Contains(typeof(ClassInNamespaceScope));
+		await That(sut.GetDescription())
+			.IsEqualTo(
+				$"types within namespace \"{NamespaceScope}\" in assembly containing type ClassInNamespaceScope");
+	}
+
+	[Fact]
+	public async Task InNamespace_InAssemblyContaining_WithType_WhenAssemblyDoesNotContainNamespace_ShouldBeEmpty()
+	{
+		Filtered.Types sut = Types.InNamespace(NamespaceScope).InAssemblyContaining(typeof(In));
+
+		await That(sut).IsEmpty();
+		await That(sut.GetDescription())
+			.IsEqualTo($"types within namespace \"{NamespaceScope}\" in assembly containing type In");
+	}
+
+	[Fact]
+	public async Task InNamespace_InEntryAssembly_ShouldUseEntryAssemblyAsSource()
+	{
+		Filtered.Types sut = Types.InNamespace(NamespaceScope).InEntryAssembly();
+
+		await That(sut).IsEmpty();
+		await That(sut.GetDescription())
+			.IsEqualTo($"types within namespace \"{NamespaceScope}\" in entry assembly");
+	}
+
+	[Fact]
+	public async Task InNamespace_InExecutingAssembly_ShouldUseExecutingAssemblyAsSource()
+	{
+		Filtered.Types sut = Types.InNamespace(NamespaceScope).InExecutingAssembly();
+
+		await That(sut).IsEmpty();
+		await That(sut.GetDescription())
+			.IsEqualTo($"types within namespace \"{NamespaceScope}\" in executing assembly");
+	}
+
+	[Fact]
+	public async Task InNamespace_AfterClarification_OriginalShouldStillUseAllLoadedAssemblies()
+	{
+		Filtered.Types.InNamespaceResult sut = Types.InNamespace(NamespaceScope);
+		_ = sut.InAssemblyContaining(typeof(In));
+
+		await That(sut).Contains(typeof(ClassInNamespaceScope));
+		await That(sut.GetDescription())
+			.IsEqualTo($"types within namespace \"{NamespaceScope}\" in all loaded assemblies");
+	}
+}


### PR DESCRIPTION
`In.Namespace(...)` (introduced in #319) read poorly in architecture rules and hid that it selects types. The new `Types` class is the entry point for selecting types by criteria, while `In` keeps starting from concrete reflection objects:

- `Types.InNamespace(ns)` replaces `In.Namespace(ns)` and returns `Filtered.Types.InNamespaceResult`, which defaults to all loaded assemblies and allows clarifying the assembly source once (before any further filters) via the same `In*` methods.
- `Types.InAllLoadedAssemblies()`, `Types.InAssemblies(...)`, `Types.InAssemblyContaining<T>()` / `(Type)`, `Types.InEntryAssembly()` and `Types.InExecutingAssembly()` select all types in the respective assemblies.