### PR TITLE
feat: add immutability assertions and filters for types

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,7 @@ outside the namespace.
 | assignable to       | `.WhichAreAssignableTo<T>()`                    | `.IsAssignableTo<T>()`      | `.AreAssignableTo<T>()`      |
 | assignable from     | `.WhichAreAssignableFrom<T>()`                  | `.IsAssignableFrom<T>()`    | `.AreAssignableFrom<T>()`    |
 | instantiable        | `.WhichAreInstantiable()`                       | `.IsInstantiable()`         | `.AreInstantiable()`         |
+| immutable           | `.WhichAreImmutable()`                          | `.IsImmutable()`            | `.AreImmutable()`            |
 | default constructor | `.WhichHaveADefaultConstructor()`               | `.HasADefaultConstructor()` | `.HaveADefaultConstructor()` |
 | custom predicate    | `.Which(t => …)`                                | `.Satisfies(t => …)`        | `.All().Satisfy(t => …)`     |
 
@@ -322,6 +323,10 @@ A type is *instantiable* when it is a concrete type that is neither abstract, st
 an open generic type definition. *Default constructor* checks for an accessible parameterless constructor
 (value types always have one); this is independent of instantiability (e.g. a type with only a parameterized
 constructor is instantiable but has no default constructor).
+
+A type is *immutable* when all instance fields (including inherited ones) are `readonly` and all instance
+properties (including inherited ones) have no setter or an `init`-only setter. Static members do not affect
+immutability. Failure messages list the offending mutable members for actionable feedback.
 
 > **Negation:** every kind/modifier row above has a negated form. Most use `WhichAreNot…` on filters and
 > `IsNot…` / `AreNot…` on assertions (e.g. `WhichAreNotSealed()`, `IsNotAClass()`, `AreNotStatic()`,

--- a/Source/aweXpect.Reflection/Filters/TypeFilters.WhichAreImmutable.cs
+++ b/Source/aweXpect.Reflection/Filters/TypeFilters.WhichAreImmutable.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Helpers;
+
+namespace aweXpect.Reflection;
+
+public static partial class TypeFilters
+{
+	/// <summary>
+	///     Filters for types that are immutable.
+	/// </summary>
+	/// <remarks>
+	///     A type is considered immutable when all instance fields (including inherited ones) are
+	///     <see langword="readonly" /> and all instance properties (including inherited ones) have no setter
+	///     or an init-only setter.
+	/// </remarks>
+	public static Filtered.Types WhichAreImmutable(this Filtered.Types @this)
+		=> @this.Which(Filter.Prefix<Type>(
+			type => type.IsImmutable(),
+			"immutable "));
+
+	/// <summary>
+	///     Filters for types that are not immutable.
+	/// </summary>
+	/// <remarks>
+	///     A type is considered immutable when all instance fields (including inherited ones) are
+	///     <see langword="readonly" /> and all instance properties (including inherited ones) have no setter
+	///     or an init-only setter.
+	/// </remarks>
+	public static Filtered.Types WhichAreNotImmutable(this Filtered.Types @this)
+		=> @this.Which(Filter.Prefix<Type>(
+			type => !type.IsImmutable(),
+			"mutable "));
+}

--- a/Source/aweXpect.Reflection/Helpers/TypeHelpers.cs
+++ b/Source/aweXpect.Reflection/Helpers/TypeHelpers.cs
@@ -1312,6 +1312,32 @@ internal static class TypeHelpers
 		=> type is { IsAbstract: false, IsGenericTypeDefinition: false, };
 
 	/// <summary>
+	///     Gets a value indicating whether the <see cref="Type" /> is immutable.
+	/// </summary>
+	/// <param name="type">The <see cref="Type" />.</param>
+	/// <remarks>
+	///     A type is considered immutable when all instance fields (including inherited ones) are
+	///     <see langword="readonly" /> and all instance properties (including inherited ones) have no setter
+	///     or an init-only setter.
+	/// </remarks>
+	public static bool IsImmutable(this Type? type)
+		=> type is not null && type.GetMutableMembers().Length == 0;
+
+	/// <summary>
+	///     Gets the mutable instance members of the <paramref name="type" />: fields (including inherited ones)
+	///     that are not <see langword="readonly" /> and properties (including inherited ones) with a regular
+	///     (non-init) setter.
+	/// </summary>
+	/// <param name="type">The <see cref="Type" />.</param>
+	public static MemberInfo[] GetMutableMembers(this Type type)
+		=> type.GetDeclaredFields(MemberScope.IncludingInherited)
+			.Where(field => field is { IsStatic: false, IsInitOnly: false, })
+			.OfType<MemberInfo>()
+			.Concat(type.GetDeclaredProperties(MemberScope.IncludingInherited)
+				.Where(property => !property.IsReallyStatic() && property.HasSetter()))
+			.ToArray();
+
+	/// <summary>
 	///     Gets a value indicating whether the <see cref="Type" /> has an accessible parameterless (default) constructor.
 	/// </summary>
 	/// <param name="type">The <see cref="Type" />.</param>

--- a/Source/aweXpect.Reflection/ThatType.IsImmutable.cs
+++ b/Source/aweXpect.Reflection/ThatType.IsImmutable.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Text;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Reflection.Helpers;
+using aweXpect.Results;
+
+namespace aweXpect.Reflection;
+
+public static partial class ThatType
+{
+	/// <summary>
+	///     Verifies that the <see cref="Type" /> is immutable.
+	/// </summary>
+	/// <remarks>
+	///     A type is considered immutable when all instance fields (including inherited ones) are
+	///     <see langword="readonly" /> and all instance properties (including inherited ones) have no setter
+	///     or an init-only setter.
+	/// </remarks>
+	public static AndOrResult<Type?, IThat<Type?>> IsImmutable(
+		this IThat<Type?> subject)
+		=> new(subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new IsImmutableConstraint(it, grammars)),
+			subject);
+
+	/// <summary>
+	///     Verifies that the <see cref="Type" /> is not immutable.
+	/// </summary>
+	/// <remarks>
+	///     A type is considered immutable when all instance fields (including inherited ones) are
+	///     <see langword="readonly" /> and all instance properties (including inherited ones) have no setter
+	///     or an init-only setter.
+	/// </remarks>
+	public static AndOrResult<Type?, IThat<Type?>> IsNotImmutable(
+		this IThat<Type?> subject)
+		=> new(subject.Get().ExpectationBuilder.AddConstraint((it, grammars)
+				=> new IsImmutableConstraint(it, grammars).Invert()),
+			subject);
+
+	private sealed class IsImmutableConstraint(string it, ExpectationGrammars grammars)
+		: ConstraintResult.WithNotNullValue<Type?>(it, grammars),
+			IValueConstraint<Type?>
+	{
+		public ConstraintResult IsMetBy(Type? actual)
+		{
+			Actual = actual;
+			Outcome = actual.IsImmutable() ? Outcome.Success : Outcome.Failure;
+			return this;
+		}
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("is immutable");
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			// The mutable members are only needed for this failure message, so they are collected lazily here
+			// instead of on every (typically succeeding) evaluation.
+			stringBuilder.Append(It).Append(" was mutable ");
+			Formatter.Format(stringBuilder, Actual);
+			stringBuilder.Append(" with mutable members ");
+			Formatter.Format(stringBuilder, Actual!.GetMutableMembers(), FormattingOptions.Indented(indentation));
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("is not immutable");
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(It).Append(" was immutable ");
+			Formatter.Format(stringBuilder, Actual);
+		}
+	}
+}

--- a/Source/aweXpect.Reflection/ThatTypes.AreImmutable.cs
+++ b/Source/aweXpect.Reflection/ThatTypes.AreImmutable.cs
@@ -1,0 +1,148 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using aweXpect.Core;
+using aweXpect.Core.Constraints;
+using aweXpect.Reflection.Helpers;
+using aweXpect.Results;
+#if NET8_0_OR_GREATER
+using System.Threading;
+using System.Threading.Tasks;
+#endif
+
+// ReSharper disable PossibleMultipleEnumeration
+
+namespace aweXpect.Reflection;
+
+public static partial class ThatTypes
+{
+	/// <summary>
+	///     Verifies that all items in the filtered collection of <see cref="Type" /> are immutable.
+	/// </summary>
+	/// <remarks>
+	///     A type is considered immutable when all instance fields (including inherited ones) are
+	///     <see langword="readonly" /> and all instance properties (including inherited ones) have no setter
+	///     or an init-only setter.
+	/// </remarks>
+	public static AndOrResult<IEnumerable<Type?>, IThat<IEnumerable<Type?>>> AreImmutable(
+		this IThat<IEnumerable<Type?>> subject)
+		=> new(subject.Get().ExpectationBuilder.AddConstraint<IEnumerable<Type?>>((it, grammars)
+				=> new AreImmutableConstraint(it, grammars)),
+			subject);
+
+#if NET8_0_OR_GREATER
+	/// <summary>
+	///     Verifies that all items in the filtered collection of <see cref="Type" /> are immutable.
+	/// </summary>
+	/// <remarks>
+	///     A type is considered immutable when all instance fields (including inherited ones) are
+	///     <see langword="readonly" /> and all instance properties (including inherited ones) have no setter
+	///     or an init-only setter.
+	/// </remarks>
+	public static AndOrResult<IAsyncEnumerable<Type?>, IThat<IAsyncEnumerable<Type?>>> AreImmutable(
+		this IThat<IAsyncEnumerable<Type?>> subject)
+		=> new(subject.Get().ExpectationBuilder.AddConstraint<IAsyncEnumerable<Type?>>((it, grammars)
+				=> new AreImmutableConstraint(it, grammars)),
+			subject);
+#endif
+
+	/// <summary>
+	///     Verifies that all items in the filtered collection of <see cref="Type" /> are not immutable.
+	/// </summary>
+	/// <remarks>
+	///     A type is considered immutable when all instance fields (including inherited ones) are
+	///     <see langword="readonly" /> and all instance properties (including inherited ones) have no setter
+	///     or an init-only setter.
+	/// </remarks>
+	public static AndOrResult<IEnumerable<Type?>, IThat<IEnumerable<Type?>>> AreNotImmutable(
+		this IThat<IEnumerable<Type?>> subject)
+		=> new(subject.Get().ExpectationBuilder.AddConstraint<IEnumerable<Type?>>((it, grammars)
+				=> new AreNotImmutableConstraint(it, grammars)),
+			subject);
+
+#if NET8_0_OR_GREATER
+	/// <summary>
+	///     Verifies that all items in the filtered collection of <see cref="Type" /> are not immutable.
+	/// </summary>
+	/// <remarks>
+	///     A type is considered immutable when all instance fields (including inherited ones) are
+	///     <see langword="readonly" /> and all instance properties (including inherited ones) have no setter
+	///     or an init-only setter.
+	/// </remarks>
+	public static AndOrResult<IAsyncEnumerable<Type?>, IThat<IAsyncEnumerable<Type?>>> AreNotImmutable(
+		this IThat<IAsyncEnumerable<Type?>> subject)
+		=> new(subject.Get().ExpectationBuilder.AddConstraint<IAsyncEnumerable<Type?>>((it, grammars)
+				=> new AreNotImmutableConstraint(it, grammars)),
+			subject);
+#endif
+
+	private sealed class AreImmutableConstraint(string it, ExpectationGrammars grammars)
+		: CollectionConstraintResult<Type?>(grammars),
+			IValueConstraint<IEnumerable<Type?>>
+#if NET8_0_OR_GREATER
+			, IAsyncConstraint<IAsyncEnumerable<Type?>>
+#endif
+	{
+#if NET8_0_OR_GREATER
+		public async Task<ConstraintResult> IsMetBy(IAsyncEnumerable<Type?> actual,
+			CancellationToken cancellationToken)
+			=> await SetAsyncValue(actual, type => type.IsImmutable());
+#endif
+
+		public ConstraintResult IsMetBy(IEnumerable<Type?> actual)
+			=> SetValue(actual, type => type.IsImmutable());
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("are all immutable");
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(it).Append(" contained mutable types ");
+			Formatter.Format(stringBuilder, NotMatching, FormattingOptions.Indented(indentation));
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("are not all immutable");
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(it).Append(" only contained immutable types ");
+			Formatter.Format(stringBuilder, Matching, FormattingOptions.Indented(indentation));
+		}
+	}
+
+	private sealed class AreNotImmutableConstraint(string it, ExpectationGrammars grammars)
+		: CollectionConstraintResult<Type?>(grammars),
+			IValueConstraint<IEnumerable<Type?>>
+#if NET8_0_OR_GREATER
+			, IAsyncConstraint<IAsyncEnumerable<Type?>>
+#endif
+	{
+#if NET8_0_OR_GREATER
+		public async Task<ConstraintResult> IsMetBy(IAsyncEnumerable<Type?> actual,
+			CancellationToken cancellationToken)
+			=> await SetAsyncValue(actual, type => !type.IsImmutable());
+#endif
+
+		public ConstraintResult IsMetBy(IEnumerable<Type?> actual)
+			=> SetValue(actual, type => !type.IsImmutable());
+
+		protected override void AppendNormalExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("are all not immutable");
+
+		protected override void AppendNormalResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(it).Append(" contained immutable types ");
+			Formatter.Format(stringBuilder, NotMatching, FormattingOptions.Indented(indentation));
+		}
+
+		protected override void AppendNegatedExpectation(StringBuilder stringBuilder, string? indentation = null)
+			=> stringBuilder.Append("also contain an immutable type");
+
+		protected override void AppendNegatedResult(StringBuilder stringBuilder, string? indentation = null)
+		{
+			stringBuilder.Append(it).Append(" only contained mutable types ");
+			Formatter.Format(stringBuilder, Matching, FormattingOptions.Indented(indentation));
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net10.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net10.0.txt
@@ -1674,6 +1674,7 @@ namespace aweXpect.Reflection
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsAssignableTo(this aweXpect.Core.IThat<System.Type?> subject, System.Type type) { }
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsAssignableTo<TType>(this aweXpect.Core.IThat<System.Type?> subject) { }
         public static aweXpect.Reflection.Results.GenericArgumentCollectionResult<System.Type?> IsGeneric(this aweXpect.Core.IThat<System.Type?> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsImmutable(this aweXpect.Core.IThat<System.Type?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsInstantiable(this aweXpect.Core.IThat<System.Type?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsNested(this aweXpect.Core.IThat<System.Type?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsNotAClass(this aweXpect.Core.IThat<System.Type?> subject) { }
@@ -1692,6 +1693,7 @@ namespace aweXpect.Reflection
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsNotAssignableTo(this aweXpect.Core.IThat<System.Type?> subject, System.Type type) { }
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsNotAssignableTo<TType>(this aweXpect.Core.IThat<System.Type?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsNotGeneric(this aweXpect.Core.IThat<System.Type?> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsNotImmutable(this aweXpect.Core.IThat<System.Type?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsNotInstantiable(this aweXpect.Core.IThat<System.Type?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsNotNested(this aweXpect.Core.IThat<System.Type?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsNotReadOnly(this aweXpect.Core.IThat<System.Type?> subject) { }
@@ -1727,6 +1729,8 @@ namespace aweXpect.Reflection
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreExceptions(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
         public static aweXpect.Reflection.Results.GenericArgumentCollectionResult<System.Collections.Generic.IAsyncEnumerable<System.Type?>> AreGeneric(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>> subject) { }
         public static aweXpect.Reflection.Results.GenericArgumentCollectionResult<System.Collections.Generic.IEnumerable<System.Type?>> AreGeneric(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>>> AreImmutable(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreImmutable(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>>> AreInstantiable(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreInstantiable(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>>> AreInterfaces(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>> subject) { }
@@ -1755,6 +1759,8 @@ namespace aweXpect.Reflection
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreNotExceptions(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>>> AreNotGeneric(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreNotGeneric(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>>> AreNotImmutable(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreNotImmutable(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>>> AreNotInstantiable(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreNotInstantiable(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>>> AreNotInterfaces(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>> subject) { }
@@ -1900,6 +1906,7 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreEnums(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreExceptions(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.TypeFilters.GenericTypes WhichAreGeneric(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
+        public static aweXpect.Reflection.Collections.Filtered.Types WhichAreImmutable(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreInstantiable(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreInterfaces(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreInternal(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
@@ -1916,6 +1923,7 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreNotEnums(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreNotExceptions(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreNotGeneric(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
+        public static aweXpect.Reflection.Collections.Filtered.Types WhichAreNotImmutable(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreNotInstantiable(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreNotInterfaces(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreNotInternal(this aweXpect.Reflection.Collections.Filtered.Types @this) { }

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net8.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_net8.0.txt
@@ -1674,6 +1674,7 @@ namespace aweXpect.Reflection
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsAssignableTo(this aweXpect.Core.IThat<System.Type?> subject, System.Type type) { }
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsAssignableTo<TType>(this aweXpect.Core.IThat<System.Type?> subject) { }
         public static aweXpect.Reflection.Results.GenericArgumentCollectionResult<System.Type?> IsGeneric(this aweXpect.Core.IThat<System.Type?> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsImmutable(this aweXpect.Core.IThat<System.Type?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsInstantiable(this aweXpect.Core.IThat<System.Type?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsNested(this aweXpect.Core.IThat<System.Type?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsNotAClass(this aweXpect.Core.IThat<System.Type?> subject) { }
@@ -1692,6 +1693,7 @@ namespace aweXpect.Reflection
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsNotAssignableTo(this aweXpect.Core.IThat<System.Type?> subject, System.Type type) { }
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsNotAssignableTo<TType>(this aweXpect.Core.IThat<System.Type?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsNotGeneric(this aweXpect.Core.IThat<System.Type?> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsNotImmutable(this aweXpect.Core.IThat<System.Type?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsNotInstantiable(this aweXpect.Core.IThat<System.Type?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsNotNested(this aweXpect.Core.IThat<System.Type?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsNotReadOnly(this aweXpect.Core.IThat<System.Type?> subject) { }
@@ -1727,6 +1729,8 @@ namespace aweXpect.Reflection
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreExceptions(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
         public static aweXpect.Reflection.Results.GenericArgumentCollectionResult<System.Collections.Generic.IAsyncEnumerable<System.Type?>> AreGeneric(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>> subject) { }
         public static aweXpect.Reflection.Results.GenericArgumentCollectionResult<System.Collections.Generic.IEnumerable<System.Type?>> AreGeneric(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>>> AreImmutable(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreImmutable(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>>> AreInstantiable(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreInstantiable(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>>> AreInterfaces(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>> subject) { }
@@ -1755,6 +1759,8 @@ namespace aweXpect.Reflection
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreNotExceptions(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>>> AreNotGeneric(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreNotGeneric(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>>> AreNotImmutable(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreNotImmutable(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>>> AreNotInstantiable(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreNotInstantiable(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IAsyncEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>>> AreNotInterfaces(this aweXpect.Core.IThat<System.Collections.Generic.IAsyncEnumerable<System.Type?>> subject) { }
@@ -1900,6 +1906,7 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreEnums(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreExceptions(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.TypeFilters.GenericTypes WhichAreGeneric(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
+        public static aweXpect.Reflection.Collections.Filtered.Types WhichAreImmutable(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreInstantiable(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreInterfaces(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreInternal(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
@@ -1916,6 +1923,7 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreNotEnums(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreNotExceptions(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreNotGeneric(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
+        public static aweXpect.Reflection.Collections.Filtered.Types WhichAreNotImmutable(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreNotInstantiable(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreNotInterfaces(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreNotInternal(this aweXpect.Reflection.Collections.Filtered.Types @this) { }

--- a/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_netstandard2.0.txt
+++ b/Tests/aweXpect.Reflection.Api.Tests/Expected/aweXpect.Reflection_netstandard2.0.txt
@@ -1398,6 +1398,7 @@ namespace aweXpect.Reflection
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsAssignableTo(this aweXpect.Core.IThat<System.Type?> subject, System.Type type) { }
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsAssignableTo<TType>(this aweXpect.Core.IThat<System.Type?> subject) { }
         public static aweXpect.Reflection.Results.GenericArgumentCollectionResult<System.Type?> IsGeneric(this aweXpect.Core.IThat<System.Type?> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsImmutable(this aweXpect.Core.IThat<System.Type?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsInstantiable(this aweXpect.Core.IThat<System.Type?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsNested(this aweXpect.Core.IThat<System.Type?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsNotAClass(this aweXpect.Core.IThat<System.Type?> subject) { }
@@ -1416,6 +1417,7 @@ namespace aweXpect.Reflection
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsNotAssignableTo(this aweXpect.Core.IThat<System.Type?> subject, System.Type type) { }
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsNotAssignableTo<TType>(this aweXpect.Core.IThat<System.Type?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsNotGeneric(this aweXpect.Core.IThat<System.Type?> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsNotImmutable(this aweXpect.Core.IThat<System.Type?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsNotInstantiable(this aweXpect.Core.IThat<System.Type?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsNotNested(this aweXpect.Core.IThat<System.Type?> subject) { }
         public static aweXpect.Results.AndOrResult<System.Type?, aweXpect.Core.IThat<System.Type?>> IsNotReadOnly(this aweXpect.Core.IThat<System.Type?> subject) { }
@@ -1440,6 +1442,7 @@ namespace aweXpect.Reflection
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreEnums(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreExceptions(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
         public static aweXpect.Reflection.Results.GenericArgumentCollectionResult<System.Collections.Generic.IEnumerable<System.Type?>> AreGeneric(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreImmutable(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreInstantiable(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreInterfaces(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreNested(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
@@ -1454,6 +1457,7 @@ namespace aweXpect.Reflection
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreNotEnums(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreNotExceptions(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreNotGeneric(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
+        public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreNotImmutable(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreNotInstantiable(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreNotInterfaces(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
         public static aweXpect.Results.AndOrResult<System.Collections.Generic.IEnumerable<System.Type?>, aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>>> AreNotNested(this aweXpect.Core.IThat<System.Collections.Generic.IEnumerable<System.Type?>> subject) { }
@@ -1536,6 +1540,7 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreEnums(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreExceptions(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.TypeFilters.GenericTypes WhichAreGeneric(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
+        public static aweXpect.Reflection.Collections.Filtered.Types WhichAreImmutable(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreInstantiable(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreInterfaces(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreInternal(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
@@ -1552,6 +1557,7 @@ namespace aweXpect.Reflection
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreNotEnums(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreNotExceptions(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreNotGeneric(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
+        public static aweXpect.Reflection.Collections.Filtered.Types WhichAreNotImmutable(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreNotInstantiable(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreNotInterfaces(this aweXpect.Reflection.Collections.Filtered.Types @this) { }
         public static aweXpect.Reflection.Collections.Filtered.Types WhichAreNotInternal(this aweXpect.Reflection.Collections.Filtered.Types @this) { }

--- a/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreImmutable.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreImmutable.Tests.cs
@@ -1,0 +1,24 @@
+﻿using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Tests.TestHelpers.Types;
+
+namespace aweXpect.Reflection.Tests.Filters;
+
+public sealed partial class TypeFilters
+{
+	public sealed class WhichAreImmutable
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task ShouldAllowFilteringForImmutableTypes()
+			{
+				Filtered.Types types = In.AssemblyContaining<ImmutableClass>()
+					.Types().WhichAreImmutable();
+
+				await That(types).AreImmutable().And.IsNotEmpty();
+				await That(types.GetDescription())
+					.IsEqualTo("immutable types in assembly").AsPrefix();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreNotImmutable.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreNotImmutable.Tests.cs
@@ -1,0 +1,24 @@
+﻿using aweXpect.Reflection.Collections;
+using aweXpect.Reflection.Tests.TestHelpers.Types;
+
+namespace aweXpect.Reflection.Tests.Filters;
+
+public sealed partial class TypeFilters
+{
+	public sealed class WhichAreNotImmutable
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task ShouldAllowFilteringForMutableTypes()
+			{
+				Filtered.Types types = In.AssemblyContaining<ClassWithMutableField>()
+					.Types().WhichAreNotImmutable();
+
+				await That(types).AreNotImmutable().And.IsNotEmpty();
+				await That(types.GetDescription())
+					.IsEqualTo("mutable types in assembly").AsPrefix();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/ImmutabilityTestTypes.cs
+++ b/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/ImmutabilityTestTypes.cs
@@ -4,7 +4,7 @@
 public class ImmutableClass
 {
 	public const int ConstantField = 4;
-	public static int StaticMutableField = 1;
+	private static int _staticMutableField = 1;
 	public readonly int ReadOnlyField = 2;
 	private readonly string _privateReadOnlyField = "";
 	public static int StaticSettableProperty { get; set; }
@@ -49,3 +49,67 @@ public class MutableBaseClass
 }
 
 public class ClassInheritingMutableField : MutableBaseClass;
+
+public class MutableBaseClassWithProtectedField
+{
+	protected int ProtectedValue = 1;
+}
+
+public class ClassInheritingProtectedMutableField : MutableBaseClassWithProtectedField;
+
+public class ClassWithSettableIndexer
+{
+	private readonly int[] _values = new int[10];
+
+	public int this[int index]
+	{
+		get => _values[index];
+		set => _values[index] = value;
+	}
+}
+
+public class ClassWithPrivateSettableProperty
+{
+	public int Value { get; private set; }
+}
+
+public struct MutableStruct
+{
+	public int Value;
+}
+
+public readonly struct ImmutableReadOnlyStruct
+{
+	public readonly int Value;
+
+	public ImmutableReadOnlyStruct(int value)
+	{
+		Value = value;
+	}
+}
+
+public record struct MutableRecordStruct(int Value);
+
+public readonly record struct ImmutableRecordStruct(int Value);
+
+public record PositionalRecord(int Value);
+
+public interface IImmutableInterface
+{
+	int Value { get; }
+}
+
+public interface IMutableInterface
+{
+	int Value { get; set; }
+}
+
+public class GenericImmutableClass<T>
+{
+	public readonly T Value = default!;
+}
+
+public class GenericMutableClass<T>
+{
+	public T Value = default!;
+}

--- a/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/ImmutabilityTestTypes.cs
+++ b/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/ImmutabilityTestTypes.cs
@@ -1,0 +1,51 @@
+﻿namespace aweXpect.Reflection.Tests.TestHelpers.Types;
+
+#pragma warning disable CS0414 // Field is assigned but its value is never used
+public class ImmutableClass
+{
+	public const int ConstantField = 4;
+	public static int StaticMutableField = 1;
+	public readonly int ReadOnlyField = 2;
+	private readonly string _privateReadOnlyField = "";
+	public static int StaticSettableProperty { get; set; }
+	public int GetOnlyProperty { get; }
+	public string ComputedProperty => _privateReadOnlyField;
+}
+#pragma warning restore CS0414
+
+public class ImmutableClassWithInitProperty
+{
+	public int Value { get; init; }
+}
+
+public class ImmutableDerivedClass : ImmutableClass
+{
+	public readonly int DerivedReadOnlyField = 3;
+}
+
+public class ClassWithMutableField
+{
+	public int Value = 1;
+}
+
+public class ClassWithSettableProperty
+{
+	public int Value { get; set; }
+}
+
+public class ClassWithMutableFieldAndSettableProperty
+{
+	public int Field = 1;
+	public int Property { get; set; }
+}
+
+public class MutableBaseClass
+{
+	private int _value = 1;
+
+	public int GetValue() => _value;
+
+	public void SetValue(int value) => _value = value;
+}
+
+public class ClassInheritingMutableField : MutableBaseClass;

--- a/Tests/aweXpect.Reflection.Tests/ThatType.IsImmutable.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatType.IsImmutable.Tests.cs
@@ -103,6 +103,86 @@ public sealed partial class ThatType
 			}
 
 			[Fact]
+			public async Task WhenTypeHasSettableIndexer_ShouldFail()
+			{
+				Type subject = typeof(ClassWithSettableIndexer);
+
+				async Task Act()
+				{
+					await That(subject).IsImmutable();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             is immutable,
+					             but it was mutable ClassWithSettableIndexer with mutable members [
+					               public int ClassWithSettableIndexer.Item { get; set; }
+					             ]
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenTypeHasPropertyWithPrivateSetter_ShouldFail()
+			{
+				Type subject = typeof(ClassWithPrivateSettableProperty);
+
+				async Task Act()
+				{
+					await That(subject).IsImmutable();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             is immutable,
+					             but it was mutable ClassWithPrivateSettableProperty with mutable members [
+					               public int ClassWithPrivateSettableProperty.Value { get; private set; }
+					             ]
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenTypeInheritsProtectedMutableField_ShouldFail()
+			{
+				Type subject = typeof(ClassInheritingProtectedMutableField);
+
+				async Task Act()
+				{
+					await That(subject).IsImmutable();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             is immutable,
+					             but it was mutable ClassInheritingProtectedMutableField with mutable members [
+					               int MutableBaseClassWithProtectedField.ProtectedValue
+					             ]
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenTypeIsPositionalRecordStruct_ShouldFail()
+			{
+				Type subject = typeof(MutableRecordStruct);
+
+				async Task Act()
+				{
+					await That(subject).IsImmutable();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             is immutable,
+					             but it was mutable MutableRecordStruct with mutable members [
+					               public int MutableRecordStruct.Value { get; set; }
+					             ]
+					             """);
+			}
+
+			[Fact]
 			public async Task WhenTypeIsNull_ShouldFail()
 			{
 				Type? subject = null;
@@ -120,15 +200,21 @@ public sealed partial class ThatType
 					             """);
 			}
 
-			public static TheoryData<Type> ImmutableTypes()
-				=>
-				[
-					typeof(ImmutableClass),
-					typeof(ImmutableClassWithInitProperty),
-					typeof(ImmutableDerivedClass),
-					typeof(PublicRecord),
-					typeof(PublicSealedClass),
-				];
+			public static TheoryData<Type> ImmutableTypes() => new()
+			{
+				typeof(ImmutableClass),
+				typeof(ImmutableClassWithInitProperty),
+				typeof(ImmutableDerivedClass),
+				typeof(PublicRecord),
+				typeof(PublicSealedClass),
+				typeof(PositionalRecord),
+				typeof(ImmutableReadOnlyStruct),
+				typeof(ImmutableRecordStruct),
+				typeof(IImmutableInterface),
+				typeof(PublicEnum),
+				typeof(PublicStaticClass),
+				typeof(GenericImmutableClass<>),
+			};
 		}
 
 		public sealed class NegatedTests

--- a/Tests/aweXpect.Reflection.Tests/ThatType.IsImmutable.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatType.IsImmutable.Tests.cs
@@ -1,0 +1,168 @@
+﻿using aweXpect.Reflection.Tests.TestHelpers.Types;
+using Xunit.Sdk;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatType
+{
+	public sealed class IsImmutable
+	{
+		public sealed class Tests
+		{
+			[Theory]
+			[MemberData(nameof(ImmutableTypes))]
+			public async Task WhenTypeIsImmutable_ShouldSucceed(Type subject)
+			{
+				async Task Act()
+				{
+					await That(subject).IsImmutable();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenTypeHasMutableField_ShouldFail()
+			{
+				Type subject = typeof(ClassWithMutableField);
+
+				async Task Act()
+				{
+					await That(subject).IsImmutable();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             is immutable,
+					             but it was mutable ClassWithMutableField with mutable members [
+					               int ClassWithMutableField.Value
+					             ]
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenTypeHasSettableProperty_ShouldFail()
+			{
+				Type subject = typeof(ClassWithSettableProperty);
+
+				async Task Act()
+				{
+					await That(subject).IsImmutable();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             is immutable,
+					             but it was mutable ClassWithSettableProperty with mutable members [
+					               public int ClassWithSettableProperty.Value { get; set; }
+					             ]
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenTypeHasMultipleMutableMembers_ShouldFail()
+			{
+				Type subject = typeof(ClassWithMutableFieldAndSettableProperty);
+
+				async Task Act()
+				{
+					await That(subject).IsImmutable();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             is immutable,
+					             but it was mutable ClassWithMutableFieldAndSettableProperty with mutable members [
+					               int ClassWithMutableFieldAndSettableProperty.Field,
+					               public int ClassWithMutableFieldAndSettableProperty.Property { get; set; }
+					             ]
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenTypeInheritsMutableField_ShouldFail()
+			{
+				Type subject = typeof(ClassInheritingMutableField);
+
+				async Task Act()
+				{
+					await That(subject).IsImmutable();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             is immutable,
+					             but it was mutable ClassInheritingMutableField with mutable members [
+					               int MutableBaseClass._value
+					             ]
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenTypeIsNull_ShouldFail()
+			{
+				Type? subject = null;
+
+				async Task Act()
+				{
+					await That(subject).IsImmutable();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             is immutable,
+					             but it was <null>
+					             """);
+			}
+
+			public static TheoryData<Type> ImmutableTypes()
+				=>
+				[
+					typeof(ImmutableClass),
+					typeof(ImmutableClassWithInitProperty),
+					typeof(ImmutableDerivedClass),
+					typeof(PublicRecord),
+					typeof(PublicSealedClass),
+				];
+		}
+
+		public sealed class NegatedTests
+		{
+			[Fact]
+			public async Task WhenTypeIsImmutable_ShouldFail()
+			{
+				Type subject = typeof(ImmutableClass);
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(it => it.IsImmutable());
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is not immutable,
+					             but it was immutable ImmutableClass
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenTypeIsMutable_ShouldSucceed()
+			{
+				Type subject = typeof(ClassWithMutableField);
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(it => it.IsImmutable());
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatType.IsNotImmutable.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatType.IsNotImmutable.Tests.cs
@@ -1,0 +1,107 @@
+﻿using aweXpect.Reflection.Tests.TestHelpers.Types;
+using Xunit.Sdk;
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatType
+{
+	public sealed class IsNotImmutable
+	{
+		public sealed class Tests
+		{
+			[Theory]
+			[MemberData(nameof(MutableTypes))]
+			public async Task WhenTypeIsMutable_ShouldSucceed(Type subject)
+			{
+				async Task Act()
+				{
+					await That(subject).IsNotImmutable();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenTypeIsImmutable_ShouldFail()
+			{
+				Type subject = typeof(ImmutableClass);
+
+				async Task Act()
+				{
+					await That(subject).IsNotImmutable();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             is not immutable,
+					             but it was immutable ImmutableClass
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenTypeIsNull_ShouldFail()
+			{
+				Type? subject = null;
+
+				async Task Act()
+				{
+					await That(subject).IsNotImmutable();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             is not immutable,
+					             but it was <null>
+					             """);
+			}
+
+			public static TheoryData<Type> MutableTypes()
+				=>
+				[
+					typeof(ClassWithMutableField),
+					typeof(ClassWithSettableProperty),
+					typeof(ClassWithMutableFieldAndSettableProperty),
+					typeof(MutableBaseClass),
+					typeof(ClassInheritingMutableField),
+				];
+		}
+
+		public sealed class NegatedTests
+		{
+			[Fact]
+			public async Task WhenTypeIsImmutable_ShouldSucceed()
+			{
+				Type subject = typeof(ImmutableClass);
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(it => it.IsNotImmutable());
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenTypeIsMutable_ShouldFail()
+			{
+				Type subject = typeof(ClassWithMutableField);
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(it => it.IsNotImmutable());
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             is immutable,
+					             but it was mutable ClassWithMutableField with mutable members [
+					               int ClassWithMutableField.Value
+					             ]
+					             """);
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatType.IsNotImmutable.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatType.IsNotImmutable.Tests.cs
@@ -57,15 +57,22 @@ public sealed partial class ThatType
 					             """);
 			}
 
-			public static TheoryData<Type> MutableTypes()
-				=>
-				[
-					typeof(ClassWithMutableField),
-					typeof(ClassWithSettableProperty),
-					typeof(ClassWithMutableFieldAndSettableProperty),
-					typeof(MutableBaseClass),
-					typeof(ClassInheritingMutableField),
-				];
+			public static TheoryData<Type> MutableTypes() => new()
+			{
+				typeof(ClassWithMutableField),
+				typeof(ClassWithSettableProperty),
+				typeof(ClassWithMutableFieldAndSettableProperty),
+				typeof(MutableBaseClass),
+				typeof(ClassInheritingMutableField),
+				typeof(MutableBaseClassWithProtectedField),
+				typeof(ClassInheritingProtectedMutableField),
+				typeof(ClassWithSettableIndexer),
+				typeof(ClassWithPrivateSettableProperty),
+				typeof(MutableStruct),
+				typeof(MutableRecordStruct),
+				typeof(IMutableInterface),
+				typeof(GenericMutableClass<>),
+			};
 		}
 
 		public sealed class NegatedTests

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.AreImmutable.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.AreImmutable.Tests.cs
@@ -1,0 +1,139 @@
+﻿using System.Collections.Generic;
+using aweXpect.Reflection.Tests.TestHelpers.Types;
+using Xunit.Sdk;
+#if NET8_0_OR_GREATER
+using aweXpect.Reflection.Tests.TestHelpers;
+#endif
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatTypes
+{
+	public sealed class AreImmutable
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenAllTypesAreImmutable_ShouldSucceed()
+			{
+				IEnumerable<Type?> subject = new[]
+				{
+					typeof(ImmutableClass), typeof(ImmutableClassWithInitProperty),
+				};
+
+				async Task Act()
+				{
+					await That(subject).AreImmutable();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSomeTypesAreMutable_ShouldFail()
+			{
+				IEnumerable<Type?> subject = new[]
+				{
+					typeof(ImmutableClass), typeof(ClassWithMutableField),
+				};
+
+				async Task Act()
+				{
+					await That(subject).AreImmutable();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             are all immutable,
+					             but it contained mutable types [
+					               ClassWithMutableField
+					             ]
+					             """);
+			}
+
+#if NET8_0_OR_GREATER
+			[Fact]
+			public async Task WhenAsyncEnumerableAllTypesAreImmutable_ShouldSucceed()
+			{
+				IAsyncEnumerable<Type?> subject = new[]
+				{
+					typeof(ImmutableClass), typeof(ImmutableClassWithInitProperty),
+				}.ToTestAsyncEnumerable();
+
+				async Task Act()
+				{
+					await That(subject).AreImmutable();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenAsyncEnumerableSomeTypesAreMutable_ShouldFail()
+			{
+				IAsyncEnumerable<Type?> subject = new[]
+				{
+					typeof(ImmutableClass), typeof(ClassWithMutableField),
+				}.ToTestAsyncEnumerable();
+
+				async Task Act()
+				{
+					await That(subject).AreImmutable();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             are all immutable,
+					             but it contained mutable types [
+					               ClassWithMutableField
+					             ]
+					             """);
+			}
+#endif
+		}
+
+		public sealed class NegatedTests
+		{
+			[Fact]
+			public async Task WhenAllTypesAreImmutable_ShouldFail()
+			{
+				IEnumerable<Type?> subject = new[]
+				{
+					typeof(ImmutableClass),
+				};
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(they => they.AreImmutable());
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             are not all immutable,
+					             but it only contained immutable types [
+					               ImmutableClass
+					             ]
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenSomeTypesAreMutable_ShouldSucceed()
+			{
+				IEnumerable<Type?> subject = new[]
+				{
+					typeof(ImmutableClass), typeof(ClassWithMutableField),
+				};
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(they => they.AreImmutable());
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.AreNotImmutable.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.AreNotImmutable.Tests.cs
@@ -1,0 +1,139 @@
+﻿using System.Collections.Generic;
+using aweXpect.Reflection.Tests.TestHelpers.Types;
+using Xunit.Sdk;
+#if NET8_0_OR_GREATER
+using aweXpect.Reflection.Tests.TestHelpers;
+#endif
+
+namespace aweXpect.Reflection.Tests;
+
+public sealed partial class ThatTypes
+{
+	public sealed class AreNotImmutable
+	{
+		public sealed class Tests
+		{
+			[Fact]
+			public async Task WhenAllTypesAreMutable_ShouldSucceed()
+			{
+				IEnumerable<Type?> subject = new[]
+				{
+					typeof(ClassWithMutableField), typeof(ClassWithSettableProperty),
+				};
+
+				async Task Act()
+				{
+					await That(subject).AreNotImmutable();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSomeTypesAreImmutable_ShouldFail()
+			{
+				IEnumerable<Type?> subject = new[]
+				{
+					typeof(ClassWithMutableField), typeof(ImmutableClass),
+				};
+
+				async Task Act()
+				{
+					await That(subject).AreNotImmutable();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             are all not immutable,
+					             but it contained immutable types [
+					               ImmutableClass
+					             ]
+					             """);
+			}
+
+#if NET8_0_OR_GREATER
+			[Fact]
+			public async Task WhenAsyncEnumerableAllTypesAreMutable_ShouldSucceed()
+			{
+				IAsyncEnumerable<Type?> subject = new[]
+				{
+					typeof(ClassWithMutableField), typeof(ClassWithSettableProperty),
+				}.ToTestAsyncEnumerable();
+
+				async Task Act()
+				{
+					await That(subject).AreNotImmutable();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenAsyncEnumerableSomeTypesAreImmutable_ShouldFail()
+			{
+				IAsyncEnumerable<Type?> subject = new[]
+				{
+					typeof(ClassWithMutableField), typeof(ImmutableClass),
+				}.ToTestAsyncEnumerable();
+
+				async Task Act()
+				{
+					await That(subject).AreNotImmutable();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             are all not immutable,
+					             but it contained immutable types [
+					               ImmutableClass
+					             ]
+					             """);
+			}
+#endif
+		}
+
+		public sealed class NegatedTests
+		{
+			[Fact]
+			public async Task WhenAllTypesAreMutable_ShouldFail()
+			{
+				IEnumerable<Type?> subject = new[]
+				{
+					typeof(ClassWithMutableField),
+				};
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(they => they.AreNotImmutable());
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             also contain an immutable type,
+					             but it only contained mutable types [
+					               ClassWithMutableField
+					             ]
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenSomeTypesAreImmutable_ShouldSucceed()
+			{
+				IEnumerable<Type?> subject = new[]
+				{
+					typeof(ClassWithMutableField), typeof(ImmutableClass),
+				};
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(they => they.AreNotImmutable());
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+	}
+}


### PR DESCRIPTION
`IsImmutable` / `IsNotImmutable` for single types, `AreImmutable` / `AreNotImmutable` for type collections (including `IAsyncEnumerable` overloads) and `WhichAreImmutable` / `WhichAreNotImmutable` filters.

A type is considered immutable when all instance fields (including inherited ones) are readonly and all instance properties (including inherited ones) have no setter or an init-only setter; init-only setters count as immutable, static members are ignored. Failure messages list the offending mutable members for actionable feedback.

---

- *Implements #329*