### PR TITLE
chore: normalize .cs file encoding to UTF-8 BOM and apply code style cleanup

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -17,6 +17,7 @@ insert_final_newline = true
 
 # C# files
 [*.cs]
+charset = utf-8-bom
 
 #### .NET Coding Conventions ####
 

--- a/.gitattributes
+++ b/.gitattributes
@@ -8,6 +8,7 @@
 # ReSharper DotSettings files are in Unix Format
 *.DotSettings text eol=lf
 *.sln   text eol=crlf
+*.cs    text eol=crlf
 
 # Allows checking out and developing in Windows
 # while mounting and running tests in Linux

--- a/.gitattributes
+++ b/.gitattributes
@@ -8,7 +8,10 @@
 # ReSharper DotSettings files are in Unix Format
 *.DotSettings text eol=lf
 *.sln   text eol=crlf
-*.cs    text eol=crlf
+# .cs files use native line endings (CRLF on Windows, LF on Linux/macOS):
+# tests compare raw string literals against messages built with Environment.NewLine,
+# so the checkout eol must match the platform. Do not force eol=crlf here.
+*.cs    text
 
 # Allows checking out and developing in Windows
 # while mounting and running tests in Linux

--- a/Pipeline/Build.ApiChecks.cs
+++ b/Pipeline/Build.ApiChecks.cs
@@ -1,4 +1,4 @@
-using Nuke.Common;
+﻿using Nuke.Common;
 using Nuke.Common.ProjectModel;
 using Nuke.Common.Tooling;
 using Nuke.Common.Tools.DotNet;

--- a/Pipeline/Build.Benchmarks.cs
+++ b/Pipeline/Build.Benchmarks.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;

--- a/Pipeline/Build.CodeAnalysis.cs
+++ b/Pipeline/Build.CodeAnalysis.cs
@@ -1,4 +1,4 @@
-using Nuke.Common;
+﻿using Nuke.Common;
 using Nuke.Common.Tools.SonarScanner;
 
 // ReSharper disable AllUnderscoreLocalParameterName

--- a/Pipeline/Build.CodeCoverage.cs
+++ b/Pipeline/Build.CodeCoverage.cs
@@ -1,4 +1,4 @@
-using Nuke.Common;
+﻿using Nuke.Common;
 using Nuke.Common.Tooling;
 using Nuke.Common.Tools.ReportGenerator;
 using static Nuke.Common.Tools.ReportGenerator.ReportGeneratorTasks;

--- a/Pipeline/Build.Compile.cs
+++ b/Pipeline/Build.Compile.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Linq;
 using Nuke.Common;
 using Nuke.Common.IO;

--- a/Pipeline/Build.MutationTests.cs
+++ b/Pipeline/Build.MutationTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/Pipeline/Build.Pack.cs
+++ b/Pipeline/Build.Pack.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;

--- a/Pipeline/Build.UnitTest.cs
+++ b/Pipeline/Build.UnitTest.cs
@@ -1,4 +1,4 @@
-using System.Linq;
+﻿using System.Linq;
 using Nuke.Common;
 using Nuke.Common.ProjectModel;
 using Nuke.Common.Tooling;

--- a/Pipeline/Build.cs
+++ b/Pipeline/Build.cs
@@ -1,4 +1,4 @@
-using Nuke.Common;
+﻿using Nuke.Common;
 using Nuke.Common.CI.GitHubActions;
 using Nuke.Common.IO;
 using Nuke.Common.ProjectModel;

--- a/Pipeline/Configuration.cs
+++ b/Pipeline/Configuration.cs
@@ -1,4 +1,4 @@
-using System.ComponentModel;
+﻿using System.ComponentModel;
 using Nuke.Common.Tooling;
 
 [TypeConverter(typeof(TypeConverter<Configuration>))]

--- a/README.md
+++ b/README.md
@@ -103,12 +103,12 @@ evaluated collection that you can navigate and filter further.
 While `In` starts from concrete reflection objects, `Types` selects types *by criteria* — the natural entry
 point for architecture rules:
 
-| Source                                                          | Returns                                                                         |
-|-----------------------------------------------------------------|---------------------------------------------------------------------------------|
-| `Types.InNamespace("ns")`                                       | all types within a namespace and its sub-namespaces (across loaded assemblies) |
-| `Types.InAllLoadedAssemblies()`                                 | all types in all currently loaded assemblies                                   |
-| `Types.InAssemblies(a1, a2, …)`                                 | all types in the given assemblies                                              |
-| `Types.InAssemblyContaining<T>()` / `…(typeof(T))`              | all types in the assembly that declares `T`                                    |
+| Source                                             | Returns                                                                        |
+|----------------------------------------------------|--------------------------------------------------------------------------------|
+| `Types.InNamespace("ns")`                          | all types within a namespace and its sub-namespaces (across loaded assemblies) |
+| `Types.InAllLoadedAssemblies()`                    | all types in all currently loaded assemblies                                   |
+| `Types.InAssemblies(a1, a2, …)`                    | all types in the given assemblies                                              |
+| `Types.InAssemblyContaining<T>()` / `…(typeof(T))` | all types in the assembly that declares `T`                                    |
 
 `Types.InNamespace(…)` searches all loaded assemblies by default; chain one of the same `In*` methods directly
 after it to clarify the assembly source (it can only be specified once, before any further filters):
@@ -267,34 +267,34 @@ outside the namespace.
 
 ### Types
 
-| Kind                | Filter                                          | Assert (single)             | Assert (many)                |
-|---------------------|-------------------------------------------------|-----------------------------|------------------------------|
-| class               | `.WhichAreClasses()` / `.Classes()`             | `.IsAClass()`               | `.AreClasses()`              |
-| interface           | `.WhichAreInterfaces()` / `.Interfaces()`       | `.IsAnInterface()`          | `.AreInterfaces()`           |
-| enum                | `.WhichAreEnums()` / `.Enums()`                 | `.IsAnEnum()`               | `.AreEnums()`                |
-| struct              | `.WhichAreStructs()` / `.Structs()`             | `.IsAStruct()`              | `.AreStructs()`              |
-| record              | `.WhichAreRecords()` / `.Records()`             | `.IsARecord()`              | `.AreRecords()`              |
-| record struct       | `.WhichAreRecordStructs()` / `.RecordStructs()` | `.IsARecordStruct()`        | `.AreRecordStructs()`        |
-| readonly struct     | `.WhichAreReadOnly()`                           | `.IsReadOnly()`             | `.AreReadOnly()`             |
-| ref struct          | `.WhichAreRefStructs()`                         | `.IsARefStruct()`           | `.AreRefStructs()`           |
-| delegate            | `.WhichAreDelegates()`                          | `.IsADelegate()`            | `.AreDelegates()`            |
-| exception           | `.WhichAreExceptions()`                         | `.IsAnException()`          | `.AreExceptions()`           |
-| attribute           | `.WhichAreAttributes()`                         | `.IsAnAttribute()`          | `.AreAttributes()`           |
-| abstract            | `.WhichAreAbstract()` / `.Abstract`             | `.IsAbstract()`             | `.AreAbstract()`             |
-| sealed              | `.WhichAreSealed()` / `.Sealed`                 | `.IsSealed()`               | `.AreSealed()`               |
-| static              | `.WhichAreStatic()` / `.Static`                 | `.IsStatic()`               | `.AreStatic()`               |
-| generic             | `.WhichAreGeneric()` / `.Generic`               | `.IsGeneric()`              | `.AreGeneric()`              |
-| nested              | `.WhichAreNested()` / `.Nested`                 | `.IsNested()`               | `.AreNested()`               |
-| inherits from       | `.WhichInheritFrom<T>()`                        | `.InheritsFrom<T>()`        | `.InheritFrom<T>()`          |
-| implements          | `.WhichImplement<T>()`                          | `.Implements<T>()`          | `.Implement<T>()`            |
-| assignable to       | `.WhichAreAssignableTo<T>()`                    | `.IsAssignableTo<T>()`      | `.AreAssignableTo<T>()`      |
-| assignable from     | `.WhichAreAssignableFrom<T>()`                  | `.IsAssignableFrom<T>()`    | `.AreAssignableFrom<T>()`    |
-| instantiable        | `.WhichAreInstantiable()`                       | `.IsInstantiable()`         | `.AreInstantiable()`         |
-| immutable           | `.WhichAreImmutable()`                          | `.IsImmutable()`            | `.AreImmutable()`            |
-| default constructor | `.WhichHaveADefaultConstructor()`               | `.HasADefaultConstructor()` | `.HaveADefaultConstructor()` |
-| only nullable members | `.WhichOnlyHaveNullableMembers()`             | `.OnlyHasNullableMembers()` | `.OnlyHaveNullableMembers()` |
-| only non-nullable members | `.WhichOnlyHaveNonNullableMembers()`      | `.OnlyHasNonNullableMembers()` | `.OnlyHaveNonNullableMembers()` |
-| custom predicate    | `.Which(t => …)`                                | `.Satisfies(t => …)`        | `.All().Satisfy(t => …)`     |
+| Kind                      | Filter                                          | Assert (single)                | Assert (many)                   |
+|---------------------------|-------------------------------------------------|--------------------------------|---------------------------------|
+| class                     | `.WhichAreClasses()` / `.Classes()`             | `.IsAClass()`                  | `.AreClasses()`                 |
+| interface                 | `.WhichAreInterfaces()` / `.Interfaces()`       | `.IsAnInterface()`             | `.AreInterfaces()`              |
+| enum                      | `.WhichAreEnums()` / `.Enums()`                 | `.IsAnEnum()`                  | `.AreEnums()`                   |
+| struct                    | `.WhichAreStructs()` / `.Structs()`             | `.IsAStruct()`                 | `.AreStructs()`                 |
+| record                    | `.WhichAreRecords()` / `.Records()`             | `.IsARecord()`                 | `.AreRecords()`                 |
+| record struct             | `.WhichAreRecordStructs()` / `.RecordStructs()` | `.IsARecordStruct()`           | `.AreRecordStructs()`           |
+| readonly struct           | `.WhichAreReadOnly()`                           | `.IsReadOnly()`                | `.AreReadOnly()`                |
+| ref struct                | `.WhichAreRefStructs()`                         | `.IsARefStruct()`              | `.AreRefStructs()`              |
+| delegate                  | `.WhichAreDelegates()`                          | `.IsADelegate()`               | `.AreDelegates()`               |
+| exception                 | `.WhichAreExceptions()`                         | `.IsAnException()`             | `.AreExceptions()`              |
+| attribute                 | `.WhichAreAttributes()`                         | `.IsAnAttribute()`             | `.AreAttributes()`              |
+| abstract                  | `.WhichAreAbstract()` / `.Abstract`             | `.IsAbstract()`                | `.AreAbstract()`                |
+| sealed                    | `.WhichAreSealed()` / `.Sealed`                 | `.IsSealed()`                  | `.AreSealed()`                  |
+| static                    | `.WhichAreStatic()` / `.Static`                 | `.IsStatic()`                  | `.AreStatic()`                  |
+| generic                   | `.WhichAreGeneric()` / `.Generic`               | `.IsGeneric()`                 | `.AreGeneric()`                 |
+| nested                    | `.WhichAreNested()` / `.Nested`                 | `.IsNested()`                  | `.AreNested()`                  |
+| inherits from             | `.WhichInheritFrom<T>()`                        | `.InheritsFrom<T>()`           | `.InheritFrom<T>()`             |
+| implements                | `.WhichImplement<T>()`                          | `.Implements<T>()`             | `.Implement<T>()`               |
+| assignable to             | `.WhichAreAssignableTo<T>()`                    | `.IsAssignableTo<T>()`         | `.AreAssignableTo<T>()`         |
+| assignable from           | `.WhichAreAssignableFrom<T>()`                  | `.IsAssignableFrom<T>()`       | `.AreAssignableFrom<T>()`       |
+| instantiable              | `.WhichAreInstantiable()`                       | `.IsInstantiable()`            | `.AreInstantiable()`            |
+| immutable                 | `.WhichAreImmutable()`                          | `.IsImmutable()`               | `.AreImmutable()`               |
+| default constructor       | `.WhichHaveADefaultConstructor()`               | `.HasADefaultConstructor()`    | `.HaveADefaultConstructor()`    |
+| only nullable members     | `.WhichOnlyHaveNullableMembers()`               | `.OnlyHasNullableMembers()`    | `.OnlyHaveNullableMembers()`    |
+| only non-nullable members | `.WhichOnlyHaveNonNullableMembers()`            | `.OnlyHasNonNullableMembers()` | `.OnlyHaveNonNullableMembers()` |
+| custom predicate          | `.Which(t => …)`                                | `.Satisfies(t => …)`           | `.All().Satisfy(t => …)`        |
 
 `WhichInheritFrom` / `InheritsFrom` consider only the **base-class chain** (not implemented interfaces) and
 accept a generic argument or a `Type`, plus an optional `forceDirect` flag to require *direct* inheritance.
@@ -788,11 +788,11 @@ how to combine them with reusable type selections into a full architecture test 
 
 The dependency filters and assertions follow the familiar filter/assert pairing:
 
-|                          | Filter                       | Assert (single)         | Assert (many)          |
-|--------------------------|------------------------------|-------------------------|------------------------|
-| depends on namespace     | `.WhichDependOn("x", …)`     | `.DependsOn("x", …)`    | `.DependOn("x", …)`    |
-| does not depend on       | `.WhichDoNotDependOn("x", …)`| `.DoesNotDependOn("x", …)` | `.DoNotDependOn("x", …)` |
-| depends only on set      | `.WhichDependOnlyOn("x", …)` | `.DependsOnlyOn("x", …)`| `.DependOnlyOn("x", …)`|
+|                              | Filter                                  | Assert (single)                   | Assert (many)                      |
+|------------------------------|-----------------------------------------|-----------------------------------|------------------------------------|
+| depends on namespace         | `.WhichDependOn("x", …)`                | `.DependsOn("x", …)`              | `.DependOn("x", …)`                |
+| does not depend on           | `.WhichDoNotDependOn("x", …)`           | `.DoesNotDependOn("x", …)`        | `.DoNotDependOn("x", …)`           |
+| depends only on set          | `.WhichDependOnlyOn("x", …)`            | `.DependsOnlyOn("x", …)`          | `.DependOnlyOn("x", …)`            |
 | has dependencies outside set | `.WhichHaveDependenciesOutside("x", …)` | `.HasDependenciesOutside("x", …)` | `.HaveDependenciesOutside("x", …)` |
 
 ```csharp

--- a/Source/aweXpect.Reflection/Collections/AssembliesAbstractSealedBuilder.cs
+++ b/Source/aweXpect.Reflection/Collections/AssembliesAbstractSealedBuilder.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;

--- a/Source/aweXpect.Reflection/Collections/AssembliesTypeBuilder.cs
+++ b/Source/aweXpect.Reflection/Collections/AssembliesTypeBuilder.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;

--- a/Source/aweXpect.Reflection/Collections/Filter.cs
+++ b/Source/aweXpect.Reflection/Collections/Filter.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 

--- a/Source/aweXpect.Reflection/Collections/Filtered.Assemblies.cs
+++ b/Source/aweXpect.Reflection/Collections/Filtered.Assemblies.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;

--- a/Source/aweXpect.Reflection/Collections/Filtered.Assemblies.cs
+++ b/Source/aweXpect.Reflection/Collections/Filtered.Assemblies.cs
@@ -59,10 +59,6 @@ public static partial class Filtered
 			_description = inner._description;
 		}
 
-		/// <inheritdoc />
-		private protected override Assemblies CloneWith(List<IFilter<Assembly>> filters)
-			=> new(this, filters);
-
 		/// <summary>
 		///     Filters for public types.
 		/// </summary>
@@ -164,6 +160,10 @@ public static partial class Filtered
 
 		/// <inheritdoc cref="ILimitedStaticTypeAssemblies.Properties()" />
 		public Properties Properties() => NewBuilder(MemberFilterState.Empty).Properties();
+
+		/// <inheritdoc />
+		private protected override Assemblies CloneWith(List<IFilter<Assembly>> filters)
+			=> new(this, filters);
 
 		private AssembliesTypeBuilder NewBuilder(MemberFilterState memberState)
 			=> new(this, memberState, new List<Func<Type, bool>>(), "");

--- a/Source/aweXpect.Reflection/Collections/Filtered.Constructors.cs
+++ b/Source/aweXpect.Reflection/Collections/Filtered.Constructors.cs
@@ -51,10 +51,6 @@ public static partial class Filtered
 		}
 
 		/// <inheritdoc />
-		private protected override Constructors CloneWith(List<IFilter<ConstructorInfo>> filters)
-			=> new(this, filters);
-
-		/// <inheritdoc />
 		public string GetDescription()
 		{
 			string description = _description;
@@ -70,6 +66,10 @@ public static partial class Filtered
 
 			return description;
 		}
+
+		/// <inheritdoc />
+		private protected override Constructors CloneWith(List<IFilter<ConstructorInfo>> filters)
+			=> new(this, filters);
 
 		/// <summary>
 		///     Get all declaring types of the filtered constructors.

--- a/Source/aweXpect.Reflection/Collections/Filtered.Constructors.cs
+++ b/Source/aweXpect.Reflection/Collections/Filtered.Constructors.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using aweXpect.Core;

--- a/Source/aweXpect.Reflection/Collections/Filtered.Events.cs
+++ b/Source/aweXpect.Reflection/Collections/Filtered.Events.cs
@@ -54,10 +54,6 @@ public static partial class Filtered
 		}
 
 		/// <inheritdoc />
-		private protected override Events CloneWith(List<IFilter<EventInfo>> filters)
-			=> new(this, filters);
-
-		/// <inheritdoc />
 		public string GetDescription()
 		{
 			string description = _description;
@@ -73,6 +69,10 @@ public static partial class Filtered
 
 			return description;
 		}
+
+		/// <inheritdoc />
+		private protected override Events CloneWith(List<IFilter<EventInfo>> filters)
+			=> new(this, filters);
 
 		/// <summary>
 		///     Get all declaring types of the filtered events.

--- a/Source/aweXpect.Reflection/Collections/Filtered.Events.cs
+++ b/Source/aweXpect.Reflection/Collections/Filtered.Events.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;

--- a/Source/aweXpect.Reflection/Collections/Filtered.Fields.cs
+++ b/Source/aweXpect.Reflection/Collections/Filtered.Fields.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;

--- a/Source/aweXpect.Reflection/Collections/Filtered.Fields.cs
+++ b/Source/aweXpect.Reflection/Collections/Filtered.Fields.cs
@@ -54,10 +54,6 @@ public static partial class Filtered
 		}
 
 		/// <inheritdoc />
-		private protected override Fields CloneWith(List<IFilter<FieldInfo>> filters)
-			=> new(this, filters);
-
-		/// <inheritdoc />
 		public string GetDescription()
 		{
 			string description = _description;
@@ -73,6 +69,10 @@ public static partial class Filtered
 
 			return description;
 		}
+
+		/// <inheritdoc />
+		private protected override Fields CloneWith(List<IFilter<FieldInfo>> filters)
+			=> new(this, filters);
 
 		/// <summary>
 		///     Get all declaring types of the filtered fields.

--- a/Source/aweXpect.Reflection/Collections/Filtered.Methods.cs
+++ b/Source/aweXpect.Reflection/Collections/Filtered.Methods.cs
@@ -27,7 +27,7 @@ public static partial class Filtered
 		/// </summary>
 		internal Methods(Types types, string description,
 			MemberScope memberScope = MemberScope.DeclaredOnly)
-			: this(types, description, memberScope, includeOperators: false)
+			: this(types, description, memberScope, false)
 		{
 		}
 
@@ -65,10 +65,6 @@ public static partial class Filtered
 		}
 
 		/// <inheritdoc />
-		private protected override Methods CloneWith(List<IFilter<MethodInfo>> filters)
-			=> new(this, filters);
-
-		/// <inheritdoc />
 		public string GetDescription()
 		{
 			string description = _description;
@@ -84,6 +80,10 @@ public static partial class Filtered
 
 			return description;
 		}
+
+		/// <inheritdoc />
+		private protected override Methods CloneWith(List<IFilter<MethodInfo>> filters)
+			=> new(this, filters);
 
 		/// <summary>
 		///     Returns a copy of this collection that additionally includes operator special-name members, so that operator
@@ -102,7 +102,7 @@ public static partial class Filtered
 				return this;
 			}
 
-			Methods rebuilt = new(_types, _description, _memberScope, includeOperators: true);
+			Methods rebuilt = new(_types, _description, _memberScope, true);
 			return rebuilt.CloneWith([.. Filters,]);
 		}
 

--- a/Source/aweXpect.Reflection/Collections/Filtered.Methods.cs
+++ b/Source/aweXpect.Reflection/Collections/Filtered.Methods.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;

--- a/Source/aweXpect.Reflection/Collections/Filtered.Properties.cs
+++ b/Source/aweXpect.Reflection/Collections/Filtered.Properties.cs
@@ -54,10 +54,6 @@ public static partial class Filtered
 		}
 
 		/// <inheritdoc />
-		private protected override Properties CloneWith(List<IFilter<PropertyInfo>> filters)
-			=> new(this, filters);
-
-		/// <inheritdoc />
 		public string GetDescription()
 		{
 			string description = _description;
@@ -73,6 +69,10 @@ public static partial class Filtered
 
 			return description;
 		}
+
+		/// <inheritdoc />
+		private protected override Properties CloneWith(List<IFilter<PropertyInfo>> filters)
+			=> new(this, filters);
 
 		/// <summary>
 		///     Get all declaring types of the filtered properties.

--- a/Source/aweXpect.Reflection/Collections/Filtered.Properties.cs
+++ b/Source/aweXpect.Reflection/Collections/Filtered.Properties.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;

--- a/Source/aweXpect.Reflection/Collections/Filtered.Types.cs
+++ b/Source/aweXpect.Reflection/Collections/Filtered.Types.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;

--- a/Source/aweXpect.Reflection/Collections/Filtered.Types.cs
+++ b/Source/aweXpect.Reflection/Collections/Filtered.Types.cs
@@ -116,10 +116,6 @@ public static partial class Filtered
 			_assemblies = inner._assemblies;
 		}
 
-		/// <inheritdoc />
-		private protected override Types CloneWith(List<IFilter<Type>> filters)
-			=> new(this, filters);
-
 		/// <summary>
 		///     Filters for public members.
 		/// </summary>
@@ -217,6 +213,10 @@ public static partial class Filtered
 		/// <inheritdoc cref="IMembers.IProtected.Internal" />
 		IMembers IMembers.IProtected.Internal
 			=> new TypesMemberBuilder(this, MemberFilterState.Empty.WithAccess(AccessModifiers.ProtectedInternal));
+
+		/// <inheritdoc />
+		private protected override Types CloneWith(List<IFilter<Type>> filters)
+			=> new(this, filters);
 
 		/// <summary>
 		///     Gets the types of the <paramref name="assembly" />, ignoring those that fail to load.
@@ -629,7 +629,7 @@ public static partial class Filtered
 			/// <summary>
 			///     Widens the filter by the given <paramref name="targets" />.
 			/// </summary>
-			public TypeSetDependencyFilterResult OrOn(params Filtered.Types[] targets)
+			public TypeSetDependencyFilterResult OrOn(params Types[] targets)
 			{
 				TypeSetDependencyOptions widened = _options.Copy();
 				widened.OrOn(targets);
@@ -665,7 +665,7 @@ public static partial class Filtered
 			/// <summary>
 			///     Widens the filter by the given <paramref name="targets" />.
 			/// </summary>
-			public TypeSetDependencyOnlyOnFilterResult OrOn(params Filtered.Types[] targets)
+			public TypeSetDependencyOnlyOnFilterResult OrOn(params Types[] targets)
 			{
 				TypeSetDependencyOptions widened = _options.Copy();
 				widened.OrOn(targets);
@@ -717,7 +717,7 @@ public static partial class Filtered
 			///     Widens the allowed set by the given <paramref name="targets" />, so that dependencies on their
 			///     types no longer count as outside.
 			/// </summary>
-			public TypeSetDependencyOutsideFilterResult OrOn(params Filtered.Types[] targets)
+			public TypeSetDependencyOutsideFilterResult OrOn(params Types[] targets)
 			{
 				TypeSetDependencyOptions widened = _options.Copy();
 				widened.OrOn(targets);

--- a/Source/aweXpect.Reflection/Collections/Filtered.cs
+++ b/Source/aweXpect.Reflection/Collections/Filtered.cs
@@ -1,4 +1,4 @@
-#if NET8_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System.Threading;
 using System.Threading.Tasks;
 #else

--- a/Source/aweXpect.Reflection/Collections/ILimitedAbstractSealedTypeAssemblies.cs
+++ b/Source/aweXpect.Reflection/Collections/ILimitedAbstractSealedTypeAssemblies.cs
@@ -1,4 +1,4 @@
-namespace aweXpect.Reflection.Collections;
+﻿namespace aweXpect.Reflection.Collections;
 
 /// <summary>
 ///     A limited interface for filtering types in assemblies after an <c>Abstract</c> or <c>Sealed</c> modifier.

--- a/Source/aweXpect.Reflection/Collections/ILimitedStaticTypeAssemblies.cs
+++ b/Source/aweXpect.Reflection/Collections/ILimitedStaticTypeAssemblies.cs
@@ -1,4 +1,4 @@
-namespace aweXpect.Reflection.Collections;
+﻿namespace aweXpect.Reflection.Collections;
 
 /// <summary>
 ///     A limited interface to allow basic filtering for types in assemblies.

--- a/Source/aweXpect.Reflection/Collections/IMembers.cs
+++ b/Source/aweXpect.Reflection/Collections/IMembers.cs
@@ -1,4 +1,4 @@
-namespace aweXpect.Reflection.Collections;
+﻿namespace aweXpect.Reflection.Collections;
 
 /// <summary>
 ///     A terminal interface that exposes the five member-kind selectors.

--- a/Source/aweXpect.Reflection/Collections/ITypeAssemblies.cs
+++ b/Source/aweXpect.Reflection/Collections/ITypeAssemblies.cs
@@ -1,4 +1,4 @@
-namespace aweXpect.Reflection.Collections;
+﻿namespace aweXpect.Reflection.Collections;
 
 /// <summary>
 ///     An interface to allow filtering for types in assemblies.

--- a/Source/aweXpect.Reflection/Collections/MemberFilterState.cs
+++ b/Source/aweXpect.Reflection/Collections/MemberFilterState.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using aweXpect.Reflection.Helpers;
 
 namespace aweXpect.Reflection.Collections;

--- a/Source/aweXpect.Reflection/Collections/TypesMemberBuilder.cs
+++ b/Source/aweXpect.Reflection/Collections/TypesMemberBuilder.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 
 namespace aweXpect.Reflection.Collections;
 

--- a/Source/aweXpect.Reflection/Filters/AssemblyFilters.Except.cs
+++ b/Source/aweXpect.Reflection/Filters/AssemblyFilters.Except.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using aweXpect.Reflection.Collections;

--- a/Source/aweXpect.Reflection/Filters/AssemblyFilters.WhichAreStrongNamed.cs
+++ b/Source/aweXpect.Reflection/Filters/AssemblyFilters.WhichAreStrongNamed.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Helpers;
 

--- a/Source/aweXpect.Reflection/Filters/AssemblyFilters.WhichDependOn.cs
+++ b/Source/aweXpect.Reflection/Filters/AssemblyFilters.WhichDependOn.cs
@@ -1,4 +1,4 @@
-using System.Linq;
+﻿using System.Linq;
 using System.Reflection;
 using aweXpect.Core;
 using aweXpect.Options;

--- a/Source/aweXpect.Reflection/Filters/AssemblyFilters.WhichDependOnlyOn.cs
+++ b/Source/aweXpect.Reflection/Filters/AssemblyFilters.WhichDependOnlyOn.cs
@@ -1,4 +1,4 @@
-using System.Linq;
+﻿using System.Linq;
 using System.Reflection;
 using aweXpect.Core;
 using aweXpect.Customization;

--- a/Source/aweXpect.Reflection/Filters/AssemblyFilters.WhichDoNotDependOn.cs
+++ b/Source/aweXpect.Reflection/Filters/AssemblyFilters.WhichDoNotDependOn.cs
@@ -1,4 +1,4 @@
-using System.Linq;
+﻿using System.Linq;
 using System.Reflection;
 using aweXpect.Core;
 using aweXpect.Options;

--- a/Source/aweXpect.Reflection/Filters/AssemblyFilters.WhichTarget.cs
+++ b/Source/aweXpect.Reflection/Filters/AssemblyFilters.WhichTarget.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using aweXpect.Core;
 using aweXpect.Options;
 using aweXpect.Reflection.Collections;

--- a/Source/aweXpect.Reflection/Filters/AssemblyFilters.With.cs
+++ b/Source/aweXpect.Reflection/Filters/AssemblyFilters.With.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using aweXpect.Reflection.Collections;

--- a/Source/aweXpect.Reflection/Filters/AssemblyFilters.WithVersion.cs
+++ b/Source/aweXpect.Reflection/Filters/AssemblyFilters.WithVersion.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using aweXpect.Reflection.Collections;

--- a/Source/aweXpect.Reflection/Filters/ConstructorFilters.Except.cs
+++ b/Source/aweXpect.Reflection/Filters/ConstructorFilters.Except.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using aweXpect.Reflection.Collections;

--- a/Source/aweXpect.Reflection/Filters/ConstructorFilters.WhichAreObsolete.cs
+++ b/Source/aweXpect.Reflection/Filters/ConstructorFilters.WhichAreObsolete.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Helpers;
 

--- a/Source/aweXpect.Reflection/Filters/ConstructorFilters.WhichAreStatic.cs
+++ b/Source/aweXpect.Reflection/Filters/ConstructorFilters.WhichAreStatic.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection;

--- a/Source/aweXpect.Reflection/Filters/ConstructorFilters.WithInParameter.cs
+++ b/Source/aweXpect.Reflection/Filters/ConstructorFilters.WithInParameter.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Linq;
 using System.Reflection;
 using aweXpect.Reflection.Collections;

--- a/Source/aweXpect.Reflection/Filters/ConstructorFilters.WithOptionalParameter.cs
+++ b/Source/aweXpect.Reflection/Filters/ConstructorFilters.WithOptionalParameter.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Linq;
 using System.Reflection;
 using aweXpect.Reflection.Collections;

--- a/Source/aweXpect.Reflection/Filters/ConstructorFilters.WithOutParameter.cs
+++ b/Source/aweXpect.Reflection/Filters/ConstructorFilters.WithOutParameter.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Linq;
 using System.Reflection;
 using aweXpect.Reflection.Collections;

--- a/Source/aweXpect.Reflection/Filters/ConstructorFilters.WithParameter.cs
+++ b/Source/aweXpect.Reflection/Filters/ConstructorFilters.WithParameter.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;

--- a/Source/aweXpect.Reflection/Filters/ConstructorFilters.WithParameterCount.cs
+++ b/Source/aweXpect.Reflection/Filters/ConstructorFilters.WithParameterCount.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection;

--- a/Source/aweXpect.Reflection/Filters/ConstructorFilters.WithParameterExactly.cs
+++ b/Source/aweXpect.Reflection/Filters/ConstructorFilters.WithParameterExactly.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Linq;
 using System.Reflection;
 using aweXpect.Core;

--- a/Source/aweXpect.Reflection/Filters/ConstructorFilters.WithParamsParameter.cs
+++ b/Source/aweXpect.Reflection/Filters/ConstructorFilters.WithParamsParameter.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Linq;
 using System.Reflection;
 using aweXpect.Reflection.Collections;

--- a/Source/aweXpect.Reflection/Filters/ConstructorFilters.WithRefParameter.cs
+++ b/Source/aweXpect.Reflection/Filters/ConstructorFilters.WithRefParameter.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Linq;
 using System.Reflection;
 using aweXpect.Reflection.Collections;

--- a/Source/aweXpect.Reflection/Filters/ConstructorFilters.WithoutParameters.cs
+++ b/Source/aweXpect.Reflection/Filters/ConstructorFilters.WithoutParameters.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection;
 

--- a/Source/aweXpect.Reflection/Filters/EventFilters.Except.cs
+++ b/Source/aweXpect.Reflection/Filters/EventFilters.Except.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using aweXpect.Reflection.Collections;

--- a/Source/aweXpect.Reflection/Filters/EventFilters.WhichAreAbstract.cs
+++ b/Source/aweXpect.Reflection/Filters/EventFilters.WhichAreAbstract.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Helpers;
 

--- a/Source/aweXpect.Reflection/Filters/EventFilters.WhichAreObsolete.cs
+++ b/Source/aweXpect.Reflection/Filters/EventFilters.WhichAreObsolete.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Helpers;
 

--- a/Source/aweXpect.Reflection/Filters/EventFilters.WhichAreSealed.cs
+++ b/Source/aweXpect.Reflection/Filters/EventFilters.WhichAreSealed.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Helpers;
 

--- a/Source/aweXpect.Reflection/Filters/FieldFilters.Except.cs
+++ b/Source/aweXpect.Reflection/Filters/FieldFilters.Except.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using aweXpect.Reflection.Collections;

--- a/Source/aweXpect.Reflection/Filters/FieldFilters.WhichAreConstant.cs
+++ b/Source/aweXpect.Reflection/Filters/FieldFilters.WhichAreConstant.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection;

--- a/Source/aweXpect.Reflection/Filters/FieldFilters.WhichAreObsolete.cs
+++ b/Source/aweXpect.Reflection/Filters/FieldFilters.WhichAreObsolete.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Helpers;
 

--- a/Source/aweXpect.Reflection/Filters/FieldFilters.WhichAreReadOnly.cs
+++ b/Source/aweXpect.Reflection/Filters/FieldFilters.WhichAreReadOnly.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection;

--- a/Source/aweXpect.Reflection/Filters/FieldFilters.WhichAreStatic.cs
+++ b/Source/aweXpect.Reflection/Filters/FieldFilters.WhichAreStatic.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection;

--- a/Source/aweXpect.Reflection/Filters/MethodFilters.Except.cs
+++ b/Source/aweXpect.Reflection/Filters/MethodFilters.Except.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using aweXpect.Reflection.Collections;

--- a/Source/aweXpect.Reflection/Filters/MethodFilters.WhichAreAbstract.cs
+++ b/Source/aweXpect.Reflection/Filters/MethodFilters.WhichAreAbstract.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection;

--- a/Source/aweXpect.Reflection/Filters/MethodFilters.WhichAreAsync.cs
+++ b/Source/aweXpect.Reflection/Filters/MethodFilters.WhichAreAsync.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Helpers;
 

--- a/Source/aweXpect.Reflection/Filters/MethodFilters.WhichAreExtensionMethods.cs
+++ b/Source/aweXpect.Reflection/Filters/MethodFilters.WhichAreExtensionMethods.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Helpers;
 

--- a/Source/aweXpect.Reflection/Filters/MethodFilters.WhichAreObsolete.cs
+++ b/Source/aweXpect.Reflection/Filters/MethodFilters.WhichAreObsolete.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Helpers;
 

--- a/Source/aweXpect.Reflection/Filters/MethodFilters.WhichAreSealed.cs
+++ b/Source/aweXpect.Reflection/Filters/MethodFilters.WhichAreSealed.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection;

--- a/Source/aweXpect.Reflection/Filters/MethodFilters.WhichAreStatic.cs
+++ b/Source/aweXpect.Reflection/Filters/MethodFilters.WhichAreStatic.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection;

--- a/Source/aweXpect.Reflection/Filters/MethodFilters.WhichReturn.cs
+++ b/Source/aweXpect.Reflection/Filters/MethodFilters.WhichReturn.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Reflection;
 using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Helpers;

--- a/Source/aweXpect.Reflection/Filters/MethodFilters.WhichReturnExactly.cs
+++ b/Source/aweXpect.Reflection/Filters/MethodFilters.WhichReturnExactly.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Reflection;
 using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Helpers;

--- a/Source/aweXpect.Reflection/Filters/MethodFilters.WhichReturnVoid.cs
+++ b/Source/aweXpect.Reflection/Filters/MethodFilters.WhichReturnVoid.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection;
 

--- a/Source/aweXpect.Reflection/Filters/MethodFilters.WithInParameter.cs
+++ b/Source/aweXpect.Reflection/Filters/MethodFilters.WithInParameter.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Linq;
 using System.Reflection;
 using aweXpect.Reflection.Collections;

--- a/Source/aweXpect.Reflection/Filters/MethodFilters.WithOptionalParameter.cs
+++ b/Source/aweXpect.Reflection/Filters/MethodFilters.WithOptionalParameter.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Linq;
 using System.Reflection;
 using aweXpect.Reflection.Collections;

--- a/Source/aweXpect.Reflection/Filters/MethodFilters.WithOutParameter.cs
+++ b/Source/aweXpect.Reflection/Filters/MethodFilters.WithOutParameter.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Linq;
 using System.Reflection;
 using aweXpect.Reflection.Collections;

--- a/Source/aweXpect.Reflection/Filters/MethodFilters.WithParameter.cs
+++ b/Source/aweXpect.Reflection/Filters/MethodFilters.WithParameter.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;

--- a/Source/aweXpect.Reflection/Filters/MethodFilters.WithParameterCount.cs
+++ b/Source/aweXpect.Reflection/Filters/MethodFilters.WithParameterCount.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection;

--- a/Source/aweXpect.Reflection/Filters/MethodFilters.WithParameterExactly.cs
+++ b/Source/aweXpect.Reflection/Filters/MethodFilters.WithParameterExactly.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Linq;
 using System.Reflection;
 using aweXpect.Core;

--- a/Source/aweXpect.Reflection/Filters/MethodFilters.WithParamsParameter.cs
+++ b/Source/aweXpect.Reflection/Filters/MethodFilters.WithParamsParameter.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Linq;
 using System.Reflection;
 using aweXpect.Reflection.Collections;

--- a/Source/aweXpect.Reflection/Filters/MethodFilters.WithRefParameter.cs
+++ b/Source/aweXpect.Reflection/Filters/MethodFilters.WithRefParameter.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Linq;
 using System.Reflection;
 using aweXpect.Reflection.Collections;

--- a/Source/aweXpect.Reflection/Filters/MethodFilters.WithoutParameters.cs
+++ b/Source/aweXpect.Reflection/Filters/MethodFilters.WithoutParameters.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection;
 

--- a/Source/aweXpect.Reflection/Filters/PropertyFilters.Except.cs
+++ b/Source/aweXpect.Reflection/Filters/PropertyFilters.Except.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using aweXpect.Reflection.Collections;

--- a/Source/aweXpect.Reflection/Filters/PropertyFilters.WhichAreAbstract.cs
+++ b/Source/aweXpect.Reflection/Filters/PropertyFilters.WhichAreAbstract.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Helpers;
 

--- a/Source/aweXpect.Reflection/Filters/PropertyFilters.WhichAreExtensionProperties.cs
+++ b/Source/aweXpect.Reflection/Filters/PropertyFilters.WhichAreExtensionProperties.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Helpers;
 

--- a/Source/aweXpect.Reflection/Filters/PropertyFilters.WhichAreIndexers.cs
+++ b/Source/aweXpect.Reflection/Filters/PropertyFilters.WhichAreIndexers.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Helpers;
 

--- a/Source/aweXpect.Reflection/Filters/PropertyFilters.WhichAreObsolete.cs
+++ b/Source/aweXpect.Reflection/Filters/PropertyFilters.WhichAreObsolete.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Helpers;
 

--- a/Source/aweXpect.Reflection/Filters/PropertyFilters.WhichAreReadOnly.cs
+++ b/Source/aweXpect.Reflection/Filters/PropertyFilters.WhichAreReadOnly.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Helpers;
 

--- a/Source/aweXpect.Reflection/Filters/PropertyFilters.WhichAreReadWrite.cs
+++ b/Source/aweXpect.Reflection/Filters/PropertyFilters.WhichAreReadWrite.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Helpers;
 

--- a/Source/aweXpect.Reflection/Filters/PropertyFilters.WhichAreReadable.cs
+++ b/Source/aweXpect.Reflection/Filters/PropertyFilters.WhichAreReadable.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Helpers;
 

--- a/Source/aweXpect.Reflection/Filters/PropertyFilters.WhichAreSealed.cs
+++ b/Source/aweXpect.Reflection/Filters/PropertyFilters.WhichAreSealed.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Helpers;
 

--- a/Source/aweXpect.Reflection/Filters/PropertyFilters.WhichAreStatic.cs
+++ b/Source/aweXpect.Reflection/Filters/PropertyFilters.WhichAreStatic.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Helpers;
 

--- a/Source/aweXpect.Reflection/Filters/PropertyFilters.WhichAreWritable.cs
+++ b/Source/aweXpect.Reflection/Filters/PropertyFilters.WhichAreWritable.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Helpers;
 

--- a/Source/aweXpect.Reflection/Filters/PropertyFilters.WhichAreWriteOnly.cs
+++ b/Source/aweXpect.Reflection/Filters/PropertyFilters.WhichAreWriteOnly.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Helpers;
 

--- a/Source/aweXpect.Reflection/Filters/TypeFilters.Except.cs
+++ b/Source/aweXpect.Reflection/Filters/TypeFilters.Except.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Runtime.CompilerServices;
 using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Helpers;

--- a/Source/aweXpect.Reflection/Filters/TypeFilters.WhichAreAbstract.cs
+++ b/Source/aweXpect.Reflection/Filters/TypeFilters.WhichAreAbstract.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Helpers;
 

--- a/Source/aweXpect.Reflection/Filters/TypeFilters.WhichAreClasses.cs
+++ b/Source/aweXpect.Reflection/Filters/TypeFilters.WhichAreClasses.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Helpers;
 

--- a/Source/aweXpect.Reflection/Filters/TypeFilters.WhichAreEnums.cs
+++ b/Source/aweXpect.Reflection/Filters/TypeFilters.WhichAreEnums.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection;

--- a/Source/aweXpect.Reflection/Filters/TypeFilters.WhichAreInterfaces.cs
+++ b/Source/aweXpect.Reflection/Filters/TypeFilters.WhichAreInterfaces.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection;

--- a/Source/aweXpect.Reflection/Filters/TypeFilters.WhichAreNested.cs
+++ b/Source/aweXpect.Reflection/Filters/TypeFilters.WhichAreNested.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection;

--- a/Source/aweXpect.Reflection/Filters/TypeFilters.WhichAreObsolete.cs
+++ b/Source/aweXpect.Reflection/Filters/TypeFilters.WhichAreObsolete.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Helpers;
 

--- a/Source/aweXpect.Reflection/Filters/TypeFilters.WhichAreReadOnly.cs
+++ b/Source/aweXpect.Reflection/Filters/TypeFilters.WhichAreReadOnly.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Helpers;
 

--- a/Source/aweXpect.Reflection/Filters/TypeFilters.WhichAreRecordStructs.cs
+++ b/Source/aweXpect.Reflection/Filters/TypeFilters.WhichAreRecordStructs.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Helpers;
 

--- a/Source/aweXpect.Reflection/Filters/TypeFilters.WhichAreRecords.cs
+++ b/Source/aweXpect.Reflection/Filters/TypeFilters.WhichAreRecords.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Helpers;
 

--- a/Source/aweXpect.Reflection/Filters/TypeFilters.WhichAreRefStructs.cs
+++ b/Source/aweXpect.Reflection/Filters/TypeFilters.WhichAreRefStructs.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Helpers;
 

--- a/Source/aweXpect.Reflection/Filters/TypeFilters.WhichAreSealed.cs
+++ b/Source/aweXpect.Reflection/Filters/TypeFilters.WhichAreSealed.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Helpers;
 

--- a/Source/aweXpect.Reflection/Filters/TypeFilters.WhichAreStatic.cs
+++ b/Source/aweXpect.Reflection/Filters/TypeFilters.WhichAreStatic.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Helpers;
 

--- a/Source/aweXpect.Reflection/Filters/TypeFilters.WhichAreStructs.cs
+++ b/Source/aweXpect.Reflection/Filters/TypeFilters.WhichAreStructs.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Helpers;
 

--- a/Source/aweXpect.Reflection/Filters/TypeFilters.WhichContainConstructors.cs
+++ b/Source/aweXpect.Reflection/Filters/TypeFilters.WhichContainConstructors.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Reflection;
 using aweXpect.Core;
 using aweXpect.Reflection.Collections;

--- a/Source/aweXpect.Reflection/Filters/TypeFilters.WhichContainEvents.cs
+++ b/Source/aweXpect.Reflection/Filters/TypeFilters.WhichContainEvents.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Reflection;
 using aweXpect.Core;
 using aweXpect.Reflection.Collections;

--- a/Source/aweXpect.Reflection/Filters/TypeFilters.WhichContainFields.cs
+++ b/Source/aweXpect.Reflection/Filters/TypeFilters.WhichContainFields.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Reflection;
 using aweXpect.Core;
 using aweXpect.Reflection.Collections;

--- a/Source/aweXpect.Reflection/Filters/TypeFilters.WhichContainMethods.cs
+++ b/Source/aweXpect.Reflection/Filters/TypeFilters.WhichContainMethods.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Reflection;
 using aweXpect.Core;
 using aweXpect.Reflection.Collections;

--- a/Source/aweXpect.Reflection/Filters/TypeFilters.WhichContainProperties.cs
+++ b/Source/aweXpect.Reflection/Filters/TypeFilters.WhichContainProperties.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Reflection;
 using aweXpect.Core;
 using aweXpect.Reflection.Collections;

--- a/Source/aweXpect.Reflection/Formatting/FormatterRegistration.cs
+++ b/Source/aweXpect.Reflection/Formatting/FormatterRegistration.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using aweXpect.Core.Initialization;
 
 namespace aweXpect.Reflection.Formatting;

--- a/Source/aweXpect.Reflection/Helpers/AssemblyHelpers.cs
+++ b/Source/aweXpect.Reflection/Helpers/AssemblyHelpers.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;

--- a/Source/aweXpect.Reflection/Helpers/AtIndexMatch.cs
+++ b/Source/aweXpect.Reflection/Helpers/AtIndexMatch.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using aweXpect.Options;
 
 namespace aweXpect.Reflection.Helpers;

--- a/Source/aweXpect.Reflection/Helpers/DependencyViolationRenderer.cs
+++ b/Source/aweXpect.Reflection/Helpers/DependencyViolationRenderer.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
-using aweXpect.Core;
 
 namespace aweXpect.Reflection.Helpers;
 

--- a/Source/aweXpect.Reflection/Helpers/DependencyViolationRenderer.cs
+++ b/Source/aweXpect.Reflection/Helpers/DependencyViolationRenderer.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Text;
 using aweXpect.Core;

--- a/Source/aweXpect.Reflection/Helpers/MemberViolationRenderer.cs
+++ b/Source/aweXpect.Reflection/Helpers/MemberViolationRenderer.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Reflection;
 using System.Text;
-using aweXpect.Core;
 
 namespace aweXpect.Reflection.Helpers;
 

--- a/Source/aweXpect.Reflection/Helpers/NamespaceDependencyGraph.cs
+++ b/Source/aweXpect.Reflection/Helpers/NamespaceDependencyGraph.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 

--- a/Source/aweXpect.Reflection/Helpers/NamespaceDependencyGraph.cs
+++ b/Source/aweXpect.Reflection/Helpers/NamespaceDependencyGraph.cs
@@ -29,7 +29,9 @@ namespace aweXpect.Reflection.Helpers;
 internal sealed class NamespaceDependencyGraph
 {
 	private NamespaceDependencyGraph(IReadOnlyList<IReadOnlyList<string>> cycles)
-		=> Cycles = cycles;
+	{
+		Cycles = cycles;
+	}
 
 	/// <summary>
 	///     The detected dependency cycles, each as an ordered list of node names that returns to its first node
@@ -133,7 +135,7 @@ internal sealed class NamespaceDependencyGraph
 			foreach (string candidate in present)
 			{
 				if (candidate.Length < representative.Length &&
-				    TypeHelpers.NamespaceMatches(key, candidate, includeSubNamespaces: true))
+				    TypeHelpers.NamespaceMatches(key, candidate, true))
 				{
 					representative = candidate;
 				}
@@ -157,7 +159,7 @@ internal sealed class NamespaceDependencyGraph
 		}
 
 		if (sliceRoot is null ||
-		    !TypeHelpers.NamespaceMatches(@namespace, sliceRoot, includeSubNamespaces: true) ||
+		    !TypeHelpers.NamespaceMatches(@namespace, sliceRoot, true) ||
 		    string.Equals(@namespace, sliceRoot, StringComparison.Ordinal))
 		{
 			return @namespace;
@@ -199,7 +201,10 @@ internal sealed class NamespaceDependencyGraph
 	{
 		string start = component.OrderBy(node => node, StringComparer.Ordinal).First();
 		Dictionary<string, string> predecessor = new(StringComparer.Ordinal);
-		HashSet<string> visited = new(StringComparer.Ordinal) { start, };
+		HashSet<string> visited = new(StringComparer.Ordinal)
+		{
+			start,
+		};
 		Queue<string> queue = new();
 		queue.Enqueue(start);
 
@@ -253,11 +258,11 @@ internal sealed class NamespaceDependencyGraph
 	/// </summary>
 	private sealed class TarjanScc(Dictionary<string, HashSet<string>> adjacency)
 	{
+		private readonly List<HashSet<string>> _components = [];
 		private readonly Dictionary<string, int> _indices = new(StringComparer.Ordinal);
 		private readonly Dictionary<string, int> _lowLinks = new(StringComparer.Ordinal);
 		private readonly HashSet<string> _onStack = new(StringComparer.Ordinal);
 		private readonly Stack<string> _stack = new();
-		private readonly List<HashSet<string>> _components = [];
 		private int _nextIndex;
 
 		public List<HashSet<string>> StronglyConnectedComponents()

--- a/Source/aweXpect.Reflection/Helpers/NullabilityHelpers.cs
+++ b/Source/aweXpect.Reflection/Helpers/NullabilityHelpers.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Reflection;
 using aweXpect.Reflection.Collections;

--- a/Source/aweXpect.Reflection/Helpers/ParameterInfoHelpers.cs
+++ b/Source/aweXpect.Reflection/Helpers/ParameterInfoHelpers.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Linq;
 using System.Reflection;
 

--- a/Source/aweXpect.Reflection/Helpers/ParameterModifierHelpers.cs
+++ b/Source/aweXpect.Reflection/Helpers/ParameterModifierHelpers.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Reflection;
 using aweXpect.Core;
 using aweXpect.Reflection.Options;

--- a/Source/aweXpect.Reflection/Helpers/PropertyInfoHelpers.cs
+++ b/Source/aweXpect.Reflection/Helpers/PropertyInfoHelpers.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Linq;
 using System.Reflection;
 using aweXpect.Reflection.Collections;

--- a/Source/aweXpect.Reflection/Helpers/TypeHelpers.cs
+++ b/Source/aweXpect.Reflection/Helpers/TypeHelpers.cs
@@ -888,9 +888,8 @@ internal static class TypeHelpers
 	{
 		List<string> violations = [];
 		HashSet<string> seen = new(StringComparer.Ordinal);
-		foreach (Type dependency in type.GetDependencyViolations(
-			         (dependency, ownNamespace, excludedPrefixes)
-				         => IsDependencyViolation(dependency, ownNamespace, allowed, excludedPrefixes)))
+		foreach (Type dependency in type.GetDependencyViolations((dependency, ownNamespace, excludedPrefixes)
+			         => IsDependencyViolation(dependency, ownNamespace, allowed, excludedPrefixes)))
 		{
 			string display = dependency.Namespace ?? GlobalNamespaceDisplay;
 			if (seen.Add(display))
@@ -912,9 +911,8 @@ internal static class TypeHelpers
 	///     a verdict and not the violation list.
 	/// </remarks>
 	internal static bool HasDependencyNamespaceViolations(this Type type, NamespaceDependencyOptions allowed)
-		=> type.GetDependencyViolations(
-			(dependency, ownNamespace, excludedPrefixes)
-				=> IsDependencyViolation(dependency, ownNamespace, allowed, excludedPrefixes)).Any();
+		=> type.GetDependencyViolations((dependency, ownNamespace, excludedPrefixes)
+			=> IsDependencyViolation(dependency, ownNamespace, allowed, excludedPrefixes)).Any();
 
 	private static bool IsDependencyViolation(
 		Type dependency, string? ownNamespace, NamespaceDependencyOptions allowed, string[] excludedPrefixes)
@@ -972,9 +970,8 @@ internal static class TypeHelpers
 		this Type type, ResolvedTypeSet allowed)
 	{
 		List<string> violations = [];
-		foreach (IGrouping<string, Type> sameName in type.GetDependencyViolations(
-				         (dependency, ownNamespace, excludedPrefixes)
-					         => IsDependencyTypeSetViolation(dependency, ownNamespace, allowed, excludedPrefixes))
+		foreach (IGrouping<string, Type> sameName in type.GetDependencyViolations((dependency, ownNamespace, excludedPrefixes)
+				         => IsDependencyTypeSetViolation(dependency, ownNamespace, allowed, excludedPrefixes))
 			         .GroupBy(dependency => Formatter.Format(dependency), StringComparer.Ordinal))
 		{
 			Type[] violators = sameName.ToArray();
@@ -1003,9 +1000,8 @@ internal static class TypeHelpers
 	///     a verdict and not the violation list.
 	/// </remarks>
 	internal static bool HasDependencyTypeSetViolations(this Type type, ResolvedTypeSet allowed)
-		=> type.GetDependencyViolations(
-			(dependency, ownNamespace, excludedPrefixes)
-				=> IsDependencyTypeSetViolation(dependency, ownNamespace, allowed, excludedPrefixes)).Any();
+		=> type.GetDependencyViolations((dependency, ownNamespace, excludedPrefixes)
+			=> IsDependencyTypeSetViolation(dependency, ownNamespace, allowed, excludedPrefixes)).Any();
 
 	private static bool IsDependencyTypeSetViolation(
 		Type dependency, string? ownNamespace, ResolvedTypeSet allowed, string[] excludedPrefixes)

--- a/Source/aweXpect.Reflection/Options/DependencyCyclesOptions.cs
+++ b/Source/aweXpect.Reflection/Options/DependencyCyclesOptions.cs
@@ -1,4 +1,4 @@
-namespace aweXpect.Reflection.Options;
+﻿namespace aweXpect.Reflection.Options;
 
 /// <summary>
 ///     Options for a namespace dependency cycle assertion.

--- a/Source/aweXpect.Reflection/Options/NamespaceDependencyOptions.cs
+++ b/Source/aweXpect.Reflection/Options/NamespaceDependencyOptions.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using aweXpect.Core;
 using aweXpect.Reflection.Helpers;
 
 namespace aweXpect.Reflection.Options;
@@ -17,24 +16,19 @@ internal sealed class NamespaceDependencyOptions
 {
 	private readonly List<string> _namespaces = [];
 	private bool _excludeOwnSubNamespaces;
-	private bool _excludeSubNamespaces;
 
 	public NamespaceDependencyOptions(IEnumerable<string> namespaces)
-		=> OrOn(namespaces);
+	{
+		OrOn(namespaces);
+	}
 
 	private NamespaceDependencyOptions(IEnumerable<string> namespaces, bool excludeSubNamespaces,
 		bool excludeOwnSubNamespaces)
 	{
 		_namespaces.AddRange(namespaces);
-		_excludeSubNamespaces = excludeSubNamespaces;
+		ExcludeSubNamespaces = excludeSubNamespaces;
 		_excludeOwnSubNamespaces = excludeOwnSubNamespaces;
 	}
-
-	/// <summary>
-	///     Creates an independent copy, so that refining a (reusable) filter does not mutate the shared instance.
-	/// </summary>
-	public NamespaceDependencyOptions Copy()
-		=> new(_namespaces, _excludeSubNamespaces, _excludeOwnSubNamespaces);
 
 	/// <summary>
 	///     The namespaces that are targeted (for depends-on / does-not-depend-on) or allowed (for depends-only-on).
@@ -44,7 +38,7 @@ internal sealed class NamespaceDependencyOptions
 	/// <summary>
 	///     Indicates whether sub-namespaces are excluded from matching.
 	/// </summary>
-	public bool ExcludeSubNamespaces => _excludeSubNamespaces;
+	public bool ExcludeSubNamespaces { get; private set; }
 
 	/// <summary>
 	///     Indicates whether sub-namespaces of the type's own namespace are still allowed (for depends-only-on
@@ -55,6 +49,12 @@ internal sealed class NamespaceDependencyOptions
 	///     <see cref="ExcludingOwnSubNamespaces" />.
 	/// </remarks>
 	public bool IncludeOwnSubNamespaces => !_excludeOwnSubNamespaces;
+
+	/// <summary>
+	///     Creates an independent copy, so that refining a (reusable) filter does not mutate the shared instance.
+	/// </summary>
+	public NamespaceDependencyOptions Copy()
+		=> new(_namespaces, ExcludeSubNamespaces, _excludeOwnSubNamespaces);
 
 	/// <summary>
 	///     Widens the set of targeted/allowed namespaces by the given <paramref name="namespaces" />.
@@ -121,7 +121,7 @@ internal sealed class NamespaceDependencyOptions
 	///     Excludes sub-namespaces of the targeted/allowed namespaces from matching for the whole expression.
 	/// </summary>
 	public void ExcludingSubNamespaces()
-		=> _excludeSubNamespaces = true;
+		=> ExcludeSubNamespaces = true;
 
 	/// <summary>
 	///     Excludes sub-namespaces of the type's own namespace from being implicitly allowed (for depends-only-on

--- a/Source/aweXpect.Reflection/Options/TypeDependencyOptions.cs
+++ b/Source/aweXpect.Reflection/Options/TypeDependencyOptions.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using aweXpect.Core;
 using aweXpect.Reflection.Helpers;
 
 namespace aweXpect.Reflection.Options;
@@ -18,7 +17,9 @@ internal sealed class TypeDependencyOptions
 	private readonly List<Type> _types = [];
 
 	public TypeDependencyOptions(Type type)
-		=> _types.Add(type ?? throw new ArgumentNullException(nameof(type)));
+	{
+		_types.Add(type ?? throw new ArgumentNullException(nameof(type)));
+	}
 
 	/// <summary>
 	///     The targeted types.

--- a/Source/aweXpect.Reflection/Options/TypeSetDependencyOptions.cs
+++ b/Source/aweXpect.Reflection/Options/TypeSetDependencyOptions.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;

--- a/Source/aweXpect.Reflection/Results/DependencyCyclesResult.cs
+++ b/Source/aweXpect.Reflection/Results/DependencyCyclesResult.cs
@@ -18,7 +18,9 @@ public sealed class DependencyCyclesResult<TThat>
 		IThat<TThat> subject,
 		DependencyCyclesOptions options)
 		: base(expectationBuilder, subject)
-		=> _options = options;
+	{
+		_options = options;
+	}
 
 	/// <summary>
 	///     Treats every namespace as its own node, so that a reference between a namespace and one of its sub-namespaces

--- a/Source/aweXpect.Reflection/Results/DependencyCyclesResult.cs
+++ b/Source/aweXpect.Reflection/Results/DependencyCyclesResult.cs
@@ -1,4 +1,4 @@
-using aweXpect.Core;
+﻿using aweXpect.Core;
 using aweXpect.Reflection.Options;
 using aweXpect.Results;
 

--- a/Source/aweXpect.Reflection/Results/NamespaceDependencyOnlyOnResult.cs
+++ b/Source/aweXpect.Reflection/Results/NamespaceDependencyOnlyOnResult.cs
@@ -19,7 +19,9 @@ public sealed class NamespaceDependencyOnlyOnResult<TThat>
 		IThat<TThat> subject,
 		NamespaceDependencyOptions options)
 		: base(expectationBuilder, subject)
-		=> _options = options;
+	{
+		_options = options;
+	}
 
 	/// <summary>
 	///     Widens the expression by the given <paramref name="namespaces" /> (including sub-namespaces unless

--- a/Source/aweXpect.Reflection/Results/NamespaceDependencyOnlyOnResult.cs
+++ b/Source/aweXpect.Reflection/Results/NamespaceDependencyOnlyOnResult.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using aweXpect.Core;
 using aweXpect.Reflection.Options;
 using aweXpect.Results;

--- a/Source/aweXpect.Reflection/Results/NamespaceDependencyOutsideResult.cs
+++ b/Source/aweXpect.Reflection/Results/NamespaceDependencyOutsideResult.cs
@@ -20,7 +20,9 @@ public sealed class NamespaceDependencyOutsideResult<TThat>
 		IThat<TThat> subject,
 		NamespaceDependencyOptions options)
 		: base(expectationBuilder, subject)
-		=> _options = options;
+	{
+		_options = options;
+	}
 
 	/// <summary>
 	///     Widens the allowed set by the given <paramref name="namespaces" /> (including sub-namespaces unless

--- a/Source/aweXpect.Reflection/Results/NamespaceDependencyResult.cs
+++ b/Source/aweXpect.Reflection/Results/NamespaceDependencyResult.cs
@@ -19,7 +19,9 @@ public sealed class NamespaceDependencyResult<TThat>
 		IThat<TThat> subject,
 		NamespaceDependencyOptions options)
 		: base(expectationBuilder, subject)
-		=> _options = options;
+	{
+		_options = options;
+	}
 
 	/// <summary>
 	///     Widens the expression by the given <paramref name="namespaces" /> (including sub-namespaces unless

--- a/Source/aweXpect.Reflection/Results/TypeDependencyResult.cs
+++ b/Source/aweXpect.Reflection/Results/TypeDependencyResult.cs
@@ -18,7 +18,9 @@ public sealed class TypeDependencyResult<TThat>
 		IThat<TThat> subject,
 		TypeDependencyOptions options)
 		: base(expectationBuilder, subject)
-		=> _options = options;
+	{
+		_options = options;
+	}
 
 	/// <summary>
 	///     Widens the expression by the type <typeparamref name="T" />.

--- a/Source/aweXpect.Reflection/Results/TypeSetDependencyOnlyOnResult.cs
+++ b/Source/aweXpect.Reflection/Results/TypeSetDependencyOnlyOnResult.cs
@@ -1,4 +1,4 @@
-using aweXpect.Core;
+﻿using aweXpect.Core;
 using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Options;
 using aweXpect.Results;

--- a/Source/aweXpect.Reflection/Results/TypeSetDependencyOnlyOnResult.cs
+++ b/Source/aweXpect.Reflection/Results/TypeSetDependencyOnlyOnResult.cs
@@ -20,7 +20,9 @@ public sealed class TypeSetDependencyOnlyOnResult<TThat>
 		IThat<TThat> subject,
 		TypeSetDependencyOptions options)
 		: base(expectationBuilder, subject)
-		=> _options = options;
+	{
+		_options = options;
+	}
 
 	/// <summary>
 	///     Widens the expression by the given <paramref name="targets" />.

--- a/Source/aweXpect.Reflection/Results/TypeSetDependencyOutsideResult.cs
+++ b/Source/aweXpect.Reflection/Results/TypeSetDependencyOutsideResult.cs
@@ -20,7 +20,9 @@ public sealed class TypeSetDependencyOutsideResult<TThat>
 		IThat<TThat> subject,
 		TypeSetDependencyOptions options)
 		: base(expectationBuilder, subject)
-		=> _options = options;
+	{
+		_options = options;
+	}
 
 	/// <summary>
 	///     Widens the allowed set by the given <paramref name="targets" />, so that dependencies on their types no

--- a/Source/aweXpect.Reflection/Results/TypeSetDependencyResult.cs
+++ b/Source/aweXpect.Reflection/Results/TypeSetDependencyResult.cs
@@ -1,4 +1,4 @@
-using aweXpect.Core;
+﻿using aweXpect.Core;
 using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Options;
 using aweXpect.Results;

--- a/Source/aweXpect.Reflection/Results/TypeSetDependencyResult.cs
+++ b/Source/aweXpect.Reflection/Results/TypeSetDependencyResult.cs
@@ -19,7 +19,9 @@ public sealed class TypeSetDependencyResult<TThat>
 		IThat<TThat> subject,
 		TypeSetDependencyOptions options)
 		: base(expectationBuilder, subject)
-		=> _options = options;
+	{
+		_options = options;
+	}
 
 	/// <summary>
 	///     Widens the expression by the given <paramref name="targets" />.

--- a/Source/aweXpect.Reflection/ThatAssemblies.AreStrongNamed.cs
+++ b/Source/aweXpect.Reflection/ThatAssemblies.AreStrongNamed.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Reflection;
 using System.Text;
 using aweXpect.Core;

--- a/Source/aweXpect.Reflection/ThatAssemblies.DependOnlyOn.cs
+++ b/Source/aweXpect.Reflection/ThatAssemblies.DependOnlyOn.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Text;

--- a/Source/aweXpect.Reflection/ThatAssemblies.Target.cs
+++ b/Source/aweXpect.Reflection/ThatAssemblies.Target.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Reflection;
 using System.Text;
 using System.Threading;

--- a/Source/aweXpect.Reflection/ThatAssembly.DependsOn.cs
+++ b/Source/aweXpect.Reflection/ThatAssembly.DependsOn.cs
@@ -1,4 +1,4 @@
-using System.Linq;
+﻿using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Threading;

--- a/Source/aweXpect.Reflection/ThatAssembly.DependsOnlyOn.cs
+++ b/Source/aweXpect.Reflection/ThatAssembly.DependsOnlyOn.cs
@@ -1,4 +1,4 @@
-using System.Linq;
+﻿using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Threading;

--- a/Source/aweXpect.Reflection/ThatAssembly.DoesNotDependOn.cs
+++ b/Source/aweXpect.Reflection/ThatAssembly.DoesNotDependOn.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using aweXpect.Core;
 using aweXpect.Core.Constraints;
 using aweXpect.Options;

--- a/Source/aweXpect.Reflection/ThatAssembly.IsStrongNamed.cs
+++ b/Source/aweXpect.Reflection/ThatAssembly.IsStrongNamed.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using System.Text;
 using aweXpect.Core;
 using aweXpect.Core.Constraints;

--- a/Source/aweXpect.Reflection/ThatAssembly.Targets.cs
+++ b/Source/aweXpect.Reflection/ThatAssembly.Targets.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;

--- a/Source/aweXpect.Reflection/ThatConstructor.HasInParameter.cs
+++ b/Source/aweXpect.Reflection/ThatConstructor.HasInParameter.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Linq;
 using System.Reflection;
 using System.Text;

--- a/Source/aweXpect.Reflection/ThatConstructor.HasOptionalParameter.cs
+++ b/Source/aweXpect.Reflection/ThatConstructor.HasOptionalParameter.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Linq;
 using System.Reflection;
 using System.Text;

--- a/Source/aweXpect.Reflection/ThatConstructor.HasOutParameter.cs
+++ b/Source/aweXpect.Reflection/ThatConstructor.HasOutParameter.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Linq;
 using System.Reflection;
 using System.Text;

--- a/Source/aweXpect.Reflection/ThatConstructor.HasParamsParameter.cs
+++ b/Source/aweXpect.Reflection/ThatConstructor.HasParamsParameter.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Linq;
 using System.Reflection;
 using System.Text;

--- a/Source/aweXpect.Reflection/ThatConstructor.HasRefParameter.cs
+++ b/Source/aweXpect.Reflection/ThatConstructor.HasRefParameter.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Linq;
 using System.Reflection;
 using System.Text;

--- a/Source/aweXpect.Reflection/ThatConstructor.cs
+++ b/Source/aweXpect.Reflection/ThatConstructor.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 
 namespace aweXpect.Reflection;
 

--- a/Source/aweXpect.Reflection/ThatConstructors.HaveInParameter.cs
+++ b/Source/aweXpect.Reflection/ThatConstructors.HaveInParameter.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;

--- a/Source/aweXpect.Reflection/ThatConstructors.HaveOptionalParameter.cs
+++ b/Source/aweXpect.Reflection/ThatConstructors.HaveOptionalParameter.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;

--- a/Source/aweXpect.Reflection/ThatConstructors.HaveOutParameter.cs
+++ b/Source/aweXpect.Reflection/ThatConstructors.HaveOutParameter.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;

--- a/Source/aweXpect.Reflection/ThatConstructors.HaveParamsParameter.cs
+++ b/Source/aweXpect.Reflection/ThatConstructors.HaveParamsParameter.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;

--- a/Source/aweXpect.Reflection/ThatConstructors.HaveRefParameter.cs
+++ b/Source/aweXpect.Reflection/ThatConstructors.HaveRefParameter.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;

--- a/Source/aweXpect.Reflection/ThatEvent.IsAbstract.cs
+++ b/Source/aweXpect.Reflection/ThatEvent.IsAbstract.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using System.Text;
 using aweXpect.Core;
 using aweXpect.Core.Constraints;

--- a/Source/aweXpect.Reflection/ThatEvent.IsSealed.cs
+++ b/Source/aweXpect.Reflection/ThatEvent.IsSealed.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using System.Text;
 using aweXpect.Core;
 using aweXpect.Core.Constraints;

--- a/Source/aweXpect.Reflection/ThatEvents.AreAbstract.cs
+++ b/Source/aweXpect.Reflection/ThatEvents.AreAbstract.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Reflection;
 using System.Text;
 using aweXpect.Core;

--- a/Source/aweXpect.Reflection/ThatField.IsConstant.cs
+++ b/Source/aweXpect.Reflection/ThatField.IsConstant.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using System.Text;
 using aweXpect.Core;
 using aweXpect.Core.Constraints;

--- a/Source/aweXpect.Reflection/ThatField.IsReadOnly.cs
+++ b/Source/aweXpect.Reflection/ThatField.IsReadOnly.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using System.Text;
 using aweXpect.Core;
 using aweXpect.Core.Constraints;

--- a/Source/aweXpect.Reflection/ThatFields.AreConstant.cs
+++ b/Source/aweXpect.Reflection/ThatFields.AreConstant.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Reflection;
 using System.Text;
 using aweXpect.Core;

--- a/Source/aweXpect.Reflection/ThatFields.AreReadOnly.cs
+++ b/Source/aweXpect.Reflection/ThatFields.AreReadOnly.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Reflection;
 using System.Text;
 using aweXpect.Core;

--- a/Source/aweXpect.Reflection/ThatMember.IsObsolete.cs
+++ b/Source/aweXpect.Reflection/ThatMember.IsObsolete.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using System.Text;
 using aweXpect.Core;
 using aweXpect.Core.Constraints;

--- a/Source/aweXpect.Reflection/ThatMembers.AreObsolete.cs
+++ b/Source/aweXpect.Reflection/ThatMembers.AreObsolete.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Reflection;
 using System.Text;
 using aweXpect.Core;

--- a/Source/aweXpect.Reflection/ThatMethod.HasInParameter.cs
+++ b/Source/aweXpect.Reflection/ThatMethod.HasInParameter.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Linq;
 using System.Reflection;
 using System.Text;

--- a/Source/aweXpect.Reflection/ThatMethod.HasOptionalParameter.cs
+++ b/Source/aweXpect.Reflection/ThatMethod.HasOptionalParameter.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Linq;
 using System.Reflection;
 using System.Text;

--- a/Source/aweXpect.Reflection/ThatMethod.HasOutParameter.cs
+++ b/Source/aweXpect.Reflection/ThatMethod.HasOutParameter.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Linq;
 using System.Reflection;
 using System.Text;

--- a/Source/aweXpect.Reflection/ThatMethod.HasParameter.cs
+++ b/Source/aweXpect.Reflection/ThatMethod.HasParameter.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Linq;
 using System.Reflection;
 using System.Text;

--- a/Source/aweXpect.Reflection/ThatMethod.HasParamsParameter.cs
+++ b/Source/aweXpect.Reflection/ThatMethod.HasParamsParameter.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Linq;
 using System.Reflection;
 using System.Text;

--- a/Source/aweXpect.Reflection/ThatMethod.HasRefParameter.cs
+++ b/Source/aweXpect.Reflection/ThatMethod.HasRefParameter.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Linq;
 using System.Reflection;
 using System.Text;

--- a/Source/aweXpect.Reflection/ThatMethod.IsAbstract.cs
+++ b/Source/aweXpect.Reflection/ThatMethod.IsAbstract.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using System.Text;
 using aweXpect.Core;
 using aweXpect.Core.Constraints;

--- a/Source/aweXpect.Reflection/ThatMethod.IsAnExtensionMethod.cs
+++ b/Source/aweXpect.Reflection/ThatMethod.IsAnExtensionMethod.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using System.Text;
 using aweXpect.Core;
 using aweXpect.Core.Constraints;

--- a/Source/aweXpect.Reflection/ThatMethod.IsAsync.cs
+++ b/Source/aweXpect.Reflection/ThatMethod.IsAsync.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using System.Text;
 using aweXpect.Core;
 using aweXpect.Core.Constraints;

--- a/Source/aweXpect.Reflection/ThatMethod.IsGeneric.cs
+++ b/Source/aweXpect.Reflection/ThatMethod.IsGeneric.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;

--- a/Source/aweXpect.Reflection/ThatMethod.IsSealed.cs
+++ b/Source/aweXpect.Reflection/ThatMethod.IsSealed.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using System.Text;
 using aweXpect.Core;
 using aweXpect.Core.Constraints;

--- a/Source/aweXpect.Reflection/ThatMethod.Returns.cs
+++ b/Source/aweXpect.Reflection/ThatMethod.Returns.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Reflection;
 using System.Text;
 using aweXpect.Core;

--- a/Source/aweXpect.Reflection/ThatMethod.ReturnsExactly.cs
+++ b/Source/aweXpect.Reflection/ThatMethod.ReturnsExactly.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Reflection;
 using aweXpect.Core;
 using aweXpect.Reflection.Helpers;

--- a/Source/aweXpect.Reflection/ThatMethod.ReturnsVoid.cs
+++ b/Source/aweXpect.Reflection/ThatMethod.ReturnsVoid.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using aweXpect.Core;
 
 namespace aweXpect.Reflection;

--- a/Source/aweXpect.Reflection/ThatMethods.AreAsync.cs
+++ b/Source/aweXpect.Reflection/ThatMethods.AreAsync.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Reflection;
 using System.Text;
 using aweXpect.Core;

--- a/Source/aweXpect.Reflection/ThatMethods.AreExtensionMethods.cs
+++ b/Source/aweXpect.Reflection/ThatMethods.AreExtensionMethods.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Reflection;
 using System.Text;
 using aweXpect.Core;

--- a/Source/aweXpect.Reflection/ThatMethods.AreOperators.cs
+++ b/Source/aweXpect.Reflection/ThatMethods.AreOperators.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Reflection;
 using System.Text;
 using aweXpect.Core;

--- a/Source/aweXpect.Reflection/ThatMethods.HaveInParameter.cs
+++ b/Source/aweXpect.Reflection/ThatMethods.HaveInParameter.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;

--- a/Source/aweXpect.Reflection/ThatMethods.HaveOptionalParameter.cs
+++ b/Source/aweXpect.Reflection/ThatMethods.HaveOptionalParameter.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;

--- a/Source/aweXpect.Reflection/ThatMethods.HaveOutParameter.cs
+++ b/Source/aweXpect.Reflection/ThatMethods.HaveOutParameter.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;

--- a/Source/aweXpect.Reflection/ThatMethods.HaveParamsParameter.cs
+++ b/Source/aweXpect.Reflection/ThatMethods.HaveParamsParameter.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;

--- a/Source/aweXpect.Reflection/ThatMethods.HaveRefParameter.cs
+++ b/Source/aweXpect.Reflection/ThatMethods.HaveRefParameter.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;

--- a/Source/aweXpect.Reflection/ThatMethods.ReturnVoid.cs
+++ b/Source/aweXpect.Reflection/ThatMethods.ReturnVoid.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Reflection;
 using aweXpect.Core;
 

--- a/Source/aweXpect.Reflection/ThatProperties.AreExtensionProperties.cs
+++ b/Source/aweXpect.Reflection/ThatProperties.AreExtensionProperties.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Reflection;
 using System.Text;
 using aweXpect.Core;

--- a/Source/aweXpect.Reflection/ThatProperties.AreIndexers.cs
+++ b/Source/aweXpect.Reflection/ThatProperties.AreIndexers.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Reflection;
 using System.Text;
 using aweXpect.Core;

--- a/Source/aweXpect.Reflection/ThatProperties.AreReadOnly.cs
+++ b/Source/aweXpect.Reflection/ThatProperties.AreReadOnly.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Reflection;
 using System.Text;
 using aweXpect.Core;

--- a/Source/aweXpect.Reflection/ThatProperties.AreReadWrite.cs
+++ b/Source/aweXpect.Reflection/ThatProperties.AreReadWrite.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Reflection;
 using System.Text;
 using aweXpect.Core;

--- a/Source/aweXpect.Reflection/ThatProperties.AreReadable.cs
+++ b/Source/aweXpect.Reflection/ThatProperties.AreReadable.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Reflection;
 using System.Text;
 using aweXpect.Core;

--- a/Source/aweXpect.Reflection/ThatProperties.AreWritable.cs
+++ b/Source/aweXpect.Reflection/ThatProperties.AreWritable.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Reflection;
 using System.Text;
 using aweXpect.Core;

--- a/Source/aweXpect.Reflection/ThatProperties.AreWriteOnly.cs
+++ b/Source/aweXpect.Reflection/ThatProperties.AreWriteOnly.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Reflection;
 using System.Text;
 using aweXpect.Core;

--- a/Source/aweXpect.Reflection/ThatProperty.IsAbstract.cs
+++ b/Source/aweXpect.Reflection/ThatProperty.IsAbstract.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using System.Text;
 using aweXpect.Core;
 using aweXpect.Core.Constraints;

--- a/Source/aweXpect.Reflection/ThatProperty.IsAnExtensionProperty.cs
+++ b/Source/aweXpect.Reflection/ThatProperty.IsAnExtensionProperty.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using System.Text;
 using aweXpect.Core;
 using aweXpect.Core.Constraints;

--- a/Source/aweXpect.Reflection/ThatProperty.IsAnIndexer.cs
+++ b/Source/aweXpect.Reflection/ThatProperty.IsAnIndexer.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using System.Text;
 using aweXpect.Core;
 using aweXpect.Core.Constraints;

--- a/Source/aweXpect.Reflection/ThatProperty.IsReadOnly.cs
+++ b/Source/aweXpect.Reflection/ThatProperty.IsReadOnly.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using System.Text;
 using aweXpect.Core;
 using aweXpect.Core.Constraints;

--- a/Source/aweXpect.Reflection/ThatProperty.IsReadWrite.cs
+++ b/Source/aweXpect.Reflection/ThatProperty.IsReadWrite.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using System.Text;
 using aweXpect.Core;
 using aweXpect.Core.Constraints;

--- a/Source/aweXpect.Reflection/ThatProperty.IsReadable.cs
+++ b/Source/aweXpect.Reflection/ThatProperty.IsReadable.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using System.Text;
 using aweXpect.Core;
 using aweXpect.Core.Constraints;

--- a/Source/aweXpect.Reflection/ThatProperty.IsSealed.cs
+++ b/Source/aweXpect.Reflection/ThatProperty.IsSealed.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using System.Text;
 using aweXpect.Core;
 using aweXpect.Core.Constraints;

--- a/Source/aweXpect.Reflection/ThatProperty.IsWritable.cs
+++ b/Source/aweXpect.Reflection/ThatProperty.IsWritable.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using System.Text;
 using aweXpect.Core;
 using aweXpect.Core.Constraints;

--- a/Source/aweXpect.Reflection/ThatProperty.IsWriteOnly.cs
+++ b/Source/aweXpect.Reflection/ThatProperty.IsWriteOnly.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using System.Text;
 using aweXpect.Core;
 using aweXpect.Core.Constraints;

--- a/Source/aweXpect.Reflection/ThatType.InheritsFrom.cs
+++ b/Source/aweXpect.Reflection/ThatType.InheritsFrom.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Text;
 using aweXpect.Core;
 using aweXpect.Core.Constraints;

--- a/Source/aweXpect.Reflection/ThatType.IsARefStruct.cs
+++ b/Source/aweXpect.Reflection/ThatType.IsARefStruct.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Text;
 using aweXpect.Core;
 using aweXpect.Core.Constraints;

--- a/Source/aweXpect.Reflection/ThatType.IsGeneric.cs
+++ b/Source/aweXpect.Reflection/ThatType.IsGeneric.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;

--- a/Source/aweXpect.Reflection/ThatType.IsReadOnly.cs
+++ b/Source/aweXpect.Reflection/ThatType.IsReadOnly.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Text;
 using aweXpect.Core;
 using aweXpect.Core.Constraints;

--- a/Source/aweXpect.Reflection/ThatTypes.AreReadOnly.cs
+++ b/Source/aweXpect.Reflection/ThatTypes.AreReadOnly.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Text;
 using aweXpect.Core;

--- a/Source/aweXpect.Reflection/ThatTypes.AreRefStructs.cs
+++ b/Source/aweXpect.Reflection/ThatTypes.AreRefStructs.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Text;
 using aweXpect.Core;

--- a/Source/aweXpect.Reflection/ThatTypes.HaveConversionOperator.cs
+++ b/Source/aweXpect.Reflection/ThatTypes.HaveConversionOperator.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Text;
 using aweXpect.Core;

--- a/Source/aweXpect.Reflection/ThatTypes.HaveNoDependencyCycles.cs
+++ b/Source/aweXpect.Reflection/ThatTypes.HaveNoDependencyCycles.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/Source/aweXpect.Reflection/ThatTypes.HaveNoDependencyCycles.cs
+++ b/Source/aweXpect.Reflection/ThatTypes.HaveNoDependencyCycles.cs
@@ -110,7 +110,7 @@ public static partial class ThatTypes
 		{
 			// Materialize once: the source (e.g. Types.InNamespace(...)) may be lazy and re-scan assemblies on every
 			// enumeration, while both the cycle detection and the later result formatting read Actual.
-			List<Type?> materialized = [.. actual];
+			List<Type?> materialized = [.. actual,];
 			Actual = materialized;
 			return SetResult(materialized);
 		}

--- a/Source/aweXpect.Reflection/Types.cs
+++ b/Source/aweXpect.Reflection/Types.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Reflection;
 using aweXpect.Reflection.Collections;

--- a/Tests/aweXpect.Reflection.Internal.Tests/Helpers/AssemblyHelpersTests.cs
+++ b/Tests/aweXpect.Reflection.Internal.Tests/Helpers/AssemblyHelpersTests.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using System.Runtime.Versioning;
 using aweXpect.Reflection.Helpers;
 

--- a/Tests/aweXpect.Reflection.Internal.Tests/Helpers/AssemblyHelpersTests.cs
+++ b/Tests/aweXpect.Reflection.Internal.Tests/Helpers/AssemblyHelpersTests.cs
@@ -33,6 +33,44 @@ public class AssemblyHelpersTests
 	}
 
 	[Theory]
+	[InlineData("System", "System", true)]
+	[InlineData("System.Text.Json", "System", true)]
+	[InlineData("SystemsBiology.Core", "System", false)]
+	[InlineData("SystemsBiology", "System", false)]
+	// A customized prefix written with a trailing dot is boundary-safe by construction.
+	[InlineData("MyCompany.Domain", "MyCompany.", true)]
+	[InlineData("MyCompany.", "MyCompany.", true)]
+	[InlineData("MyCompany", "MyCompany.", false)]
+	[InlineData("MyCompanyOther", "MyCompany.", false)]
+	public async Task IsExcludedAssemblyName_ShouldMatchAtNameSegmentBoundary(
+		string assemblyName, string prefix, bool expected)
+	{
+		bool result = assemblyName.IsExcludedAssemblyName([prefix,]);
+
+		await That(result).IsEqualTo(expected);
+	}
+
+	[Fact]
+	public async Task IsExcludedAssemblyName_WhenAssemblyNameIsNull_ShouldReturnFalse()
+	{
+		string? assemblyName = null;
+
+		bool result = assemblyName.IsExcludedAssemblyName(["System",]);
+
+		await That(result).IsFalse();
+	}
+
+	[Fact]
+	public async Task IsExcludedAssemblyName_WhenPrefixIsEmpty_ShouldBeIgnored()
+	{
+		// An empty prefix cannot identify an assembly; it must neither exclude everything
+		// (the old StartsWith behavior) nor be silently evaluated against the boundary check.
+		bool result = "AnyAssembly".IsExcludedAssemblyName(["",]);
+
+		await That(result).IsFalse();
+	}
+
+	[Theory]
 	[InlineData(".NETCoreApp,Version=v5.0", "net5.0")]
 	[InlineData(".NETCoreApp,Version=v6.0", "net6.0")]
 	[InlineData(".NETCoreApp,Version=v7.0", "net7.0")]
@@ -75,44 +113,6 @@ public class AssemblyHelpersTests
 		string? result = AssemblyHelpers.MapFrameworkName("SomethingWithoutAVersion");
 
 		await That(result).IsEqualTo("SomethingWithoutAVersion");
-	}
-
-	[Theory]
-	[InlineData("System", "System", true)]
-	[InlineData("System.Text.Json", "System", true)]
-	[InlineData("SystemsBiology.Core", "System", false)]
-	[InlineData("SystemsBiology", "System", false)]
-	// A customized prefix written with a trailing dot is boundary-safe by construction.
-	[InlineData("MyCompany.Domain", "MyCompany.", true)]
-	[InlineData("MyCompany.", "MyCompany.", true)]
-	[InlineData("MyCompany", "MyCompany.", false)]
-	[InlineData("MyCompanyOther", "MyCompany.", false)]
-	public async Task IsExcludedAssemblyName_ShouldMatchAtNameSegmentBoundary(
-		string assemblyName, string prefix, bool expected)
-	{
-		bool result = assemblyName.IsExcludedAssemblyName([prefix,]);
-
-		await That(result).IsEqualTo(expected);
-	}
-
-	[Fact]
-	public async Task IsExcludedAssemblyName_WhenAssemblyNameIsNull_ShouldReturnFalse()
-	{
-		string? assemblyName = null;
-
-		bool result = assemblyName.IsExcludedAssemblyName(["System",]);
-
-		await That(result).IsFalse();
-	}
-
-	[Fact]
-	public async Task IsExcludedAssemblyName_WhenPrefixIsEmpty_ShouldBeIgnored()
-	{
-		// An empty prefix cannot identify an assembly; it must neither exclude everything
-		// (the old StartsWith behavior) nor be silently evaluated against the boundary check.
-		bool result = "AnyAssembly".IsExcludedAssemblyName(["",]);
-
-		await That(result).IsFalse();
 	}
 }
 

--- a/Tests/aweXpect.Reflection.Internal.Tests/Helpers/AtIndexMatchTests.cs
+++ b/Tests/aweXpect.Reflection.Internal.Tests/Helpers/AtIndexMatchTests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Options;
+﻿using aweXpect.Options;
 using aweXpect.Reflection.Helpers;
 
 namespace aweXpect.Reflection.Internal.Tests.Helpers;

--- a/Tests/aweXpect.Reflection.Internal.Tests/Helpers/CollectionConstraintResultTests.cs
+++ b/Tests/aweXpect.Reflection.Internal.Tests/Helpers/CollectionConstraintResultTests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Text;
 using aweXpect.Core;
 using aweXpect.Reflection.Helpers;

--- a/Tests/aweXpect.Reflection.Internal.Tests/Helpers/LinqAsyncHelpersTests.cs
+++ b/Tests/aweXpect.Reflection.Internal.Tests/Helpers/LinqAsyncHelpersTests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 #if NET8_0_OR_GREATER
 #endif

--- a/Tests/aweXpect.Reflection.Internal.Tests/Helpers/LinqAsyncHelpersTests.cs
+++ b/Tests/aweXpect.Reflection.Internal.Tests/Helpers/LinqAsyncHelpersTests.cs
@@ -127,7 +127,7 @@ public sealed class LinqAsyncHelpersTests
 		int[] source = [1, 1, 2, 3, 3, 3,];
 
 		List<int> result = new();
-		await foreach (int item in LinqAsyncHelpers.Distinct(ToAsync(source)))
+		await foreach (int item in ToAsync(source).Distinct())
 		{
 			result.Add(item);
 		}

--- a/Tests/aweXpect.Reflection.Internal.Tests/Helpers/NullabilityHelpersTests.cs
+++ b/Tests/aweXpect.Reflection.Internal.Tests/Helpers/NullabilityHelpersTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 using aweXpect.Reflection.Helpers;
@@ -8,19 +9,34 @@ namespace aweXpect.Reflection.Internal.Tests.Helpers;
 public sealed class NullabilityHelpersTests
 {
 	[Fact]
-	public async Task IsNullable_WithNullFieldInfo_ShouldReturnFalse()
+	public async Task GetNotNullableMembers_ShouldReturnNonNullableFieldsAndProperties()
 	{
-		FieldInfo? fieldInfo = null;
+		MemberInfo[] notNullableMembers = typeof(NullabilityTestClass).GetNotNullableMembers();
 
-		await That(fieldInfo.IsNullable()).IsFalse();
+		await That(notNullableMembers.Select(member => member.Name)).IsEqualTo([
+			nameof(NullabilityTestClass.NonNullableValueField),
+			nameof(NullabilityTestClass.NonNullableReferenceField),
+			nameof(NullabilityTestClass.NonNullableGenericField),
+			nameof(NullabilityTestClass.NonNullableValueProperty),
+			nameof(NullabilityTestClass.NonNullableReferenceProperty),
+			nameof(NullabilityTestClass.NonNullableGenericProperty),
+		]).InAnyOrder();
 	}
 
 	[Fact]
-	public async Task IsNullable_WithNullPropertyInfo_ShouldReturnFalse()
+	public async Task GetNullableMembers_ShouldReturnNullableFieldsAndProperties()
 	{
-		PropertyInfo? propertyInfo = null;
+		MemberInfo[] nullableMembers = typeof(NullabilityTestClass).GetNullableMembers();
 
-		await That(propertyInfo.IsNullable()).IsFalse();
+		await That(nullableMembers.Select(member => member.Name)).IsEqualTo([
+			nameof(NullabilityTestClass.NullableValueField),
+			nameof(NullabilityTestClass.NullableReferenceField),
+			nameof(NullabilityTestClass.NullableGenericField),
+			nameof(NullabilityTestClass.NullableValueProperty),
+			nameof(NullabilityTestClass.NullableReferenceProperty),
+			nameof(NullabilityTestClass.NullableGenericProperty),
+			nameof(NullabilityTestClass.NullableWriteOnlyProperty),
+		]).InAnyOrder();
 	}
 
 	[Theory]
@@ -50,125 +66,6 @@ public sealed class NullabilityHelpersTests
 		PropertyInfo propertyInfo = typeof(NullabilityTestClass).GetProperty(propertyName)!;
 
 		await That(propertyInfo.IsNullable()).IsEqualTo(expectNullable);
-	}
-
-	[Theory]
-	[InlineData(nameof(AllNullableTestClass.FirstNullableField))]
-	[InlineData(nameof(AllNullableTestClass.SecondNullableField))]
-	[InlineData(nameof(AllNullableTestClass.FirstNullableProperty))]
-	public async Task IsNullable_WhenNullabilityIsStoredInContextOfDeclaringType_ShouldReturnTrue(string memberName)
-	{
-		MemberInfo memberInfo = typeof(AllNullableTestClass).GetMember(memberName).Single();
-
-		bool result = memberInfo is FieldInfo fieldInfo
-			? fieldInfo.IsNullable()
-			: ((PropertyInfo)memberInfo).IsNullable();
-
-		await That(result).IsTrue();
-	}
-
-	[Theory]
-	[InlineData(nameof(NullabilityEdgeCaseTestClass.NullableArrayField), true)]
-	[InlineData(nameof(NullabilityEdgeCaseTestClass.ArrayOfNullableField), false)]
-	[InlineData(nameof(NullabilityEdgeCaseTestClass.NullableArrayProperty), true)]
-	[InlineData(nameof(NullabilityEdgeCaseTestClass.ArrayOfNullableProperty), false)]
-	public async Task IsNullable_WithArrayMembers_ShouldOnlyConsiderTheTopLevelAnnotation(
-		string memberName, bool expectNullable)
-	{
-		MemberInfo memberInfo = typeof(NullabilityEdgeCaseTestClass).GetMember(memberName).Single();
-
-		bool result = memberInfo is FieldInfo fieldInfo
-			? fieldInfo.IsNullable()
-			: ((PropertyInfo)memberInfo).IsNullable();
-
-		await That(result).IsEqualTo(expectNullable);
-	}
-
-	[Fact]
-	public async Task IsNullable_WithNullableIndexer_ShouldReturnTrue()
-	{
-		PropertyInfo propertyInfo = typeof(NullabilityEdgeCaseTestClass).GetProperty("Item")!;
-
-		await That(propertyInfo.IsNullable()).IsTrue();
-	}
-
-	[Theory]
-	[InlineData(nameof(NullabilityEdgeCaseTestClass.AllowNullProperty))]
-	[InlineData(nameof(NullabilityEdgeCaseTestClass.MaybeNullProperty))]
-	public async Task IsNullable_WithPostConditionAttributes_ShouldIgnoreThemAndReturnFalse(string propertyName)
-	{
-		PropertyInfo propertyInfo = typeof(NullabilityEdgeCaseTestClass).GetProperty(propertyName)!;
-
-		await That(propertyInfo.IsNullable()).IsFalse();
-	}
-
-	[Theory]
-	[InlineData(nameof(GenericTestClass<object>.UnannotatedField), false)]
-	[InlineData(nameof(GenericTestClass<object>.AnnotatedField), true)]
-	[InlineData(nameof(GenericTestClass<object>.UnannotatedProperty), false)]
-	[InlineData(nameof(GenericTestClass<object>.AnnotatedProperty), true)]
-	public async Task IsNullable_WithGenericTypeParameterMembers_ShouldOnlyConsiderTheAnnotation(
-		string memberName, bool expectNullable)
-	{
-		MemberInfo memberInfo = typeof(GenericTestClass<>).GetMember(memberName).Single();
-
-		bool result = memberInfo is FieldInfo fieldInfo
-			? fieldInfo.IsNullable()
-			: ((PropertyInfo)memberInfo).IsNullable();
-
-		await That(result).IsEqualTo(expectNullable);
-	}
-
-	[Theory]
-	[InlineData(nameof(GenericTestClass<object>.UnannotatedField))]
-	[InlineData(nameof(GenericTestClass<object>.AnnotatedField))]
-	[InlineData(nameof(GenericTestClass<object>.UnannotatedProperty))]
-	[InlineData(nameof(GenericTestClass<object>.AnnotatedProperty))]
-	public async Task IsNullable_WithGenericParameterMembers_WhenDerivedTypeUsesNullableArgument_ShouldReturnTrue(
-		string memberName)
-	{
-		MemberInfo memberInfo = typeof(DerivedFromGenericTestClassWithNullableArgument).GetMember(memberName).Single();
-
-		bool result = memberInfo is FieldInfo fieldInfo
-			? fieldInfo.IsNullable()
-			: ((PropertyInfo)memberInfo).IsNullable();
-
-		await That(result).IsTrue();
-	}
-
-	[Theory]
-	[InlineData(nameof(GenericTestClass<object>.UnannotatedField), false)]
-	[InlineData(nameof(GenericTestClass<object>.AnnotatedField), true)]
-	[InlineData(nameof(GenericTestClass<object>.UnannotatedProperty), false)]
-	[InlineData(nameof(GenericTestClass<object>.AnnotatedProperty), true)]
-	public async Task IsNullable_WithGenericParameterMembers_WhenDerivedTypeUsesNonNullableArgument_ShouldEvaluateAnnotation(
-		string memberName, bool expectNullable)
-	{
-		MemberInfo memberInfo =
-			typeof(DerivedFromGenericTestClassWithNonNullableArgument).GetMember(memberName).Single();
-
-		bool result = memberInfo is FieldInfo fieldInfo
-			? fieldInfo.IsNullable()
-			: ((PropertyInfo)memberInfo).IsNullable();
-
-		await That(result).IsEqualTo(expectNullable);
-	}
-
-	[Theory]
-	[InlineData(nameof(GenericTestClass<object>.UnannotatedField))]
-	[InlineData(nameof(GenericTestClass<object>.UnannotatedProperty))]
-	public async Task IsNullable_WithGenericParameterMembers_WhenAccessedViaConstructedType_ShouldReturnFalse(
-		string memberName)
-	{
-		// The nullable annotation of a type argument is not part of System.Type, so it can only be
-		// resolved through the base type metadata of a derived type.
-		MemberInfo memberInfo = typeof(GenericTestClass<string>).GetMember(memberName).Single();
-
-		bool result = memberInfo is FieldInfo fieldInfo
-			? fieldInfo.IsNullable()
-			: ((PropertyInfo)memberInfo).IsNullable();
-
-		await That(result).IsFalse();
 	}
 
 	[Theory]
@@ -215,46 +112,150 @@ public sealed class NullabilityHelpersTests
 		await That(result).IsFalse();
 	}
 
-	[Fact]
-	public async Task GetNullableMembers_ShouldReturnNullableFieldsAndProperties()
+	[Theory]
+	[InlineData(nameof(AllNullableTestClass.FirstNullableField))]
+	[InlineData(nameof(AllNullableTestClass.SecondNullableField))]
+	[InlineData(nameof(AllNullableTestClass.FirstNullableProperty))]
+	public async Task IsNullable_WhenNullabilityIsStoredInContextOfDeclaringType_ShouldReturnTrue(string memberName)
 	{
-		MemberInfo[] nullableMembers = typeof(NullabilityTestClass).GetNullableMembers();
+		MemberInfo memberInfo = typeof(AllNullableTestClass).GetMember(memberName).Single();
 
-		await That(nullableMembers.Select(member => member.Name)).IsEqualTo([
-			nameof(NullabilityTestClass.NullableValueField),
-			nameof(NullabilityTestClass.NullableReferenceField),
-			nameof(NullabilityTestClass.NullableGenericField),
-			nameof(NullabilityTestClass.NullableValueProperty),
-			nameof(NullabilityTestClass.NullableReferenceProperty),
-			nameof(NullabilityTestClass.NullableGenericProperty),
-			nameof(NullabilityTestClass.NullableWriteOnlyProperty),
-		]).InAnyOrder();
+		bool result = memberInfo is FieldInfo fieldInfo
+			? fieldInfo.IsNullable()
+			: ((PropertyInfo)memberInfo).IsNullable();
+
+		await That(result).IsTrue();
+	}
+
+	[Theory]
+	[InlineData(nameof(NullabilityEdgeCaseTestClass.NullableArrayField), true)]
+	[InlineData(nameof(NullabilityEdgeCaseTestClass.ArrayOfNullableField), false)]
+	[InlineData(nameof(NullabilityEdgeCaseTestClass.NullableArrayProperty), true)]
+	[InlineData(nameof(NullabilityEdgeCaseTestClass.ArrayOfNullableProperty), false)]
+	public async Task IsNullable_WithArrayMembers_ShouldOnlyConsiderTheTopLevelAnnotation(
+		string memberName, bool expectNullable)
+	{
+		MemberInfo memberInfo = typeof(NullabilityEdgeCaseTestClass).GetMember(memberName).Single();
+
+		bool result = memberInfo is FieldInfo fieldInfo
+			? fieldInfo.IsNullable()
+			: ((PropertyInfo)memberInfo).IsNullable();
+
+		await That(result).IsEqualTo(expectNullable);
+	}
+
+	[Theory]
+	[InlineData(nameof(GenericTestClass<object>.UnannotatedField))]
+	[InlineData(nameof(GenericTestClass<object>.UnannotatedProperty))]
+	public async Task IsNullable_WithGenericParameterMembers_WhenAccessedViaConstructedType_ShouldReturnFalse(
+		string memberName)
+	{
+		// The nullable annotation of a type argument is not part of System.Type, so it can only be
+		// resolved through the base type metadata of a derived type.
+		MemberInfo memberInfo = typeof(GenericTestClass<string>).GetMember(memberName).Single();
+
+		bool result = memberInfo is FieldInfo fieldInfo
+			? fieldInfo.IsNullable()
+			: ((PropertyInfo)memberInfo).IsNullable();
+
+		await That(result).IsFalse();
+	}
+
+	[Theory]
+	[InlineData(nameof(GenericTestClass<object>.UnannotatedField), false)]
+	[InlineData(nameof(GenericTestClass<object>.AnnotatedField), true)]
+	[InlineData(nameof(GenericTestClass<object>.UnannotatedProperty), false)]
+	[InlineData(nameof(GenericTestClass<object>.AnnotatedProperty), true)]
+	public async Task IsNullable_WithGenericParameterMembers_WhenDerivedTypeUsesNonNullableArgument_ShouldEvaluateAnnotation(
+		string memberName, bool expectNullable)
+	{
+		MemberInfo memberInfo =
+			typeof(DerivedFromGenericTestClassWithNonNullableArgument).GetMember(memberName).Single();
+
+		bool result = memberInfo is FieldInfo fieldInfo
+			? fieldInfo.IsNullable()
+			: ((PropertyInfo)memberInfo).IsNullable();
+
+		await That(result).IsEqualTo(expectNullable);
+	}
+
+	[Theory]
+	[InlineData(nameof(GenericTestClass<object>.UnannotatedField))]
+	[InlineData(nameof(GenericTestClass<object>.AnnotatedField))]
+	[InlineData(nameof(GenericTestClass<object>.UnannotatedProperty))]
+	[InlineData(nameof(GenericTestClass<object>.AnnotatedProperty))]
+	public async Task IsNullable_WithGenericParameterMembers_WhenDerivedTypeUsesNullableArgument_ShouldReturnTrue(
+		string memberName)
+	{
+		MemberInfo memberInfo = typeof(DerivedFromGenericTestClassWithNullableArgument).GetMember(memberName).Single();
+
+		bool result = memberInfo is FieldInfo fieldInfo
+			? fieldInfo.IsNullable()
+			: ((PropertyInfo)memberInfo).IsNullable();
+
+		await That(result).IsTrue();
+	}
+
+	[Theory]
+	[InlineData(nameof(GenericTestClass<object>.UnannotatedField), false)]
+	[InlineData(nameof(GenericTestClass<object>.AnnotatedField), true)]
+	[InlineData(nameof(GenericTestClass<object>.UnannotatedProperty), false)]
+	[InlineData(nameof(GenericTestClass<object>.AnnotatedProperty), true)]
+	public async Task IsNullable_WithGenericTypeParameterMembers_ShouldOnlyConsiderTheAnnotation(
+		string memberName, bool expectNullable)
+	{
+		MemberInfo memberInfo = typeof(GenericTestClass<>).GetMember(memberName).Single();
+
+		bool result = memberInfo is FieldInfo fieldInfo
+			? fieldInfo.IsNullable()
+			: ((PropertyInfo)memberInfo).IsNullable();
+
+		await That(result).IsEqualTo(expectNullable);
 	}
 
 	[Fact]
-	public async Task GetNotNullableMembers_ShouldReturnNonNullableFieldsAndProperties()
+	public async Task IsNullable_WithNullableIndexer_ShouldReturnTrue()
 	{
-		MemberInfo[] notNullableMembers = typeof(NullabilityTestClass).GetNotNullableMembers();
+		PropertyInfo propertyInfo = typeof(NullabilityEdgeCaseTestClass).GetProperty("Item")!;
 
-		await That(notNullableMembers.Select(member => member.Name)).IsEqualTo([
-			nameof(NullabilityTestClass.NonNullableValueField),
-			nameof(NullabilityTestClass.NonNullableReferenceField),
-			nameof(NullabilityTestClass.NonNullableGenericField),
-			nameof(NullabilityTestClass.NonNullableValueProperty),
-			nameof(NullabilityTestClass.NonNullableReferenceProperty),
-			nameof(NullabilityTestClass.NonNullableGenericProperty),
-		]).InAnyOrder();
+		await That(propertyInfo.IsNullable()).IsTrue();
+	}
+
+	[Fact]
+	public async Task IsNullable_WithNullFieldInfo_ShouldReturnFalse()
+	{
+		FieldInfo? fieldInfo = null;
+
+		await That(fieldInfo.IsNullable()).IsFalse();
+	}
+
+	[Fact]
+	public async Task IsNullable_WithNullPropertyInfo_ShouldReturnFalse()
+	{
+		PropertyInfo? propertyInfo = null;
+
+		await That(propertyInfo.IsNullable()).IsFalse();
+	}
+
+	[Theory]
+	[InlineData(nameof(NullabilityEdgeCaseTestClass.AllowNullProperty))]
+	[InlineData(nameof(NullabilityEdgeCaseTestClass.MaybeNullProperty))]
+	public async Task IsNullable_WithPostConditionAttributes_ShouldIgnoreThemAndReturnFalse(string propertyName)
+	{
+		PropertyInfo propertyInfo = typeof(NullabilityEdgeCaseTestClass).GetProperty(propertyName)!;
+
+		await That(propertyInfo.IsNullable()).IsFalse();
 	}
 
 #pragma warning disable CS0649 // Field is never assigned to, and will always have its default value
 	public class NullabilityTestClass
 	{
-		public int? NullableValueField;
-		public int NonNullableValueField;
-		public string? NullableReferenceField;
-		public string NonNullableReferenceField = "";
-		public List<string>? NullableGenericField;
 		public List<string?> NonNullableGenericField = [];
+		public string NonNullableReferenceField = "";
+		public int NonNullableValueField;
+		public List<string>? NullableGenericField;
+		public string? NullableReferenceField;
+		public int? NullableValueField;
 		public int? NullableValueProperty { get; set; }
 		public int NonNullableValueProperty { get; set; }
 		public string? NullableReferenceProperty { get; set; }
@@ -279,16 +280,14 @@ public sealed class NullabilityHelpersTests
 
 	public class NullabilityEdgeCaseTestClass
 	{
-		public string[]? NullableArrayField;
 		public string?[] ArrayOfNullableField = [];
+		public string[]? NullableArrayField;
 		public string[]? NullableArrayProperty { get; set; }
 		public string?[] ArrayOfNullableProperty { get; set; } = [];
 
-		[System.Diagnostics.CodeAnalysis.AllowNull]
-		public string AllowNullProperty { get; set; } = "";
+		[AllowNull] public string AllowNullProperty { get; set; } = "";
 
-		[System.Diagnostics.CodeAnalysis.MaybeNull]
-		public string MaybeNullProperty { get; set; } = "";
+		[MaybeNull] public string MaybeNullProperty { get; set; } = "";
 
 		public string? this[int index] => null;
 	}
@@ -296,8 +295,8 @@ public sealed class NullabilityHelpersTests
 	// ReSharper disable once UnusedTypeParameter
 	public class GenericTestClass<T>
 	{
-		public T UnannotatedField = default!;
 		public T? AnnotatedField;
+		public T UnannotatedField = default!;
 		public T UnannotatedProperty { get; set; } = default!;
 		public T? AnnotatedProperty { get; set; }
 	}
@@ -309,9 +308,9 @@ public sealed class NullabilityHelpersTests
 	public class MostlyNullableTestClass
 	{
 		public string? FirstNullableField;
+		public string NonNullableField = "";
 		public string? SecondNullableField;
 		public string? ThirdNullableField;
-		public string NonNullableField = "";
 		public string? FirstNullableProperty { get; set; }
 		public string? SecondNullableProperty { get; set; }
 		public string? ThirdNullableProperty { get; set; }
@@ -330,6 +329,5 @@ public sealed class NullabilityHelpersTests
 			public string NestedObliviousProperty { get; set; }
 		}
 	}
-#nullable restore
 #pragma warning restore CS0649
 }

--- a/Tests/aweXpect.Reflection.Internal.Tests/Helpers/TypeHelpersTests.cs
+++ b/Tests/aweXpect.Reflection.Internal.Tests/Helpers/TypeHelpersTests.cs
@@ -174,7 +174,7 @@ public sealed class TypeHelpersTests
 	{
 		Type sut = typeof(DerivedImplementingFoo);
 
-		await That(sut.Implements(typeof(IFooInterface), false)).IsTrue();
+		await That(sut.Implements(typeof(IFooInterface))).IsTrue();
 		await That(sut.Implements(typeof(IFooInterface), true)).IsFalse();
 	}
 

--- a/Tests/aweXpect.Reflection.Internal.Tests/TestHelpers/ValueFormatterHelper.cs
+++ b/Tests/aweXpect.Reflection.Internal.Tests/TestHelpers/ValueFormatterHelper.cs
@@ -1,4 +1,4 @@
-using System.Text;
+﻿using System.Text;
 using aweXpect.Formatting;
 
 namespace aweXpect.Reflection.Internal.Tests.TestHelpers;

--- a/Tests/aweXpect.Reflection.Tests/ArchitectureRules.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ArchitectureRules.Tests.cs
@@ -9,9 +9,24 @@ namespace aweXpect.Reflection.Tests;
 /// </summary>
 public sealed class ArchitectureRulesTests
 {
-	private const string ConsumersNamespace = "aweXpect.Reflection.Tests.TestHelpers.Dependencies.Consumers";
-	private const string Layer1Namespace = "aweXpect.Reflection.Tests.TestHelpers.Dependencies.Layer1";
-	private const string Layer2Namespace = "aweXpect.Reflection.Tests.TestHelpers.Dependencies.Layer2";
+	[Fact]
+	public async Task ShouldSupportExemptionsViaExcept()
+	{
+		Filtered.Types layer2 = Types.InNamespace(Layer2Namespace);
+
+		async Task Act()
+		{
+			await ThatAll(
+				// The consumers that intentionally reference Layer2 are exempted from the rule:
+				That(Types.InNamespace(ConsumersNamespace)
+						.Except<OnlyLayer2>()
+						.Except<Layer1AndLayer2>()
+						.Except<ViaAttributeArgument>())
+					.DoNotDependOn(layer2));
+		}
+
+		await That(Act).DoesNotThrow();
+	}
 
 	[Fact]
 	public async Task ShouldVerifyMultipleRulesWithThatAll()
@@ -21,13 +36,15 @@ public sealed class ArchitectureRulesTests
 		Filtered.Types layer2 = Types.InNamespace(Layer2Namespace);
 
 		async Task Act()
-			=> await ThatAll(
+		{
+			await ThatAll(
 				// Filtered.Types as dependency target:
 				That(layer2).DoNotDependOn(layer1),
 				// Namespace as dependency target on the same selection:
 				That(layer2).DoNotDependOn(Layer1Namespace),
 				// Any other assertion works on the same selection:
 				That(layer2).AreWithinNamespace(Layer2Namespace));
+		}
 
 		await That(Act).DoesNotThrow();
 	}
@@ -39,30 +56,19 @@ public sealed class ArchitectureRulesTests
 		Filtered.Types layer2 = Types.InNamespace(Layer2Namespace);
 
 		async Task Act()
-			=> await ThatAll(
+		{
+			await ThatAll(
 				// Fails: Layer1's TargetSeverityAttribute references Layer2's TargetSeverity.
 				That(layer1).DoNotDependOn(layer2),
 				// Succeeds:
 				That(layer2).AreWithinNamespace(Layer2Namespace));
+		}
 
 		await That(Act).ThrowsException()
 			.WithMessage("*TargetSeverityAttribute*").AsWildcard();
 	}
 
-	[Fact]
-	public async Task ShouldSupportExemptionsViaExcept()
-	{
-		Filtered.Types layer2 = Types.InNamespace(Layer2Namespace);
-
-		async Task Act()
-			=> await ThatAll(
-				// The consumers that intentionally reference Layer2 are exempted from the rule:
-				That(Types.InNamespace(ConsumersNamespace)
-						.Except<OnlyLayer2>()
-						.Except<Layer1AndLayer2>()
-						.Except<ViaAttributeArgument>())
-					.DoNotDependOn(layer2));
-
-		await That(Act).DoesNotThrow();
-	}
+	private const string ConsumersNamespace = "aweXpect.Reflection.Tests.TestHelpers.Dependencies.Consumers";
+	private const string Layer1Namespace = "aweXpect.Reflection.Tests.TestHelpers.Dependencies.Layer1";
+	private const string Layer2Namespace = "aweXpect.Reflection.Tests.TestHelpers.Dependencies.Layer2";
 }

--- a/Tests/aweXpect.Reflection.Tests/Collections/AccessModifiersExtensions.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Collections/AccessModifiersExtensions.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Collections;
 

--- a/Tests/aweXpect.Reflection.Tests/Collections/FilteredReuseIndependenceTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Collections/FilteredReuseIndependenceTests.cs
@@ -92,6 +92,41 @@ public sealed class FilteredReuseIndependenceTests
 	}
 
 	[Fact]
+	public async Task MethodsWhichAreGenericWithArgument_BranchingFromSharedBase_ShouldBeIndependent()
+	{
+		MethodFilters.GenericMethods @base = In.Type<SampleGenericArgumentMethods>().Methods()
+			.WhichAreGeneric();
+
+		Filtered.Methods view1 = @base.WithArgument<BaseA>();
+		Filtered.Methods view2 = @base.WithArgument<BaseB>();
+
+		await That(view1).IsEqualTo([
+			typeof(SampleGenericArgumentMethods).GetMethod(nameof(SampleGenericArgumentMethods.ArgumentOfBaseA))!,
+		]).InAnyOrder();
+		await That(view2).IsEqualTo([
+			typeof(SampleGenericArgumentMethods).GetMethod(nameof(SampleGenericArgumentMethods.ArgumentOfBaseB))!,
+		]).InAnyOrder();
+		await That(@base).HasCount(2);
+	}
+
+	[Fact]
+	public async Task MethodsWhichAreGenericWithArgumentCount_BranchingFromSharedBase_ShouldBeIndependent()
+	{
+		MethodFilters.GenericMethods @base = In.Type<SampleGenericMethods>().Methods()
+			.WhichAreGeneric();
+
+		Filtered.Methods view1 = @base.WithArgumentCount(1);
+		Filtered.Methods view2 = @base.WithArgumentCount(2);
+
+		await That(view1).All().Satisfy(m => m.GetGenericArguments().Length == 1);
+		await That(view1).HasCount(1);
+		await That(view2).All().Satisfy(m => m.GetGenericArguments().Length == 2);
+		await That(view2).HasCount(1);
+		await That(@base).All().Satisfy(m => m.IsGenericMethod);
+		await That(@base).HasCount(2);
+	}
+
+	[Fact]
 	public async Task Properties_BranchingFromSharedBase_ShouldBeIndependent()
 	{
 		PropertyInfo propertyA = typeof(SampleWithMembers).GetProperty(nameof(SampleWithMembers.PropA))!;
@@ -120,38 +155,19 @@ public sealed class FilteredReuseIndependenceTests
 	}
 
 	[Fact]
-	public async Task MethodsWhichAreGenericWithArgumentCount_BranchingFromSharedBase_ShouldBeIndependent()
+	public async Task TypesWhichAreGenericWithArgumentCount_BranchingFromSharedBase_ShouldBeIndependent()
 	{
-		MethodFilters.GenericMethods @base = In.Type<SampleGenericMethods>().Methods()
+		TypeFilters.GenericTypes @base = In.Types<SampleGenericType1<int>, SampleGenericType2<int, int>>()
 			.WhichAreGeneric();
 
-		Filtered.Methods view1 = @base.WithArgumentCount(1);
-		Filtered.Methods view2 = @base.WithArgumentCount(2);
+		Filtered.Types view1 = @base.WithArgumentCount(1);
+		Filtered.Types view2 = @base.WithArgumentCount(2);
 
-		await That(view1).All().Satisfy(m => m.GetGenericArguments().Length == 1);
-		await That(view1).HasCount(1);
-		await That(view2).All().Satisfy(m => m.GetGenericArguments().Length == 2);
-		await That(view2).HasCount(1);
-		await That(@base).All().Satisfy(m => m.IsGenericMethod);
-		await That(@base).HasCount(2);
-	}
-
-	[Fact]
-	public async Task MethodsWhichAreGenericWithArgument_BranchingFromSharedBase_ShouldBeIndependent()
-	{
-		MethodFilters.GenericMethods @base = In.Type<SampleGenericArgumentMethods>().Methods()
-			.WhichAreGeneric();
-
-		Filtered.Methods view1 = @base.WithArgument<BaseA>();
-		Filtered.Methods view2 = @base.WithArgument<BaseB>();
-
-		await That(view1).IsEqualTo([
-			typeof(SampleGenericArgumentMethods).GetMethod(nameof(SampleGenericArgumentMethods.ArgumentOfBaseA))!,
+		await That(view1).IsEqualTo([typeof(SampleGenericType1<int>),]).InAnyOrder();
+		await That(view2).IsEqualTo([typeof(SampleGenericType2<int, int>),]).InAnyOrder();
+		await That(@base).IsEqualTo([
+			typeof(SampleGenericType1<int>), typeof(SampleGenericType2<int, int>),
 		]).InAnyOrder();
-		await That(view2).IsEqualTo([
-			typeof(SampleGenericArgumentMethods).GetMethod(nameof(SampleGenericArgumentMethods.ArgumentOfBaseB))!,
-		]).InAnyOrder();
-		await That(@base).HasCount(2);
 	}
 
 	[Fact]
@@ -171,22 +187,6 @@ public sealed class FilteredReuseIndependenceTests
 		await That(branch).DoesNotContain(typeof(OnlyLayer2));
 		await That(widened).Contains(typeof(OnlyLayer1));
 		await That(widened).Contains(typeof(OnlyLayer2));
-	}
-
-	[Fact]
-	public async Task TypesWhichAreGenericWithArgumentCount_BranchingFromSharedBase_ShouldBeIndependent()
-	{
-		TypeFilters.GenericTypes @base = In.Types<SampleGenericType1<int>, SampleGenericType2<int, int>>()
-			.WhichAreGeneric();
-
-		Filtered.Types view1 = @base.WithArgumentCount(1);
-		Filtered.Types view2 = @base.WithArgumentCount(2);
-
-		await That(view1).IsEqualTo([typeof(SampleGenericType1<int>),]).InAnyOrder();
-		await That(view2).IsEqualTo([typeof(SampleGenericType2<int, int>),]).InAnyOrder();
-		await That(@base).IsEqualTo([
-			typeof(SampleGenericType1<int>), typeof(SampleGenericType2<int, int>),
-		]).InAnyOrder();
 	}
 
 	private class BaseA;
@@ -237,11 +237,11 @@ public sealed class FilteredReuseIndependenceTests
 			FieldA = value;
 		}
 
-		public event EventHandler? EventA;
-		public event EventHandler? EventB;
-
 		public int PropA { get; set; }
 		public int PropB { get; set; }
+
+		public event EventHandler? EventA;
+		public event EventHandler? EventB;
 
 		public static void DoA()
 		{

--- a/Tests/aweXpect.Reflection.Tests/Collections/FilteredReuseIndependenceTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Collections/FilteredReuseIndependenceTests.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Tests.TestHelpers.Dependencies.Consumers;
 

--- a/Tests/aweXpect.Reflection.Tests/Collections/MemberFilterState.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Collections/MemberFilterState.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Tests.TestHelpers.Types;
+﻿using aweXpect.Reflection.Tests.TestHelpers.Types;
 
 namespace aweXpect.Reflection.Tests.Collections;
 

--- a/Tests/aweXpect.Reflection.Tests/DependencyResolverCustomizationTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/DependencyResolverCustomizationTests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using aweXpect.Customization;
 using aweXpect.Reflection.Tests.TestHelpers.Dependencies.Consumers;

--- a/Tests/aweXpect.Reflection.Tests/Examples/CecilDependencyResolver.cs
+++ b/Tests/aweXpect.Reflection.Tests/Examples/CecilDependencyResolver.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
 

--- a/Tests/aweXpect.Reflection.Tests/Examples/CecilDependencyResolverTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Examples/CecilDependencyResolverTests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Customization;
+﻿using aweXpect.Customization;
 using aweXpect.Reflection.Tests.TestHelpers.Dependencies.Synthetic;
 
 namespace aweXpect.Reflection.Tests.Examples;

--- a/Tests/aweXpect.Reflection.Tests/Examples/ExampleTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Examples/ExampleTests.cs
@@ -1,4 +1,4 @@
-namespace aweXpect.Reflection.Tests.Examples;
+﻿namespace aweXpect.Reflection.Tests.Examples;
 
 public sealed class ExampleTests
 {

--- a/Tests/aweXpect.Reflection.Tests/ExtensionGroupingTypeFilteringTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ExtensionGroupingTypeFilteringTests.cs
@@ -1,4 +1,4 @@
-#if NET10_0_OR_GREATER
+﻿#if NET10_0_OR_GREATER
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Tests/aweXpect.Reflection.Tests/ExtensionPropertyDiscoveryTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ExtensionPropertyDiscoveryTests.cs
@@ -1,4 +1,4 @@
-#if NET10_0_OR_GREATER
+﻿#if NET10_0_OR_GREATER
 using System.Collections.Generic;
 using System.Reflection;
 using System.Threading.Tasks;

--- a/Tests/aweXpect.Reflection.Tests/Filters/AssemblyFilters.Except.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/AssemblyFilters.Except.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/AssemblyFilters.MemberAccess.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/AssemblyFilters.MemberAccess.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/AssemblyFilters.WhichAreNotStrongNamed.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/AssemblyFilters.WhichAreNotStrongNamed.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Tests.TestHelpers;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/AssemblyFilters.WhichAreStrongNamed.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/AssemblyFilters.WhichAreStrongNamed.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Tests.TestHelpers;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/AssemblyFilters.WhichDependOn.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/AssemblyFilters.WhichDependOn.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 
 namespace aweXpect.Reflection.Tests.Filters;

--- a/Tests/aweXpect.Reflection.Tests/Filters/AssemblyFilters.WhichDependOnlyOn.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/AssemblyFilters.WhichDependOnlyOn.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 
 namespace aweXpect.Reflection.Tests.Filters;

--- a/Tests/aweXpect.Reflection.Tests/Filters/AssemblyFilters.WhichDoNotDependOn.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/AssemblyFilters.WhichDoNotDependOn.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 
 namespace aweXpect.Reflection.Tests.Filters;

--- a/Tests/aweXpect.Reflection.Tests/Filters/AssemblyFilters.WhichTarget.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/AssemblyFilters.WhichTarget.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/AssemblyFilters.With.AttributeTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/AssemblyFilters.With.AttributeTests.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;

--- a/Tests/aweXpect.Reflection.Tests/Filters/AssemblyFilters.WithVersion.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/AssemblyFilters.WithVersion.Tests.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/ConstructorFilters.Except.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/ConstructorFilters.Except.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/ConstructorFilters.ParameterModifierExactlyOverloads.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/ConstructorFilters.ParameterModifierExactlyOverloads.Tests.cs
@@ -1,4 +1,4 @@
-using System.IO;
+﻿using System.IO;
 using System.Linq;
 using System.Reflection;
 using aweXpect.Reflection.Collections;

--- a/Tests/aweXpect.Reflection.Tests/Filters/ConstructorFilters.ParameterModifierTypedOverloads.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/ConstructorFilters.ParameterModifierTypedOverloads.Tests.cs
@@ -1,4 +1,4 @@
-using System.Linq;
+﻿using System.Linq;
 using System.Reflection;
 using aweXpect.Reflection.Collections;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/ConstructorFilters.WhichAre.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/ConstructorFilters.WhichAre.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/ConstructorFilters.WhichAreInternal.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/ConstructorFilters.WhichAreInternal.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/ConstructorFilters.WhichAreNotInternal.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/ConstructorFilters.WhichAreNotInternal.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/ConstructorFilters.WhichAreNotObsolete.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/ConstructorFilters.WhichAreNotObsolete.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 
 namespace aweXpect.Reflection.Tests.Filters;

--- a/Tests/aweXpect.Reflection.Tests/Filters/ConstructorFilters.WhichAreNotPrivate.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/ConstructorFilters.WhichAreNotPrivate.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/ConstructorFilters.WhichAreNotPrivateProtected.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/ConstructorFilters.WhichAreNotPrivateProtected.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/ConstructorFilters.WhichAreNotProtected.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/ConstructorFilters.WhichAreNotProtected.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/ConstructorFilters.WhichAreNotProtectedInternal.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/ConstructorFilters.WhichAreNotProtectedInternal.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/ConstructorFilters.WhichAreNotPublic.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/ConstructorFilters.WhichAreNotPublic.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/ConstructorFilters.WhichAreNotStatic.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/ConstructorFilters.WhichAreNotStatic.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/ConstructorFilters.WhichAreObsolete.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/ConstructorFilters.WhichAreObsolete.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 
 namespace aweXpect.Reflection.Tests.Filters;

--- a/Tests/aweXpect.Reflection.Tests/Filters/ConstructorFilters.WhichArePrivate.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/ConstructorFilters.WhichArePrivate.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/ConstructorFilters.WhichArePrivateProtected.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/ConstructorFilters.WhichArePrivateProtected.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/ConstructorFilters.WhichAreProtected.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/ConstructorFilters.WhichAreProtected.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/ConstructorFilters.WhichAreProtectedInternal.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/ConstructorFilters.WhichAreProtectedInternal.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/ConstructorFilters.WhichArePublic.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/ConstructorFilters.WhichArePublic.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/ConstructorFilters.WhichAreStatic.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/ConstructorFilters.WhichAreStatic.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/ConstructorFilters.WithInParameter.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/ConstructorFilters.WithInParameter.Tests.cs
@@ -1,4 +1,4 @@
-using System.Linq;
+﻿using System.Linq;
 using System.Reflection;
 using aweXpect.Reflection.Collections;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/ConstructorFilters.WithOptionalParameter.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/ConstructorFilters.WithOptionalParameter.Tests.cs
@@ -1,4 +1,4 @@
-using System.Linq;
+﻿using System.Linq;
 using System.Reflection;
 using aweXpect.Reflection.Collections;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/ConstructorFilters.WithOutParameter.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/ConstructorFilters.WithOutParameter.Tests.cs
@@ -1,4 +1,4 @@
-using System.Linq;
+﻿using System.Linq;
 using System.Reflection;
 using aweXpect.Reflection.Collections;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/ConstructorFilters.WithParameter.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/ConstructorFilters.WithParameter.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Tests.TestHelpers;
 
 namespace aweXpect.Reflection.Tests.Filters;

--- a/Tests/aweXpect.Reflection.Tests/Filters/ConstructorFilters.WithParameterCount.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/ConstructorFilters.WithParameterCount.Tests.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;

--- a/Tests/aweXpect.Reflection.Tests/Filters/ConstructorFilters.WithParameterExactly.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/ConstructorFilters.WithParameterExactly.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/ConstructorFilters.WithParameterModifier.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/ConstructorFilters.WithParameterModifier.Tests.cs
@@ -1,4 +1,4 @@
-using System.Linq;
+﻿using System.Linq;
 using System.Reflection;
 using aweXpect.Reflection.Collections;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/ConstructorFilters.WithParamsParameter.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/ConstructorFilters.WithParamsParameter.Tests.cs
@@ -1,4 +1,4 @@
-using System.Linq;
+﻿using System.Linq;
 using System.Reflection;
 using aweXpect.Reflection.Collections;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/ConstructorFilters.WithRefParameter.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/ConstructorFilters.WithRefParameter.Tests.cs
@@ -1,4 +1,4 @@
-using System.Linq;
+﻿using System.Linq;
 using System.Reflection;
 using aweXpect.Reflection.Collections;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/ConstructorFilters.WithoutParameters.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/ConstructorFilters.WithoutParameters.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/EventFilters.Except.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/EventFilters.Except.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/EventFilters.WhichAre.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/EventFilters.WhichAre.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/EventFilters.WhichAreAbstract.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/EventFilters.WhichAreAbstract.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/EventFilters.WhichAreInternal.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/EventFilters.WhichAreInternal.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/EventFilters.WhichAreNotAbstract.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/EventFilters.WhichAreNotAbstract.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/EventFilters.WhichAreNotInternal.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/EventFilters.WhichAreNotInternal.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/EventFilters.WhichAreNotObsolete.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/EventFilters.WhichAreNotObsolete.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 
 namespace aweXpect.Reflection.Tests.Filters;

--- a/Tests/aweXpect.Reflection.Tests/Filters/EventFilters.WhichAreNotPrivate.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/EventFilters.WhichAreNotPrivate.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/EventFilters.WhichAreNotPrivateProtected.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/EventFilters.WhichAreNotPrivateProtected.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/EventFilters.WhichAreNotProtected.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/EventFilters.WhichAreNotProtected.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/EventFilters.WhichAreNotProtectedInternal.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/EventFilters.WhichAreNotProtectedInternal.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/EventFilters.WhichAreNotPublic.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/EventFilters.WhichAreNotPublic.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/EventFilters.WhichAreNotSealed.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/EventFilters.WhichAreNotSealed.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/EventFilters.WhichAreObsolete.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/EventFilters.WhichAreObsolete.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 
 namespace aweXpect.Reflection.Tests.Filters;

--- a/Tests/aweXpect.Reflection.Tests/Filters/EventFilters.WhichArePrivate.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/EventFilters.WhichArePrivate.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/EventFilters.WhichArePrivateProtected.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/EventFilters.WhichArePrivateProtected.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/EventFilters.WhichAreProtected.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/EventFilters.WhichAreProtected.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/EventFilters.WhichAreProtectedInternal.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/EventFilters.WhichAreProtectedInternal.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/EventFilters.WhichArePublic.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/EventFilters.WhichArePublic.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/EventFilters.WhichAreSealed.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/EventFilters.WhichAreSealed.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/FieldFilters.Except.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/FieldFilters.Except.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/FieldFilters.WhichAre.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/FieldFilters.WhichAre.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/FieldFilters.WhichAreConstant.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/FieldFilters.WhichAreConstant.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/FieldFilters.WhichAreInternal.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/FieldFilters.WhichAreInternal.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/FieldFilters.WhichAreNotConstant.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/FieldFilters.WhichAreNotConstant.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/FieldFilters.WhichAreNotInternal.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/FieldFilters.WhichAreNotInternal.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/FieldFilters.WhichAreNotObsolete.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/FieldFilters.WhichAreNotObsolete.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 
 namespace aweXpect.Reflection.Tests.Filters;

--- a/Tests/aweXpect.Reflection.Tests/Filters/FieldFilters.WhichAreNotPrivate.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/FieldFilters.WhichAreNotPrivate.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/FieldFilters.WhichAreNotPrivateProtected.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/FieldFilters.WhichAreNotPrivateProtected.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/FieldFilters.WhichAreNotProtected.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/FieldFilters.WhichAreNotProtected.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/FieldFilters.WhichAreNotProtectedInternal.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/FieldFilters.WhichAreNotProtectedInternal.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/FieldFilters.WhichAreNotPublic.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/FieldFilters.WhichAreNotPublic.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/FieldFilters.WhichAreNotReadOnly.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/FieldFilters.WhichAreNotReadOnly.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/FieldFilters.WhichAreNotStatic.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/FieldFilters.WhichAreNotStatic.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/FieldFilters.WhichAreObsolete.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/FieldFilters.WhichAreObsolete.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 
 namespace aweXpect.Reflection.Tests.Filters;

--- a/Tests/aweXpect.Reflection.Tests/Filters/FieldFilters.WhichArePrivate.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/FieldFilters.WhichArePrivate.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/FieldFilters.WhichArePrivateProtected.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/FieldFilters.WhichArePrivateProtected.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/FieldFilters.WhichAreProtected.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/FieldFilters.WhichAreProtected.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/FieldFilters.WhichAreProtectedInternal.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/FieldFilters.WhichAreProtectedInternal.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/FieldFilters.WhichArePublic.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/FieldFilters.WhichArePublic.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/FieldFilters.WhichAreReadOnly.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/FieldFilters.WhichAreReadOnly.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/FieldFilters.WhichAreStatic.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/FieldFilters.WhichAreStatic.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.Except.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.Except.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.ParameterModifierExactlyOverloads.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.ParameterModifierExactlyOverloads.Tests.cs
@@ -1,4 +1,4 @@
-using System.IO;
+﻿using System.IO;
 using System.Reflection;
 using aweXpect.Reflection.Collections;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.ParameterModifierTypedOverloads.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.ParameterModifierTypedOverloads.Tests.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;

--- a/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WhichAre.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WhichAre.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WhichAreAbstract.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WhichAreAbstract.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WhichAreAsync.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WhichAreAsync.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Tests.TestHelpers;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WhichAreExtensionMethods.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WhichAreExtensionMethods.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Tests.TestHelpers;
 #if NET10_0_OR_GREATER
 using aweXpect.Reflection.Tests.TestHelpers.Types;

--- a/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WhichAreInternal.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WhichAreInternal.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WhichAreNotAbstract.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WhichAreNotAbstract.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WhichAreNotAsync.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WhichAreNotAsync.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Tests.TestHelpers;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WhichAreNotExtensionMethods.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WhichAreNotExtensionMethods.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Tests.TestHelpers;
 #if NET10_0_OR_GREATER
 using aweXpect.Reflection.Tests.TestHelpers.Types;

--- a/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WhichAreNotInternal.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WhichAreNotInternal.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WhichAreNotObsolete.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WhichAreNotObsolete.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 
 namespace aweXpect.Reflection.Tests.Filters;

--- a/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WhichAreNotOperators.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WhichAreNotOperators.Tests.cs
@@ -26,18 +26,6 @@ public sealed partial class MethodFilters
 		public sealed class WithOperatorTests
 		{
 			[Fact]
-			public async Task ShouldKeepOtherOperatorsWithoutCustomization()
-			{
-				Filtered.Methods methods = In.Type<ClassWithOperators>()
-					.Methods().WhichAreNotOperators(Operator.Addition);
-
-				await That(methods).All().Satisfy(x => x!.Name != "op_Addition").And.IsNotEmpty();
-				await That(methods).Contains(x => x.Name == "op_Subtraction");
-				await That(methods.GetDescription())
-					.IsEqualTo("non-Addition operator methods in").AsPrefix();
-			}
-
-			[Fact]
 			public async Task ShouldExcludeTheSpecificOperatorButKeepOthers()
 			{
 				using (Customize.aweXpect.Reflection().IncludedSpecialNameMembers()
@@ -51,6 +39,18 @@ public sealed partial class MethodFilters
 					await That(methods.GetDescription())
 						.IsEqualTo("non-Addition operator methods in").AsPrefix();
 				}
+			}
+
+			[Fact]
+			public async Task ShouldKeepOtherOperatorsWithoutCustomization()
+			{
+				Filtered.Methods methods = In.Type<ClassWithOperators>()
+					.Methods().WhichAreNotOperators(Operator.Addition);
+
+				await That(methods).All().Satisfy(x => x!.Name != "op_Addition").And.IsNotEmpty();
+				await That(methods).Contains(x => x.Name == "op_Subtraction");
+				await That(methods.GetDescription())
+					.IsEqualTo("non-Addition operator methods in").AsPrefix();
 			}
 		}
 	}

--- a/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WhichAreNotPrivate.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WhichAreNotPrivate.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WhichAreNotPrivateProtected.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WhichAreNotPrivateProtected.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WhichAreNotProtected.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WhichAreNotProtected.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WhichAreNotProtectedInternal.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WhichAreNotProtectedInternal.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WhichAreNotPublic.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WhichAreNotPublic.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WhichAreNotSealed.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WhichAreNotSealed.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WhichAreNotStatic.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WhichAreNotStatic.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WhichAreObsolete.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WhichAreObsolete.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 
 namespace aweXpect.Reflection.Tests.Filters;

--- a/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WhichArePrivate.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WhichArePrivate.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WhichArePrivateProtected.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WhichArePrivateProtected.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WhichAreProtected.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WhichAreProtected.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WhichAreProtectedInternal.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WhichAreProtectedInternal.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WhichArePublic.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WhichArePublic.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WhichAreSealed.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WhichAreSealed.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WhichAreStatic.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WhichAreStatic.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WhichReturn.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WhichReturn.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WhichReturnExactly.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WhichReturnExactly.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WhichReturnVoid.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WhichReturnVoid.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WithInParameter.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WithInParameter.Tests.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;

--- a/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WithOptionalParameter.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WithOptionalParameter.Tests.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;

--- a/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WithOutParameter.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WithOutParameter.Tests.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;

--- a/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WithParameter.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WithParameter.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Tests.TestHelpers;
 
 namespace aweXpect.Reflection.Tests.Filters;

--- a/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WithParameterCount.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WithParameterCount.Tests.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;

--- a/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WithParameterExactly.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WithParameterExactly.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WithParameterModifier.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WithParameterModifier.Tests.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;

--- a/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WithParamsParameter.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WithParamsParameter.Tests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Reflection;
 using aweXpect.Reflection.Collections;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WithRefParameter.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WithRefParameter.Tests.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;

--- a/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WithoutParameters.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/MethodFilters.WithoutParameters.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/PropertyFilters.Except.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/PropertyFilters.Except.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/PropertyFilters.WhichAre.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/PropertyFilters.WhichAre.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/PropertyFilters.WhichAreAbstract.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/PropertyFilters.WhichAreAbstract.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Tests.TestHelpers;
 
 namespace aweXpect.Reflection.Tests.Filters;

--- a/Tests/aweXpect.Reflection.Tests/Filters/PropertyFilters.WhichAreExtensionProperties.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/PropertyFilters.WhichAreExtensionProperties.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Tests.TestHelpers;
 
 namespace aweXpect.Reflection.Tests.Filters;

--- a/Tests/aweXpect.Reflection.Tests/Filters/PropertyFilters.WhichAreIndexers.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/PropertyFilters.WhichAreIndexers.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 
 namespace aweXpect.Reflection.Tests.Filters;

--- a/Tests/aweXpect.Reflection.Tests/Filters/PropertyFilters.WhichAreInternal.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/PropertyFilters.WhichAreInternal.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/PropertyFilters.WhichAreNotAbstract.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/PropertyFilters.WhichAreNotAbstract.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Tests.TestHelpers;
 
 namespace aweXpect.Reflection.Tests.Filters;

--- a/Tests/aweXpect.Reflection.Tests/Filters/PropertyFilters.WhichAreNotExtensionProperties.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/PropertyFilters.WhichAreNotExtensionProperties.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Tests.TestHelpers;
 
 namespace aweXpect.Reflection.Tests.Filters;

--- a/Tests/aweXpect.Reflection.Tests/Filters/PropertyFilters.WhichAreNotIndexers.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/PropertyFilters.WhichAreNotIndexers.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 
 namespace aweXpect.Reflection.Tests.Filters;

--- a/Tests/aweXpect.Reflection.Tests/Filters/PropertyFilters.WhichAreNotInternal.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/PropertyFilters.WhichAreNotInternal.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/PropertyFilters.WhichAreNotObsolete.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/PropertyFilters.WhichAreNotObsolete.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 
 namespace aweXpect.Reflection.Tests.Filters;

--- a/Tests/aweXpect.Reflection.Tests/Filters/PropertyFilters.WhichAreNotPrivate.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/PropertyFilters.WhichAreNotPrivate.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/PropertyFilters.WhichAreNotPrivateProtected.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/PropertyFilters.WhichAreNotPrivateProtected.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/PropertyFilters.WhichAreNotProtected.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/PropertyFilters.WhichAreNotProtected.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/PropertyFilters.WhichAreNotProtectedInternal.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/PropertyFilters.WhichAreNotProtectedInternal.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/PropertyFilters.WhichAreNotPublic.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/PropertyFilters.WhichAreNotPublic.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/PropertyFilters.WhichAreNotSealed.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/PropertyFilters.WhichAreNotSealed.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Tests.TestHelpers;
 
 namespace aweXpect.Reflection.Tests.Filters;

--- a/Tests/aweXpect.Reflection.Tests/Filters/PropertyFilters.WhichAreNotStatic.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/PropertyFilters.WhichAreNotStatic.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Tests.TestHelpers;
 
 namespace aweXpect.Reflection.Tests.Filters;

--- a/Tests/aweXpect.Reflection.Tests/Filters/PropertyFilters.WhichAreObsolete.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/PropertyFilters.WhichAreObsolete.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 
 namespace aweXpect.Reflection.Tests.Filters;

--- a/Tests/aweXpect.Reflection.Tests/Filters/PropertyFilters.WhichArePrivate.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/PropertyFilters.WhichArePrivate.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/PropertyFilters.WhichArePrivateProtected.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/PropertyFilters.WhichArePrivateProtected.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/PropertyFilters.WhichAreProtected.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/PropertyFilters.WhichAreProtected.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/PropertyFilters.WhichAreProtectedInternal.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/PropertyFilters.WhichAreProtectedInternal.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/PropertyFilters.WhichArePublic.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/PropertyFilters.WhichArePublic.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/PropertyFilters.WhichAreReadOnly.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/PropertyFilters.WhichAreReadOnly.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 
 namespace aweXpect.Reflection.Tests.Filters;

--- a/Tests/aweXpect.Reflection.Tests/Filters/PropertyFilters.WhichAreReadWrite.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/PropertyFilters.WhichAreReadWrite.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 
 namespace aweXpect.Reflection.Tests.Filters;

--- a/Tests/aweXpect.Reflection.Tests/Filters/PropertyFilters.WhichAreReadable.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/PropertyFilters.WhichAreReadable.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 
 namespace aweXpect.Reflection.Tests.Filters;

--- a/Tests/aweXpect.Reflection.Tests/Filters/PropertyFilters.WhichAreSealed.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/PropertyFilters.WhichAreSealed.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Tests.TestHelpers;
 
 namespace aweXpect.Reflection.Tests.Filters;

--- a/Tests/aweXpect.Reflection.Tests/Filters/PropertyFilters.WhichAreStatic.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/PropertyFilters.WhichAreStatic.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Tests.TestHelpers;
 
 namespace aweXpect.Reflection.Tests.Filters;

--- a/Tests/aweXpect.Reflection.Tests/Filters/PropertyFilters.WhichAreWritable.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/PropertyFilters.WhichAreWritable.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 
 namespace aweXpect.Reflection.Tests.Filters;

--- a/Tests/aweXpect.Reflection.Tests/Filters/PropertyFilters.WhichAreWriteOnly.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/PropertyFilters.WhichAreWriteOnly.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 
 namespace aweXpect.Reflection.Tests.Filters;

--- a/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.Except.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.Except.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.Except.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.Except.Tests.cs
@@ -9,6 +9,17 @@ public sealed partial class TypeFilters
 		public sealed class Tests
 		{
 			[Fact]
+			public async Task ShouldFilterOutTheGenericType()
+			{
+				Filtered.Types types = In.AssemblyContaining<AssemblyFilters>()
+					.Types().Except<TypeToExclude>();
+
+				await That(types).DoesNotContain(typeof(TypeToExclude)).And.IsNotEmpty();
+				await That(types.GetDescription())
+					.IsEqualTo("types except TypeFilters.Except.Tests.TypeToExclude in assembly").AsPrefix();
+			}
+
+			[Fact]
 			public async Task ShouldFilterOutTypesThatSatisfyThePredicate()
 			{
 				Filtered.Types types = In.AssemblyContaining<AssemblyFilters>()
@@ -18,17 +29,6 @@ public sealed partial class TypeFilters
 				await That(types).DoesNotContain(typeof(TypeToExclude));
 				await That(types.GetDescription())
 					.IsEqualTo("types except type => type.Name == \"TypeToExclude\" in assembly").AsPrefix();
-			}
-
-			[Fact]
-			public async Task ShouldFilterOutTheGenericType()
-			{
-				Filtered.Types types = In.AssemblyContaining<AssemblyFilters>()
-					.Types().Except<TypeToExclude>();
-
-				await That(types).DoesNotContain(typeof(TypeToExclude)).And.IsNotEmpty();
-				await That(types.GetDescription())
-					.IsEqualTo("types except TypeFilters.Except.Tests.TypeToExclude in assembly").AsPrefix();
 			}
 
 			private class TypeToExclude;

--- a/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.MemberAccess.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.MemberAccess.Tests.cs
@@ -145,8 +145,8 @@ public sealed partial class TypeFilters
 			{
 				// 'sealed' is required so MethodInfo.IsFinal is true, which the .Sealed
 				// filter relies on (see ShouldChainSealedBeforeMethods); do not remove.
-				public sealed override string ToString() => "Sealed";
-				public sealed override void VirtualMethod() { }
+				public override string ToString() => "Sealed";
+				public override void VirtualMethod() { }
 			}
 		}
 	}

--- a/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.MemberAccess.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.MemberAccess.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.MemberAccess.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.MemberAccess.Tests.cs
@@ -145,8 +145,10 @@ public sealed partial class TypeFilters
 			{
 				// 'sealed' is required so MethodInfo.IsFinal is true, which the .Sealed
 				// filter relies on (see ShouldChainSealedBeforeMethods); do not remove.
-				public override string ToString() => "Sealed";
-				public override void VirtualMethod() { }
+				// ReSharper disable SealedMemberInSealedClass
+				public sealed override string ToString() => "Sealed";
+				public sealed override void VirtualMethod() { }
+				// ReSharper restore SealedMemberInSealedClass
 			}
 		}
 	}

--- a/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAre.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAre.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreAbstract.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreAbstract.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreClasses.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreClasses.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreEnums.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreEnums.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreInterfaces.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreInterfaces.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreInternal.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreInternal.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreNested.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreNested.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreNotAbstract.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreNotAbstract.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreNotClasses.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreNotClasses.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreNotEnums.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreNotEnums.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreNotInterfaces.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreNotInterfaces.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreNotInternal.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreNotInternal.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreNotNested.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreNotNested.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreNotObsolete.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreNotObsolete.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 
 namespace aweXpect.Reflection.Tests.Filters;

--- a/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreNotPrivate.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreNotPrivate.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreNotPrivateProtected.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreNotPrivateProtected.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreNotProtected.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreNotProtected.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreNotProtectedInternal.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreNotProtectedInternal.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreNotPublic.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreNotPublic.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreNotReadOnly.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreNotReadOnly.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreNotRecordStructs.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreNotRecordStructs.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreNotRecords.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreNotRecords.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreNotRefStructs.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreNotRefStructs.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreNotSealed.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreNotSealed.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreNotStatic.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreNotStatic.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Tests.TestHelpers;
 
 namespace aweXpect.Reflection.Tests.Filters;

--- a/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreNotStructs.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreNotStructs.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreObsolete.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreObsolete.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 
 namespace aweXpect.Reflection.Tests.Filters;

--- a/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichArePrivate.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichArePrivate.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichArePrivateProtected.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichArePrivateProtected.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreProtected.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreProtected.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreProtectedInternal.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreProtectedInternal.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichArePublic.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichArePublic.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreReadOnly.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreReadOnly.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreRecordStructs.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreRecordStructs.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreRecords.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreRecords.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreRefStructs.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreRefStructs.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreSealed.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreSealed.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreStatic.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreStatic.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Tests.TestHelpers;
 
 namespace aweXpect.Reflection.Tests.Filters;

--- a/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreStructs.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichAreStructs.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichContainConstructors.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichContainConstructors.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichContainEvents.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichContainEvents.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichContainFields.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichContainFields.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichContainMethods.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichContainMethods.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 using Xunit.Sdk;
 
 namespace aweXpect.Reflection.Tests.Filters;

--- a/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichContainProperties.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichContainProperties.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests.Filters;
 

--- a/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichDependOn.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichDependOn.Tests.cs
@@ -33,6 +33,18 @@ public sealed partial class TypeFilters
 			}
 
 			[Fact]
+			public async Task WhenNoNamespaceIsSpecified_ShouldThrowArgumentException()
+			{
+				void Act()
+				{
+					_ = Types.InNamespace(ConsumersNamespace).WhichDependOn();
+				}
+
+				await That(Act).Throws<ArgumentException>()
+					.WithMessage("At least one namespace must be specified.");
+			}
+
+			[Fact]
 			public async Task WhenWidenedWithOrOn_ShouldMatchEither()
 			{
 				Filtered.Types types = Types.InNamespace(ConsumersNamespace)
@@ -40,40 +52,10 @@ public sealed partial class TypeFilters
 
 				await That(types).Contains(typeof(ViaField));
 			}
-
-			[Fact]
-			public async Task WhenNoNamespaceIsSpecified_ShouldThrowArgumentException()
-			{
-				void Act() => _ = Types.InNamespace(ConsumersNamespace).WhichDependOn();
-
-				await That(Act).Throws<ArgumentException>()
-					.WithMessage("At least one namespace must be specified.");
-			}
 		}
 
 		public sealed class FilteredTypesTargetTests
 		{
-			[Fact]
-			public async Task ShouldFilterForTypesDependingOnTargetCollection()
-			{
-				Filtered.Types types = Types.InNamespace(ConsumersNamespace)
-					.WhichDependOn(Types.InNamespace(Layer1Namespace));
-
-				await That(types).Contains(typeof(ViaField));
-				await That(types).Contains(typeof(ViaSubNamespace));
-				await That(types).DoesNotContain(typeof(FrameworkConsumer));
-			}
-
-			[Fact]
-			public async Task WhenWidenedWithOrOn_ShouldMatchEither()
-			{
-				Filtered.Types types = Types.InNamespace(ConsumersNamespace)
-					.WhichDependOn(Types.InNamespace("Non.Existent.Namespace"))
-					.OrOn(Types.InNamespace(Layer1Namespace));
-
-				await That(types).Contains(typeof(ViaField));
-			}
-
 			[Fact]
 			public async Task OrOn_ShouldNotAffectOriginalFilter()
 			{
@@ -96,6 +78,27 @@ public sealed partial class TypeFilters
 					$"types within namespace \"{ConsumersNamespace}\" which depend on " +
 					$"(types within namespace \"{Layer1Namespace}\" in all loaded assemblies) " +
 					"in all loaded assemblies");
+			}
+
+			[Fact]
+			public async Task ShouldFilterForTypesDependingOnTargetCollection()
+			{
+				Filtered.Types types = Types.InNamespace(ConsumersNamespace)
+					.WhichDependOn(Types.InNamespace(Layer1Namespace));
+
+				await That(types).Contains(typeof(ViaField));
+				await That(types).Contains(typeof(ViaSubNamespace));
+				await That(types).DoesNotContain(typeof(FrameworkConsumer));
+			}
+
+			[Fact]
+			public async Task WhenWidenedWithOrOn_ShouldMatchEither()
+			{
+				Filtered.Types types = Types.InNamespace(ConsumersNamespace)
+					.WhichDependOn(Types.InNamespace("Non.Existent.Namespace"))
+					.OrOn(Types.InNamespace(Layer1Namespace));
+
+				await That(types).Contains(typeof(ViaField));
 			}
 		}
 	}

--- a/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichDependOnlyOn.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichDependOnlyOn.Tests.cs
@@ -26,6 +26,16 @@ public sealed partial class TypeFilters
 		public sealed class FilteredTypesTargetTests
 		{
 			[Fact]
+			public async Task ExcludingOwnSubNamespaces_ShouldNotAffectOriginalFilter()
+			{
+				Filtered.Types.TypeSetDependencyOnlyOnFilterResult original = Types.InNamespace(ConsumersNamespace)
+					.WhichDependOnlyOn(Types.InNamespace(Layer1Namespace));
+				_ = original.ExcludingOwnSubNamespaces();
+
+				await That(original).Contains(typeof(ReferencesOwnSubNamespace));
+			}
+
+			[Fact]
 			public async Task ShouldFilterForTypesDependingOnlyOnTargetCollection()
 			{
 				Filtered.Types types = Types.InNamespace(ConsumersNamespace)
@@ -35,17 +45,6 @@ public sealed partial class TypeFilters
 				await That(types).Contains(typeof(FrameworkConsumer));
 				await That(types).Contains(typeof(ReferencesOwnNamespace));
 				await That(types).DoesNotContain(typeof(Layer1AndLayer2));
-			}
-
-			[Fact]
-			public async Task WhenWidenedWithOrOn_ShouldAllowEither()
-			{
-				const string layer2Namespace = "aweXpect.Reflection.Tests.TestHelpers.Dependencies.Layer2";
-				Filtered.Types types = Types.InNamespace(ConsumersNamespace)
-					.WhichDependOnlyOn(Types.InNamespace(Layer1Namespace))
-					.OrOn(Types.InNamespace(layer2Namespace));
-
-				await That(types).Contains(typeof(Layer1AndLayer2));
 			}
 
 			[Fact]
@@ -60,13 +59,14 @@ public sealed partial class TypeFilters
 			}
 
 			[Fact]
-			public async Task ExcludingOwnSubNamespaces_ShouldNotAffectOriginalFilter()
+			public async Task WhenWidenedWithOrOn_ShouldAllowEither()
 			{
-				Filtered.Types.TypeSetDependencyOnlyOnFilterResult original = Types.InNamespace(ConsumersNamespace)
-					.WhichDependOnlyOn(Types.InNamespace(Layer1Namespace));
-				_ = original.ExcludingOwnSubNamespaces();
+				const string layer2Namespace = "aweXpect.Reflection.Tests.TestHelpers.Dependencies.Layer2";
+				Filtered.Types types = Types.InNamespace(ConsumersNamespace)
+					.WhichDependOnlyOn(Types.InNamespace(Layer1Namespace))
+					.OrOn(Types.InNamespace(layer2Namespace));
 
-				await That(original).Contains(typeof(ReferencesOwnSubNamespace));
+				await That(types).Contains(typeof(Layer1AndLayer2));
 			}
 		}
 	}

--- a/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichHaveDependenciesOutside.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/Filters/TypeFilters.WhichHaveDependenciesOutside.Tests.cs
@@ -14,6 +14,16 @@ public sealed partial class TypeFilters
 		public sealed class Tests
 		{
 			[Fact]
+			public async Task ExcludingOwnSubNamespaces_ShouldNotAffectOriginalFilter()
+			{
+				Filtered.Types.NamespaceDependencyOutsideFilterResult original =
+					Types.InNamespace(ConsumersNamespace).WhichHaveDependenciesOutside(Layer1Namespace);
+				_ = original.ExcludingOwnSubNamespaces();
+
+				await That(original).DoesNotContain(typeof(ReferencesOwnSubNamespace));
+			}
+
+			[Fact]
 			public async Task ShouldFilterForTypesWithDependenciesOutsideAllowedNamespaces()
 			{
 				Filtered.Types types = Types.InNamespace(ConsumersNamespace)
@@ -37,23 +47,13 @@ public sealed partial class TypeFilters
 			}
 
 			[Fact]
-			public async Task WhenWidenedWithOrOn_ShouldFilterOutTypesDependingOnEither()
+			public async Task WhenExcludingOwnSubNamespaces_ShouldSelectTypesReferencingOwnSubNamespace()
 			{
 				Filtered.Types types = Types.InNamespace(ConsumersNamespace)
 					.WhichHaveDependenciesOutside(Layer1Namespace)
-					.OrOn(Layer2Namespace);
+					.ExcludingOwnSubNamespaces();
 
-				await That(types).DoesNotContain(typeof(Layer1AndLayer2));
-				await That(types).DoesNotContain(typeof(OnlyLayer2));
-			}
-
-			[Fact]
-			public async Task WhenNotExcludingSubNamespaces_SubNamespaceDependencyStaysInside()
-			{
-				Filtered.Types types = Types.InNamespace(ConsumersNamespace)
-					.WhichHaveDependenciesOutside(Layer1Namespace);
-
-				await That(types).DoesNotContain(typeof(ViaSubNamespace));
+				await That(types).Contains(typeof(ReferencesOwnSubNamespace));
 			}
 
 			[Fact]
@@ -67,16 +67,6 @@ public sealed partial class TypeFilters
 			}
 
 			[Fact]
-			public async Task WhenExcludingOwnSubNamespaces_ShouldSelectTypesReferencingOwnSubNamespace()
-			{
-				Filtered.Types types = Types.InNamespace(ConsumersNamespace)
-					.WhichHaveDependenciesOutside(Layer1Namespace)
-					.ExcludingOwnSubNamespaces();
-
-				await That(types).Contains(typeof(ReferencesOwnSubNamespace));
-			}
-
-			[Fact]
 			public async Task WhenNotExcludingOwnSubNamespaces_OwnSubNamespaceStaysInside()
 			{
 				Filtered.Types types = Types.InNamespace(ConsumersNamespace)
@@ -86,18 +76,39 @@ public sealed partial class TypeFilters
 			}
 
 			[Fact]
-			public async Task ExcludingOwnSubNamespaces_ShouldNotAffectOriginalFilter()
+			public async Task WhenNotExcludingSubNamespaces_SubNamespaceDependencyStaysInside()
 			{
-				Filtered.Types.NamespaceDependencyOutsideFilterResult original =
-					Types.InNamespace(ConsumersNamespace).WhichHaveDependenciesOutside(Layer1Namespace);
-				_ = original.ExcludingOwnSubNamespaces();
+				Filtered.Types types = Types.InNamespace(ConsumersNamespace)
+					.WhichHaveDependenciesOutside(Layer1Namespace);
 
-				await That(original).DoesNotContain(typeof(ReferencesOwnSubNamespace));
+				await That(types).DoesNotContain(typeof(ViaSubNamespace));
+			}
+
+			[Fact]
+			public async Task WhenWidenedWithOrOn_ShouldFilterOutTypesDependingOnEither()
+			{
+				Filtered.Types types = Types.InNamespace(ConsumersNamespace)
+					.WhichHaveDependenciesOutside(Layer1Namespace)
+					.OrOn(Layer2Namespace);
+
+				await That(types).DoesNotContain(typeof(Layer1AndLayer2));
+				await That(types).DoesNotContain(typeof(OnlyLayer2));
 			}
 		}
 
 		public sealed class FilteredTypesTargetTests
 		{
+			[Fact]
+			public async Task ExcludingOwnSubNamespaces_ShouldNotAffectOriginalFilter()
+			{
+				Filtered.Types.TypeSetDependencyOutsideFilterResult original =
+					Types.InNamespace(ConsumersNamespace)
+						.WhichHaveDependenciesOutside(Types.InNamespace(Layer1Namespace));
+				_ = original.ExcludingOwnSubNamespaces();
+
+				await That(original).DoesNotContain(typeof(ReferencesOwnSubNamespace));
+			}
+
 			[Fact]
 			public async Task ShouldFilterForTypesWithDependenciesOutsideTargetCollection()
 			{
@@ -123,17 +134,6 @@ public sealed partial class TypeFilters
 			}
 
 			[Fact]
-			public async Task WhenWidenedWithOrOn_ShouldFilterOutTypesDependingOnEither()
-			{
-				Filtered.Types types = Types.InNamespace(ConsumersNamespace)
-					.WhichHaveDependenciesOutside(Types.InNamespace(Layer1Namespace))
-					.OrOn(Types.InNamespace(Layer2Namespace));
-
-				await That(types).DoesNotContain(typeof(Layer1AndLayer2));
-				await That(types).DoesNotContain(typeof(OnlyLayer2));
-			}
-
-			[Fact]
 			public async Task WhenExcludingOwnSubNamespaces_ShouldSelectTypesReferencingOwnSubNamespace()
 			{
 				Filtered.Types types = Types.InNamespace(ConsumersNamespace)
@@ -144,14 +144,14 @@ public sealed partial class TypeFilters
 			}
 
 			[Fact]
-			public async Task ExcludingOwnSubNamespaces_ShouldNotAffectOriginalFilter()
+			public async Task WhenWidenedWithOrOn_ShouldFilterOutTypesDependingOnEither()
 			{
-				Filtered.Types.TypeSetDependencyOutsideFilterResult original =
-					Types.InNamespace(ConsumersNamespace)
-						.WhichHaveDependenciesOutside(Types.InNamespace(Layer1Namespace));
-				_ = original.ExcludingOwnSubNamespaces();
+				Filtered.Types types = Types.InNamespace(ConsumersNamespace)
+					.WhichHaveDependenciesOutside(Types.InNamespace(Layer1Namespace))
+					.OrOn(Types.InNamespace(Layer2Namespace));
 
-				await That(original).DoesNotContain(typeof(ReferencesOwnSubNamespace));
+				await That(types).DoesNotContain(typeof(Layer1AndLayer2));
+				await That(types).DoesNotContain(typeof(OnlyLayer2));
 			}
 		}
 	}

--- a/Tests/aweXpect.Reflection.Tests/TestHelpers/AssemblyExtensions.cs
+++ b/Tests/aweXpect.Reflection.Tests/TestHelpers/AssemblyExtensions.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 
 namespace aweXpect.Reflection.Tests.TestHelpers;
 

--- a/Tests/aweXpect.Reflection.Tests/TestHelpers/AsyncEnumerableExtensions.cs
+++ b/Tests/aweXpect.Reflection.Tests/TestHelpers/AsyncEnumerableExtensions.cs
@@ -1,4 +1,4 @@
-#if NET8_0_OR_GREATER
+﻿#if NET8_0_OR_GREATER
 using System.Collections.Generic;
 
 namespace aweXpect.Reflection.Tests.TestHelpers;

--- a/Tests/aweXpect.Reflection.Tests/TestHelpers/Dependencies/CycleFixtures.cs
+++ b/Tests/aweXpect.Reflection.Tests/TestHelpers/Dependencies/CycleFixtures.cs
@@ -1,4 +1,4 @@
-// ReSharper disable All
+﻿// ReSharper disable All
 
 #pragma warning disable CS0169 // field is never used
 #pragma warning disable CS0649 // field is never assigned

--- a/Tests/aweXpect.Reflection.Tests/TestHelpers/Dependencies/CycleFixtures.cs
+++ b/Tests/aweXpect.Reflection.Tests/TestHelpers/Dependencies/CycleFixtures.cs
@@ -6,6 +6,21 @@
 
 using System.Collections.Generic;
 using System.Text;
+using aweXpect.Reflection.Tests.TestHelpers.Dependencies.Cycles.Acyclic.Low;
+using aweXpect.Reflection.Tests.TestHelpers.Dependencies.Cycles.Family.Inner;
+using aweXpect.Reflection.Tests.TestHelpers.Dependencies.Cycles.GlobalRing;
+using aweXpect.Reflection.Tests.TestHelpers.Dependencies.Cycles.Grouped.Orders.Api;
+using aweXpect.Reflection.Tests.TestHelpers.Dependencies.Cycles.Grouped.Orders.Domain;
+using aweXpect.Reflection.Tests.TestHelpers.Dependencies.Cycles.Indirect.Other;
+using aweXpect.Reflection.Tests.TestHelpers.Dependencies.Cycles.Indirect.Parent.Child;
+using aweXpect.Reflection.Tests.TestHelpers.Dependencies.Cycles.Resolver.B;
+using aweXpect.Reflection.Tests.TestHelpers.Dependencies.Cycles.Sliced.Module.Part1;
+using aweXpect.Reflection.Tests.TestHelpers.Dependencies.Cycles.Sliced.Module.Part2;
+using aweXpect.Reflection.Tests.TestHelpers.Dependencies.Cycles.Three.A;
+using aweXpect.Reflection.Tests.TestHelpers.Dependencies.Cycles.Three.B;
+using aweXpect.Reflection.Tests.TestHelpers.Dependencies.Cycles.Three.C;
+using aweXpect.Reflection.Tests.TestHelpers.Dependencies.Cycles.Two.Billing;
+using aweXpect.Reflection.Tests.TestHelpers.Dependencies.Cycles.Two.Orders;
 
 // Fixtures for namespace dependency cycle detection. Each type references the next via a private field, which is a
 // signature-level dependency, so the namespaces form the intended directed graph.
@@ -14,7 +29,7 @@ namespace aweXpect.Reflection.Tests.TestHelpers.Dependencies.Cycles.Acyclic.High
 {
 	public class HighType
 	{
-		private Low.LowType _low;
+		private LowType _low;
 	}
 }
 
@@ -27,7 +42,7 @@ namespace aweXpect.Reflection.Tests.TestHelpers.Dependencies.Cycles.Two.Orders
 {
 	public class Order
 	{
-		private Billing.Invoice _invoice;
+		private Invoice _invoice;
 	}
 }
 
@@ -35,7 +50,7 @@ namespace aweXpect.Reflection.Tests.TestHelpers.Dependencies.Cycles.Two.Billing
 {
 	public class Invoice
 	{
-		private Orders.Order _order;
+		private Order _order;
 	}
 }
 
@@ -43,7 +58,7 @@ namespace aweXpect.Reflection.Tests.TestHelpers.Dependencies.Cycles.Three.A
 {
 	public class TypeA
 	{
-		private B.TypeB _b;
+		private TypeB _b;
 	}
 }
 
@@ -51,7 +66,7 @@ namespace aweXpect.Reflection.Tests.TestHelpers.Dependencies.Cycles.Three.B
 {
 	public class TypeB
 	{
-		private C.TypeC _c;
+		private TypeC _c;
 	}
 }
 
@@ -59,7 +74,7 @@ namespace aweXpect.Reflection.Tests.TestHelpers.Dependencies.Cycles.Three.C
 {
 	public class TypeC
 	{
-		private A.TypeA _a;
+		private TypeA _a;
 	}
 }
 
@@ -69,7 +84,7 @@ namespace aweXpect.Reflection.Tests.TestHelpers.Dependencies.Cycles.Sliced.Modul
 {
 	public class Part1Type
 	{
-		private Part2.Part2Type _other;
+		private Part2Type _other;
 	}
 }
 
@@ -77,7 +92,7 @@ namespace aweXpect.Reflection.Tests.TestHelpers.Dependencies.Cycles.Sliced.Modul
 {
 	public class Part2Type
 	{
-		private Part1.Part1Type _other;
+		private Part1Type _other;
 	}
 }
 
@@ -95,7 +110,7 @@ namespace aweXpect.Reflection.Tests.TestHelpers.Dependencies.Cycles.Grouped.Orde
 {
 	public class OrderApi
 	{
-		private Domain.OrderDomain _domain;
+		private OrderDomain _domain;
 	}
 }
 
@@ -103,7 +118,7 @@ namespace aweXpect.Reflection.Tests.TestHelpers.Dependencies.Cycles.Grouped.Bill
 {
 	public class Invoice
 	{
-		private Orders.Api.OrderApi _api;
+		private OrderApi _api;
 	}
 }
 
@@ -124,7 +139,7 @@ namespace aweXpect.Reflection.Tests.TestHelpers.Dependencies.Cycles.Resolver.A
 {
 	public class ResolverA
 	{
-		private B.ResolverB _b;
+		private ResolverB _b;
 	}
 }
 
@@ -139,7 +154,7 @@ namespace aweXpect.Reflection.Tests.TestHelpers.Dependencies.Cycles.GlobalRing
 {
 	public class GlobalRingType
 	{
-		private global::GlobalCycleType _global;
+		private GlobalCycleType _global;
 	}
 }
 
@@ -149,7 +164,7 @@ namespace aweXpect.Reflection.Tests.TestHelpers.Dependencies.Cycles.Family
 {
 	public class FamilyParent
 	{
-		private Inner.FamilyChild _child;
+		private FamilyChild _child;
 	}
 }
 
@@ -169,7 +184,7 @@ namespace aweXpect.Reflection.Tests.TestHelpers.Dependencies.Cycles.Indirect.Par
 {
 	public class IndirectParentType
 	{
-		private Other.IndirectOtherType _other;
+		private IndirectOtherType _other;
 	}
 }
 
@@ -182,7 +197,7 @@ namespace aweXpect.Reflection.Tests.TestHelpers.Dependencies.Cycles.Indirect.Oth
 {
 	public class IndirectOtherType
 	{
-		private Parent.Child.IndirectChildType _child;
+		private IndirectChildType _child;
 	}
 }
 
@@ -191,5 +206,5 @@ namespace aweXpect.Reflection.Tests.TestHelpers.Dependencies.Cycles.Indirect.Oth
 // This type intentionally lives in the global namespace to exercise global-namespace cycle rendering.
 public class GlobalCycleType
 {
-	private aweXpect.Reflection.Tests.TestHelpers.Dependencies.Cycles.GlobalRing.GlobalRingType _ring;
+	private GlobalRingType _ring;
 }

--- a/Tests/aweXpect.Reflection.Tests/TestHelpers/Dependencies/DependencyFixtures.cs
+++ b/Tests/aweXpect.Reflection.Tests/TestHelpers/Dependencies/DependencyFixtures.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using aweXpect.Reflection.Tests.TestHelpers.Dependencies.AmbiguousA;
 using aweXpect.Reflection.Tests.TestHelpers.Dependencies.Consumers.OwnSub;
 using aweXpect.Reflection.Tests.TestHelpers.Dependencies.Layer1.Sub;
 using aweXpect.Reflection.Tests.TestHelpers.Dependencies.Layer2;
@@ -150,7 +151,7 @@ namespace aweXpect.Reflection.Tests.TestHelpers.Dependencies.Consumers
 
 	public class ReferencesGlobal
 	{
-		private global::GlobalNamespaceTarget _target;
+		private GlobalNamespaceTarget _target;
 	}
 }
 
@@ -235,7 +236,7 @@ namespace aweXpect.Reflection.Tests.TestHelpers.Dependencies.Synthetic
 	// must keep them apart by qualifying each with its namespace.
 	public class WithSameNamedDependencies
 	{
-		private AmbiguousA.AmbiguousTarget _a;
+		private AmbiguousTarget _a;
 		private AmbiguousB.AmbiguousTarget _b;
 	}
 

--- a/Tests/aweXpect.Reflection.Tests/TestHelpers/MethodInfoExtensions.cs
+++ b/Tests/aweXpect.Reflection.Tests/TestHelpers/MethodInfoExtensions.cs
@@ -1,4 +1,4 @@
-using System.Globalization;
+﻿using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;

--- a/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/AbstractClassWithMembers.cs
+++ b/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/AbstractClassWithMembers.cs
@@ -1,4 +1,4 @@
-namespace aweXpect.Reflection.Tests.TestHelpers.Types;
+﻿namespace aweXpect.Reflection.Tests.TestHelpers.Types;
 
 public abstract class AbstractClassWithMembers
 {

--- a/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/ClassInNamespaceScope.cs
+++ b/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/ClassInNamespaceScope.cs
@@ -1,4 +1,4 @@
-// ReSharper disable once CheckNamespace
+﻿// ReSharper disable once CheckNamespace
 
 namespace aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope;
 

--- a/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/ClassInNestedNamespaceScope.cs
+++ b/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/ClassInNestedNamespaceScope.cs
@@ -1,4 +1,4 @@
-// ReSharper disable once CheckNamespace
+﻿// ReSharper disable once CheckNamespace
 
 namespace aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope.Nested;
 

--- a/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/ClassInSiblingNamespaceScope.cs
+++ b/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/ClassInSiblingNamespaceScope.cs
@@ -1,4 +1,4 @@
-// ReSharper disable once CheckNamespace
+﻿// ReSharper disable once CheckNamespace
 
 namespace aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScopeSibling;
 

--- a/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/ClassWithAsyncMembers.cs
+++ b/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/ClassWithAsyncMembers.cs
@@ -1,4 +1,4 @@
-namespace aweXpect.Reflection.Tests.TestHelpers.Types;
+﻿namespace aweXpect.Reflection.Tests.TestHelpers.Types;
 
 public class ClassWithAsyncMembers
 {

--- a/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/ClassWithObsoleteMembers.cs
+++ b/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/ClassWithObsoleteMembers.cs
@@ -1,4 +1,4 @@
-namespace aweXpect.Reflection.Tests.TestHelpers.Types;
+﻿namespace aweXpect.Reflection.Tests.TestHelpers.Types;
 
 public class ClassWithObsoleteMembers
 {

--- a/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/ClassWithOperators.cs
+++ b/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/ClassWithOperators.cs
@@ -1,4 +1,4 @@
-namespace aweXpect.Reflection.Tests.TestHelpers.Types;
+﻿namespace aweXpect.Reflection.Tests.TestHelpers.Types;
 
 public class ClassWithOperators
 {

--- a/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/ClassWithSealedMembers.cs
+++ b/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/ClassWithSealedMembers.cs
@@ -1,4 +1,4 @@
-namespace aweXpect.Reflection.Tests.TestHelpers.Types;
+﻿namespace aweXpect.Reflection.Tests.TestHelpers.Types;
 
 public class ClassWithSealedMembers : AbstractClassWithMembers
 {

--- a/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/GenericClassWithNewExtensionMethods.cs
+++ b/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/GenericClassWithNewExtensionMethods.cs
@@ -1,4 +1,4 @@
-#if NET10_0_OR_GREATER
+﻿#if NET10_0_OR_GREATER
 using System.Collections.Generic;
 
 namespace aweXpect.Reflection.Tests.TestHelpers.Types;

--- a/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/GenericClassWithNewExtensionProperties.cs
+++ b/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/GenericClassWithNewExtensionProperties.cs
@@ -1,4 +1,4 @@
-#if NET10_0_OR_GREATER
+﻿#if NET10_0_OR_GREATER
 namespace aweXpect.Reflection.Tests.TestHelpers.Types;
 
 /// <summary>

--- a/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/ImmutabilityTestTypes.cs
+++ b/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/ImmutabilityTestTypes.cs
@@ -6,10 +6,9 @@ public class ImmutableClass
 	public const int ConstantField = 4;
 	private static int _staticMutableField = 1;
 	public readonly int ReadOnlyField = 2;
-	private readonly string _privateReadOnlyField = "";
 	public static int StaticSettableProperty { get; set; }
 	public int GetOnlyProperty { get; }
-	public string ComputedProperty => _privateReadOnlyField;
+	public string ComputedProperty { get; } = "";
 }
 #pragma warning restore CS0414
 

--- a/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/InternalClass.cs
+++ b/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/InternalClass.cs
@@ -1,3 +1,3 @@
-namespace aweXpect.Reflection.Tests.TestHelpers.Types;
+﻿namespace aweXpect.Reflection.Tests.TestHelpers.Types;
 
 internal class InternalClass;

--- a/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/InternalEnum.cs
+++ b/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/InternalEnum.cs
@@ -1,3 +1,3 @@
-namespace aweXpect.Reflection.Tests.TestHelpers.Types;
+﻿namespace aweXpect.Reflection.Tests.TestHelpers.Types;
 
 internal enum InternalEnum;

--- a/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/InternalGenericRecord.cs
+++ b/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/InternalGenericRecord.cs
@@ -1,3 +1,3 @@
-namespace aweXpect.Reflection.Tests.TestHelpers.Types;
+﻿namespace aweXpect.Reflection.Tests.TestHelpers.Types;
 
 internal record InternalGenericRecord<T>;

--- a/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/InternalGenericRecordStruct.cs
+++ b/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/InternalGenericRecordStruct.cs
@@ -1,3 +1,3 @@
-namespace aweXpect.Reflection.Tests.TestHelpers.Types;
+﻿namespace aweXpect.Reflection.Tests.TestHelpers.Types;
 
 internal record struct InternalGenericRecordStruct<T>;

--- a/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/InternalGenericStruct.cs
+++ b/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/InternalGenericStruct.cs
@@ -1,3 +1,3 @@
-namespace aweXpect.Reflection.Tests.TestHelpers.Types;
+﻿namespace aweXpect.Reflection.Tests.TestHelpers.Types;
 
 internal struct InternalGenericStruct<T>;

--- a/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/InternalRecord.cs
+++ b/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/InternalRecord.cs
@@ -1,3 +1,3 @@
-namespace aweXpect.Reflection.Tests.TestHelpers.Types;
+﻿namespace aweXpect.Reflection.Tests.TestHelpers.Types;
 
 internal record InternalRecord;

--- a/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/InternalRecordStruct.cs
+++ b/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/InternalRecordStruct.cs
@@ -1,3 +1,3 @@
-namespace aweXpect.Reflection.Tests.TestHelpers.Types;
+﻿namespace aweXpect.Reflection.Tests.TestHelpers.Types;
 
 internal record struct InternalRecordStruct;

--- a/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/InternalStruct.cs
+++ b/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/InternalStruct.cs
@@ -1,3 +1,3 @@
-namespace aweXpect.Reflection.Tests.TestHelpers.Types;
+﻿namespace aweXpect.Reflection.Tests.TestHelpers.Types;
 
 internal struct InternalStruct;

--- a/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/ObsoleteClass.cs
+++ b/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/ObsoleteClass.cs
@@ -1,4 +1,4 @@
-namespace aweXpect.Reflection.Tests.TestHelpers.Types;
+﻿namespace aweXpect.Reflection.Tests.TestHelpers.Types;
 
 [Obsolete("This class is obsolete.")]
 public class ObsoleteClass

--- a/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/ProtectedGenericRecord.cs
+++ b/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/ProtectedGenericRecord.cs
@@ -1,4 +1,4 @@
-namespace aweXpect.Reflection.Tests.TestHelpers.Types;
+﻿namespace aweXpect.Reflection.Tests.TestHelpers.Types;
 
 public partial class Container
 {

--- a/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/ProtectedGenericRecordStruct.cs
+++ b/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/ProtectedGenericRecordStruct.cs
@@ -1,4 +1,4 @@
-namespace aweXpect.Reflection.Tests.TestHelpers.Types;
+﻿namespace aweXpect.Reflection.Tests.TestHelpers.Types;
 
 public partial class Container
 {

--- a/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/ProtectedGenericStruct.cs
+++ b/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/ProtectedGenericStruct.cs
@@ -1,4 +1,4 @@
-namespace aweXpect.Reflection.Tests.TestHelpers.Types;
+﻿namespace aweXpect.Reflection.Tests.TestHelpers.Types;
 
 public partial class Container
 {

--- a/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/PublicAbstractRecord.cs
+++ b/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/PublicAbstractRecord.cs
@@ -1,3 +1,3 @@
-namespace aweXpect.Reflection.Tests.TestHelpers.Types;
+﻿namespace aweXpect.Reflection.Tests.TestHelpers.Types;
 
 public abstract record PublicAbstractRecord;

--- a/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/PublicClass.cs
+++ b/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/PublicClass.cs
@@ -1,3 +1,3 @@
-namespace aweXpect.Reflection.Tests.TestHelpers.Types;
+﻿namespace aweXpect.Reflection.Tests.TestHelpers.Types;
 
 public class PublicClass;

--- a/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/PublicEnum.cs
+++ b/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/PublicEnum.cs
@@ -1,3 +1,3 @@
-namespace aweXpect.Reflection.Tests.TestHelpers.Types;
+﻿namespace aweXpect.Reflection.Tests.TestHelpers.Types;
 
 public enum PublicEnum;

--- a/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/PublicReadOnlyStruct.cs
+++ b/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/PublicReadOnlyStruct.cs
@@ -1,3 +1,3 @@
-namespace aweXpect.Reflection.Tests.TestHelpers.Types;
+﻿namespace aweXpect.Reflection.Tests.TestHelpers.Types;
 
 public readonly struct PublicReadOnlyStruct;

--- a/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/PublicRecord.cs
+++ b/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/PublicRecord.cs
@@ -1,3 +1,3 @@
-namespace aweXpect.Reflection.Tests.TestHelpers.Types;
+﻿namespace aweXpect.Reflection.Tests.TestHelpers.Types;
 
 public record PublicRecord;

--- a/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/PublicRecordStruct.cs
+++ b/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/PublicRecordStruct.cs
@@ -1,3 +1,3 @@
-namespace aweXpect.Reflection.Tests.TestHelpers.Types;
+﻿namespace aweXpect.Reflection.Tests.TestHelpers.Types;
 
 public record struct PublicRecordStruct;

--- a/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/PublicRefStruct.cs
+++ b/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/PublicRefStruct.cs
@@ -1,3 +1,3 @@
-namespace aweXpect.Reflection.Tests.TestHelpers.Types;
+﻿namespace aweXpect.Reflection.Tests.TestHelpers.Types;
 
 public ref struct PublicRefStruct;

--- a/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/PublicStruct.cs
+++ b/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/PublicStruct.cs
@@ -1,3 +1,3 @@
-namespace aweXpect.Reflection.Tests.TestHelpers.Types;
+﻿namespace aweXpect.Reflection.Tests.TestHelpers.Types;
 
 public struct PublicStruct;

--- a/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/StaticClassWithExtensionMethods.cs
+++ b/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/StaticClassWithExtensionMethods.cs
@@ -1,4 +1,4 @@
-namespace aweXpect.Reflection.Tests.TestHelpers.Types;
+﻿namespace aweXpect.Reflection.Tests.TestHelpers.Types;
 
 public static class StaticClassWithExtensionMethods
 {

--- a/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/StaticClassWithNewExtensionMethods.cs
+++ b/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/StaticClassWithNewExtensionMethods.cs
@@ -1,4 +1,4 @@
-#if NET10_0_OR_GREATER
+﻿#if NET10_0_OR_GREATER
 using System;
 
 namespace aweXpect.Reflection.Tests.TestHelpers.Types;

--- a/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/StaticClassWithNewExtensionProperties.cs
+++ b/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/StaticClassWithNewExtensionProperties.cs
@@ -1,4 +1,4 @@
-#if NET10_0_OR_GREATER
+﻿#if NET10_0_OR_GREATER
 using System;
 
 namespace aweXpect.Reflection.Tests.TestHelpers.Types;

--- a/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/TestClassWithFieldModifiers.cs
+++ b/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/TestClassWithFieldModifiers.cs
@@ -1,4 +1,4 @@
-namespace aweXpect.Reflection.Tests.TestHelpers.Types;
+﻿namespace aweXpect.Reflection.Tests.TestHelpers.Types;
 
 #pragma warning disable CS0169 // Field is never used
 #pragma warning disable CS0649 // Field is never assigned to, and will always have its default value

--- a/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/TestClassWithIndexers.cs
+++ b/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/TestClassWithIndexers.cs
@@ -1,4 +1,4 @@
-namespace aweXpect.Reflection.Tests.TestHelpers.Types;
+﻿namespace aweXpect.Reflection.Tests.TestHelpers.Types;
 
 public class TestClassWithIndexers
 {

--- a/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/TestClassWithReadWriteProperties.cs
+++ b/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/TestClassWithReadWriteProperties.cs
@@ -1,4 +1,4 @@
-namespace aweXpect.Reflection.Tests.TestHelpers.Types;
+﻿namespace aweXpect.Reflection.Tests.TestHelpers.Types;
 
 public class TestClassWithReadWriteProperties
 {

--- a/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/TypesWithNullableMembers.cs
+++ b/Tests/aweXpect.Reflection.Tests/TestHelpers/Types/TypesWithNullableMembers.cs
@@ -21,8 +21,8 @@ public class ClassWithNullableMembers
 
 public class ClassWithNonNullableMembers
 {
-	public List<string?> NonNullableGenericField = [];
 	public string NonNullableField = "";
+	public List<string?> NonNullableGenericField = [];
 	public int NonNullableValueField;
 	public string NonNullableProperty { get; set; } = "";
 	public List<string?> NonNullableGenericProperty { get; set; } = [];
@@ -31,10 +31,10 @@ public class ClassWithNonNullableMembers
 
 public class ClassWithMixedNullableMembers
 {
-	public string? NullableField;
 	public string NonNullableField = "";
-	public int? NullableValueField;
 	public int NonNullableValueField;
+	public string? NullableField;
+	public int? NullableValueField;
 	public string? NullableProperty { get; set; }
 	public string NonNullableProperty { get; set; } = "";
 	public int? NullableValueProperty { get; set; }
@@ -44,9 +44,9 @@ public class ClassWithMixedNullableMembers
 public class ClassWithMostlyNullableMembers
 {
 	public string? FirstNullableField;
+	public string NonNullableField = "";
 	public string? SecondNullableField;
 	public string? ThirdNullableField;
-	public string NonNullableField = "";
 	public string? FirstNullableProperty { get; set; }
 	public string? SecondNullableProperty { get; set; }
 	public string? ThirdNullableProperty { get; set; }
@@ -77,5 +77,4 @@ public class ClassWithObliviousMembers
 	public string ObliviousField;
 	public string ObliviousProperty { get; set; }
 }
-#nullable restore
 #pragma warning restore CS0649

--- a/Tests/aweXpect.Reflection.Tests/ThatAssemblies.AreNotStrongNamed.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatAssemblies.AreNotStrongNamed.Tests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 #if NET8_0_OR_GREATER

--- a/Tests/aweXpect.Reflection.Tests/ThatAssemblies.AreStrongNamed.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatAssemblies.AreStrongNamed.Tests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 #if NET8_0_OR_GREATER

--- a/Tests/aweXpect.Reflection.Tests/ThatAssemblies.DependOn.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatAssemblies.DependOn.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 using Xunit.Sdk;
 

--- a/Tests/aweXpect.Reflection.Tests/ThatAssemblies.DependOnlyOn.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatAssemblies.DependOnlyOn.Tests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Reflection;
 using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Tests.TestHelpers.Types;

--- a/Tests/aweXpect.Reflection.Tests/ThatAssemblies.DoNotDependOn.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatAssemblies.DoNotDependOn.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 using Xunit.Sdk;
 

--- a/Tests/aweXpect.Reflection.Tests/ThatAssemblies.Have.AttributeTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatAssemblies.Have.AttributeTests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Reflection;
 using Xunit.Sdk;
 

--- a/Tests/aweXpect.Reflection.Tests/ThatAssemblies.Target.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatAssemblies.Target.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 using Xunit.Sdk;
 

--- a/Tests/aweXpect.Reflection.Tests/ThatAssembly.DependsOn.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatAssembly.DependsOn.Tests.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 using Xunit.Sdk;
 

--- a/Tests/aweXpect.Reflection.Tests/ThatAssembly.DependsOnlyOn.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatAssembly.DependsOnlyOn.Tests.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using aweXpect.Customization;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 using Xunit.Sdk;

--- a/Tests/aweXpect.Reflection.Tests/ThatAssembly.DependsOnlyOn.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatAssembly.DependsOnlyOn.Tests.cs
@@ -69,23 +69,6 @@ public sealed partial class ThatAssembly
 			}
 
 			[Fact]
-			public async Task WhenCustomizedPrefixEndsWithDot_ShouldExcludeMatchingAssemblies()
-			{
-				Assembly subject = typeof(In).Assembly;
-
-				// A customized prefix in the natural trailing-dot form ("aweXpect.") must exclude the
-				// aweXpect.Core reference at the (then explicit) name-segment boundary.
-				using (Customize.aweXpect.Reflection().ExcludedAssemblyPrefixes
-					       .Set(["System", "netstandard", "mscorlib", "Microsoft", "aweXpect.",]))
-				{
-					async Task Act()
-						=> await That(subject).DependsOnlyOn();
-
-					await That(Act).DoesNotThrow();
-				}
-			}
-
-			[Fact]
 			public async Task WhenAssemblyIsNull_ShouldFail()
 			{
 				Assembly? subject = null;
@@ -101,6 +84,25 @@ public sealed partial class ThatAssembly
 					             has dependencies only on assemblies equal to "aweXpect.Core",
 					             but it was <null>
 					             """);
+			}
+
+			[Fact]
+			public async Task WhenCustomizedPrefixEndsWithDot_ShouldExcludeMatchingAssemblies()
+			{
+				Assembly subject = typeof(In).Assembly;
+
+				// A customized prefix in the natural trailing-dot form ("aweXpect.") must exclude the
+				// aweXpect.Core reference at the (then explicit) name-segment boundary.
+				using (Customize.aweXpect.Reflection().ExcludedAssemblyPrefixes
+					       .Set(["System", "netstandard", "mscorlib", "Microsoft", "aweXpect.",]))
+				{
+					async Task Act()
+					{
+						await That(subject).DependsOnlyOn();
+					}
+
+					await That(Act).DoesNotThrow();
+				}
 			}
 
 			[Fact]

--- a/Tests/aweXpect.Reflection.Tests/ThatAssembly.DoesNotDependOn.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatAssembly.DoesNotDependOn.Tests.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 using Xunit.Sdk;
 

--- a/Tests/aweXpect.Reflection.Tests/ThatAssembly.Has.AttributeTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatAssembly.Has.AttributeTests.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using Xunit.Sdk;
 
 namespace aweXpect.Reflection.Tests;

--- a/Tests/aweXpect.Reflection.Tests/ThatAssembly.IsNotStrongNamed.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatAssembly.IsNotStrongNamed.Tests.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 using Xunit.Sdk;
 

--- a/Tests/aweXpect.Reflection.Tests/ThatAssembly.IsStrongNamed.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatAssembly.IsStrongNamed.Tests.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 using Xunit.Sdk;
 

--- a/Tests/aweXpect.Reflection.Tests/ThatAssembly.Targets.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatAssembly.Targets.Tests.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 using Xunit.Sdk;
 

--- a/Tests/aweXpect.Reflection.Tests/ThatConstructor.Has.AttributeTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatConstructor.Has.AttributeTests.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using Xunit.Sdk;
 
 namespace aweXpect.Reflection.Tests;

--- a/Tests/aweXpect.Reflection.Tests/ThatConstructor.HasInParameter.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatConstructor.HasInParameter.Tests.cs
@@ -1,4 +1,4 @@
-using System.Linq;
+﻿using System.Linq;
 using System.Reflection;
 using Xunit.Sdk;
 

--- a/Tests/aweXpect.Reflection.Tests/ThatConstructor.HasOptionalParameter.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatConstructor.HasOptionalParameter.Tests.cs
@@ -1,4 +1,4 @@
-using System.Linq;
+﻿using System.Linq;
 using System.Reflection;
 using Xunit.Sdk;
 

--- a/Tests/aweXpect.Reflection.Tests/ThatConstructor.HasOutParameter.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatConstructor.HasOutParameter.Tests.cs
@@ -1,4 +1,4 @@
-using System.Linq;
+﻿using System.Linq;
 using System.Reflection;
 using Xunit.Sdk;
 

--- a/Tests/aweXpect.Reflection.Tests/ThatConstructor.HasParamsParameter.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatConstructor.HasParamsParameter.Tests.cs
@@ -1,4 +1,4 @@
-using System.Linq;
+﻿using System.Linq;
 using System.Reflection;
 using Xunit.Sdk;
 

--- a/Tests/aweXpect.Reflection.Tests/ThatConstructor.HasRefParameter.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatConstructor.HasRefParameter.Tests.cs
@@ -1,4 +1,4 @@
-using System.Linq;
+﻿using System.Linq;
 using System.Reflection;
 using Xunit.Sdk;
 

--- a/Tests/aweXpect.Reflection.Tests/ThatConstructor.IsNotObsolete.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatConstructor.IsNotObsolete.Tests.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 using Xunit.Sdk;
 

--- a/Tests/aweXpect.Reflection.Tests/ThatConstructor.IsNotStatic.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatConstructor.IsNotStatic.Tests.cs
@@ -1,4 +1,4 @@
-using System.Linq;
+﻿using System.Linq;
 using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 

--- a/Tests/aweXpect.Reflection.Tests/ThatConstructor.IsObsolete.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatConstructor.IsObsolete.Tests.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 using Xunit.Sdk;
 

--- a/Tests/aweXpect.Reflection.Tests/ThatConstructor.ParameterModifierExactlyOverloads.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatConstructor.ParameterModifierExactlyOverloads.Tests.cs
@@ -1,4 +1,4 @@
-using System.IO;
+﻿using System.IO;
 using System.Linq;
 using System.Reflection;
 using Xunit.Sdk;

--- a/Tests/aweXpect.Reflection.Tests/ThatConstructor.ParameterModifierTypedOverloads.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatConstructor.ParameterModifierTypedOverloads.Tests.cs
@@ -1,4 +1,4 @@
-using System.Linq;
+﻿using System.Linq;
 using System.Reflection;
 using Xunit.Sdk;
 

--- a/Tests/aweXpect.Reflection.Tests/ThatConstructors.AreNotObsolete.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatConstructors.AreNotObsolete.Tests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers;
 using aweXpect.Reflection.Tests.TestHelpers.Types;

--- a/Tests/aweXpect.Reflection.Tests/ThatConstructors.AreObsolete.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatConstructors.AreObsolete.Tests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers;
 using aweXpect.Reflection.Tests.TestHelpers.Types;

--- a/Tests/aweXpect.Reflection.Tests/ThatConstructors.HaveInParameter.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatConstructors.HaveInParameter.Tests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Xunit.Sdk;

--- a/Tests/aweXpect.Reflection.Tests/ThatConstructors.HaveOptionalParameter.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatConstructors.HaveOptionalParameter.Tests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Xunit.Sdk;

--- a/Tests/aweXpect.Reflection.Tests/ThatConstructors.HaveOutParameter.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatConstructors.HaveOutParameter.Tests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Xunit.Sdk;

--- a/Tests/aweXpect.Reflection.Tests/ThatConstructors.HaveParameterExactly.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatConstructors.HaveParameterExactly.Tests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using Xunit.Sdk;

--- a/Tests/aweXpect.Reflection.Tests/ThatConstructors.HaveParamsParameter.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatConstructors.HaveParamsParameter.Tests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Xunit.Sdk;

--- a/Tests/aweXpect.Reflection.Tests/ThatConstructors.HaveRefParameter.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatConstructors.HaveRefParameter.Tests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Xunit.Sdk;

--- a/Tests/aweXpect.Reflection.Tests/ThatConstructors.ParameterModifierExactlyOverloads.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatConstructors.ParameterModifierExactlyOverloads.Tests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;

--- a/Tests/aweXpect.Reflection.Tests/ThatConstructors.ParameterModifierTypedOverloads.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatConstructors.ParameterModifierTypedOverloads.Tests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Xunit.Sdk;

--- a/Tests/aweXpect.Reflection.Tests/ThatEvent.Has.AttributeTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatEvent.Has.AttributeTests.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using Xunit.Sdk;
 
 namespace aweXpect.Reflection.Tests;

--- a/Tests/aweXpect.Reflection.Tests/ThatEvent.IsAbstract.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatEvent.IsAbstract.Tests.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 using Xunit.Sdk;
 

--- a/Tests/aweXpect.Reflection.Tests/ThatEvent.IsNotAbstract.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatEvent.IsNotAbstract.Tests.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 using Xunit.Sdk;
 

--- a/Tests/aweXpect.Reflection.Tests/ThatEvent.IsNotObsolete.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatEvent.IsNotObsolete.Tests.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 using Xunit.Sdk;
 

--- a/Tests/aweXpect.Reflection.Tests/ThatEvent.IsNotSealed.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatEvent.IsNotSealed.Tests.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 using Xunit.Sdk;
 

--- a/Tests/aweXpect.Reflection.Tests/ThatEvent.IsObsolete.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatEvent.IsObsolete.Tests.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 using Xunit.Sdk;
 

--- a/Tests/aweXpect.Reflection.Tests/ThatEvent.IsSealed.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatEvent.IsSealed.Tests.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 using Xunit.Sdk;
 

--- a/Tests/aweXpect.Reflection.Tests/ThatEvents.AreAbstract.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatEvents.AreAbstract.Tests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers.Types;

--- a/Tests/aweXpect.Reflection.Tests/ThatEvents.AreNotObsolete.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatEvents.AreNotObsolete.Tests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers;
 using aweXpect.Reflection.Tests.TestHelpers.Types;

--- a/Tests/aweXpect.Reflection.Tests/ThatEvents.AreObsolete.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatEvents.AreObsolete.Tests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers;
 using aweXpect.Reflection.Tests.TestHelpers.Types;

--- a/Tests/aweXpect.Reflection.Tests/ThatEvents.AreSealed.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatEvents.AreSealed.Tests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers.Types;

--- a/Tests/aweXpect.Reflection.Tests/ThatField.Has.AttributeTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatField.Has.AttributeTests.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using Xunit.Sdk;
 
 namespace aweXpect.Reflection.Tests;

--- a/Tests/aweXpect.Reflection.Tests/ThatField.IsConstant.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatField.IsConstant.Tests.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 
 namespace aweXpect.Reflection.Tests;

--- a/Tests/aweXpect.Reflection.Tests/ThatField.IsNotConstant.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatField.IsNotConstant.Tests.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 
 namespace aweXpect.Reflection.Tests;

--- a/Tests/aweXpect.Reflection.Tests/ThatField.IsNotNullable.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatField.IsNotNullable.Tests.cs
@@ -38,17 +38,21 @@ public sealed partial class ThatField
 			}
 
 			[Fact]
-			public async Task WhenFieldIsOblivious_ShouldSucceed()
+			public async Task WhenFieldIsNull_ShouldFail()
 			{
-				FieldInfo subject = typeof(ClassWithObliviousMembers)
-					.GetField(nameof(ClassWithObliviousMembers.ObliviousField))!;
+				FieldInfo? subject = null;
 
 				async Task Act()
 				{
 					await That(subject).IsNotNullable();
 				}
 
-				await That(Act).DoesNotThrow();
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             is not nullable,
+					             but it was <null>
+					             """);
 			}
 
 			[Fact]
@@ -90,21 +94,17 @@ public sealed partial class ThatField
 			}
 
 			[Fact]
-			public async Task WhenFieldIsNull_ShouldFail()
+			public async Task WhenFieldIsOblivious_ShouldSucceed()
 			{
-				FieldInfo? subject = null;
+				FieldInfo subject = typeof(ClassWithObliviousMembers)
+					.GetField(nameof(ClassWithObliviousMembers.ObliviousField))!;
 
 				async Task Act()
 				{
 					await That(subject).IsNotNullable();
 				}
 
-				await That(Act).ThrowsException()
-					.WithMessage("""
-					             Expected that subject
-					             is not nullable,
-					             but it was <null>
-					             """);
+				await That(Act).DoesNotThrow();
 			}
 		}
 

--- a/Tests/aweXpect.Reflection.Tests/ThatField.IsNotObsolete.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatField.IsNotObsolete.Tests.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 using Xunit.Sdk;
 

--- a/Tests/aweXpect.Reflection.Tests/ThatField.IsNotReadOnly.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatField.IsNotReadOnly.Tests.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 
 namespace aweXpect.Reflection.Tests;

--- a/Tests/aweXpect.Reflection.Tests/ThatField.IsNotStatic.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatField.IsNotStatic.Tests.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 
 namespace aweXpect.Reflection.Tests;

--- a/Tests/aweXpect.Reflection.Tests/ThatField.IsNullable.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatField.IsNullable.Tests.cs
@@ -10,59 +10,41 @@ public sealed partial class ThatField
 		public sealed class Tests
 		{
 			[Fact]
-			public async Task WhenFieldIsNullableReferenceType_ShouldSucceed()
+			public async Task WhenFieldIsNonNullableGenericType_ShouldFail()
 			{
-				FieldInfo subject = typeof(ClassWithNullableMembers)
-					.GetField(nameof(ClassWithNullableMembers.NullableField))!;
+				FieldInfo subject = typeof(ClassWithNonNullableMembers)
+					.GetField(nameof(ClassWithNonNullableMembers.NonNullableGenericField))!;
 
 				async Task Act()
 				{
 					await That(subject).IsNullable();
 				}
 
-				await That(Act).DoesNotThrow();
+				await That(Act).ThrowsException()
+					.WithMessage($"""
+					              Expected that subject
+					              is nullable,
+					              but it was non-nullable {Formatter.Format(subject)}
+					              """);
 			}
 
 			[Fact]
-			public async Task WhenFieldIsNullableValueType_ShouldSucceed()
+			public async Task WhenFieldIsNonNullableInMostlyNullableClass_ShouldFail()
 			{
-				FieldInfo subject = typeof(ClassWithNullableMembers)
-					.GetField(nameof(ClassWithNullableMembers.NullableValueField))!;
+				FieldInfo subject = typeof(ClassWithMostlyNullableMembers)
+					.GetField(nameof(ClassWithMostlyNullableMembers.NonNullableField))!;
 
 				async Task Act()
 				{
 					await That(subject).IsNullable();
 				}
 
-				await That(Act).DoesNotThrow();
-			}
-
-			[Fact]
-			public async Task WhenFieldIsNullableGenericType_ShouldSucceed()
-			{
-				FieldInfo subject = typeof(ClassWithNullableMembers)
-					.GetField(nameof(ClassWithNullableMembers.NullableGenericField))!;
-
-				async Task Act()
-				{
-					await That(subject).IsNullable();
-				}
-
-				await That(Act).DoesNotThrow();
-			}
-
-			[Fact]
-			public async Task WhenFieldIsNullableInMixedClass_ShouldSucceed()
-			{
-				FieldInfo subject = typeof(ClassWithMixedNullableMembers)
-					.GetField(nameof(ClassWithMixedNullableMembers.NullableField))!;
-
-				async Task Act()
-				{
-					await That(subject).IsNullable();
-				}
-
-				await That(Act).DoesNotThrow();
+				await That(Act).ThrowsException()
+					.WithMessage($"""
+					              Expected that subject
+					              is nullable,
+					              but it was non-nullable {Formatter.Format(subject)}
+					              """);
 			}
 
 			[Fact]
@@ -104,10 +86,9 @@ public sealed partial class ThatField
 			}
 
 			[Fact]
-			public async Task WhenFieldIsNonNullableGenericType_ShouldFail()
+			public async Task WhenFieldIsNull_ShouldFail()
 			{
-				FieldInfo subject = typeof(ClassWithNonNullableMembers)
-					.GetField(nameof(ClassWithNonNullableMembers.NonNullableGenericField))!;
+				FieldInfo? subject = null;
 
 				async Task Act()
 				{
@@ -115,30 +96,67 @@ public sealed partial class ThatField
 				}
 
 				await That(Act).ThrowsException()
-					.WithMessage($"""
-					              Expected that subject
-					              is nullable,
-					              but it was non-nullable {Formatter.Format(subject)}
-					              """);
+					.WithMessage("""
+					             Expected that subject
+					             is nullable,
+					             but it was <null>
+					             """);
 			}
 
 			[Fact]
-			public async Task WhenFieldIsNonNullableInMostlyNullableClass_ShouldFail()
+			public async Task WhenFieldIsNullableGenericType_ShouldSucceed()
 			{
-				FieldInfo subject = typeof(ClassWithMostlyNullableMembers)
-					.GetField(nameof(ClassWithMostlyNullableMembers.NonNullableField))!;
+				FieldInfo subject = typeof(ClassWithNullableMembers)
+					.GetField(nameof(ClassWithNullableMembers.NullableGenericField))!;
 
 				async Task Act()
 				{
 					await That(subject).IsNullable();
 				}
 
-				await That(Act).ThrowsException()
-					.WithMessage($"""
-					              Expected that subject
-					              is nullable,
-					              but it was non-nullable {Formatter.Format(subject)}
-					              """);
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenFieldIsNullableInMixedClass_ShouldSucceed()
+			{
+				FieldInfo subject = typeof(ClassWithMixedNullableMembers)
+					.GetField(nameof(ClassWithMixedNullableMembers.NullableField))!;
+
+				async Task Act()
+				{
+					await That(subject).IsNullable();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenFieldIsNullableReferenceType_ShouldSucceed()
+			{
+				FieldInfo subject = typeof(ClassWithNullableMembers)
+					.GetField(nameof(ClassWithNullableMembers.NullableField))!;
+
+				async Task Act()
+				{
+					await That(subject).IsNullable();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenFieldIsNullableValueType_ShouldSucceed()
+			{
+				FieldInfo subject = typeof(ClassWithNullableMembers)
+					.GetField(nameof(ClassWithNullableMembers.NullableValueField))!;
+
+				async Task Act()
+				{
+					await That(subject).IsNullable();
+				}
+
+				await That(Act).DoesNotThrow();
 			}
 
 			[Fact]
@@ -158,24 +176,6 @@ public sealed partial class ThatField
 					              is nullable,
 					              but it was non-nullable {Formatter.Format(subject)}
 					              """);
-			}
-
-			[Fact]
-			public async Task WhenFieldIsNull_ShouldFail()
-			{
-				FieldInfo? subject = null;
-
-				async Task Act()
-				{
-					await That(subject).IsNullable();
-				}
-
-				await That(Act).ThrowsException()
-					.WithMessage("""
-					             Expected that subject
-					             is nullable,
-					             but it was <null>
-					             """);
 			}
 		}
 

--- a/Tests/aweXpect.Reflection.Tests/ThatField.IsObsolete.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatField.IsObsolete.Tests.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 using Xunit.Sdk;
 

--- a/Tests/aweXpect.Reflection.Tests/ThatField.IsReadOnly.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatField.IsReadOnly.Tests.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 
 namespace aweXpect.Reflection.Tests;

--- a/Tests/aweXpect.Reflection.Tests/ThatFields.AreConstant.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatFields.AreConstant.Tests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 #if NET8_0_OR_GREATER

--- a/Tests/aweXpect.Reflection.Tests/ThatFields.AreNotConstant.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatFields.AreNotConstant.Tests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 #if NET8_0_OR_GREATER

--- a/Tests/aweXpect.Reflection.Tests/ThatFields.AreNotNullable.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatFields.AreNotNullable.Tests.cs
@@ -28,6 +28,26 @@ public sealed partial class ThatFields
 			}
 
 			[Fact]
+			public async Task WhenFieldsContainNull_ShouldFail()
+			{
+				IEnumerable<FieldInfo?> subject = [null,];
+
+				async Task Act()
+				{
+					await That(subject).AreNotNullable();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             are all not nullable,
+					             but it contained nullable fields [
+					               <null>
+					             ]
+					             """);
+			}
+
+			[Fact]
 			public async Task WhenFieldsContainNullableFields_ShouldFail()
 			{
 				IEnumerable<FieldInfo> subject = typeof(ClassWithMixedNullableMembers)
@@ -46,26 +66,6 @@ public sealed partial class ThatFields
 					               *
 					             ]
 					             """).AsWildcard();
-			}
-
-			[Fact]
-			public async Task WhenFieldsContainNull_ShouldFail()
-			{
-				IEnumerable<FieldInfo?> subject = [null,];
-
-				async Task Act()
-				{
-					await That(subject).AreNotNullable();
-				}
-
-				await That(Act).ThrowsException()
-					.WithMessage("""
-					             Expected that subject
-					             are all not nullable,
-					             but it contained nullable fields [
-					               <null>
-					             ]
-					             """);
 			}
 		}
 

--- a/Tests/aweXpect.Reflection.Tests/ThatFields.AreNotObsolete.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatFields.AreNotObsolete.Tests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers;
 using aweXpect.Reflection.Tests.TestHelpers.Types;

--- a/Tests/aweXpect.Reflection.Tests/ThatFields.AreNotReadOnly.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatFields.AreNotReadOnly.Tests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 #if NET8_0_OR_GREATER

--- a/Tests/aweXpect.Reflection.Tests/ThatFields.AreObsolete.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatFields.AreObsolete.Tests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers;
 using aweXpect.Reflection.Tests.TestHelpers.Types;

--- a/Tests/aweXpect.Reflection.Tests/ThatFields.AreReadOnly.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatFields.AreReadOnly.Tests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 #if NET8_0_OR_GREATER

--- a/Tests/aweXpect.Reflection.Tests/ThatMethod.Has.AttributeTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethod.Has.AttributeTests.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using Xunit.Sdk;
 
 namespace aweXpect.Reflection.Tests;

--- a/Tests/aweXpect.Reflection.Tests/ThatMethod.HasInParameter.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethod.HasInParameter.Tests.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using Xunit.Sdk;
 
 namespace aweXpect.Reflection.Tests;

--- a/Tests/aweXpect.Reflection.Tests/ThatMethod.HasOptionalParameter.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethod.HasOptionalParameter.Tests.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using Xunit.Sdk;
 
 namespace aweXpect.Reflection.Tests;

--- a/Tests/aweXpect.Reflection.Tests/ThatMethod.HasOutParameter.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethod.HasOutParameter.Tests.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using Xunit.Sdk;
 
 namespace aweXpect.Reflection.Tests;

--- a/Tests/aweXpect.Reflection.Tests/ThatMethod.HasParamsParameter.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethod.HasParamsParameter.Tests.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using Xunit.Sdk;
 
 namespace aweXpect.Reflection.Tests;

--- a/Tests/aweXpect.Reflection.Tests/ThatMethod.HasRefParameter.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethod.HasRefParameter.Tests.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using Xunit.Sdk;
 
 namespace aweXpect.Reflection.Tests;

--- a/Tests/aweXpect.Reflection.Tests/ThatMethod.IsAbstract.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethod.IsAbstract.Tests.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 using Xunit.Sdk;
 

--- a/Tests/aweXpect.Reflection.Tests/ThatMethod.IsAnExtensionMethod.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethod.IsAnExtensionMethod.Tests.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using System.Reflection.Emit;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 using Xunit.Sdk;

--- a/Tests/aweXpect.Reflection.Tests/ThatMethod.IsAsync.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethod.IsAsync.Tests.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 using Xunit.Sdk;
 

--- a/Tests/aweXpect.Reflection.Tests/ThatMethod.IsGeneric.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethod.IsGeneric.Tests.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 
 namespace aweXpect.Reflection.Tests;
 

--- a/Tests/aweXpect.Reflection.Tests/ThatMethod.IsGeneric.WithArgument.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethod.IsGeneric.WithArgument.Tests.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers;
 
 namespace aweXpect.Reflection.Tests;

--- a/Tests/aweXpect.Reflection.Tests/ThatMethod.IsGeneric.WithArgumentCount.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethod.IsGeneric.WithArgumentCount.Tests.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 
 namespace aweXpect.Reflection.Tests;
 

--- a/Tests/aweXpect.Reflection.Tests/ThatMethod.IsNotAbstract.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethod.IsNotAbstract.Tests.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 using Xunit.Sdk;
 

--- a/Tests/aweXpect.Reflection.Tests/ThatMethod.IsNotAnExtensionMethod.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethod.IsNotAnExtensionMethod.Tests.cs
@@ -1,4 +1,4 @@
-#if NET10_0_OR_GREATER
+﻿#if NET10_0_OR_GREATER
 using System;
 #endif
 using System.Reflection;

--- a/Tests/aweXpect.Reflection.Tests/ThatMethod.IsNotAsync.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethod.IsNotAsync.Tests.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 using Xunit.Sdk;
 

--- a/Tests/aweXpect.Reflection.Tests/ThatMethod.IsNotGeneric.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethod.IsNotGeneric.Tests.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 
 namespace aweXpect.Reflection.Tests;
 

--- a/Tests/aweXpect.Reflection.Tests/ThatMethod.IsNotObsolete.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethod.IsNotObsolete.Tests.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 using Xunit.Sdk;
 

--- a/Tests/aweXpect.Reflection.Tests/ThatMethod.IsNotSealed.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethod.IsNotSealed.Tests.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 using Xunit.Sdk;
 

--- a/Tests/aweXpect.Reflection.Tests/ThatMethod.IsNotStatic.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethod.IsNotStatic.Tests.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 
 namespace aweXpect.Reflection.Tests;

--- a/Tests/aweXpect.Reflection.Tests/ThatMethod.IsObsolete.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethod.IsObsolete.Tests.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 using Xunit.Sdk;
 

--- a/Tests/aweXpect.Reflection.Tests/ThatMethod.IsSealed.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethod.IsSealed.Tests.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 using Xunit.Sdk;
 

--- a/Tests/aweXpect.Reflection.Tests/ThatMethod.ParameterModifierExactlyOverloads.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethod.ParameterModifierExactlyOverloads.Tests.cs
@@ -1,4 +1,4 @@
-using System.IO;
+﻿using System.IO;
 using System.Reflection;
 using Xunit.Sdk;
 

--- a/Tests/aweXpect.Reflection.Tests/ThatMethod.ParameterModifierTypedOverloads.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethod.ParameterModifierTypedOverloads.Tests.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using Xunit.Sdk;
 
 namespace aweXpect.Reflection.Tests;

--- a/Tests/aweXpect.Reflection.Tests/ThatMethod.ReturnsVoid.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethod.ReturnsVoid.Tests.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using Xunit.Sdk;
 
 namespace aweXpect.Reflection.Tests;

--- a/Tests/aweXpect.Reflection.Tests/ThatMethods.AreAbstract.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethods.AreAbstract.Tests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers.Types;

--- a/Tests/aweXpect.Reflection.Tests/ThatMethods.AreAsync.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethods.AreAsync.Tests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers;

--- a/Tests/aweXpect.Reflection.Tests/ThatMethods.AreExtensionMethods.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethods.AreExtensionMethods.Tests.cs
@@ -1,4 +1,4 @@
-#if NET10_0_OR_GREATER
+﻿#if NET10_0_OR_GREATER
 using System;
 #endif
 using System.Collections.Generic;

--- a/Tests/aweXpect.Reflection.Tests/ThatMethods.AreGeneric.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethods.AreGeneric.Tests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Reflection;
 using aweXpect.Reflection.Collections;
 using Xunit.Sdk;

--- a/Tests/aweXpect.Reflection.Tests/ThatMethods.AreGeneric.WithArgument.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethods.AreGeneric.WithArgument.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Tests.TestHelpers;
 
 namespace aweXpect.Reflection.Tests;

--- a/Tests/aweXpect.Reflection.Tests/ThatMethods.AreGeneric.WithArgumentCount.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethods.AreGeneric.WithArgumentCount.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 
 namespace aweXpect.Reflection.Tests;
 

--- a/Tests/aweXpect.Reflection.Tests/ThatMethods.AreNotAbstract.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethods.AreNotAbstract.Tests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers.Types;

--- a/Tests/aweXpect.Reflection.Tests/ThatMethods.AreNotAsync.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethods.AreNotAsync.Tests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers;

--- a/Tests/aweXpect.Reflection.Tests/ThatMethods.AreNotExtensionMethods.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethods.AreNotExtensionMethods.Tests.cs
@@ -1,4 +1,4 @@
-#if NET10_0_OR_GREATER
+﻿#if NET10_0_OR_GREATER
 using System;
 #endif
 using System.Collections.Generic;

--- a/Tests/aweXpect.Reflection.Tests/ThatMethods.AreNotGeneric.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethods.AreNotGeneric.Tests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Reflection;
 using aweXpect.Reflection.Collections;
 using Xunit.Sdk;

--- a/Tests/aweXpect.Reflection.Tests/ThatMethods.AreNotObsolete.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethods.AreNotObsolete.Tests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers;
 using aweXpect.Reflection.Tests.TestHelpers.Types;

--- a/Tests/aweXpect.Reflection.Tests/ThatMethods.AreNotOperators.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethods.AreNotOperators.Tests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers;

--- a/Tests/aweXpect.Reflection.Tests/ThatMethods.AreObsolete.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethods.AreObsolete.Tests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers;
 using aweXpect.Reflection.Tests.TestHelpers.Types;

--- a/Tests/aweXpect.Reflection.Tests/ThatMethods.AreOperators.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethods.AreOperators.Tests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers;

--- a/Tests/aweXpect.Reflection.Tests/ThatMethods.AreSealed.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethods.AreSealed.Tests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers.Types;

--- a/Tests/aweXpect.Reflection.Tests/ThatMethods.HaveInParameter.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethods.HaveInParameter.Tests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Reflection;
 using Xunit.Sdk;
 

--- a/Tests/aweXpect.Reflection.Tests/ThatMethods.HaveOptionalParameter.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethods.HaveOptionalParameter.Tests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Reflection;
 using Xunit.Sdk;
 

--- a/Tests/aweXpect.Reflection.Tests/ThatMethods.HaveOutParameter.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethods.HaveOutParameter.Tests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Reflection;
 using Xunit.Sdk;
 

--- a/Tests/aweXpect.Reflection.Tests/ThatMethods.HaveParameterExactly.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethods.HaveParameterExactly.Tests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using Xunit.Sdk;

--- a/Tests/aweXpect.Reflection.Tests/ThatMethods.HaveParamsParameter.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethods.HaveParamsParameter.Tests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Reflection;
 using Xunit.Sdk;
 

--- a/Tests/aweXpect.Reflection.Tests/ThatMethods.HaveRefParameter.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethods.HaveRefParameter.Tests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Reflection;
 using Xunit.Sdk;
 

--- a/Tests/aweXpect.Reflection.Tests/ThatMethods.ParameterModifierExactlyOverloads.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethods.ParameterModifierExactlyOverloads.Tests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using Xunit.Sdk;

--- a/Tests/aweXpect.Reflection.Tests/ThatMethods.ParameterModifierTypedOverloads.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethods.ParameterModifierTypedOverloads.Tests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Reflection;
 using Xunit.Sdk;
 

--- a/Tests/aweXpect.Reflection.Tests/ThatMethods.ReturnVoid.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatMethods.ReturnVoid.Tests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Reflection;
 using aweXpect.Reflection.Collections;
 using Xunit.Sdk;

--- a/Tests/aweXpect.Reflection.Tests/ThatProperties.AreAbstract.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatProperties.AreAbstract.Tests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers.Types;

--- a/Tests/aweXpect.Reflection.Tests/ThatProperties.AreExtensionProperties.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatProperties.AreExtensionProperties.Tests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers;
 using aweXpect.Reflection.Tests.TestHelpers.Types;

--- a/Tests/aweXpect.Reflection.Tests/ThatProperties.AreIndexers.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatProperties.AreIndexers.Tests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 #if NET8_0_OR_GREATER

--- a/Tests/aweXpect.Reflection.Tests/ThatProperties.AreNotExtensionProperties.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatProperties.AreNotExtensionProperties.Tests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers;
 using aweXpect.Reflection.Tests.TestHelpers.Types;

--- a/Tests/aweXpect.Reflection.Tests/ThatProperties.AreNotIndexers.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatProperties.AreNotIndexers.Tests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 #if NET8_0_OR_GREATER

--- a/Tests/aweXpect.Reflection.Tests/ThatProperties.AreNotNullable.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatProperties.AreNotNullable.Tests.cs
@@ -28,6 +28,26 @@ public sealed partial class ThatProperties
 			}
 
 			[Fact]
+			public async Task WhenPropertiesContainNull_ShouldFail()
+			{
+				IEnumerable<PropertyInfo?> subject = [null,];
+
+				async Task Act()
+				{
+					await That(subject).AreNotNullable();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             are all not nullable,
+					             but it contained nullable properties [
+					               <null>
+					             ]
+					             """);
+			}
+
+			[Fact]
 			public async Task WhenPropertiesContainNullableProperties_ShouldFail()
 			{
 				IEnumerable<PropertyInfo> subject = typeof(ClassWithMixedNullableMembers)
@@ -46,26 +66,6 @@ public sealed partial class ThatProperties
 					               *
 					             ]
 					             """).AsWildcard();
-			}
-
-			[Fact]
-			public async Task WhenPropertiesContainNull_ShouldFail()
-			{
-				IEnumerable<PropertyInfo?> subject = [null,];
-
-				async Task Act()
-				{
-					await That(subject).AreNotNullable();
-				}
-
-				await That(Act).ThrowsException()
-					.WithMessage("""
-					             Expected that subject
-					             are all not nullable,
-					             but it contained nullable properties [
-					               <null>
-					             ]
-					             """);
 			}
 		}
 

--- a/Tests/aweXpect.Reflection.Tests/ThatProperties.AreNotObsolete.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatProperties.AreNotObsolete.Tests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers;
 using aweXpect.Reflection.Tests.TestHelpers.Types;

--- a/Tests/aweXpect.Reflection.Tests/ThatProperties.AreObsolete.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatProperties.AreObsolete.Tests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers;
 using aweXpect.Reflection.Tests.TestHelpers.Types;

--- a/Tests/aweXpect.Reflection.Tests/ThatProperties.AreReadOnly.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatProperties.AreReadOnly.Tests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers.Types;

--- a/Tests/aweXpect.Reflection.Tests/ThatProperties.AreReadWrite.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatProperties.AreReadWrite.Tests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers.Types;

--- a/Tests/aweXpect.Reflection.Tests/ThatProperties.AreReadable.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatProperties.AreReadable.Tests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers.Types;

--- a/Tests/aweXpect.Reflection.Tests/ThatProperties.AreSealed.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatProperties.AreSealed.Tests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers.Types;

--- a/Tests/aweXpect.Reflection.Tests/ThatProperties.AreStatic.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatProperties.AreStatic.Tests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 

--- a/Tests/aweXpect.Reflection.Tests/ThatProperties.AreWritable.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatProperties.AreWritable.Tests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers.Types;

--- a/Tests/aweXpect.Reflection.Tests/ThatProperties.AreWriteOnly.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatProperties.AreWriteOnly.Tests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers.Types;

--- a/Tests/aweXpect.Reflection.Tests/ThatProperty.Has.AttributeTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatProperty.Has.AttributeTests.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using Xunit.Sdk;
 
 namespace aweXpect.Reflection.Tests;

--- a/Tests/aweXpect.Reflection.Tests/ThatProperty.IsAbstract.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatProperty.IsAbstract.Tests.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 using Xunit.Sdk;
 

--- a/Tests/aweXpect.Reflection.Tests/ThatProperty.IsAnExtensionProperty.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatProperty.IsAnExtensionProperty.Tests.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 using Xunit.Sdk;

--- a/Tests/aweXpect.Reflection.Tests/ThatProperty.IsAnExtensionProperty.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatProperty.IsAnExtensionProperty.Tests.cs
@@ -1,7 +1,9 @@
 ﻿using System.Reflection;
-using aweXpect.Reflection.Tests.TestHelpers;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
+#if NET10_0_OR_GREATER
+using aweXpect.Reflection.Tests.TestHelpers;
 using Xunit.Sdk;
+#endif
 
 namespace aweXpect.Reflection.Tests;
 
@@ -70,53 +72,43 @@ public sealed partial class ThatProperty
 		public sealed class NewSyntaxTests
 		{
 			[Fact]
-			public async Task WhenPropertyIsAnInstanceExtensionProperty_ShouldSucceed()
+			public async Task WhenPropertyIsAGenericStaticExtensionProperty_ShouldSucceed()
+			{
+				PropertyInfo subject =
+					typeof(GenericClassWithNewExtensionProperties).GetExtensionProperty("Capacity");
+
+				async Task Act()
+				{
+					await That(subject).IsAnExtensionProperty();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenPropertyIsAnInstanceExtensionProperty_Negated_ShouldFail()
 			{
 				PropertyInfo subject =
 					typeof(StaticClassWithNewExtensionProperties).GetExtensionProperty("IsBlankText");
 
 				async Task Act()
 				{
-					await That(subject).IsAnExtensionProperty();
+					await That(subject).DoesNotComplyWith(it => it.IsAnExtensionProperty());
 				}
 
-				await That(Act).DoesNotThrow();
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              is not an extension property,
+					              but it was an extension property {Formatter.Format(subject)}
+					              """);
 			}
 
 			[Fact]
-			public async Task WhenPropertyIsAStaticExtensionProperty_ShouldSucceed()
+			public async Task WhenPropertyIsAnInstanceExtensionProperty_ShouldSucceed()
 			{
 				PropertyInfo subject =
-					typeof(StaticClassWithNewExtensionProperties).GetExtensionProperty("DefaultValue");
-
-				async Task Act()
-				{
-					await That(subject).IsAnExtensionProperty();
-				}
-
-				await That(Act).DoesNotThrow();
-			}
-
-			[Fact]
-			public async Task WhenPropertyIsASettableStaticExtensionProperty_ShouldSucceed()
-			{
-				PropertyInfo subject =
-					typeof(StaticClassWithNewExtensionProperties).GetExtensionProperty("MutableDefault");
-
-				async Task Act()
-				{
-					await That(subject).IsAnExtensionProperty();
-				}
-
-				await That(Act).DoesNotThrow();
-				await That(subject.CanWrite).IsTrue();
-			}
-
-			[Fact]
-			public async Task WhenPropertyIsAGenericStaticExtensionProperty_ShouldSucceed()
-			{
-				PropertyInfo subject =
-					typeof(GenericClassWithNewExtensionProperties).GetExtensionProperty("Capacity");
+					typeof(StaticClassWithNewExtensionProperties).GetExtensionProperty("IsBlankText");
 
 				async Task Act()
 				{
@@ -147,22 +139,32 @@ public sealed partial class ThatProperty
 			}
 
 			[Fact]
-			public async Task WhenPropertyIsAnInstanceExtensionProperty_Negated_ShouldFail()
+			public async Task WhenPropertyIsASettableStaticExtensionProperty_ShouldSucceed()
 			{
 				PropertyInfo subject =
-					typeof(StaticClassWithNewExtensionProperties).GetExtensionProperty("IsBlankText");
+					typeof(StaticClassWithNewExtensionProperties).GetExtensionProperty("MutableDefault");
 
 				async Task Act()
 				{
-					await That(subject).DoesNotComplyWith(it => it.IsAnExtensionProperty());
+					await That(subject).IsAnExtensionProperty();
 				}
 
-				await That(Act).Throws<XunitException>()
-					.WithMessage($"""
-					              Expected that subject
-					              is not an extension property,
-					              but it was an extension property {Formatter.Format(subject)}
-					              """);
+				await That(Act).DoesNotThrow();
+				await That(subject.CanWrite).IsTrue();
+			}
+
+			[Fact]
+			public async Task WhenPropertyIsAStaticExtensionProperty_ShouldSucceed()
+			{
+				PropertyInfo subject =
+					typeof(StaticClassWithNewExtensionProperties).GetExtensionProperty("DefaultValue");
+
+				async Task Act()
+				{
+					await That(subject).IsAnExtensionProperty();
+				}
+
+				await That(Act).DoesNotThrow();
 			}
 		}
 #endif

--- a/Tests/aweXpect.Reflection.Tests/ThatProperty.IsAnIndexer.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatProperty.IsAnIndexer.Tests.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 
 namespace aweXpect.Reflection.Tests;

--- a/Tests/aweXpect.Reflection.Tests/ThatProperty.IsNotAbstract.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatProperty.IsNotAbstract.Tests.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 using Xunit.Sdk;
 

--- a/Tests/aweXpect.Reflection.Tests/ThatProperty.IsNotAnExtensionProperty.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatProperty.IsNotAnExtensionProperty.Tests.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 using Xunit.Sdk;
 #if NET10_0_OR_GREATER

--- a/Tests/aweXpect.Reflection.Tests/ThatProperty.IsNotAnIndexer.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatProperty.IsNotAnIndexer.Tests.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 using Xunit.Sdk;
 

--- a/Tests/aweXpect.Reflection.Tests/ThatProperty.IsNotNullable.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatProperty.IsNotNullable.Tests.cs
@@ -38,17 +38,21 @@ public sealed partial class ThatProperty
 			}
 
 			[Fact]
-			public async Task WhenPropertyIsOblivious_ShouldSucceed()
+			public async Task WhenPropertyIsNull_ShouldFail()
 			{
-				PropertyInfo subject = typeof(ClassWithObliviousMembers)
-					.GetProperty(nameof(ClassWithObliviousMembers.ObliviousProperty))!;
+				PropertyInfo? subject = null;
 
 				async Task Act()
 				{
 					await That(subject).IsNotNullable();
 				}
 
-				await That(Act).DoesNotThrow();
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             is not nullable,
+					             but it was <null>
+					             """);
 			}
 
 			[Fact]
@@ -90,21 +94,17 @@ public sealed partial class ThatProperty
 			}
 
 			[Fact]
-			public async Task WhenPropertyIsNull_ShouldFail()
+			public async Task WhenPropertyIsOblivious_ShouldSucceed()
 			{
-				PropertyInfo? subject = null;
+				PropertyInfo subject = typeof(ClassWithObliviousMembers)
+					.GetProperty(nameof(ClassWithObliviousMembers.ObliviousProperty))!;
 
 				async Task Act()
 				{
 					await That(subject).IsNotNullable();
 				}
 
-				await That(Act).ThrowsException()
-					.WithMessage("""
-					             Expected that subject
-					             is not nullable,
-					             but it was <null>
-					             """);
+				await That(Act).DoesNotThrow();
 			}
 		}
 

--- a/Tests/aweXpect.Reflection.Tests/ThatProperty.IsNotObsolete.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatProperty.IsNotObsolete.Tests.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 using Xunit.Sdk;
 

--- a/Tests/aweXpect.Reflection.Tests/ThatProperty.IsNotSealed.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatProperty.IsNotSealed.Tests.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 using Xunit.Sdk;
 

--- a/Tests/aweXpect.Reflection.Tests/ThatProperty.IsNotStatic.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatProperty.IsNotStatic.Tests.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 
 namespace aweXpect.Reflection.Tests;

--- a/Tests/aweXpect.Reflection.Tests/ThatProperty.IsNullable.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatProperty.IsNullable.Tests.cs
@@ -10,73 +10,41 @@ public sealed partial class ThatProperty
 		public sealed class Tests
 		{
 			[Fact]
-			public async Task WhenPropertyIsNullableReferenceType_ShouldSucceed()
+			public async Task WhenPropertyIsNonNullableGenericType_ShouldFail()
 			{
-				PropertyInfo subject = typeof(ClassWithNullableMembers)
-					.GetProperty(nameof(ClassWithNullableMembers.NullableProperty))!;
+				PropertyInfo subject = typeof(ClassWithNonNullableMembers)
+					.GetProperty(nameof(ClassWithNonNullableMembers.NonNullableGenericProperty))!;
 
 				async Task Act()
 				{
 					await That(subject).IsNullable();
 				}
 
-				await That(Act).DoesNotThrow();
+				await That(Act).ThrowsException()
+					.WithMessage($"""
+					              Expected that subject
+					              is nullable,
+					              but it was non-nullable {Formatter.Format(subject)}
+					              """);
 			}
 
 			[Fact]
-			public async Task WhenPropertyIsNullableValueType_ShouldSucceed()
+			public async Task WhenPropertyIsNonNullableInMostlyNullableClass_ShouldFail()
 			{
-				PropertyInfo subject = typeof(ClassWithNullableMembers)
-					.GetProperty(nameof(ClassWithNullableMembers.NullableValueProperty))!;
+				PropertyInfo subject = typeof(ClassWithMostlyNullableMembers)
+					.GetProperty(nameof(ClassWithMostlyNullableMembers.NonNullableProperty))!;
 
 				async Task Act()
 				{
 					await That(subject).IsNullable();
 				}
 
-				await That(Act).DoesNotThrow();
-			}
-
-			[Fact]
-			public async Task WhenPropertyIsNullableGenericType_ShouldSucceed()
-			{
-				PropertyInfo subject = typeof(ClassWithNullableMembers)
-					.GetProperty(nameof(ClassWithNullableMembers.NullableGenericProperty))!;
-
-				async Task Act()
-				{
-					await That(subject).IsNullable();
-				}
-
-				await That(Act).DoesNotThrow();
-			}
-
-			[Fact]
-			public async Task WhenPropertyIsWriteOnlyNullable_ShouldSucceed()
-			{
-				PropertyInfo subject = typeof(ClassWithNullableMembers)
-					.GetProperty(nameof(ClassWithNullableMembers.NullableWriteOnlyProperty))!;
-
-				async Task Act()
-				{
-					await That(subject).IsNullable();
-				}
-
-				await That(Act).DoesNotThrow();
-			}
-
-			[Fact]
-			public async Task WhenPropertyIsNullableInMixedClass_ShouldSucceed()
-			{
-				PropertyInfo subject = typeof(ClassWithMixedNullableMembers)
-					.GetProperty(nameof(ClassWithMixedNullableMembers.NullableProperty))!;
-
-				async Task Act()
-				{
-					await That(subject).IsNullable();
-				}
-
-				await That(Act).DoesNotThrow();
+				await That(Act).ThrowsException()
+					.WithMessage($"""
+					              Expected that subject
+					              is nullable,
+					              but it was non-nullable {Formatter.Format(subject)}
+					              """);
 			}
 
 			[Fact]
@@ -118,10 +86,9 @@ public sealed partial class ThatProperty
 			}
 
 			[Fact]
-			public async Task WhenPropertyIsNonNullableGenericType_ShouldFail()
+			public async Task WhenPropertyIsNull_ShouldFail()
 			{
-				PropertyInfo subject = typeof(ClassWithNonNullableMembers)
-					.GetProperty(nameof(ClassWithNonNullableMembers.NonNullableGenericProperty))!;
+				PropertyInfo? subject = null;
 
 				async Task Act()
 				{
@@ -129,30 +96,67 @@ public sealed partial class ThatProperty
 				}
 
 				await That(Act).ThrowsException()
-					.WithMessage($"""
-					              Expected that subject
-					              is nullable,
-					              but it was non-nullable {Formatter.Format(subject)}
-					              """);
+					.WithMessage("""
+					             Expected that subject
+					             is nullable,
+					             but it was <null>
+					             """);
 			}
 
 			[Fact]
-			public async Task WhenPropertyIsNonNullableInMostlyNullableClass_ShouldFail()
+			public async Task WhenPropertyIsNullableGenericType_ShouldSucceed()
 			{
-				PropertyInfo subject = typeof(ClassWithMostlyNullableMembers)
-					.GetProperty(nameof(ClassWithMostlyNullableMembers.NonNullableProperty))!;
+				PropertyInfo subject = typeof(ClassWithNullableMembers)
+					.GetProperty(nameof(ClassWithNullableMembers.NullableGenericProperty))!;
 
 				async Task Act()
 				{
 					await That(subject).IsNullable();
 				}
 
-				await That(Act).ThrowsException()
-					.WithMessage($"""
-					              Expected that subject
-					              is nullable,
-					              but it was non-nullable {Formatter.Format(subject)}
-					              """);
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenPropertyIsNullableInMixedClass_ShouldSucceed()
+			{
+				PropertyInfo subject = typeof(ClassWithMixedNullableMembers)
+					.GetProperty(nameof(ClassWithMixedNullableMembers.NullableProperty))!;
+
+				async Task Act()
+				{
+					await That(subject).IsNullable();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenPropertyIsNullableReferenceType_ShouldSucceed()
+			{
+				PropertyInfo subject = typeof(ClassWithNullableMembers)
+					.GetProperty(nameof(ClassWithNullableMembers.NullableProperty))!;
+
+				async Task Act()
+				{
+					await That(subject).IsNullable();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenPropertyIsNullableValueType_ShouldSucceed()
+			{
+				PropertyInfo subject = typeof(ClassWithNullableMembers)
+					.GetProperty(nameof(ClassWithNullableMembers.NullableValueProperty))!;
+
+				async Task Act()
+				{
+					await That(subject).IsNullable();
+				}
+
+				await That(Act).DoesNotThrow();
 			}
 
 			[Fact]
@@ -175,21 +179,17 @@ public sealed partial class ThatProperty
 			}
 
 			[Fact]
-			public async Task WhenPropertyIsNull_ShouldFail()
+			public async Task WhenPropertyIsWriteOnlyNullable_ShouldSucceed()
 			{
-				PropertyInfo? subject = null;
+				PropertyInfo subject = typeof(ClassWithNullableMembers)
+					.GetProperty(nameof(ClassWithNullableMembers.NullableWriteOnlyProperty))!;
 
 				async Task Act()
 				{
 					await That(subject).IsNullable();
 				}
 
-				await That(Act).ThrowsException()
-					.WithMessage("""
-					             Expected that subject
-					             is nullable,
-					             but it was <null>
-					             """);
+				await That(Act).DoesNotThrow();
 			}
 		}
 

--- a/Tests/aweXpect.Reflection.Tests/ThatProperty.IsObsolete.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatProperty.IsObsolete.Tests.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 using Xunit.Sdk;
 

--- a/Tests/aweXpect.Reflection.Tests/ThatProperty.IsReadOnly.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatProperty.IsReadOnly.Tests.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 
 namespace aweXpect.Reflection.Tests;

--- a/Tests/aweXpect.Reflection.Tests/ThatProperty.IsReadWrite.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatProperty.IsReadWrite.Tests.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 
 namespace aweXpect.Reflection.Tests;

--- a/Tests/aweXpect.Reflection.Tests/ThatProperty.IsReadable.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatProperty.IsReadable.Tests.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 
 namespace aweXpect.Reflection.Tests;

--- a/Tests/aweXpect.Reflection.Tests/ThatProperty.IsSealed.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatProperty.IsSealed.Tests.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 using Xunit.Sdk;
 

--- a/Tests/aweXpect.Reflection.Tests/ThatProperty.IsWritable.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatProperty.IsWritable.Tests.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 
 namespace aweXpect.Reflection.Tests;

--- a/Tests/aweXpect.Reflection.Tests/ThatProperty.IsWriteOnly.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatProperty.IsWriteOnly.Tests.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+﻿using System.Reflection;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 
 namespace aweXpect.Reflection.Tests;

--- a/Tests/aweXpect.Reflection.Tests/ThatType.ContainsMethods.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatType.ContainsMethods.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 using Xunit.Sdk;
 
 namespace aweXpect.Reflection.Tests;

--- a/Tests/aweXpect.Reflection.Tests/ThatType.DependsOn.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatType.DependsOn.Tests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Text;
 using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Tests.TestHelpers.Dependencies.Consumers;
 using aweXpect.Reflection.Tests.TestHelpers.Dependencies.Layer1;
@@ -21,63 +22,47 @@ public sealed partial class ThatType
 
 		public sealed class Tests
 		{
-			[Theory]
-			[InlineData(typeof(ViaBaseType))]
-			[InlineData(typeof(ViaInterface))]
-			[InlineData(typeof(ViaField))]
-			[InlineData(typeof(ViaProperty))]
-			[InlineData(typeof(ViaIndexer))]
-			[InlineData(typeof(ViaEvent))]
-			[InlineData(typeof(ViaMethodParameter))]
-			[InlineData(typeof(ViaMethodReturn))]
-			[InlineData(typeof(ViaGenericArgument))]
-			[InlineData(typeof(ViaAttribute))]
-			[InlineData(typeof(ViaGenericConstraint<>))]
-			public async Task WhenTypeReferencesNamespaceInSignature_ShouldSucceed(Type subject)
-			{
-				async Task Act()
-					=> await That(subject).DependsOn(Layer1Namespace);
-
-				await That(Act).DoesNotThrow();
-			}
-
 			[Fact]
-			public async Task WhenTypeDoesNotDependOnNamespace_ShouldFail()
+			public async Task WhenAnyOfMultipleNamespacesMatches_ShouldSucceed()
 			{
 				Type subject = typeof(OnlyLayer1);
 
 				async Task Act()
-					=> await That(subject).DependsOn(Layer2Namespace);
-
-				await That(Act).Throws<XunitException>()
-					.WithMessage($"""
-					              Expected that subject
-					              depends on namespace "{Layer2Namespace}",
-					              but it depended on ["{Layer1Namespace}"]
-					              """);
-			}
-
-			[Fact]
-			public async Task WhenEnumConstraintIsAuthored_ShouldCountAsDependency()
-			{
-				// Unlike the ValueType constraint `struct` compiles into, `where T : Enum` is authored.
-				Type subject = typeof(WithEnumConstraint<>);
-
-				async Task Act()
-					=> await That(subject).DependsOn("System");
+				{
+					await That(subject).DependsOn(Layer2Namespace, Layer1Namespace);
+				}
 
 				await That(Act).DoesNotThrow();
 			}
 
 			[Fact]
-			public async Task WhenObsoleteIsAuthoredOnRequiredMembersConstructor_ShouldCountAsDependency()
+			public async Task WhenArrayTargetIsUsed_ShouldMatchElementType()
 			{
-				// Only the compiler-emitted [Obsolete(marker, error: true)] paired with required members is
-				// skipped; an authored [Obsolete] on the same constructor still counts.
-				Type subject = typeof(WithRequiredPropertyAndAuthoredObsoleteConstructor);
+				// Dependencies are collected with array wrappers stripped, so an array target is
+				// unwrapped symmetrically: typeof(TargetA[]) matches like typeof(TargetA).
+				Type subject = typeof(WithArrayField);
 
 				async Task Act()
-					=> await That(subject).DependsOn("System");
+				{
+					await That(subject).DependsOn(typeof(TargetA[]));
+					await That(subject).DependsOn(typeof(TargetA));
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenDebuggerStepThroughIsAuthoredOnAsyncMethod_ShouldCountAsDependency()
+			{
+				// In Debug builds the authored [DebuggerStepThrough] appears next to the compiler-emitted
+				// one (two entries); in Release builds it is the only occurrence in an optimized assembly —
+				// in both cases it is recognized as authored and counts.
+				Type subject = typeof(WithAuthoredDebuggerStepThroughAsyncMethod);
+
+				async Task Act()
+				{
+					await That(subject).DependsOn("System.Diagnostics");
+				}
 
 				await That(Act).DoesNotThrow();
 			}
@@ -99,157 +84,15 @@ public sealed partial class ThatType
 			}
 
 			[Fact]
-			public async Task WhenSubNamespaceMatchesViaSubtree_ShouldSucceed()
+			public async Task WhenEnumConstraintIsAuthored_ShouldCountAsDependency()
 			{
-				Type subject = typeof(ViaSubNamespace);
+				// Unlike the ValueType constraint `struct` compiles into, `where T : Enum` is authored.
+				Type subject = typeof(WithEnumConstraint<>);
 
 				async Task Act()
-					=> await That(subject).DependsOn(Layer1Namespace);
-
-				await That(Act).DoesNotThrow();
-			}
-
-			[Fact]
-			public async Task WhenExcludingSubNamespaces_ShouldNotMatchSubNamespace()
-			{
-				Type subject = typeof(ViaSubNamespace);
-
-				async Task Act()
-					=> await That(subject).DependsOn(Layer1Namespace).ExcludingSubNamespaces();
-
-				await That(Act).Throws<XunitException>();
-			}
-
-			[Fact]
-			public async Task WhenAnyOfMultipleNamespacesMatches_ShouldSucceed()
-			{
-				Type subject = typeof(OnlyLayer1);
-
-				async Task Act()
-					=> await That(subject).DependsOn(Layer2Namespace, Layer1Namespace);
-
-				await That(Act).DoesNotThrow();
-			}
-
-			[Fact]
-			public async Task WhenWidenedWithOrOn_ShouldSucceed()
-			{
-				Type subject = typeof(OnlyLayer1);
-
-				async Task Act()
-					=> await That(subject).DependsOn(Layer2Namespace).OrOn(Layer1Namespace);
-
-				await That(Act).DoesNotThrow();
-			}
-
-			[Fact]
-			public async Task WhenNamingFrameworkNamespace_ShouldSucceed()
-			{
-				Type subject = typeof(FrameworkConsumer);
-
-				async Task Act()
-					=> await That(subject).DependsOn("System.Collections.Generic");
-
-				await That(Act).DoesNotThrow();
-			}
-
-			[Fact]
-			public async Task WhenTypeReferencesSpecificType_ShouldSucceed()
-			{
-				Type subject = typeof(ViaField);
-
-				async Task Act()
-					=> await That(subject).DependsOn<TargetA>();
-
-				await That(Act).DoesNotThrow();
-			}
-
-			[Fact]
-			public async Task WhenTypeReferencesTypeOnlyViaAttributeArgument_ShouldSucceed()
-			{
-				Type subject = typeof(ViaAttributeArgument);
-
-				async Task Act()
-					=> await That(subject).DependsOn<TargetB>();
-
-				await That(Act).DoesNotThrow();
-			}
-
-			[Fact]
-			public async Task WhenTypeReferencesEnumOnlyViaAttributeArgument_ShouldSucceed()
-			{
-				// Layer2's TargetSeverity is referenced ONLY through the attribute's enum argument; the
-				// attribute type itself lives in Layer1.
-				Type subject = typeof(ViaEnumAttributeArgument);
-
-				async Task Act()
-					=> await That(subject).DependsOn(Layer2Namespace);
-
-				await That(Act).DoesNotThrow();
-			}
-
-			[Fact]
-			public async Task WhenTypeReferencesNamespaceOnlyViaParameterAttribute_ShouldSucceed()
-			{
-				// Layer1's TargetAttribute is referenced ONLY through the attribute on a method parameter.
-				Type subject = typeof(ViaParameterAttribute);
-
-				async Task Act()
-					=> await That(subject).DependsOn(Layer1Namespace);
-
-				await That(Act).DoesNotThrow();
-			}
-
-			[Fact]
-			public async Task WhenTypeReferencesNamespaceOnlyViaReturnValueAttribute_ShouldSucceed()
-			{
-				// Layer1's TargetAttribute is referenced ONLY through the [return: ...] attribute.
-				Type subject = typeof(ViaReturnValueAttribute);
-
-				async Task Act()
-					=> await That(subject).DependsOn(Layer1Namespace);
-
-				await That(Act).DoesNotThrow();
-			}
-
-			[Fact]
-			public async Task WhenDebuggerStepThroughIsAuthoredOnAsyncMethod_ShouldCountAsDependency()
-			{
-				// In Debug builds the authored [DebuggerStepThrough] appears next to the compiler-emitted
-				// one (two entries); in Release builds it is the only occurrence in an optimized assembly —
-				// in both cases it is recognized as authored and counts.
-				Type subject = typeof(WithAuthoredDebuggerStepThroughAsyncMethod);
-
-				async Task Act()
-					=> await That(subject).DependsOn("System.Diagnostics");
-
-				await That(Act).DoesNotThrow();
-			}
-
-			[Fact]
-			public async Task WhenTypeDoesNotReferenceSpecificType_ShouldFail()
-			{
-				Type subject = typeof(ViaField);
-
-				async Task Act()
-					=> await That(subject).DependsOn<TargetB>();
-
-				await That(Act).Throws<XunitException>()
-					.WithMessage("""
-					             Expected that subject
-					             depends on type TargetB,
-					             but it did not
-					             """);
-			}
-
-			[Fact]
-			public async Task WhenTargetingGlobalNamespaceWithEmptyString_ShouldSucceed()
-			{
-				// An empty string targets exactly the global namespace.
-				Type subject = typeof(ReferencesGlobal);
-
-				async Task Act()
-					=> await That(subject).DependsOn("");
+				{
+					await That(subject).DependsOn("System");
+				}
 
 				await That(Act).DoesNotThrow();
 			}
@@ -260,9 +103,24 @@ public sealed partial class ThatType
 				Type subject = typeof(ViaGenericArgument);
 
 				async Task Act()
-					=> await That(subject).DependsOn(typeof(List<TargetA>));
+				{
+					await That(subject).DependsOn(typeof(List<TargetA>));
+				}
 
 				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenExcludingSubNamespaces_ShouldNotMatchSubNamespace()
+			{
+				Type subject = typeof(ViaSubNamespace);
+
+				async Task Act()
+				{
+					await That(subject).DependsOn(Layer1Namespace).ExcludingSubNamespaces();
+				}
+
+				await That(Act).Throws<XunitException>();
 			}
 
 			[Fact]
@@ -271,169 +129,11 @@ public sealed partial class ThatType
 				Type subject = typeof(ViaGenericArgument);
 
 				async Task Act()
-					=> await That(subject).DependsOn(typeof(List<>));
-
-				await That(Act).DoesNotThrow();
-			}
-
-			[Fact]
-			public async Task WhenOnlyOtherConstructionOfGenericIsReferenced_ShouldFail()
-			{
-				// ViaGenericArgument references List<TargetA>; List<TargetB> is a different construction.
-				Type subject = typeof(ViaGenericArgument);
-
-				async Task Act()
-					=> await That(subject).DependsOn(typeof(List<TargetB>));
-
-				await That(Act).Throws<XunitException>()
-					.WithMessage("""
-					             Expected that subject
-					             depends on type List<TargetB>,
-					             but it did not
-					             """);
-			}
-
-			[Fact]
-			public async Task WhenArrayTargetIsUsed_ShouldMatchElementType()
-			{
-				// Dependencies are collected with array wrappers stripped, so an array target is
-				// unwrapped symmetrically: typeof(TargetA[]) matches like typeof(TargetA).
-				Type subject = typeof(WithArrayField);
-
-				async Task Act()
 				{
-					await That(subject).DependsOn(typeof(TargetA[]));
-					await That(subject).DependsOn(typeof(TargetA));
+					await That(subject).DependsOn(typeof(List<>));
 				}
 
 				await That(Act).DoesNotThrow();
-			}
-
-			[Fact]
-			public async Task WhenWidenedWithOrOnType_ShouldSucceed()
-			{
-				Type subject = typeof(ViaField);
-
-				async Task Act()
-					=> await That(subject).DependsOn<TargetB>().OrOn<TargetA>();
-
-				await That(Act).DoesNotThrow();
-			}
-
-			[Fact]
-			public async Task WhenTypeIsNull_ShouldFail()
-			{
-				Type? subject = null;
-
-				async Task Act()
-					=> await That(subject).DependsOn(Layer1Namespace);
-
-				await That(Act).ThrowsException()
-					.WithMessage($"""
-					              Expected that subject
-					              depends on namespace "{Layer1Namespace}",
-					              but it was <null>
-					              """);
-			}
-
-			[Fact]
-			public async Task WhenNoNamespaceIsSpecified_ShouldThrowArgumentException()
-			{
-				Type subject = typeof(OnlyLayer1);
-
-				async Task Act()
-					=> await That(subject).DependsOn();
-
-				await That(Act).Throws<ArgumentException>()
-					.WithMessage("At least one namespace must be specified.");
-			}
-
-			[Fact]
-			public async Task WhenOnlyANestedTypeReferencesNamespace_ShouldFail()
-			{
-				// Nested types are separate types with their own dependency surface; the declaring type's
-				// signature does not include what its nested types reference. The collection-based
-				// assertions enumerate nested types as their own items and cover them there.
-				Type subject = typeof(WithLayer1OnlyInNestedType);
-
-				async Task Act()
-					=> await That(subject).DependsOn(Layer1Namespace);
-
-				await That(Act).Throws<XunitException>();
-			}
-
-			[Fact]
-			public async Task WhenNamespacesEnumerableIsNull_ShouldThrowArgumentNullException()
-			{
-				Type subject = typeof(OnlyLayer1);
-
-				async Task Act()
-					=> await That(subject).DependsOn((IEnumerable<string>)null!);
-
-				await That(Act).Throws<ArgumentNullException>()
-					.WithMessage("The namespaces must not be null.*").AsWildcard();
-			}
-
-			[Fact]
-			public async Task WhenWidenedWithNullNamespacesEnumerable_ShouldThrowArgumentNullException()
-			{
-				Type subject = typeof(OnlyLayer1);
-
-				async Task Act()
-					=> await That(subject).DependsOn(Layer1Namespace).OrOn((IEnumerable<string>)null!);
-
-				await That(Act).Throws<ArgumentNullException>()
-					.WithMessage("The namespaces must not be null.*").AsWildcard();
-			}
-
-			[Fact]
-			public async Task WhenNamespaceIsNull_ShouldThrowArgumentNullException()
-			{
-				Type subject = typeof(OnlyLayer1);
-
-				async Task Act()
-					=> await That(subject).DependsOn(Layer1Namespace, null!);
-
-				await That(Act).Throws<ArgumentNullException>()
-					.WithMessage("The namespaces must not contain null.*").AsWildcard();
-			}
-
-			[Fact]
-			public async Task WhenWidenedWithNullNamespace_ShouldThrowArgumentNullException()
-			{
-				Type subject = typeof(OnlyLayer1);
-
-				async Task Act()
-					=> await That(subject).DependsOn(Layer1Namespace).OrOn(Layer2Namespace, null!);
-
-				await That(Act).Throws<ArgumentNullException>()
-					.WithMessage("The namespaces must not contain null.*").AsWildcard();
-			}
-
-			[Fact]
-			public async Task WhenNamespaceEndsWithDot_ShouldThrowArgumentException()
-			{
-				// A trailing-dot namespace could never match and would make negative assertions pass
-				// vacuously; only the excluded assembly prefixes use the trailing-dot convention.
-				Type subject = typeof(OnlyLayer1);
-
-				async Task Act()
-					=> await That(subject).DependsOn($"{Layer1Namespace}.");
-
-				await That(Act).Throws<ArgumentException>()
-					.WithMessage("The namespaces must not end with a dot (sub-namespaces are matched automatically).");
-			}
-
-			[Fact]
-			public async Task WhenWidenedWithNamespaceEndingWithDot_ShouldThrowArgumentException()
-			{
-				Type subject = typeof(OnlyLayer1);
-
-				async Task Act()
-					=> await That(subject).DependsOn(Layer1Namespace).OrOn($"{Layer2Namespace}.");
-
-				await That(Act).Throws<ArgumentException>()
-					.WithMessage("The namespaces must not end with a dot (sub-namespaces are matched automatically).");
 			}
 
 			[Theory]
@@ -449,11 +149,320 @@ public sealed partial class ThatType
 				Type subject = typeof(OnlyLayer1);
 
 				async Task Act()
-					=> await That(subject).DependsOn(@namespace);
+				{
+					await That(subject).DependsOn(@namespace);
+				}
 
 				await That(Act).Throws<ArgumentException>()
 					.WithMessage(
 						"The namespaces must not contain empty segments or whitespace (such a namespace could never match).");
+			}
+
+			[Fact]
+			public async Task WhenNamespaceEndsWithDot_ShouldThrowArgumentException()
+			{
+				// A trailing-dot namespace could never match and would make negative assertions pass
+				// vacuously; only the excluded assembly prefixes use the trailing-dot convention.
+				Type subject = typeof(OnlyLayer1);
+
+				async Task Act()
+				{
+					await That(subject).DependsOn($"{Layer1Namespace}.");
+				}
+
+				await That(Act).Throws<ArgumentException>()
+					.WithMessage("The namespaces must not end with a dot (sub-namespaces are matched automatically).");
+			}
+
+			[Fact]
+			public async Task WhenNamespaceIsNull_ShouldThrowArgumentNullException()
+			{
+				Type subject = typeof(OnlyLayer1);
+
+				async Task Act()
+				{
+					await That(subject).DependsOn(Layer1Namespace, null!);
+				}
+
+				await That(Act).Throws<ArgumentNullException>()
+					.WithMessage("The namespaces must not contain null.*").AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenNamespacesEnumerableIsNull_ShouldThrowArgumentNullException()
+			{
+				Type subject = typeof(OnlyLayer1);
+
+				async Task Act()
+				{
+					await That(subject).DependsOn((IEnumerable<string>)null!);
+				}
+
+				await That(Act).Throws<ArgumentNullException>()
+					.WithMessage("The namespaces must not be null.*").AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenNamingFrameworkNamespace_ShouldSucceed()
+			{
+				Type subject = typeof(FrameworkConsumer);
+
+				async Task Act()
+				{
+					await That(subject).DependsOn("System.Collections.Generic");
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenNoNamespaceIsSpecified_ShouldThrowArgumentException()
+			{
+				Type subject = typeof(OnlyLayer1);
+
+				async Task Act()
+				{
+					await That(subject).DependsOn();
+				}
+
+				await That(Act).Throws<ArgumentException>()
+					.WithMessage("At least one namespace must be specified.");
+			}
+
+			[Fact]
+			public async Task WhenObsoleteIsAuthoredOnRequiredMembersConstructor_ShouldCountAsDependency()
+			{
+				// Only the compiler-emitted [Obsolete(marker, error: true)] paired with required members is
+				// skipped; an authored [Obsolete] on the same constructor still counts.
+				Type subject = typeof(WithRequiredPropertyAndAuthoredObsoleteConstructor);
+
+				async Task Act()
+				{
+					await That(subject).DependsOn("System");
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenOnlyANestedTypeReferencesNamespace_ShouldFail()
+			{
+				// Nested types are separate types with their own dependency surface; the declaring type's
+				// signature does not include what its nested types reference. The collection-based
+				// assertions enumerate nested types as their own items and cover them there.
+				Type subject = typeof(WithLayer1OnlyInNestedType);
+
+				async Task Act()
+				{
+					await That(subject).DependsOn(Layer1Namespace);
+				}
+
+				await That(Act).Throws<XunitException>();
+			}
+
+			[Fact]
+			public async Task WhenOnlyOtherConstructionOfGenericIsReferenced_ShouldFail()
+			{
+				// ViaGenericArgument references List<TargetA>; List<TargetB> is a different construction.
+				Type subject = typeof(ViaGenericArgument);
+
+				async Task Act()
+				{
+					await That(subject).DependsOn(typeof(List<TargetB>));
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             depends on type List<TargetB>,
+					             but it did not
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenSubNamespaceMatchesViaSubtree_ShouldSucceed()
+			{
+				Type subject = typeof(ViaSubNamespace);
+
+				async Task Act()
+				{
+					await That(subject).DependsOn(Layer1Namespace);
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenTargetingGlobalNamespaceWithEmptyString_ShouldSucceed()
+			{
+				// An empty string targets exactly the global namespace.
+				Type subject = typeof(ReferencesGlobal);
+
+				async Task Act()
+				{
+					await That(subject).DependsOn("");
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenTypeDoesNotDependOnNamespace_ShouldFail()
+			{
+				Type subject = typeof(OnlyLayer1);
+
+				async Task Act()
+				{
+					await That(subject).DependsOn(Layer2Namespace);
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              depends on namespace "{Layer2Namespace}",
+					              but it depended on ["{Layer1Namespace}"]
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenTypeDoesNotReferenceSpecificType_ShouldFail()
+			{
+				Type subject = typeof(ViaField);
+
+				async Task Act()
+				{
+					await That(subject).DependsOn<TargetB>();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             depends on type TargetB,
+					             but it did not
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenTypeIsNull_ShouldFail()
+			{
+				Type? subject = null;
+
+				async Task Act()
+				{
+					await That(subject).DependsOn(Layer1Namespace);
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage($"""
+					              Expected that subject
+					              depends on namespace "{Layer1Namespace}",
+					              but it was <null>
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenTypeReferencesEnumOnlyViaAttributeArgument_ShouldSucceed()
+			{
+				// Layer2's TargetSeverity is referenced ONLY through the attribute's enum argument; the
+				// attribute type itself lives in Layer1.
+				Type subject = typeof(ViaEnumAttributeArgument);
+
+				async Task Act()
+				{
+					await That(subject).DependsOn(Layer2Namespace);
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
+			[InlineData(typeof(ViaBaseType))]
+			[InlineData(typeof(ViaInterface))]
+			[InlineData(typeof(ViaField))]
+			[InlineData(typeof(ViaProperty))]
+			[InlineData(typeof(ViaIndexer))]
+			[InlineData(typeof(ViaEvent))]
+			[InlineData(typeof(ViaMethodParameter))]
+			[InlineData(typeof(ViaMethodReturn))]
+			[InlineData(typeof(ViaGenericArgument))]
+			[InlineData(typeof(ViaAttribute))]
+			[InlineData(typeof(ViaGenericConstraint<>))]
+			public async Task WhenTypeReferencesNamespaceInSignature_ShouldSucceed(Type subject)
+			{
+				async Task Act()
+				{
+					await That(subject).DependsOn(Layer1Namespace);
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenTypeReferencesNamespaceOnlyViaParameterAttribute_ShouldSucceed()
+			{
+				// Layer1's TargetAttribute is referenced ONLY through the attribute on a method parameter.
+				Type subject = typeof(ViaParameterAttribute);
+
+				async Task Act()
+				{
+					await That(subject).DependsOn(Layer1Namespace);
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenTypeReferencesNamespaceOnlyViaReturnValueAttribute_ShouldSucceed()
+			{
+				// Layer1's TargetAttribute is referenced ONLY through the [return: ...] attribute.
+				Type subject = typeof(ViaReturnValueAttribute);
+
+				async Task Act()
+				{
+					await That(subject).DependsOn(Layer1Namespace);
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenTypeReferencesSpecificType_ShouldSucceed()
+			{
+				Type subject = typeof(ViaField);
+
+				async Task Act()
+				{
+					await That(subject).DependsOn<TargetA>();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenTypeReferencesTypeOnlyViaAttributeArgument_ShouldSucceed()
+			{
+				Type subject = typeof(ViaAttributeArgument);
+
+				async Task Act()
+				{
+					await That(subject).DependsOn<TargetB>();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenWidenedWithNamespaceEndingWithDot_ShouldThrowArgumentException()
+			{
+				Type subject = typeof(OnlyLayer1);
+
+				async Task Act()
+				{
+					await That(subject).DependsOn(Layer1Namespace).OrOn($"{Layer2Namespace}.");
+				}
+
+				await That(Act).Throws<ArgumentException>()
+					.WithMessage("The namespaces must not end with a dot (sub-namespaces are matched automatically).");
 			}
 
 			[Fact]
@@ -462,52 +471,41 @@ public sealed partial class ThatType
 				Type subject = typeof(OnlyLayer1);
 
 				async Task Act()
-					=> await That(subject).DependsOn(Layer1Namespace).OrOn($".{Layer2Namespace}");
+				{
+					await That(subject).DependsOn(Layer1Namespace).OrOn($".{Layer2Namespace}");
+				}
 
 				await That(Act).Throws<ArgumentException>()
 					.WithMessage(
 						"The namespaces must not contain empty segments or whitespace (such a namespace could never match).");
 			}
-		}
-
-		public sealed class FilteredTypesTargetTests
-		{
-			[Fact]
-			public async Task WhenTypeDependsOnTypeInTargetCollection_ShouldSucceed()
-			{
-				Type subject = typeof(ViaField);
-
-				async Task Act()
-					=> await That(subject).DependsOn(Types.InNamespace(Layer1Namespace));
-
-				await That(Act).DoesNotThrow();
-			}
 
 			[Fact]
-			public async Task WhenTypeDoesNotDependOnAnyTypeInTargetCollection_ShouldFail()
+			public async Task WhenWidenedWithNullNamespace_ShouldThrowArgumentNullException()
 			{
 				Type subject = typeof(OnlyLayer1);
 
 				async Task Act()
-					=> await That(subject).DependsOn(Types.InNamespace(Layer2Namespace));
+				{
+					await That(subject).DependsOn(Layer1Namespace).OrOn(Layer2Namespace, null!);
+				}
 
-				await That(Act).Throws<XunitException>()
-					.WithMessage($"""
-					              Expected that subject
-					              depends on types within namespace "{Layer2Namespace}" in all loaded assemblies,
-					              but it did not
-					              """);
+				await That(Act).Throws<ArgumentNullException>()
+					.WithMessage("The namespaces must not contain null.*").AsWildcard();
 			}
 
 			[Fact]
-			public async Task WhenAnyTargetCollectionMatches_ShouldSucceed()
+			public async Task WhenWidenedWithNullNamespacesEnumerable_ShouldThrowArgumentNullException()
 			{
 				Type subject = typeof(OnlyLayer1);
 
 				async Task Act()
-					=> await That(subject).DependsOn(Types.InNamespace(Layer2Namespace), Types.InNamespace(Layer1Namespace));
+				{
+					await That(subject).DependsOn(Layer1Namespace).OrOn(null!);
+				}
 
-				await That(Act).DoesNotThrow();
+				await That(Act).Throws<ArgumentNullException>()
+					.WithMessage("The namespaces must not be null.*").AsWildcard();
 			}
 
 			[Fact]
@@ -516,7 +514,70 @@ public sealed partial class ThatType
 				Type subject = typeof(OnlyLayer1);
 
 				async Task Act()
-					=> await That(subject).DependsOn(Types.InNamespace(Layer2Namespace)).OrOn(Types.InNamespace(Layer1Namespace));
+				{
+					await That(subject).DependsOn(Layer2Namespace).OrOn(Layer1Namespace);
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenWidenedWithOrOnType_ShouldSucceed()
+			{
+				Type subject = typeof(ViaField);
+
+				async Task Act()
+				{
+					await That(subject).DependsOn<TargetB>().OrOn<TargetA>();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+		}
+
+		public sealed class FilteredTypesTargetTests
+		{
+			[Fact]
+			public async Task WhenAdditionalTargetIsNull_ShouldThrowArgumentNullException()
+			{
+				Type subject = typeof(OnlyLayer1);
+
+				async Task Act()
+				{
+					await That(subject)
+						.DependsOn(Types.InNamespace(Layer1Namespace), null!, null!);
+				}
+
+				// The localized paramName suffix differs between frameworks ("(Parameter 'additional')" vs
+				// "Parametername: additional"), so only the shared part is matched.
+				await That(Act).Throws<ArgumentNullException>()
+					.WithMessage("The target collections of types must not contain null.*additional*")
+					.AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenAdditionalTargetsArrayIsNull_ShouldThrowArgumentNullException()
+			{
+				Type subject = typeof(OnlyLayer1);
+
+				async Task Act()
+				{
+					await That(subject).DependsOn(Types.InNamespace(Layer1Namespace), null!);
+				}
+
+				await That(Act).Throws<ArgumentNullException>()
+					.WithMessage("The additional target collections of types must not be null.*").AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenAnyTargetCollectionMatches_ShouldSucceed()
+			{
+				Type subject = typeof(OnlyLayer1);
+
+				async Task Act()
+				{
+					await That(subject).DependsOn(Types.InNamespace(Layer2Namespace), Types.InNamespace(Layer1Namespace));
+				}
 
 				await That(Act).DoesNotThrow();
 			}
@@ -529,9 +590,29 @@ public sealed partial class ThatType
 				Type subject = typeof(ViaLayer1GenericConstruction);
 
 				async Task Act()
-					=> await That(subject).DependsOn(In.Type(typeof(TargetGeneric<>)));
+				{
+					await That(subject).DependsOn(In.Type(typeof(TargetGeneric<>)));
+				}
 
 				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenNegated_ShouldListMatchingDependencies()
+			{
+				Type subject = typeof(ViaField);
+
+				async Task Act()
+				{
+					await That(subject).DoesNotComplyWith(it => it.DependsOn(Types.InNamespace(Layer1Namespace)));
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              does not depend on types within namespace "{Layer1Namespace}" in all loaded assemblies,
+					              but it depended on [TargetA]
+					              """);
 			}
 
 			[Fact]
@@ -542,7 +623,9 @@ public sealed partial class ThatType
 				Type subject = typeof(ViaField);
 
 				async Task Act()
-					=> await That(subject).DependsOn(In.Type(typeof(TargetA[])));
+				{
+					await That(subject).DependsOn(In.Type(typeof(TargetA[])));
+				}
 
 				await That(Act).DoesNotThrow();
 			}
@@ -554,7 +637,9 @@ public sealed partial class ThatType
 				Type subject = typeof(FrameworkConsumer);
 
 				async Task Act()
-					=> await That(subject).DependsOn(In.Type<System.Text.StringBuilder>());
+				{
+					await That(subject).DependsOn(In.Type<StringBuilder>());
+				}
 
 				await That(Act).DoesNotThrow();
 			}
@@ -565,9 +650,56 @@ public sealed partial class ThatType
 				Type subject = typeof(ViaField);
 
 				async Task Act()
-					=> await That(subject).DependsOn(Types.InNamespace("Non.Existent.Namespace"));
+				{
+					await That(subject).DependsOn(Types.InNamespace("Non.Existent.Namespace"));
+				}
 
 				await That(Act).Throws<XunitException>();
+			}
+
+			[Fact]
+			public async Task WhenTargetIsNull_ShouldThrowArgumentNullException()
+			{
+				Type subject = typeof(OnlyLayer1);
+
+				async Task Act()
+				{
+					await That(subject).DependsOn((Filtered.Types)null!);
+				}
+
+				await That(Act).Throws<ArgumentNullException>()
+					.WithMessage("The target collection of types must not be null.*").AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenTypeDependsOnTypeInTargetCollection_ShouldSucceed()
+			{
+				Type subject = typeof(ViaField);
+
+				async Task Act()
+				{
+					await That(subject).DependsOn(Types.InNamespace(Layer1Namespace));
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenTypeDoesNotDependOnAnyTypeInTargetCollection_ShouldFail()
+			{
+				Type subject = typeof(OnlyLayer1);
+
+				async Task Act()
+				{
+					await That(subject).DependsOn(Types.InNamespace(Layer2Namespace));
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              depends on types within namespace "{Layer2Namespace}" in all loaded assemblies,
+					              but it did not
+					              """);
 			}
 
 			[Fact]
@@ -576,7 +708,9 @@ public sealed partial class ThatType
 				Type? subject = null;
 
 				async Task Act()
-					=> await That(subject).DependsOn(Types.InNamespace(Layer1Namespace));
+				{
+					await That(subject).DependsOn(Types.InNamespace(Layer1Namespace));
+				}
 
 				await That(Act).ThrowsException()
 					.WithMessage($"""
@@ -587,43 +721,16 @@ public sealed partial class ThatType
 			}
 
 			[Fact]
-			public async Task WhenTargetIsNull_ShouldThrowArgumentNullException()
+			public async Task WhenWidenedWithOrOn_ShouldSucceed()
 			{
 				Type subject = typeof(OnlyLayer1);
 
 				async Task Act()
-					=> await That(subject).DependsOn((Filtered.Types)null!);
+				{
+					await That(subject).DependsOn(Types.InNamespace(Layer2Namespace)).OrOn(Types.InNamespace(Layer1Namespace));
+				}
 
-				await That(Act).Throws<ArgumentNullException>()
-					.WithMessage("The target collection of types must not be null.*").AsWildcard();
-			}
-
-			[Fact]
-			public async Task WhenAdditionalTargetsArrayIsNull_ShouldThrowArgumentNullException()
-			{
-				Type subject = typeof(OnlyLayer1);
-
-				async Task Act()
-					=> await That(subject).DependsOn(Types.InNamespace(Layer1Namespace), null!);
-
-				await That(Act).Throws<ArgumentNullException>()
-					.WithMessage("The additional target collections of types must not be null.*").AsWildcard();
-			}
-
-			[Fact]
-			public async Task WhenAdditionalTargetIsNull_ShouldThrowArgumentNullException()
-			{
-				Type subject = typeof(OnlyLayer1);
-
-				async Task Act()
-					=> await That(subject)
-						.DependsOn(Types.InNamespace(Layer1Namespace), (Filtered.Types)null!, (Filtered.Types)null!);
-
-				// The localized paramName suffix differs between frameworks ("(Parameter 'additional')" vs
-				// "Parametername: additional"), so only the shared part is matched.
-				await That(Act).Throws<ArgumentNullException>()
-					.WithMessage("The target collections of types must not contain null.*additional*")
-					.AsWildcard();
+				await That(Act).DoesNotThrow();
 			}
 
 			[Fact]
@@ -632,26 +739,12 @@ public sealed partial class ThatType
 				Type subject = typeof(OnlyLayer1);
 
 				async Task Act()
-					=> await That(subject).DependsOn(Types.InNamespace(Layer1Namespace)).OrOn();
+				{
+					await That(subject).DependsOn(Types.InNamespace(Layer1Namespace)).OrOn();
+				}
 
 				await That(Act).Throws<ArgumentException>()
 					.WithMessage("At least one collection of types must be specified.");
-			}
-
-			[Fact]
-			public async Task WhenNegated_ShouldListMatchingDependencies()
-			{
-				Type subject = typeof(ViaField);
-
-				async Task Act()
-					=> await That(subject).DoesNotComplyWith(it => it.DependsOn(Types.InNamespace(Layer1Namespace)));
-
-				await That(Act).Throws<XunitException>()
-					.WithMessage($"""
-					              Expected that subject
-					              does not depend on types within namespace "{Layer1Namespace}" in all loaded assemblies,
-					              but it depended on [TargetA]
-					              """);
 			}
 		}
 
@@ -663,7 +756,9 @@ public sealed partial class ThatType
 				Type subject = typeof(ViaField);
 
 				async Task Act()
-					=> await That(subject).DoesNotComplyWith(it => it.DependsOn(Layer1Namespace));
+				{
+					await That(subject).DoesNotComplyWith(it => it.DependsOn(Layer1Namespace));
+				}
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage($"""

--- a/Tests/aweXpect.Reflection.Tests/ThatType.DependsOnlyOn.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatType.DependsOnlyOn.Tests.cs
@@ -24,7 +24,22 @@ public sealed partial class ThatType
 				Type subject = typeof(OnlyLayer1);
 
 				async Task Act()
-					=> await That(subject).DependsOnlyOn(Layer1Namespace);
+				{
+					await That(subject).DependsOnlyOn(Layer1Namespace);
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenAllowingMultipleNamespaces_ShouldSucceed()
+			{
+				Type subject = typeof(Layer1AndLayer2);
+
+				async Task Act()
+				{
+					await That(subject).DependsOnlyOn(Layer1Namespace, Layer2Namespace);
+				}
 
 				await That(Act).DoesNotThrow();
 			}
@@ -35,7 +50,9 @@ public sealed partial class ThatType
 				Type subject = typeof(Layer1AndLayer2);
 
 				async Task Act()
-					=> await That(subject).DependsOnlyOn(Layer1Namespace);
+				{
+					await That(subject).DependsOnlyOn(Layer1Namespace);
+				}
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage($"""
@@ -46,111 +63,14 @@ public sealed partial class ThatType
 			}
 
 			[Fact]
-			public async Task WhenAllowingMultipleNamespaces_ShouldSucceed()
-			{
-				Type subject = typeof(Layer1AndLayer2);
-
-				async Task Act()
-					=> await That(subject).DependsOnlyOn(Layer1Namespace, Layer2Namespace);
-
-				await That(Act).DoesNotThrow();
-			}
-
-			[Fact]
-			public async Task WhenWidenedWithOrOn_ShouldSucceed()
-			{
-				Type subject = typeof(Layer1AndLayer2);
-
-				async Task Act()
-					=> await That(subject).DependsOnlyOn(Layer1Namespace).OrOn(Layer2Namespace);
-
-				await That(Act).DoesNotThrow();
-			}
-
-			[Fact]
-			public async Task WhenNoNamespaceIsSpecified_ShouldThrowArgumentException()
-			{
-				Type subject = typeof(OnlyLayer1);
-
-				async Task Act()
-					=> await That(subject).DependsOnlyOn();
-
-				await That(Act).Throws<ArgumentException>()
-					.WithMessage("At least one namespace must be specified.");
-			}
-
-			[Fact]
-			public async Task WhenDependingOnlyOnOwnNamespace_ShouldSucceed()
-			{
-				Type subject = typeof(ReferencesOwnNamespace);
-
-				async Task Act()
-					=> await That(subject).DependsOnlyOn(Layer1Namespace);
-
-				await That(Act).DoesNotThrow();
-			}
-
-			[Fact]
-			public async Task WhenExcludingSubNamespaces_OwnSubNamespaceStaysAllowed()
-			{
-				// ReferencesOwnSubNamespace (in ...Consumers) only references ...Consumers.OwnSub. By default the
-				// type's own sub-namespaces remain allowed even when sub-namespaces are excluded.
-				Type subject = typeof(ReferencesOwnSubNamespace);
-
-				async Task Act()
-					=> await That(subject).DependsOnlyOn(Layer1Namespace).ExcludingSubNamespaces();
-
-				await That(Act).DoesNotThrow();
-			}
-
-			[Fact]
-			public async Task WhenExcludingOwnSubNamespaces_OwnSubNamespaceBecomesViolation()
-			{
-				Type subject = typeof(ReferencesOwnSubNamespace);
-
-				async Task Act()
-					=> await That(subject).DependsOnlyOn(Layer1Namespace)
-						.ExcludingSubNamespaces().ExcludingOwnSubNamespaces();
-
-				await That(Act).Throws<XunitException>()
-					.WithMessage($"""
-					              Expected that subject
-					              depends only on namespace "{Layer1Namespace}",
-					              but it also depended on ["{OwnSubNamespace}"]
-					              """);
-			}
-
-			[Fact]
-			public async Task WhenOnlyExcludingOwnSubNamespaces_AllowedSubNamespacesStayIncluded()
-			{
-				// The two toggles are independent: the own sub-namespace is no longer implicitly allowed, but
-				// the allowed namespaces still include their sub-namespaces, which covers it explicitly.
-				Type subject = typeof(ReferencesOwnSubNamespace);
-
-				async Task Act()
-					=> await That(subject).DependsOnlyOn(ConsumersNamespace).ExcludingOwnSubNamespaces();
-
-				await That(Act).DoesNotThrow();
-			}
-
-			[Fact]
-			public async Task WhenDependingOnlyOnFramework_ShouldSucceed()
-			{
-				Type subject = typeof(FrameworkConsumer);
-
-				async Task Act()
-					=> await That(subject).DependsOnlyOn(Layer1Namespace);
-
-				await That(Act).DoesNotThrow();
-			}
-
-			[Fact]
 			public async Task WhenDependingOnGlobalNamespace_ShouldReportGlobalNamespace()
 			{
 				Type subject = typeof(ReferencesGlobal);
 
 				async Task Act()
-					=> await That(subject).DependsOnlyOn(Layer1Namespace);
+				{
+					await That(subject).DependsOnlyOn(Layer1Namespace);
+				}
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage($"""
@@ -161,13 +81,104 @@ public sealed partial class ThatType
 			}
 
 			[Fact]
+			public async Task WhenDependingOnlyOnFramework_ShouldSucceed()
+			{
+				Type subject = typeof(FrameworkConsumer);
+
+				async Task Act()
+				{
+					await That(subject).DependsOnlyOn(Layer1Namespace);
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenDependingOnlyOnOwnNamespace_ShouldSucceed()
+			{
+				Type subject = typeof(ReferencesOwnNamespace);
+
+				async Task Act()
+				{
+					await That(subject).DependsOnlyOn(Layer1Namespace);
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenExcludingOwnSubNamespaces_OwnSubNamespaceBecomesViolation()
+			{
+				Type subject = typeof(ReferencesOwnSubNamespace);
+
+				async Task Act()
+				{
+					await That(subject).DependsOnlyOn(Layer1Namespace)
+						.ExcludingSubNamespaces().ExcludingOwnSubNamespaces();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              depends only on namespace "{Layer1Namespace}",
+					              but it also depended on ["{OwnSubNamespace}"]
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenExcludingSubNamespaces_OwnSubNamespaceStaysAllowed()
+			{
+				// ReferencesOwnSubNamespace (in ...Consumers) only references ...Consumers.OwnSub. By default the
+				// type's own sub-namespaces remain allowed even when sub-namespaces are excluded.
+				Type subject = typeof(ReferencesOwnSubNamespace);
+
+				async Task Act()
+				{
+					await That(subject).DependsOnlyOn(Layer1Namespace).ExcludingSubNamespaces();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
 			public async Task WhenGlobalNamespaceIsAllowedWithEmptyString_ShouldSucceed()
 			{
 				// An empty string targets exactly the global namespace.
 				Type subject = typeof(ReferencesGlobal);
 
 				async Task Act()
-					=> await That(subject).DependsOnlyOn(Layer1Namespace, "");
+				{
+					await That(subject).DependsOnlyOn(Layer1Namespace, "");
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenNoNamespaceIsSpecified_ShouldThrowArgumentException()
+			{
+				Type subject = typeof(OnlyLayer1);
+
+				async Task Act()
+				{
+					await That(subject).DependsOnlyOn();
+				}
+
+				await That(Act).Throws<ArgumentException>()
+					.WithMessage("At least one namespace must be specified.");
+			}
+
+			[Fact]
+			public async Task WhenOnlyExcludingOwnSubNamespaces_AllowedSubNamespacesStayIncluded()
+			{
+				// The two toggles are independent: the own sub-namespace is no longer implicitly allowed, but
+				// the allowed namespaces still include their sub-namespaces, which covers it explicitly.
+				Type subject = typeof(ReferencesOwnSubNamespace);
+
+				async Task Act()
+				{
+					await That(subject).DependsOnlyOn(ConsumersNamespace).ExcludingOwnSubNamespaces();
+				}
 
 				await That(Act).DoesNotThrow();
 			}
@@ -178,7 +189,22 @@ public sealed partial class ThatType
 				Type subject = typeof(GlobalNamespaceTarget);
 
 				async Task Act()
-					=> await That(subject).DependsOnlyOn(Layer1Namespace);
+				{
+					await That(subject).DependsOnlyOn(Layer1Namespace);
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenWidenedWithOrOn_ShouldSucceed()
+			{
+				Type subject = typeof(Layer1AndLayer2);
+
+				async Task Act()
+				{
+					await That(subject).DependsOnlyOn(Layer1Namespace).OrOn(Layer2Namespace);
+				}
 
 				await That(Act).DoesNotThrow();
 			}
@@ -192,7 +218,9 @@ public sealed partial class ThatType
 				Type subject = typeof(OnlyLayer1);
 
 				async Task Act()
-					=> await That(subject).DependsOnlyOn(Types.InNamespace(Layer1Namespace));
+				{
+					await That(subject).DependsOnlyOn(Types.InNamespace(Layer1Namespace));
+				}
 
 				await That(Act).DoesNotThrow();
 			}
@@ -203,7 +231,9 @@ public sealed partial class ThatType
 				Type subject = typeof(Layer1AndLayer2);
 
 				async Task Act()
-					=> await That(subject).DependsOnlyOn(Types.InNamespace(Layer1Namespace));
+				{
+					await That(subject).DependsOnlyOn(Types.InNamespace(Layer1Namespace));
+				}
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage($"""
@@ -214,18 +244,6 @@ public sealed partial class ThatType
 			}
 
 			[Fact]
-			public async Task WhenWidenedWithOrOn_ShouldSucceed()
-			{
-				Type subject = typeof(Layer1AndLayer2);
-
-				async Task Act()
-					=> await That(subject).DependsOnlyOn(Types.InNamespace(Layer1Namespace))
-						.OrOn(Types.InNamespace(Layer2Namespace));
-
-				await That(Act).DoesNotThrow();
-			}
-
-			[Fact]
 			public async Task WhenDistinctViolatorsShareTheSimpleName_ShouldQualifyThemByNamespace()
 			{
 				// Both AmbiguousTarget dependencies are disallowed; they must stay apart in the message
@@ -233,66 +251,12 @@ public sealed partial class ThatType
 				Type subject = typeof(WithSameNamedDependencies);
 
 				async Task Act()
-					=> await That(subject).DependsOnlyOn(Types.InNamespace(Layer1Namespace));
+				{
+					await That(subject).DependsOnlyOn(Types.InNamespace(Layer1Namespace));
+				}
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("*AmbiguousA.AmbiguousTarget*AmbiguousB.AmbiguousTarget*").AsWildcard();
-			}
-
-			[Fact]
-			public async Task WhenTargetCollectionIsEmpty_ShouldStillAllowFrameworkDependencies()
-			{
-				Type subject = typeof(FrameworkConsumer);
-
-				async Task Act()
-					=> await That(subject).DependsOnlyOn(Types.InNamespace("Non.Existent.Namespace"));
-
-				await That(Act).DoesNotThrow();
-			}
-
-			[Fact]
-			public async Task WhenTargetCollectionIsEmpty_ShouldStillAllowOwnNamespace()
-			{
-				Type subject = typeof(ReferencesOwnNamespace);
-
-				async Task Act()
-					=> await That(subject).DependsOnlyOn(Types.InNamespace("Non.Existent.Namespace"));
-
-				await That(Act).DoesNotThrow();
-			}
-
-			[Fact]
-			public async Task WhenTargetCollectionIsEmpty_DisallowedDependencyShouldFail()
-			{
-				Type subject = typeof(OnlyLayer1);
-
-				async Task Act()
-					=> await That(subject).DependsOnlyOn(Types.InNamespace("Non.Existent.Namespace"));
-
-				await That(Act).Throws<XunitException>();
-			}
-
-			[Fact]
-			public async Task WhenNegated_ShouldSucceedForDisallowedDependency()
-			{
-				Type subject = typeof(Layer1AndLayer2);
-
-				async Task Act()
-					=> await That(subject)
-						.DoesNotComplyWith(it => it.DependsOnlyOn(Types.InNamespace(Layer1Namespace)));
-
-				await That(Act).DoesNotThrow();
-			}
-
-			[Fact]
-			public async Task WhenReferencingOwnSubNamespace_ShouldSucceedByDefault()
-			{
-				Type subject = typeof(ReferencesOwnSubNamespace);
-
-				async Task Act()
-					=> await That(subject).DependsOnlyOn(Types.InNamespace(Layer1Namespace));
-
-				await That(Act).DoesNotThrow();
 			}
 
 			[Fact]
@@ -301,8 +265,10 @@ public sealed partial class ThatType
 				Type subject = typeof(ReferencesOwnSubNamespace);
 
 				async Task Act()
-					=> await That(subject).DependsOnlyOn(Types.InNamespace(Layer1Namespace))
+				{
+					await That(subject).DependsOnlyOn(Types.InNamespace(Layer1Namespace))
 						.ExcludingOwnSubNamespaces();
+				}
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage($"""
@@ -320,8 +286,90 @@ public sealed partial class ThatType
 				Type subject = typeof(ReferencesOwnSubNamespace);
 
 				async Task Act()
-					=> await That(subject).DependsOnlyOn(Types.InNamespace(ConsumersNamespace))
+				{
+					await That(subject).DependsOnlyOn(Types.InNamespace(ConsumersNamespace))
 						.ExcludingOwnSubNamespaces();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenNegated_ShouldSucceedForDisallowedDependency()
+			{
+				Type subject = typeof(Layer1AndLayer2);
+
+				async Task Act()
+				{
+					await That(subject)
+						.DoesNotComplyWith(it => it.DependsOnlyOn(Types.InNamespace(Layer1Namespace)));
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenReferencingOwnSubNamespace_ShouldSucceedByDefault()
+			{
+				Type subject = typeof(ReferencesOwnSubNamespace);
+
+				async Task Act()
+				{
+					await That(subject).DependsOnlyOn(Types.InNamespace(Layer1Namespace));
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenTargetCollectionIsEmpty_DisallowedDependencyShouldFail()
+			{
+				Type subject = typeof(OnlyLayer1);
+
+				async Task Act()
+				{
+					await That(subject).DependsOnlyOn(Types.InNamespace("Non.Existent.Namespace"));
+				}
+
+				await That(Act).Throws<XunitException>();
+			}
+
+			[Fact]
+			public async Task WhenTargetCollectionIsEmpty_ShouldStillAllowFrameworkDependencies()
+			{
+				Type subject = typeof(FrameworkConsumer);
+
+				async Task Act()
+				{
+					await That(subject).DependsOnlyOn(Types.InNamespace("Non.Existent.Namespace"));
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenTargetCollectionIsEmpty_ShouldStillAllowOwnNamespace()
+			{
+				Type subject = typeof(ReferencesOwnNamespace);
+
+				async Task Act()
+				{
+					await That(subject).DependsOnlyOn(Types.InNamespace("Non.Existent.Namespace"));
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenWidenedWithOrOn_ShouldSucceed()
+			{
+				Type subject = typeof(Layer1AndLayer2);
+
+				async Task Act()
+				{
+					await That(subject).DependsOnlyOn(Types.InNamespace(Layer1Namespace))
+						.OrOn(Types.InNamespace(Layer2Namespace));
+				}
 
 				await That(Act).DoesNotThrow();
 			}
@@ -335,7 +383,9 @@ public sealed partial class ThatType
 				Type subject = typeof(Layer1AndLayer2);
 
 				async Task Act()
-					=> await That(subject).DoesNotComplyWith(it => it.DependsOnlyOn(Layer1Namespace));
+				{
+					await That(subject).DoesNotComplyWith(it => it.DependsOnlyOn(Layer1Namespace));
+				}
 
 				await That(Act).DoesNotThrow();
 			}

--- a/Tests/aweXpect.Reflection.Tests/ThatType.DoesNotDependOn.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatType.DoesNotDependOn.Tests.cs
@@ -22,56 +22,23 @@ public sealed partial class ThatType
 		public sealed class Tests
 		{
 			[Fact]
-			public async Task WhenTypeDoesNotDependOnNamespace_ShouldSucceed()
+			public async Task WhenArrayTargetIsUsed_ShouldMatchElementType()
 			{
-				Type subject = typeof(OnlyLayer1);
+				// The array wrapper is unwrapped on both sides: WithArrayField references TargetA[],
+				// so it depends on typeof(TargetA[]) just like on typeof(TargetA).
+				Type subject = typeof(WithArrayField);
 
 				async Task Act()
-					=> await That(subject).DoesNotDependOn(Layer2Namespace);
-
-				await That(Act).DoesNotThrow();
-			}
-
-			[Fact]
-			public async Task WhenTypeDependsOnNamespace_ShouldFail()
-			{
-				Type subject = typeof(ViaField);
-
-				async Task Act()
-					=> await That(subject).DoesNotDependOn(Layer1Namespace);
+				{
+					await That(subject).DoesNotDependOn(typeof(TargetA[]));
+				}
 
 				await That(Act).Throws<XunitException>()
-					.WithMessage($"""
-					              Expected that subject
-					              does not depend on namespace "{Layer1Namespace}",
-					              but it depended on ["{Layer1Namespace}"]
-					              """);
-			}
-
-			[Fact]
-			public async Task WhenOnlySystemReferenceIsImplicitBaseAndNullableAttributes_ShouldSucceed()
-			{
-				// OnlyLayer1's only authored dependency is Layer1.TargetA; the implicit object base type and the
-				// compiler-emitted nullable attributes must not count as a dependency on "System".
-				Type subject = typeof(OnlyLayer1);
-
-				async Task Act()
-					=> await That(subject).DoesNotDependOn("System");
-
-				await That(Act).DoesNotThrow();
-			}
-
-			[Fact]
-			public async Task WhenCompilerEmitsAttributesForRequiredMember_ShouldNotCountAsDependency()
-			{
-				// `required` makes the compiler emit [RequiredMember] on the type and property and
-				// [Obsolete] + [CompilerFeatureRequired] on the constructor; none of these are authored.
-				Type subject = typeof(WithRequiredProperty);
-
-				async Task Act()
-					=> await That(subject).DoesNotDependOn("System");
-
-				await That(Act).DoesNotThrow();
+					.WithMessage("""
+					             Expected that subject
+					             does not depend on type TargetA[],
+					             but it depended on [TargetA]
+					             """);
 			}
 
 			[Fact]
@@ -85,13 +52,17 @@ public sealed partial class ThatType
 					       .Set([typeof(TargetAttribute).FullName!,]))
 				{
 					async Task Act()
-						=> await That(subject).DoesNotDependOn(Layer1Namespace);
+					{
+						await That(subject).DoesNotDependOn(Layer1Namespace);
+					}
 
 					await That(Act).DoesNotThrow();
 				}
 
 				async Task ActOutsideScope()
-					=> await That(subject).DependsOn(Layer1Namespace);
+				{
+					await That(subject).DependsOn(Layer1Namespace);
+				}
 
 				await That(ActOutsideScope).DoesNotThrow();
 			}
@@ -114,20 +85,6 @@ public sealed partial class ThatType
 			}
 
 			[Fact]
-			public async Task WhenCompilerEmitsStateMachineForAsyncMethod_ShouldNotCountAsDependency()
-			{
-				// The nested <MethodAsync>d__0 state machine lives in the type's own namespace; the
-				// typeof(...) argument of [AsyncStateMachine] must not surface it as a dependency.
-				Type subject = typeof(WithAsyncMethod);
-
-				async Task Act()
-					=> await That(subject)
-						.DoesNotDependOn("aweXpect.Reflection.Tests.TestHelpers.Dependencies.Synthetic");
-
-				await That(Act).DoesNotThrow();
-			}
-
-			[Fact]
 			public async Task WhenCompilerEmitsAttributesForIteratorMethod_ShouldNotCountAsDependency()
 			{
 				// An iterator method makes the compiler emit [IteratorStateMachine(typeof(<M>d__0))];
@@ -135,7 +92,39 @@ public sealed partial class ThatType
 				Type subject = typeof(WithIteratorMethod);
 
 				async Task Act()
-					=> await That(subject).DoesNotDependOn("System.Runtime.CompilerServices");
+				{
+					await That(subject).DoesNotDependOn("System.Runtime.CompilerServices");
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenCompilerEmitsAttributesForRequiredMember_ShouldNotCountAsDependency()
+			{
+				// `required` makes the compiler emit [RequiredMember] on the type and property and
+				// [Obsolete] + [CompilerFeatureRequired] on the constructor; none of these are authored.
+				Type subject = typeof(WithRequiredProperty);
+
+				async Task Act()
+				{
+					await That(subject).DoesNotDependOn("System");
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenCompilerEmitsParamArrayForParamsParameter_ShouldNotCountAsDependency()
+			{
+				// The `params` keyword compiles into [ParamArray] on the parameter, which the author can
+				// never write directly (CS0674).
+				Type subject = typeof(WithParamsArrayOfOwnType);
+
+				async Task Act()
+				{
+					await That(subject).DoesNotDependOn<ParamArrayAttribute>();
+				}
 
 				await That(Act).DoesNotThrow();
 			}
@@ -149,34 +138,118 @@ public sealed partial class ThatType
 				Type subject = typeof(CovariantReturnDerived);
 
 				async Task Act()
-					=> await That(subject).DoesNotDependOn("System.Runtime.CompilerServices");
+				{
+					await That(subject).DoesNotDependOn("System.Runtime.CompilerServices");
+				}
 
 				await That(Act).DoesNotThrow();
 			}
 #endif
 
 			[Fact]
-			public async Task WhenCompilerEmitsParamArrayForParamsParameter_ShouldNotCountAsDependency()
+			public async Task WhenCompilerEmitsStateMachineForAsyncMethod_ShouldNotCountAsDependency()
 			{
-				// The `params` keyword compiles into [ParamArray] on the parameter, which the author can
-				// never write directly (CS0674).
-				Type subject = typeof(WithParamsArrayOfOwnType);
+				// The nested <MethodAsync>d__0 state machine lives in the type's own namespace; the
+				// typeof(...) argument of [AsyncStateMachine] must not surface it as a dependency.
+				Type subject = typeof(WithAsyncMethod);
 
 				async Task Act()
-					=> await That(subject).DoesNotDependOn<ParamArrayAttribute>();
+				{
+					await That(subject)
+						.DoesNotDependOn("aweXpect.Reflection.Tests.TestHelpers.Dependencies.Synthetic");
+				}
 
 				await That(Act).DoesNotThrow();
 			}
 
-			[Theory]
-			[InlineData(typeof(WithStructConstraint<>))]
-			[InlineData(typeof(WithUnmanagedConstraint<>))]
-			public async Task WhenStructConstraintCompilesIntoValueType_ShouldNotCountAsDependency(Type subject)
+			[Fact]
+			public async Task WhenDelegateInfrastructureIsRuntimeSupplied_ShouldNotCountAsDependency()
 			{
-				// `where T : struct` / `where T : unmanaged` compile into a System.ValueType constraint in
-				// metadata, which the author can never write directly (CS0702).
+				// The MulticastDelegate base, the (object, IntPtr) constructor and BeginInvoke/EndInvoke
+				// are runtime-supplied; only the Invoke signature of a delegate is authored.
+				Type subject = typeof(TargetProviderDelegate);
+
 				async Task Act()
-					=> await That(subject).DoesNotDependOn("System");
+				{
+					await That(subject).DoesNotDependOn("System");
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenInterfaceIsImplementedOnlyByBaseType_ShouldNotCountAsDependency()
+			{
+				// GetInterfaces() returns the transitive closure: DerivedWithoutOwnReferences inherits
+				// ITargetInterface from its base type without writing the reference itself.
+				Type subject = typeof(DerivedWithoutOwnReferences);
+
+				async Task Act()
+				{
+					await That(subject).DoesNotDependOn(Layer1Namespace);
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenNamingFrameworkNamespaceThatIsReferenced_ShouldFail()
+			{
+				Type subject = typeof(FrameworkConsumer);
+
+				async Task Act()
+				{
+					await That(subject).DoesNotDependOn("System.Collections.Generic");
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("""
+					             Expected that subject
+					             does not depend on namespace "System.Collections.Generic",
+					             but it depended on ["System.Collections.Generic"]
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenNoNamespaceIsSpecified_ShouldThrowArgumentException()
+			{
+				Type subject = typeof(OnlyLayer1);
+
+				async Task Act()
+				{
+					await That(subject).DoesNotDependOn();
+				}
+
+				await That(Act).Throws<ArgumentException>()
+					.WithMessage("At least one namespace must be specified.");
+			}
+
+			[Fact]
+			public async Task WhenOnlyOtherConstructionOfGenericIsReferenced_ShouldSucceed()
+			{
+				// ViaGenericArgument references List<TargetA>; List<TargetB> is a different construction
+				// and must not be reported as a dependency.
+				Type subject = typeof(ViaGenericArgument);
+
+				async Task Act()
+				{
+					await That(subject).DoesNotDependOn(typeof(List<TargetB>));
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenOnlySystemReferenceIsImplicitBaseAndNullableAttributes_ShouldSucceed()
+			{
+				// OnlyLayer1's only authored dependency is Layer1.TargetA; the implicit object base type and the
+				// compiler-emitted nullable attributes must not count as a dependency on "System".
+				Type subject = typeof(OnlyLayer1);
+
+				async Task Act()
+				{
+					await That(subject).DoesNotDependOn("System");
+				}
 
 				await That(Act).DoesNotThrow();
 			}
@@ -201,88 +274,63 @@ public sealed partial class ThatType
 			}
 
 			[Fact]
-			public async Task WhenInterfaceIsImplementedOnlyByBaseType_ShouldNotCountAsDependency()
-			{
-				// GetInterfaces() returns the transitive closure: DerivedWithoutOwnReferences inherits
-				// ITargetInterface from its base type without writing the reference itself.
-				Type subject = typeof(DerivedWithoutOwnReferences);
-
-				async Task Act()
-					=> await That(subject).DoesNotDependOn(Layer1Namespace);
-
-				await That(Act).DoesNotThrow();
-			}
-
-			[Fact]
 			public async Task WhenRecordSynthesizesEquatableInterface_ShouldNotCountAsDependency()
 			{
 				// The compiler synthesizes IEquatable<T> for records; the author never wrote that reference.
 				Type subject = typeof(RecordWithLayer1Target);
 
 				async Task Act()
-					=> await That(subject).DoesNotDependOn("System");
+				{
+					await That(subject).DoesNotDependOn("System");
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Theory]
+			[InlineData(typeof(WithStructConstraint<>))]
+			[InlineData(typeof(WithUnmanagedConstraint<>))]
+			public async Task WhenStructConstraintCompilesIntoValueType_ShouldNotCountAsDependency(Type subject)
+			{
+				// `where T : struct` / `where T : unmanaged` compile into a System.ValueType constraint in
+				// metadata, which the author can never write directly (CS0702).
+				async Task Act()
+				{
+					await That(subject).DoesNotDependOn("System");
+				}
 
 				await That(Act).DoesNotThrow();
 			}
 
 			[Fact]
-			public async Task WhenDelegateInfrastructureIsRuntimeSupplied_ShouldNotCountAsDependency()
+			public async Task WhenTypeDependsOnNamespace_ShouldFail()
 			{
-				// The MulticastDelegate base, the (object, IntPtr) constructor and BeginInvoke/EndInvoke
-				// are runtime-supplied; only the Invoke signature of a delegate is authored.
-				Type subject = typeof(TargetProviderDelegate);
+				Type subject = typeof(ViaField);
 
 				async Task Act()
-					=> await That(subject).DoesNotDependOn("System");
-
-				await That(Act).DoesNotThrow();
-			}
-
-			[Fact]
-			public async Task WhenOnlyOtherConstructionOfGenericIsReferenced_ShouldSucceed()
-			{
-				// ViaGenericArgument references List<TargetA>; List<TargetB> is a different construction
-				// and must not be reported as a dependency.
-				Type subject = typeof(ViaGenericArgument);
-
-				async Task Act()
-					=> await That(subject).DoesNotDependOn(typeof(List<TargetB>));
-
-				await That(Act).DoesNotThrow();
-			}
-
-			[Fact]
-			public async Task WhenArrayTargetIsUsed_ShouldMatchElementType()
-			{
-				// The array wrapper is unwrapped on both sides: WithArrayField references TargetA[],
-				// so it depends on typeof(TargetA[]) just like on typeof(TargetA).
-				Type subject = typeof(WithArrayField);
-
-				async Task Act()
-					=> await That(subject).DoesNotDependOn(typeof(TargetA[]));
+				{
+					await That(subject).DoesNotDependOn(Layer1Namespace);
+				}
 
 				await That(Act).Throws<XunitException>()
-					.WithMessage("""
-					             Expected that subject
-					             does not depend on type TargetA[],
-					             but it depended on [TargetA]
-					             """);
+					.WithMessage($"""
+					              Expected that subject
+					              does not depend on namespace "{Layer1Namespace}",
+					              but it depended on ["{Layer1Namespace}"]
+					              """);
 			}
 
 			[Fact]
-			public async Task WhenNamingFrameworkNamespaceThatIsReferenced_ShouldFail()
+			public async Task WhenTypeDoesNotDependOnNamespace_ShouldSucceed()
 			{
-				Type subject = typeof(FrameworkConsumer);
+				Type subject = typeof(OnlyLayer1);
 
 				async Task Act()
-					=> await That(subject).DoesNotDependOn("System.Collections.Generic");
+				{
+					await That(subject).DoesNotDependOn(Layer2Namespace);
+				}
 
-				await That(Act).Throws<XunitException>()
-					.WithMessage("""
-					             Expected that subject
-					             does not depend on namespace "System.Collections.Generic",
-					             but it depended on ["System.Collections.Generic"]
-					             """);
+				await That(Act).DoesNotThrow();
 			}
 
 			[Fact]
@@ -291,7 +339,9 @@ public sealed partial class ThatType
 				Type subject = typeof(ViaField);
 
 				async Task Act()
-					=> await That(subject).DoesNotDependOn<TargetB>();
+				{
+					await That(subject).DoesNotDependOn<TargetB>();
+				}
 
 				await That(Act).DoesNotThrow();
 			}
@@ -302,7 +352,9 @@ public sealed partial class ThatType
 				Type subject = typeof(ViaField);
 
 				async Task Act()
-					=> await That(subject).DoesNotDependOn<TargetA>();
+				{
+					await That(subject).DoesNotDependOn<TargetA>();
+				}
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
@@ -313,24 +365,14 @@ public sealed partial class ThatType
 			}
 
 			[Fact]
-			public async Task WhenNoNamespaceIsSpecified_ShouldThrowArgumentException()
-			{
-				Type subject = typeof(OnlyLayer1);
-
-				async Task Act()
-					=> await That(subject).DoesNotDependOn();
-
-				await That(Act).Throws<ArgumentException>()
-					.WithMessage("At least one namespace must be specified.");
-			}
-
-			[Fact]
 			public async Task WhenWidenedWithOrOn_ShouldFailIfAnyMatches()
 			{
 				Type subject = typeof(Layer1AndLayer2);
 
 				async Task Act()
-					=> await That(subject).DoesNotDependOn(Layer2Namespace).OrOn(Layer1Namespace);
+				{
+					await That(subject).DoesNotDependOn(Layer2Namespace).OrOn(Layer1Namespace);
+				}
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage($"""
@@ -344,12 +386,14 @@ public sealed partial class ThatType
 		public sealed class FilteredTypesTargetTests
 		{
 			[Fact]
-			public async Task WhenTypeDoesNotDependOnAnyTypeInTargetCollection_ShouldSucceed()
+			public async Task WhenTargetCollectionIsEmpty_ShouldSucceedTrivially()
 			{
-				Type subject = typeof(OnlyLayer1);
+				Type subject = typeof(ViaField);
 
 				async Task Act()
-					=> await That(subject).DoesNotDependOn(Types.InNamespace(Layer2Namespace));
+				{
+					await That(subject).DoesNotDependOn(Types.InNamespace("Non.Existent.Namespace"));
+				}
 
 				await That(Act).DoesNotThrow();
 			}
@@ -360,7 +404,9 @@ public sealed partial class ThatType
 				Type subject = typeof(ViaField);
 
 				async Task Act()
-					=> await That(subject).DoesNotDependOn(Types.InNamespace(Layer1Namespace));
+				{
+					await That(subject).DoesNotDependOn(Types.InNamespace(Layer1Namespace));
+				}
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage($"""
@@ -371,12 +417,14 @@ public sealed partial class ThatType
 			}
 
 			[Fact]
-			public async Task WhenTargetCollectionIsEmpty_ShouldSucceedTrivially()
+			public async Task WhenTypeDoesNotDependOnAnyTypeInTargetCollection_ShouldSucceed()
 			{
-				Type subject = typeof(ViaField);
+				Type subject = typeof(OnlyLayer1);
 
 				async Task Act()
-					=> await That(subject).DoesNotDependOn(Types.InNamespace("Non.Existent.Namespace"));
+				{
+					await That(subject).DoesNotDependOn(Types.InNamespace(Layer2Namespace));
+				}
 
 				await That(Act).DoesNotThrow();
 			}
@@ -387,8 +435,10 @@ public sealed partial class ThatType
 				Type subject = typeof(Layer1AndLayer2);
 
 				async Task Act()
-					=> await That(subject).DoesNotDependOn(Types.InNamespace(Layer2Namespace))
+				{
+					await That(subject).DoesNotDependOn(Types.InNamespace(Layer2Namespace))
 						.OrOn(Types.InNamespace(Layer1Namespace));
+				}
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage($"""
@@ -407,7 +457,9 @@ public sealed partial class ThatType
 				Type subject = typeof(ViaField);
 
 				async Task Act()
-					=> await That(subject).DoesNotComplyWith(it => it.DoesNotDependOn(Layer1Namespace));
+				{
+					await That(subject).DoesNotComplyWith(it => it.DoesNotDependOn(Layer1Namespace));
+				}
 
 				await That(Act).DoesNotThrow();
 			}

--- a/Tests/aweXpect.Reflection.Tests/ThatType.DoesNotInheritFrom.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatType.DoesNotInheritFrom.Tests.cs
@@ -1,4 +1,4 @@
-using Xunit.Sdk;
+﻿using Xunit.Sdk;
 
 namespace aweXpect.Reflection.Tests;
 

--- a/Tests/aweXpect.Reflection.Tests/ThatType.HasDependenciesOutside.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatType.HasDependenciesOutside.Tests.cs
@@ -14,23 +14,14 @@ public sealed partial class ThatType
 		public sealed class Tests
 		{
 			[Fact]
-			public async Task WhenDependingOnNamespaceOutsideAllowedSet_ShouldSucceed()
-			{
-				Type subject = typeof(Layer1AndLayer2);
-
-				async Task Act()
-					=> await That(subject).HasDependenciesOutside(Layer1Namespace);
-
-				await That(Act).DoesNotThrow();
-			}
-
-			[Fact]
 			public async Task WhenAllDependenciesAreAllowed_ShouldFail()
 			{
 				Type subject = typeof(OnlyLayer1);
 
 				async Task Act()
-					=> await That(subject).HasDependenciesOutside(Layer1Namespace);
+				{
+					await That(subject).HasDependenciesOutside(Layer1Namespace);
+				}
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage($"""
@@ -46,7 +37,9 @@ public sealed partial class ThatType
 				Type subject = typeof(Layer1AndLayer2);
 
 				async Task Act()
-					=> await That(subject).HasDependenciesOutside(Layer1Namespace, Layer2Namespace);
+				{
+					await That(subject).HasDependenciesOutside(Layer1Namespace, Layer2Namespace);
+				}
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage($"""
@@ -57,48 +50,16 @@ public sealed partial class ThatType
 			}
 
 			[Fact]
-			public async Task WhenWidenedWithOrOn_ShouldFail()
+			public async Task WhenDependingOnGlobalNamespace_ShouldSucceed()
 			{
-				Type subject = typeof(Layer1AndLayer2);
+				Type subject = typeof(ReferencesGlobal);
 
 				async Task Act()
-					=> await That(subject).HasDependenciesOutside(Layer1Namespace).OrOn(Layer2Namespace);
+				{
+					await That(subject).HasDependenciesOutside(Layer1Namespace);
+				}
 
-				await That(Act).Throws<XunitException>()
-					.WithMessage($"""
-					              Expected that subject
-					              has dependencies outside namespace "{Layer1Namespace}" or "{Layer2Namespace}",
-					              but it only depended on the allowed namespaces
-					              """);
-			}
-
-			[Fact]
-			public async Task WhenNoNamespaceIsSpecified_ShouldThrowArgumentException()
-			{
-				Type subject = typeof(OnlyLayer2);
-
-				async Task Act()
-					=> await That(subject).HasDependenciesOutside();
-
-				await That(Act).Throws<ArgumentException>()
-					.WithMessage("At least one namespace must be specified.");
-			}
-
-			[Fact]
-			public async Task WhenDependingOnlyOnOwnNamespace_ShouldFail()
-			{
-				// The type's own namespace never counts as outside.
-				Type subject = typeof(ReferencesOwnNamespace);
-
-				async Task Act()
-					=> await That(subject).HasDependenciesOutside(Layer1Namespace);
-
-				await That(Act).Throws<XunitException>()
-					.WithMessage($"""
-					              Expected that subject
-					              has dependencies outside namespace "{Layer1Namespace}",
-					              but it only depended on the allowed namespaces
-					              """);
+				await That(Act).DoesNotThrow();
 			}
 
 			[Fact]
@@ -108,7 +69,9 @@ public sealed partial class ThatType
 				Type subject = typeof(FrameworkConsumer);
 
 				async Task Act()
-					=> await That(subject).HasDependenciesOutside(Layer1Namespace);
+				{
+					await That(subject).HasDependenciesOutside(Layer1Namespace);
+				}
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage($"""
@@ -119,13 +82,80 @@ public sealed partial class ThatType
 			}
 
 			[Fact]
+			public async Task WhenDependingOnlyOnOwnNamespace_ShouldFail()
+			{
+				// The type's own namespace never counts as outside.
+				Type subject = typeof(ReferencesOwnNamespace);
+
+				async Task Act()
+				{
+					await That(subject).HasDependenciesOutside(Layer1Namespace);
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              has dependencies outside namespace "{Layer1Namespace}",
+					              but it only depended on the allowed namespaces
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenDependingOnNamespaceOutsideAllowedSet_ShouldSucceed()
+			{
+				Type subject = typeof(Layer1AndLayer2);
+
+				async Task Act()
+				{
+					await That(subject).HasDependenciesOutside(Layer1Namespace);
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
 			public async Task WhenDependingOnSubNamespaceOfAllowedNamespace_ShouldFail()
 			{
 				// ViaSubNamespace references only Layer1.Sub, which is covered by Layer1 by default.
 				Type subject = typeof(ViaSubNamespace);
 
 				async Task Act()
-					=> await That(subject).HasDependenciesOutside(Layer1Namespace);
+				{
+					await That(subject).HasDependenciesOutside(Layer1Namespace);
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              has dependencies outside namespace "{Layer1Namespace}",
+					              but it only depended on the allowed namespaces
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenExcludingOwnSubNamespaces_OwnSubNamespaceCountsAsOutside()
+			{
+				Type subject = typeof(ReferencesOwnSubNamespace);
+
+				async Task Act()
+				{
+					await That(subject).HasDependenciesOutside(Layer1Namespace).ExcludingOwnSubNamespaces();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenExcludingSubNamespaces_OwnSubNamespaceStaysAllowed()
+			{
+				// ReferencesOwnSubNamespace (in ...Consumers) only references ...Consumers.OwnSub. By default the
+				// type's own sub-namespaces never count as outside, even when sub-namespaces are excluded.
+				Type subject = typeof(ReferencesOwnSubNamespace);
+
+				async Task Act()
+				{
+					await That(subject).HasDependenciesOutside(Layer1Namespace).ExcludingSubNamespaces();
+				}
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage($"""
@@ -141,47 +171,9 @@ public sealed partial class ThatType
 				Type subject = typeof(ViaSubNamespace);
 
 				async Task Act()
-					=> await That(subject).HasDependenciesOutside(Layer1Namespace).ExcludingSubNamespaces();
-
-				await That(Act).DoesNotThrow();
-			}
-
-			[Fact]
-			public async Task WhenExcludingSubNamespaces_OwnSubNamespaceStaysAllowed()
-			{
-				// ReferencesOwnSubNamespace (in ...Consumers) only references ...Consumers.OwnSub. By default the
-				// type's own sub-namespaces never count as outside, even when sub-namespaces are excluded.
-				Type subject = typeof(ReferencesOwnSubNamespace);
-
-				async Task Act()
-					=> await That(subject).HasDependenciesOutside(Layer1Namespace).ExcludingSubNamespaces();
-
-				await That(Act).Throws<XunitException>()
-					.WithMessage($"""
-					              Expected that subject
-					              has dependencies outside namespace "{Layer1Namespace}",
-					              but it only depended on the allowed namespaces
-					              """);
-			}
-
-			[Fact]
-			public async Task WhenExcludingOwnSubNamespaces_OwnSubNamespaceCountsAsOutside()
-			{
-				Type subject = typeof(ReferencesOwnSubNamespace);
-
-				async Task Act()
-					=> await That(subject).HasDependenciesOutside(Layer1Namespace).ExcludingOwnSubNamespaces();
-
-				await That(Act).DoesNotThrow();
-			}
-
-			[Fact]
-			public async Task WhenDependingOnGlobalNamespace_ShouldSucceed()
-			{
-				Type subject = typeof(ReferencesGlobal);
-
-				async Task Act()
-					=> await That(subject).HasDependenciesOutside(Layer1Namespace);
+				{
+					await That(subject).HasDependenciesOutside(Layer1Namespace).ExcludingSubNamespaces();
+				}
 
 				await That(Act).DoesNotThrow();
 			}
@@ -193,7 +185,9 @@ public sealed partial class ThatType
 				Type subject = typeof(ReferencesGlobal);
 
 				async Task Act()
-					=> await That(subject).HasDependenciesOutside(Layer1Namespace, "");
+				{
+					await That(subject).HasDependenciesOutside(Layer1Namespace, "");
+				}
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage($"""
@@ -204,12 +198,28 @@ public sealed partial class ThatType
 			}
 
 			[Fact]
+			public async Task WhenNoNamespaceIsSpecified_ShouldThrowArgumentException()
+			{
+				Type subject = typeof(OnlyLayer2);
+
+				async Task Act()
+				{
+					await That(subject).HasDependenciesOutside();
+				}
+
+				await That(Act).Throws<ArgumentException>()
+					.WithMessage("At least one namespace must be specified.");
+			}
+
+			[Fact]
 			public async Task WhenSubjectIsInGlobalNamespaceAndDependsOnlyOnFramework_ShouldFail()
 			{
 				Type subject = typeof(GlobalNamespaceTarget);
 
 				async Task Act()
-					=> await That(subject).HasDependenciesOutside(Layer1Namespace);
+				{
+					await That(subject).HasDependenciesOutside(Layer1Namespace);
+				}
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage($"""
@@ -225,43 +235,15 @@ public sealed partial class ThatType
 				Type? subject = null;
 
 				async Task Act()
-					=> await That(subject).HasDependenciesOutside(Layer1Namespace);
+				{
+					await That(subject).HasDependenciesOutside(Layer1Namespace);
+				}
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage($"""
 					              Expected that subject
 					              has dependencies outside namespace "{Layer1Namespace}",
 					              but it was <null>
-					              """);
-			}
-		}
-
-		public sealed class FilteredTypesTargetTests
-		{
-			[Fact]
-			public async Task WhenDependingOnTypeOutsideTargetCollections_ShouldSucceed()
-			{
-				Type subject = typeof(Layer1AndLayer2);
-
-				async Task Act()
-					=> await That(subject).HasDependenciesOutside(Types.InNamespace(Layer1Namespace));
-
-				await That(Act).DoesNotThrow();
-			}
-
-			[Fact]
-			public async Task WhenAllDependenciesAreInTargetCollection_ShouldFail()
-			{
-				Type subject = typeof(OnlyLayer1);
-
-				async Task Act()
-					=> await That(subject).HasDependenciesOutside(Types.InNamespace(Layer1Namespace));
-
-				await That(Act).Throws<XunitException>()
-					.WithMessage($"""
-					              Expected that subject
-					              has dependencies outside types within namespace "{Layer1Namespace}" in all loaded assemblies,
-					              but it only depended on the allowed types
 					              """);
 			}
 
@@ -271,57 +253,30 @@ public sealed partial class ThatType
 				Type subject = typeof(Layer1AndLayer2);
 
 				async Task Act()
-					=> await That(subject).HasDependenciesOutside(Types.InNamespace(Layer1Namespace))
-						.OrOn(Types.InNamespace(Layer2Namespace));
+				{
+					await That(subject).HasDependenciesOutside(Layer1Namespace).OrOn(Layer2Namespace);
+				}
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage($"""
 					              Expected that subject
-					              has dependencies outside types within namespace "{Layer1Namespace}" in all loaded assemblies or types within namespace "{Layer2Namespace}" in all loaded assemblies,
-					              but it only depended on the allowed types
+					              has dependencies outside namespace "{Layer1Namespace}" or "{Layer2Namespace}",
+					              but it only depended on the allowed namespaces
 					              """);
 			}
+		}
 
+		public sealed class FilteredTypesTargetTests
+		{
 			[Fact]
-			public async Task WhenTargetCollectionIsEmpty_FrameworkDependenciesStayInside()
-			{
-				Type subject = typeof(FrameworkConsumer);
-
-				async Task Act()
-					=> await That(subject).HasDependenciesOutside(Types.InNamespace("Non.Existent.Namespace"));
-
-				await That(Act).Throws<XunitException>();
-			}
-
-			[Fact]
-			public async Task WhenTargetCollectionIsEmpty_OwnNamespaceStaysInside()
-			{
-				Type subject = typeof(ReferencesOwnNamespace);
-
-				async Task Act()
-					=> await That(subject).HasDependenciesOutside(Types.InNamespace("Non.Existent.Namespace"));
-
-				await That(Act).Throws<XunitException>();
-			}
-
-			[Fact]
-			public async Task WhenTargetCollectionIsEmpty_DisallowedDependencyShouldSucceed()
+			public async Task WhenAllDependenciesAreInTargetCollection_ShouldFail()
 			{
 				Type subject = typeof(OnlyLayer1);
 
 				async Task Act()
-					=> await That(subject).HasDependenciesOutside(Types.InNamespace("Non.Existent.Namespace"));
-
-				await That(Act).DoesNotThrow();
-			}
-
-			[Fact]
-			public async Task WhenReferencingOwnSubNamespace_ShouldFailByDefault()
-			{
-				Type subject = typeof(ReferencesOwnSubNamespace);
-
-				async Task Act()
-					=> await That(subject).HasDependenciesOutside(Types.InNamespace(Layer1Namespace));
+				{
+					await That(subject).HasDependenciesOutside(Types.InNamespace(Layer1Namespace));
+				}
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage($"""
@@ -329,6 +284,19 @@ public sealed partial class ThatType
 					              has dependencies outside types within namespace "{Layer1Namespace}" in all loaded assemblies,
 					              but it only depended on the allowed types
 					              """);
+			}
+
+			[Fact]
+			public async Task WhenDependingOnTypeOutsideTargetCollections_ShouldSucceed()
+			{
+				Type subject = typeof(Layer1AndLayer2);
+
+				async Task Act()
+				{
+					await That(subject).HasDependenciesOutside(Types.InNamespace(Layer1Namespace));
+				}
+
+				await That(Act).DoesNotThrow();
 			}
 
 			[Fact]
@@ -337,25 +305,30 @@ public sealed partial class ThatType
 				Type subject = typeof(ReferencesOwnSubNamespace);
 
 				async Task Act()
-					=> await That(subject).HasDependenciesOutside(Types.InNamespace(Layer1Namespace))
+				{
+					await That(subject).HasDependenciesOutside(Types.InNamespace(Layer1Namespace))
 						.ExcludingOwnSubNamespaces();
+				}
 
 				await That(Act).DoesNotThrow();
 			}
 
 			[Fact]
-			public async Task WhenTypeIsNull_ShouldFail()
+			public async Task WhenNegated_ShouldFailForTypeWithDependencyOutside()
 			{
-				Type? subject = null;
+				Type subject = typeof(Layer1AndLayer2);
 
 				async Task Act()
-					=> await That(subject).HasDependenciesOutside(Types.InNamespace(Layer1Namespace));
+				{
+					await That(subject)
+						.DoesNotComplyWith(it => it.HasDependenciesOutside(Types.InNamespace(Layer1Namespace)));
+				}
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage($"""
 					              Expected that subject
-					              has dependencies outside types within namespace "{Layer1Namespace}" in all loaded assemblies,
-					              but it was <null>
+					              does not have dependencies outside types within namespace "{Layer1Namespace}" in all loaded assemblies,
+					              but it also depended on ["TargetB"]
 					              """);
 			}
 
@@ -365,8 +338,10 @@ public sealed partial class ThatType
 				Type subject = typeof(OnlyLayer1);
 
 				async Task Act()
-					=> await That(subject)
+				{
+					await That(subject)
 						.DoesNotComplyWith(it => it.HasDependenciesOutside(Types.InNamespace(Layer1Namespace)));
+				}
 
 				await That(Act).DoesNotThrow();
 			}
@@ -379,27 +354,106 @@ public sealed partial class ThatType
 				Type subject = typeof(WithSameNamedDependencies);
 
 				async Task Act()
-					=> await That(subject)
+				{
+					await That(subject)
 						.DoesNotComplyWith(it => it.HasDependenciesOutside(Types.InNamespace(Layer1Namespace)));
+				}
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("*AmbiguousA.AmbiguousTarget*AmbiguousB.AmbiguousTarget*").AsWildcard();
 			}
 
 			[Fact]
-			public async Task WhenNegated_ShouldFailForTypeWithDependencyOutside()
+			public async Task WhenReferencingOwnSubNamespace_ShouldFailByDefault()
 			{
-				Type subject = typeof(Layer1AndLayer2);
+				Type subject = typeof(ReferencesOwnSubNamespace);
 
 				async Task Act()
-					=> await That(subject)
-						.DoesNotComplyWith(it => it.HasDependenciesOutside(Types.InNamespace(Layer1Namespace)));
+				{
+					await That(subject).HasDependenciesOutside(Types.InNamespace(Layer1Namespace));
+				}
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage($"""
 					              Expected that subject
-					              does not have dependencies outside types within namespace "{Layer1Namespace}" in all loaded assemblies,
-					              but it also depended on ["TargetB"]
+					              has dependencies outside types within namespace "{Layer1Namespace}" in all loaded assemblies,
+					              but it only depended on the allowed types
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenTargetCollectionIsEmpty_DisallowedDependencyShouldSucceed()
+			{
+				Type subject = typeof(OnlyLayer1);
+
+				async Task Act()
+				{
+					await That(subject).HasDependenciesOutside(Types.InNamespace("Non.Existent.Namespace"));
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenTargetCollectionIsEmpty_FrameworkDependenciesStayInside()
+			{
+				Type subject = typeof(FrameworkConsumer);
+
+				async Task Act()
+				{
+					await That(subject).HasDependenciesOutside(Types.InNamespace("Non.Existent.Namespace"));
+				}
+
+				await That(Act).Throws<XunitException>();
+			}
+
+			[Fact]
+			public async Task WhenTargetCollectionIsEmpty_OwnNamespaceStaysInside()
+			{
+				Type subject = typeof(ReferencesOwnNamespace);
+
+				async Task Act()
+				{
+					await That(subject).HasDependenciesOutside(Types.InNamespace("Non.Existent.Namespace"));
+				}
+
+				await That(Act).Throws<XunitException>();
+			}
+
+			[Fact]
+			public async Task WhenTypeIsNull_ShouldFail()
+			{
+				Type? subject = null;
+
+				async Task Act()
+				{
+					await That(subject).HasDependenciesOutside(Types.InNamespace(Layer1Namespace));
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              has dependencies outside types within namespace "{Layer1Namespace}" in all loaded assemblies,
+					              but it was <null>
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenWidenedWithOrOn_ShouldFail()
+			{
+				Type subject = typeof(Layer1AndLayer2);
+
+				async Task Act()
+				{
+					await That(subject).HasDependenciesOutside(Types.InNamespace(Layer1Namespace))
+						.OrOn(Types.InNamespace(Layer2Namespace));
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              has dependencies outside types within namespace "{Layer1Namespace}" in all loaded assemblies or types within namespace "{Layer2Namespace}" in all loaded assemblies,
+					              but it only depended on the allowed types
 					              """);
 			}
 		}
@@ -412,7 +466,9 @@ public sealed partial class ThatType
 				Type subject = typeof(OnlyLayer1);
 
 				async Task Act()
-					=> await That(subject).DoesNotComplyWith(it => it.HasDependenciesOutside(Layer1Namespace));
+				{
+					await That(subject).DoesNotComplyWith(it => it.HasDependenciesOutside(Layer1Namespace));
+				}
 
 				await That(Act).DoesNotThrow();
 			}
@@ -423,7 +479,9 @@ public sealed partial class ThatType
 				Type subject = typeof(Layer1AndLayer2);
 
 				async Task Act()
-					=> await That(subject).DoesNotComplyWith(it => it.HasDependenciesOutside(Layer1Namespace));
+				{
+					await That(subject).DoesNotComplyWith(it => it.HasDependenciesOutside(Layer1Namespace));
+				}
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage($"""

--- a/Tests/aweXpect.Reflection.Tests/ThatType.HasOperator.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatType.HasOperator.Tests.cs
@@ -125,19 +125,6 @@ public sealed partial class ThatType
 			}
 
 			[Fact]
-			public async Task WhenTypeHasTheOperatorWithTypeOperand_ShouldSucceed()
-			{
-				Type subject = typeof(Money);
-
-				async Task Act()
-				{
-					await That(subject).HasOperator(Operator.Addition, typeof(Money));
-				}
-
-				await That(Act).DoesNotThrow();
-			}
-
-			[Fact]
 			public async Task WhenTypeHasTheOperatorWithOpenGenericOperand_ShouldSucceed()
 			{
 				Type subject = typeof(GenericBox<int>);
@@ -145,6 +132,19 @@ public sealed partial class ThatType
 				async Task Act()
 				{
 					await That(subject).HasOperator(Operator.Addition, typeof(GenericBox<>));
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenTypeHasTheOperatorWithTypeOperand_ShouldSucceed()
+			{
+				Type subject = typeof(Money);
+
+				async Task Act()
+				{
+					await That(subject).HasOperator(Operator.Addition, typeof(Money));
 				}
 
 				await That(Act).DoesNotThrow();

--- a/Tests/aweXpect.Reflection.Tests/ThatType.InheritsFrom.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatType.InheritsFrom.Tests.cs
@@ -1,4 +1,4 @@
-using Xunit.Sdk;
+﻿using Xunit.Sdk;
 
 namespace aweXpect.Reflection.Tests;
 

--- a/Tests/aweXpect.Reflection.Tests/ThatType.IsARefStruct.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatType.IsARefStruct.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Tests.TestHelpers.Types;
+﻿using aweXpect.Reflection.Tests.TestHelpers.Types;
 using Xunit.Sdk;
 
 namespace aweXpect.Reflection.Tests;

--- a/Tests/aweXpect.Reflection.Tests/ThatType.IsGeneric.WithArgument.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatType.IsGeneric.WithArgument.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Tests.TestHelpers;
+﻿using aweXpect.Reflection.Tests.TestHelpers;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 
 namespace aweXpect.Reflection.Tests;

--- a/Tests/aweXpect.Reflection.Tests/ThatType.IsGeneric.WithArgumentCount.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatType.IsGeneric.WithArgumentCount.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Tests.TestHelpers.Types;
+﻿using aweXpect.Reflection.Tests.TestHelpers.Types;
 
 namespace aweXpect.Reflection.Tests;
 

--- a/Tests/aweXpect.Reflection.Tests/ThatType.IsImmutable.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatType.IsImmutable.Tests.cs
@@ -9,58 +9,6 @@ public sealed partial class ThatType
 	{
 		public sealed class Tests
 		{
-			[Theory]
-			[MemberData(nameof(ImmutableTypes))]
-			public async Task WhenTypeIsImmutable_ShouldSucceed(Type subject)
-			{
-				async Task Act()
-				{
-					await That(subject).IsImmutable();
-				}
-
-				await That(Act).DoesNotThrow();
-			}
-
-			[Fact]
-			public async Task WhenTypeHasMutableField_ShouldFail()
-			{
-				Type subject = typeof(ClassWithMutableField);
-
-				async Task Act()
-				{
-					await That(subject).IsImmutable();
-				}
-
-				await That(Act).ThrowsException()
-					.WithMessage("""
-					             Expected that subject
-					             is immutable,
-					             but it was mutable ClassWithMutableField with mutable members [
-					               int ClassWithMutableField.Value
-					             ]
-					             """);
-			}
-
-			[Fact]
-			public async Task WhenTypeHasSettableProperty_ShouldFail()
-			{
-				Type subject = typeof(ClassWithSettableProperty);
-
-				async Task Act()
-				{
-					await That(subject).IsImmutable();
-				}
-
-				await That(Act).ThrowsException()
-					.WithMessage("""
-					             Expected that subject
-					             is immutable,
-					             but it was mutable ClassWithSettableProperty with mutable members [
-					               public int ClassWithSettableProperty.Value { get; set; }
-					             ]
-					             """);
-			}
-
 			[Fact]
 			public async Task WhenTypeHasMultipleMutableMembers_ShouldFail()
 			{
@@ -83,9 +31,9 @@ public sealed partial class ThatType
 			}
 
 			[Fact]
-			public async Task WhenTypeInheritsMutableField_ShouldFail()
+			public async Task WhenTypeHasMutableField_ShouldFail()
 			{
-				Type subject = typeof(ClassInheritingMutableField);
+				Type subject = typeof(ClassWithMutableField);
 
 				async Task Act()
 				{
@@ -96,28 +44,8 @@ public sealed partial class ThatType
 					.WithMessage("""
 					             Expected that subject
 					             is immutable,
-					             but it was mutable ClassInheritingMutableField with mutable members [
-					               int MutableBaseClass._value
-					             ]
-					             """);
-			}
-
-			[Fact]
-			public async Task WhenTypeHasSettableIndexer_ShouldFail()
-			{
-				Type subject = typeof(ClassWithSettableIndexer);
-
-				async Task Act()
-				{
-					await That(subject).IsImmutable();
-				}
-
-				await That(Act).ThrowsException()
-					.WithMessage("""
-					             Expected that subject
-					             is immutable,
-					             but it was mutable ClassWithSettableIndexer with mutable members [
-					               public int ClassWithSettableIndexer.Item { get; set; }
+					             but it was mutable ClassWithMutableField with mutable members [
+					               int ClassWithMutableField.Value
 					             ]
 					             """);
 			}
@@ -143,6 +71,66 @@ public sealed partial class ThatType
 			}
 
 			[Fact]
+			public async Task WhenTypeHasSettableIndexer_ShouldFail()
+			{
+				Type subject = typeof(ClassWithSettableIndexer);
+
+				async Task Act()
+				{
+					await That(subject).IsImmutable();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             is immutable,
+					             but it was mutable ClassWithSettableIndexer with mutable members [
+					               public int ClassWithSettableIndexer.Item { get; set; }
+					             ]
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenTypeHasSettableProperty_ShouldFail()
+			{
+				Type subject = typeof(ClassWithSettableProperty);
+
+				async Task Act()
+				{
+					await That(subject).IsImmutable();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             is immutable,
+					             but it was mutable ClassWithSettableProperty with mutable members [
+					               public int ClassWithSettableProperty.Value { get; set; }
+					             ]
+					             """);
+			}
+
+			[Fact]
+			public async Task WhenTypeInheritsMutableField_ShouldFail()
+			{
+				Type subject = typeof(ClassInheritingMutableField);
+
+				async Task Act()
+				{
+					await That(subject).IsImmutable();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             is immutable,
+					             but it was mutable ClassInheritingMutableField with mutable members [
+					               int MutableBaseClass._value
+					             ]
+					             """);
+			}
+
+			[Fact]
 			public async Task WhenTypeInheritsProtectedMutableField_ShouldFail()
 			{
 				Type subject = typeof(ClassInheritingProtectedMutableField);
@@ -159,6 +147,36 @@ public sealed partial class ThatType
 					             but it was mutable ClassInheritingProtectedMutableField with mutable members [
 					               int MutableBaseClassWithProtectedField.ProtectedValue
 					             ]
+					             """);
+			}
+
+			[Theory]
+			[MemberData(nameof(ImmutableTypes))]
+			public async Task WhenTypeIsImmutable_ShouldSucceed(Type subject)
+			{
+				async Task Act()
+				{
+					await That(subject).IsImmutable();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenTypeIsNull_ShouldFail()
+			{
+				Type? subject = null;
+
+				async Task Act()
+				{
+					await That(subject).IsImmutable();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             is immutable,
+					             but it was <null>
 					             """);
 			}
 
@@ -179,24 +197,6 @@ public sealed partial class ThatType
 					             but it was mutable MutableRecordStruct with mutable members [
 					               public int MutableRecordStruct.Value { get; set; }
 					             ]
-					             """);
-			}
-
-			[Fact]
-			public async Task WhenTypeIsNull_ShouldFail()
-			{
-				Type? subject = null;
-
-				async Task Act()
-				{
-					await That(subject).IsImmutable();
-				}
-
-				await That(Act).ThrowsException()
-					.WithMessage("""
-					             Expected that subject
-					             is immutable,
-					             but it was <null>
 					             """);
 			}
 

--- a/Tests/aweXpect.Reflection.Tests/ThatType.IsNotARefStruct.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatType.IsNotARefStruct.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Tests.TestHelpers.Types;
+﻿using aweXpect.Reflection.Tests.TestHelpers.Types;
 using Xunit.Sdk;
 
 namespace aweXpect.Reflection.Tests;

--- a/Tests/aweXpect.Reflection.Tests/ThatType.IsNotImmutable.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatType.IsNotImmutable.Tests.cs
@@ -9,18 +9,6 @@ public sealed partial class ThatType
 	{
 		public sealed class Tests
 		{
-			[Theory]
-			[MemberData(nameof(MutableTypes))]
-			public async Task WhenTypeIsMutable_ShouldSucceed(Type subject)
-			{
-				async Task Act()
-				{
-					await That(subject).IsNotImmutable();
-				}
-
-				await That(Act).DoesNotThrow();
-			}
-
 			[Fact]
 			public async Task WhenTypeIsImmutable_ShouldFail()
 			{
@@ -37,6 +25,18 @@ public sealed partial class ThatType
 					             is not immutable,
 					             but it was immutable ImmutableClass
 					             """);
+			}
+
+			[Theory]
+			[MemberData(nameof(MutableTypes))]
+			public async Task WhenTypeIsMutable_ShouldSucceed(Type subject)
+			{
+				async Task Act()
+				{
+					await That(subject).IsNotImmutable();
+				}
+
+				await That(Act).DoesNotThrow();
 			}
 
 			[Fact]

--- a/Tests/aweXpect.Reflection.Tests/ThatType.IsNotObsolete.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatType.IsNotObsolete.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Tests.TestHelpers.Types;
+﻿using aweXpect.Reflection.Tests.TestHelpers.Types;
 using Xunit.Sdk;
 
 namespace aweXpect.Reflection.Tests;

--- a/Tests/aweXpect.Reflection.Tests/ThatType.IsNotReadOnly.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatType.IsNotReadOnly.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Tests.TestHelpers.Types;
+﻿using aweXpect.Reflection.Tests.TestHelpers.Types;
 
 namespace aweXpect.Reflection.Tests;
 

--- a/Tests/aweXpect.Reflection.Tests/ThatType.IsObsolete.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatType.IsObsolete.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Tests.TestHelpers.Types;
+﻿using aweXpect.Reflection.Tests.TestHelpers.Types;
 using Xunit.Sdk;
 
 namespace aweXpect.Reflection.Tests;

--- a/Tests/aweXpect.Reflection.Tests/ThatType.IsReadOnly.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatType.IsReadOnly.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Tests.TestHelpers.Types;
+﻿using aweXpect.Reflection.Tests.TestHelpers.Types;
 using Xunit.Sdk;
 
 namespace aweXpect.Reflection.Tests;

--- a/Tests/aweXpect.Reflection.Tests/ThatType.OnlyHasNonNullableMembers.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatType.OnlyHasNonNullableMembers.Tests.cs
@@ -10,16 +10,23 @@ public sealed partial class ThatType
 		public sealed class Tests
 		{
 			[Fact]
-			public async Task WhenTypeOnlyHasNonNullableMembers_ShouldSucceed()
+			public async Task WhenTypeHasMixedMembers_ShouldFail()
 			{
-				Type subject = typeof(ClassWithNonNullableMembers);
+				Type subject = typeof(ClassWithMixedNullableMembers);
 
 				async Task Act()
 				{
 					await That(subject).OnlyHasNonNullableMembers();
 				}
 
-				await That(Act).DoesNotThrow();
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             only has non-nullable members,
+					             but it contained nullable members [
+					               *
+					             ]
+					             """).AsWildcard();
 			}
 
 			[Fact]
@@ -58,26 +65,6 @@ public sealed partial class ThatType
 			}
 
 			[Fact]
-			public async Task WhenTypeHasMixedMembers_ShouldFail()
-			{
-				Type subject = typeof(ClassWithMixedNullableMembers);
-
-				async Task Act()
-				{
-					await That(subject).OnlyHasNonNullableMembers();
-				}
-
-				await That(Act).ThrowsException()
-					.WithMessage("""
-					             Expected that subject
-					             only has non-nullable members,
-					             but it contained nullable members [
-					               *
-					             ]
-					             """).AsWildcard();
-			}
-
-			[Fact]
 			public async Task WhenTypeIsNull_ShouldFail()
 			{
 				Type? subject = null;
@@ -93,6 +80,19 @@ public sealed partial class ThatType
 					             only has non-nullable members,
 					             but it was <null>
 					             """);
+			}
+
+			[Fact]
+			public async Task WhenTypeOnlyHasNonNullableMembers_ShouldSucceed()
+			{
+				Type subject = typeof(ClassWithNonNullableMembers);
+
+				async Task Act()
+				{
+					await That(subject).OnlyHasNonNullableMembers();
+				}
+
+				await That(Act).DoesNotThrow();
 			}
 		}
 

--- a/Tests/aweXpect.Reflection.Tests/ThatType.OnlyHasNullableMembers.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatType.OnlyHasNullableMembers.Tests.cs
@@ -11,9 +11,9 @@ public sealed partial class ThatType
 		public sealed class Tests
 		{
 			[Fact]
-			public async Task WhenTypeOnlyHasNullableMembers_ShouldSucceed()
+			public async Task WhenBaseTypeHasNonNullableMembers_ShouldSucceed()
 			{
-				Type subject = typeof(ClassWithNullableMembers);
+				Type subject = typeof(DerivedClassWithNullableMembers);
 
 				async Task Act()
 				{
@@ -21,6 +21,26 @@ public sealed partial class ThatType
 				}
 
 				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenTypeHasMixedMembers_ShouldFail()
+			{
+				Type subject = typeof(ClassWithMixedNullableMembers);
+
+				async Task Act()
+				{
+					await That(subject).OnlyHasNullableMembers();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             only has nullable members,
+					             but it contained non-nullable members [
+					               *
+					             ]
+					             """).AsWildcard();
 			}
 
 			[Fact]
@@ -59,9 +79,9 @@ public sealed partial class ThatType
 			}
 
 			[Fact]
-			public async Task WhenTypeHasMixedMembers_ShouldFail()
+			public async Task WhenTypeIsNull_ShouldFail()
 			{
-				Type subject = typeof(ClassWithMixedNullableMembers);
+				Type? subject = null;
 
 				async Task Act()
 				{
@@ -72,16 +92,14 @@ public sealed partial class ThatType
 					.WithMessage("""
 					             Expected that subject
 					             only has nullable members,
-					             but it contained non-nullable members [
-					               *
-					             ]
-					             """).AsWildcard();
+					             but it was <null>
+					             """);
 			}
 
 			[Fact]
-			public async Task WhenBaseTypeHasNonNullableMembers_ShouldSucceed()
+			public async Task WhenTypeOnlyHasNullableMembers_ShouldSucceed()
 			{
-				Type subject = typeof(DerivedClassWithNullableMembers);
+				Type subject = typeof(ClassWithNullableMembers);
 
 				async Task Act()
 				{
@@ -109,24 +127,6 @@ public sealed partial class ThatType
 					               *
 					             ]
 					             """).AsWildcard();
-			}
-
-			[Fact]
-			public async Task WhenTypeIsNull_ShouldFail()
-			{
-				Type? subject = null;
-
-				async Task Act()
-				{
-					await That(subject).OnlyHasNullableMembers();
-				}
-
-				await That(Act).ThrowsException()
-					.WithMessage("""
-					             Expected that subject
-					             only has nullable members,
-					             but it was <null>
-					             """);
 			}
 		}
 

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.AreGeneric.WithArgument.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.AreGeneric.WithArgument.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Tests.TestHelpers;
 
 namespace aweXpect.Reflection.Tests;

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.AreGeneric.WithArgumentCount.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.AreGeneric.WithArgumentCount.Tests.cs
@@ -1,4 +1,4 @@
-using aweXpect.Reflection.Collections;
+﻿using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 
 namespace aweXpect.Reflection.Tests;

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.AreNotObsolete.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.AreNotObsolete.Tests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using aweXpect.Reflection.Tests.TestHelpers;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.AreNotReadOnly.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.AreNotReadOnly.Tests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 using Xunit.Sdk;
 #if NET8_0_OR_GREATER

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.AreNotRefStructs.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.AreNotRefStructs.Tests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 using Xunit.Sdk;
 #if NET8_0_OR_GREATER

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.AreObsolete.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.AreObsolete.Tests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using aweXpect.Reflection.Tests.TestHelpers;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.AreReadOnly.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.AreReadOnly.Tests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 using Xunit.Sdk;
 #if NET8_0_OR_GREATER

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.AreRefStructs.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.AreRefStructs.Tests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using aweXpect.Reflection.Tests.TestHelpers.Types;
 using Xunit.Sdk;
 #if NET8_0_OR_GREATER

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.DependOn.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.DependOn.Tests.cs
@@ -23,9 +23,25 @@ public sealed partial class ThatTypes
 				];
 
 				async Task Act()
-					=> await That(subject).DependOn(Layer1Namespace);
+				{
+					await That(subject).DependOn(Layer1Namespace);
+				}
 
 				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenNoNamespaceIsSpecified_ShouldThrowArgumentException()
+			{
+				IEnumerable<Type?> subject = [typeof(OnlyLayer1),];
+
+				async Task Act()
+				{
+					await That(subject).DependOn();
+				}
+
+				await That(Act).Throws<ArgumentException>()
+					.WithMessage("At least one namespace must be specified.");
 			}
 
 			[Fact]
@@ -38,7 +54,9 @@ public sealed partial class ThatTypes
 				];
 
 				async Task Act()
-					=> await That(subject).DependOn(Layer1Namespace);
+				{
+					await That(subject).DependOn(Layer1Namespace);
+				}
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage($"""
@@ -51,18 +69,6 @@ public sealed partial class ThatTypes
 			}
 
 			[Fact]
-			public async Task WhenNoNamespaceIsSpecified_ShouldThrowArgumentException()
-			{
-				IEnumerable<Type?> subject = [typeof(OnlyLayer1),];
-
-				async Task Act()
-					=> await That(subject).DependOn();
-
-				await That(Act).Throws<ArgumentException>()
-					.WithMessage("At least one namespace must be specified.");
-			}
-
-			[Fact]
 			public async Task WhenWidenedWithOrOn_ShouldSucceed()
 			{
 				IEnumerable<Type?> subject =
@@ -72,7 +78,9 @@ public sealed partial class ThatTypes
 				];
 
 				async Task Act()
-					=> await That(subject).DependOn("Non.Existent.Namespace").OrOn(Layer1Namespace);
+				{
+					await That(subject).DependOn("Non.Existent.Namespace").OrOn(Layer1Namespace);
+				}
 
 				await That(Act).DoesNotThrow();
 			}
@@ -91,7 +99,9 @@ public sealed partial class ThatTypes
 				];
 
 				async Task Act()
-					=> await That(subject).DependOn(Types.InNamespace(Layer1Namespace));
+				{
+					await That(subject).DependOn(Types.InNamespace(Layer1Namespace));
+				}
 
 				await That(Act).DoesNotThrow();
 			}
@@ -106,7 +116,9 @@ public sealed partial class ThatTypes
 				];
 
 				async Task Act()
-					=> await That(subject).DependOn(Types.InNamespace(Layer1Namespace));
+				{
+					await That(subject).DependOn(Types.InNamespace(Layer1Namespace));
+				}
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage($"""
@@ -128,8 +140,10 @@ public sealed partial class ThatTypes
 				];
 
 				async Task Act()
-					=> await That(subject).DependOn(Types.InNamespace("Non.Existent.Namespace"))
+				{
+					await That(subject).DependOn(Types.InNamespace("Non.Existent.Namespace"))
 						.OrOn(Types.InNamespace(Layer1Namespace));
+				}
 
 				await That(Act).DoesNotThrow();
 			}

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.DependOnlyOn.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.DependOnlyOn.Tests.cs
@@ -24,53 +24,11 @@ public sealed partial class ThatTypes
 				];
 
 				async Task Act()
-					=> await That(subject).DependOnlyOn(Layer1Namespace);
+				{
+					await That(subject).DependOnlyOn(Layer1Namespace);
+				}
 
 				await That(Act).DoesNotThrow();
-			}
-
-			[Fact]
-			public async Task WhenSomeTypeDependsOnDisallowedNamespace_ShouldFail()
-			{
-				IEnumerable<Type?> subject =
-				[
-					typeof(OnlyLayer1),
-					typeof(Layer1AndLayer2),
-				];
-
-				async Task Act()
-					=> await That(subject).DependOnlyOn(Layer1Namespace);
-
-				await That(Act).Throws<XunitException>()
-					.WithMessage($"""
-					              Expected that subject
-					              all depend only on namespace "{Layer1Namespace}",
-					              but it contained types with disallowed dependencies [
-					                Layer1AndLayer2 depends on ["{Layer2Namespace}"]
-					              ]
-					              """);
-			}
-
-			[Fact]
-			public async Task WhenCollectionContainsNull_ShouldListNullWithoutViolations()
-			{
-				IEnumerable<Type?> subject =
-				[
-					typeof(OnlyLayer1),
-					null,
-				];
-
-				async Task Act()
-					=> await That(subject).DependOnlyOn(Layer1Namespace);
-
-				await That(Act).Throws<XunitException>()
-					.WithMessage($"""
-					              Expected that subject
-					              all depend only on namespace "{Layer1Namespace}",
-					              but it contained types with disallowed dependencies [
-					                <null>
-					              ]
-					              """);
 			}
 
 			[Fact]
@@ -83,9 +41,59 @@ public sealed partial class ThatTypes
 				];
 
 				async Task Act()
-					=> await That(subject).DependOnlyOn(Layer1Namespace, Layer2Namespace);
+				{
+					await That(subject).DependOnlyOn(Layer1Namespace, Layer2Namespace);
+				}
 
 				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenCollectionContainsNull_ShouldListNullWithoutViolations()
+			{
+				IEnumerable<Type?> subject =
+				[
+					typeof(OnlyLayer1),
+					null,
+				];
+
+				async Task Act()
+				{
+					await That(subject).DependOnlyOn(Layer1Namespace);
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              all depend only on namespace "{Layer1Namespace}",
+					              but it contained types with disallowed dependencies [
+					                <null>
+					              ]
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenSomeTypeDependsOnDisallowedNamespace_ShouldFail()
+			{
+				IEnumerable<Type?> subject =
+				[
+					typeof(OnlyLayer1),
+					typeof(Layer1AndLayer2),
+				];
+
+				async Task Act()
+				{
+					await That(subject).DependOnlyOn(Layer1Namespace);
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              all depend only on namespace "{Layer1Namespace}",
+					              but it contained types with disallowed dependencies [
+					                Layer1AndLayer2 depends on ["{Layer2Namespace}"]
+					              ]
+					              """);
 			}
 		}
 
@@ -102,9 +110,36 @@ public sealed partial class ThatTypes
 				];
 
 				async Task Act()
-					=> await That(subject).DependOnlyOn(Types.InNamespace(Layer1Namespace));
+				{
+					await That(subject).DependOnlyOn(Types.InNamespace(Layer1Namespace));
+				}
 
 				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenExcludingOwnSubNamespaces_OwnSubNamespaceBecomesViolation()
+			{
+				IEnumerable<Type?> subject =
+				[
+					typeof(OnlyLayer1),
+					typeof(ReferencesOwnSubNamespace),
+				];
+
+				async Task Act()
+				{
+					await That(subject).DependOnlyOn(Types.InNamespace(Layer1Namespace))
+						.ExcludingOwnSubNamespaces();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              all depend only on types within namespace "{Layer1Namespace}" in all loaded assemblies,
+					              but it contained types with disallowed dependencies [
+					                ReferencesOwnSubNamespace depends on ["OwnSubTarget"]
+					              ]
+					              """);
 			}
 
 			[Fact]
@@ -117,7 +152,9 @@ public sealed partial class ThatTypes
 				];
 
 				async Task Act()
-					=> await That(subject).DependOnlyOn(Types.InNamespace(Layer1Namespace));
+				{
+					await That(subject).DependOnlyOn(Types.InNamespace(Layer1Namespace));
+				}
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage($"""
@@ -139,7 +176,9 @@ public sealed partial class ThatTypes
 				];
 
 				async Task Act()
-					=> await That(subject).DependOnlyOn(Types.InNamespace("Non.Existent.Namespace"));
+				{
+					await That(subject).DependOnlyOn(Types.InNamespace("Non.Existent.Namespace"));
+				}
 
 				await That(Act).DoesNotThrow();
 			}
@@ -154,33 +193,12 @@ public sealed partial class ThatTypes
 				];
 
 				async Task Act()
-					=> await That(subject).DependOnlyOn(Types.InNamespace(Layer1Namespace))
+				{
+					await That(subject).DependOnlyOn(Types.InNamespace(Layer1Namespace))
 						.OrOn(Types.InNamespace(Layer2Namespace));
+				}
 
 				await That(Act).DoesNotThrow();
-			}
-
-			[Fact]
-			public async Task WhenExcludingOwnSubNamespaces_OwnSubNamespaceBecomesViolation()
-			{
-				IEnumerable<Type?> subject =
-				[
-					typeof(OnlyLayer1),
-					typeof(ReferencesOwnSubNamespace),
-				];
-
-				async Task Act()
-					=> await That(subject).DependOnlyOn(Types.InNamespace(Layer1Namespace))
-						.ExcludingOwnSubNamespaces();
-
-				await That(Act).Throws<XunitException>()
-					.WithMessage($"""
-					              Expected that subject
-					              all depend only on types within namespace "{Layer1Namespace}" in all loaded assemblies,
-					              but it contained types with disallowed dependencies [
-					                ReferencesOwnSubNamespace depends on ["OwnSubTarget"]
-					              ]
-					              """);
 			}
 		}
 	}

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.DoNotDependOn.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.DoNotDependOn.Tests.cs
@@ -14,6 +14,32 @@ public sealed partial class ThatTypes
 		public sealed class Tests
 		{
 			[Fact]
+			public async Task WhenCollectionContainsNull_ShouldFail()
+			{
+				// A null item's dependencies cannot be verified, so it fails the negative assertion just
+				// like it fails DependOn and DependOnlyOn, instead of slipping through.
+				IEnumerable<Type?> subject =
+				[
+					typeof(OnlyLayer1),
+					null,
+				];
+
+				async Task Act()
+				{
+					await That(subject).DoNotDependOn(Layer2Namespace);
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              all do not depend on namespace "{Layer2Namespace}",
+					              but it contained types with the dependency [
+					                <null>
+					              ]
+					              """);
+			}
+
+			[Fact]
 			public async Task WhenNoTypeDependsOnNamespace_ShouldSucceed()
 			{
 				IEnumerable<Type?> subject =
@@ -23,7 +49,9 @@ public sealed partial class ThatTypes
 				];
 
 				async Task Act()
-					=> await That(subject).DoNotDependOn(Layer2Namespace);
+				{
+					await That(subject).DoNotDependOn(Layer2Namespace);
+				}
 
 				await That(Act).DoesNotThrow();
 			}
@@ -38,7 +66,9 @@ public sealed partial class ThatTypes
 				];
 
 				async Task Act()
-					=> await That(subject).DoNotDependOn(Layer2Namespace);
+				{
+					await That(subject).DoNotDependOn(Layer2Namespace);
+				}
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage($"""
@@ -46,30 +76,6 @@ public sealed partial class ThatTypes
 					              all do not depend on namespace "{Layer2Namespace}",
 					              but it contained types with the dependency [
 					                Layer1AndLayer2
-					              ]
-					              """);
-			}
-
-			[Fact]
-			public async Task WhenCollectionContainsNull_ShouldFail()
-			{
-				// A null item's dependencies cannot be verified, so it fails the negative assertion just
-				// like it fails DependOn and DependOnlyOn, instead of slipping through.
-				IEnumerable<Type?> subject =
-				[
-					typeof(OnlyLayer1),
-					null,
-				];
-
-				async Task Act()
-					=> await That(subject).DoNotDependOn(Layer2Namespace);
-
-				await That(Act).Throws<XunitException>()
-					.WithMessage($"""
-					              Expected that subject
-					              all do not depend on namespace "{Layer2Namespace}",
-					              but it contained types with the dependency [
-					                <null>
 					              ]
 					              """);
 			}
@@ -87,7 +93,9 @@ public sealed partial class ThatTypes
 				];
 
 				async Task Act()
-					=> await That(subject).DoNotDependOn(Types.InNamespace(Layer2Namespace));
+				{
+					await That(subject).DoNotDependOn(Types.InNamespace(Layer2Namespace));
+				}
 
 				await That(Act).DoesNotThrow();
 			}
@@ -102,7 +110,9 @@ public sealed partial class ThatTypes
 				];
 
 				async Task Act()
-					=> await That(subject).DoNotDependOn(Types.InNamespace(Layer2Namespace));
+				{
+					await That(subject).DoNotDependOn(Types.InNamespace(Layer2Namespace));
+				}
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage($"""
@@ -125,7 +135,9 @@ public sealed partial class ThatTypes
 				];
 
 				async Task Act()
-					=> await That(subject).DoNotDependOn(Types.InNamespace("Non.Existent.Namespace"));
+				{
+					await That(subject).DoNotDependOn(Types.InNamespace("Non.Existent.Namespace"));
+				}
 
 				await That(Act).DoesNotThrow();
 			}
@@ -139,8 +151,10 @@ public sealed partial class ThatTypes
 				];
 
 				async Task Act()
-					=> await That(subject).DoNotDependOn(Types.InNamespace(Layer2Namespace))
+				{
+					await That(subject).DoNotDependOn(Types.InNamespace(Layer2Namespace))
 						.OrOn(Types.InNamespace(Layer1Namespace));
+				}
 
 				await That(Act).Throws<XunitException>();
 			}

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.DoNotInheritFrom.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.DoNotInheritFrom.Tests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using aweXpect.Reflection.Collections;
 using Xunit.Sdk;
 

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.HaveDependenciesOutside.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.HaveDependenciesOutside.Tests.cs
@@ -17,6 +17,29 @@ public sealed partial class ThatTypes
 		public sealed class Tests
 		{
 			[Fact]
+			public async Task WhenAllowingAllNamespaces_ShouldFail()
+			{
+				IEnumerable<Type?> subject =
+				[
+					typeof(Layer1AndLayer2),
+				];
+
+				async Task Act()
+				{
+					await That(subject).HaveDependenciesOutside(Layer1Namespace, Layer2Namespace);
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              all have dependencies outside namespace "{Layer1Namespace}" or "{Layer2Namespace}",
+					              but it contained types depending only on the allowed namespaces [
+					                Layer1AndLayer2
+					              ]
+					              """);
+			}
+
+			[Fact]
 			public async Task WhenAllTypesHaveDependenciesOutside_ShouldSucceed()
 			{
 				IEnumerable<Type?> subject =
@@ -26,31 +49,11 @@ public sealed partial class ThatTypes
 				];
 
 				async Task Act()
-					=> await That(subject).HaveDependenciesOutside(Layer1Namespace);
+				{
+					await That(subject).HaveDependenciesOutside(Layer1Namespace);
+				}
 
 				await That(Act).DoesNotThrow();
-			}
-
-			[Fact]
-			public async Task WhenSomeTypeDependsOnlyOnAllowedNamespaces_ShouldFail()
-			{
-				IEnumerable<Type?> subject =
-				[
-					typeof(Layer1AndLayer2),
-					typeof(OnlyLayer1),
-				];
-
-				async Task Act()
-					=> await That(subject).HaveDependenciesOutside(Layer1Namespace);
-
-				await That(Act).Throws<XunitException>()
-					.WithMessage($"""
-					              Expected that subject
-					              all have dependencies outside namespace "{Layer1Namespace}",
-					              but it contained types depending only on the allowed namespaces [
-					                OnlyLayer1
-					              ]
-					              """);
 			}
 
 			[Fact]
@@ -63,7 +66,9 @@ public sealed partial class ThatTypes
 				];
 
 				async Task Act()
-					=> await That(subject).HaveDependenciesOutside(Layer1Namespace);
+				{
+					await That(subject).HaveDependenciesOutside(Layer1Namespace);
+				}
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage($"""
@@ -76,22 +81,25 @@ public sealed partial class ThatTypes
 			}
 
 			[Fact]
-			public async Task WhenAllowingAllNamespaces_ShouldFail()
+			public async Task WhenSomeTypeDependsOnlyOnAllowedNamespaces_ShouldFail()
 			{
 				IEnumerable<Type?> subject =
 				[
 					typeof(Layer1AndLayer2),
+					typeof(OnlyLayer1),
 				];
 
 				async Task Act()
-					=> await That(subject).HaveDependenciesOutside(Layer1Namespace, Layer2Namespace);
+				{
+					await That(subject).HaveDependenciesOutside(Layer1Namespace);
+				}
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage($"""
 					              Expected that subject
-					              all have dependencies outside namespace "{Layer1Namespace}" or "{Layer2Namespace}",
+					              all have dependencies outside namespace "{Layer1Namespace}",
 					              but it contained types depending only on the allowed namespaces [
-					                Layer1AndLayer2
+					                OnlyLayer1
 					              ]
 					              """);
 			}
@@ -106,7 +114,9 @@ public sealed partial class ThatTypes
 				}.ToTestAsyncEnumerable<Type?>();
 
 				async Task Act()
-					=> await That(subject).HaveDependenciesOutside(Layer1Namespace);
+				{
+					await That(subject).HaveDependenciesOutside(Layer1Namespace);
+				}
 
 				await That(Act).DoesNotThrow();
 			}
@@ -120,7 +130,9 @@ public sealed partial class ThatTypes
 				}.ToTestAsyncEnumerable<Type?>();
 
 				async Task Act()
-					=> await That(subject).HaveDependenciesOutside(Layer1Namespace);
+				{
+					await That(subject).HaveDependenciesOutside(Layer1Namespace);
+				}
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage($"""
@@ -146,31 +158,11 @@ public sealed partial class ThatTypes
 				];
 
 				async Task Act()
-					=> await That(subject).HaveDependenciesOutside(Types.InNamespace(Layer1Namespace));
+				{
+					await That(subject).HaveDependenciesOutside(Types.InNamespace(Layer1Namespace));
+				}
 
 				await That(Act).DoesNotThrow();
-			}
-
-			[Fact]
-			public async Task WhenSomeTypeDependsOnlyOnTargetCollections_ShouldFail()
-			{
-				IEnumerable<Type?> subject =
-				[
-					typeof(Layer1AndLayer2),
-					typeof(OnlyLayer1),
-				];
-
-				async Task Act()
-					=> await That(subject).HaveDependenciesOutside(Types.InNamespace(Layer1Namespace));
-
-				await That(Act).Throws<XunitException>()
-					.WithMessage($"""
-					              Expected that subject
-					              all have dependencies outside types within namespace "{Layer1Namespace}" in all loaded assemblies,
-					              but it contained types depending only on the allowed types [
-					                OnlyLayer1
-					              ]
-					              """);
 			}
 
 			[Fact]
@@ -183,7 +175,9 @@ public sealed partial class ThatTypes
 				];
 
 				async Task Act()
-					=> await That(subject).HaveDependenciesOutside(Types.InNamespace(Layer1Namespace));
+				{
+					await That(subject).HaveDependenciesOutside(Types.InNamespace(Layer1Namespace));
+				}
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage($"""
@@ -191,49 +185,6 @@ public sealed partial class ThatTypes
 					              all have dependencies outside types within namespace "{Layer1Namespace}" in all loaded assemblies,
 					              but it contained types depending only on the allowed types [
 					                <null>
-					              ]
-					              """);
-			}
-
-			[Fact]
-			public async Task WhenWidenedWithOrOn_ShouldFail()
-			{
-				IEnumerable<Type?> subject =
-				[
-					typeof(Layer1AndLayer2),
-				];
-
-				async Task Act()
-					=> await That(subject).HaveDependenciesOutside(Types.InNamespace(Layer1Namespace))
-						.OrOn(Types.InNamespace(Layer2Namespace));
-
-				await That(Act).Throws<XunitException>()
-					.WithMessage($"""
-					              Expected that subject
-					              all have dependencies outside types within namespace "{Layer1Namespace}" in all loaded assemblies or types within namespace "{Layer2Namespace}" in all loaded assemblies,
-					              but it contained types depending only on the allowed types [
-					                Layer1AndLayer2
-					              ]
-					              """);
-			}
-
-			[Fact]
-			public async Task WhenReferencingOwnSubNamespace_ShouldFailByDefault()
-			{
-				IEnumerable<Type?> subject =
-				[
-					typeof(ReferencesOwnSubNamespace),
-				];
-
-				async Task Act()
-					=> await That(subject).HaveDependenciesOutside(Types.InNamespace(Layer1Namespace));
-
-				await That(Act).Throws<XunitException>()
-					.WithMessage($"""
-					              Expected that subject
-					              all have dependencies outside types within namespace "{Layer1Namespace}" in all loaded assemblies,
-					              but it contained types depending only on the allowed types [
-					                ReferencesOwnSubNamespace
 					              ]
 					              """);
 			}
@@ -247,61 +198,10 @@ public sealed partial class ThatTypes
 				];
 
 				async Task Act()
-					=> await That(subject).HaveDependenciesOutside(Types.InNamespace(Layer1Namespace))
+				{
+					await That(subject).HaveDependenciesOutside(Types.InNamespace(Layer1Namespace))
 						.ExcludingOwnSubNamespaces();
-
-				await That(Act).DoesNotThrow();
-			}
-
-#if NET8_0_OR_GREATER
-			[Fact]
-			public async Task WhenAsyncEnumerableTypesHaveDependenciesOutsideTargetCollection_ShouldSucceed()
-			{
-				IAsyncEnumerable<Type?> subject = new[]
-				{
-					typeof(Layer1AndLayer2), typeof(OnlyLayer2),
-				}.ToTestAsyncEnumerable<Type?>();
-
-				async Task Act()
-					=> await That(subject).HaveDependenciesOutside(Types.InNamespace(Layer1Namespace));
-
-				await That(Act).DoesNotThrow();
-			}
-
-			[Fact]
-			public async Task WhenAsyncEnumerableContainsTypeDependingOnlyOnTargetCollections_ShouldFail()
-			{
-				IAsyncEnumerable<Type?> subject = new[]
-				{
-					typeof(Layer1AndLayer2), typeof(OnlyLayer1),
-				}.ToTestAsyncEnumerable<Type?>();
-
-				async Task Act()
-					=> await That(subject).HaveDependenciesOutside(Types.InNamespace(Layer1Namespace));
-
-				await That(Act).Throws<XunitException>()
-					.WithMessage($"""
-					              Expected that subject
-					              all have dependencies outside types within namespace "{Layer1Namespace}" in all loaded assemblies,
-					              but it contained types depending only on the allowed types [
-					                OnlyLayer1
-					              ]
-					              """);
-			}
-#endif
-
-			[Fact]
-			public async Task WhenNegated_ShouldSucceedWhenSomeTypeDependsOnlyOnTargetCollections()
-			{
-				IEnumerable<Type?> subject =
-				[
-					typeof(Layer1AndLayer2),
-					typeof(OnlyLayer1),
-				];
-
-				async Task Act()
-					=> await That(subject)
-						.DoesNotComplyWith(they => they.HaveDependenciesOutside(Types.InNamespace(Layer1Namespace)));
+				}
 
 				await That(Act).DoesNotThrow();
 			}
@@ -316,8 +216,10 @@ public sealed partial class ThatTypes
 				];
 
 				async Task Act()
-					=> await That(subject)
+				{
+					await That(subject)
 						.DoesNotComplyWith(they => they.HaveDependenciesOutside(Types.InNamespace(Layer1Namespace)));
+				}
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage($"""
@@ -329,12 +231,9 @@ public sealed partial class ThatTypes
 					              ]
 					              """);
 			}
-		}
 
-		public sealed class NegatedTests
-		{
 			[Fact]
-			public async Task WhenSomeTypeDependsOnlyOnAllowedNamespaces_ShouldSucceed()
+			public async Task WhenNegated_ShouldSucceedWhenSomeTypeDependsOnlyOnTargetCollections()
 			{
 				IEnumerable<Type?> subject =
 				[
@@ -343,12 +242,129 @@ public sealed partial class ThatTypes
 				];
 
 				async Task Act()
-					=> await That(subject)
-						.DoesNotComplyWith(they => they.HaveDependenciesOutside(Layer1Namespace));
+				{
+					await That(subject)
+						.DoesNotComplyWith(they => they.HaveDependenciesOutside(Types.InNamespace(Layer1Namespace)));
+				}
 
 				await That(Act).DoesNotThrow();
 			}
 
+			[Fact]
+			public async Task WhenReferencingOwnSubNamespace_ShouldFailByDefault()
+			{
+				IEnumerable<Type?> subject =
+				[
+					typeof(ReferencesOwnSubNamespace),
+				];
+
+				async Task Act()
+				{
+					await That(subject).HaveDependenciesOutside(Types.InNamespace(Layer1Namespace));
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              all have dependencies outside types within namespace "{Layer1Namespace}" in all loaded assemblies,
+					              but it contained types depending only on the allowed types [
+					                ReferencesOwnSubNamespace
+					              ]
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenSomeTypeDependsOnlyOnTargetCollections_ShouldFail()
+			{
+				IEnumerable<Type?> subject =
+				[
+					typeof(Layer1AndLayer2),
+					typeof(OnlyLayer1),
+				];
+
+				async Task Act()
+				{
+					await That(subject).HaveDependenciesOutside(Types.InNamespace(Layer1Namespace));
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              all have dependencies outside types within namespace "{Layer1Namespace}" in all loaded assemblies,
+					              but it contained types depending only on the allowed types [
+					                OnlyLayer1
+					              ]
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenWidenedWithOrOn_ShouldFail()
+			{
+				IEnumerable<Type?> subject =
+				[
+					typeof(Layer1AndLayer2),
+				];
+
+				async Task Act()
+				{
+					await That(subject).HaveDependenciesOutside(Types.InNamespace(Layer1Namespace))
+						.OrOn(Types.InNamespace(Layer2Namespace));
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              all have dependencies outside types within namespace "{Layer1Namespace}" in all loaded assemblies or types within namespace "{Layer2Namespace}" in all loaded assemblies,
+					              but it contained types depending only on the allowed types [
+					                Layer1AndLayer2
+					              ]
+					              """);
+			}
+
+#if NET8_0_OR_GREATER
+			[Fact]
+			public async Task WhenAsyncEnumerableTypesHaveDependenciesOutsideTargetCollection_ShouldSucceed()
+			{
+				IAsyncEnumerable<Type?> subject = new[]
+				{
+					typeof(Layer1AndLayer2), typeof(OnlyLayer2),
+				}.ToTestAsyncEnumerable<Type?>();
+
+				async Task Act()
+				{
+					await That(subject).HaveDependenciesOutside(Types.InNamespace(Layer1Namespace));
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenAsyncEnumerableContainsTypeDependingOnlyOnTargetCollections_ShouldFail()
+			{
+				IAsyncEnumerable<Type?> subject = new[]
+				{
+					typeof(Layer1AndLayer2), typeof(OnlyLayer1),
+				}.ToTestAsyncEnumerable<Type?>();
+
+				async Task Act()
+				{
+					await That(subject).HaveDependenciesOutside(Types.InNamespace(Layer1Namespace));
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              all have dependencies outside types within namespace "{Layer1Namespace}" in all loaded assemblies,
+					              but it contained types depending only on the allowed types [
+					                OnlyLayer1
+					              ]
+					              """);
+			}
+#endif
+		}
+
+		public sealed class NegatedTests
+		{
 			[Fact]
 			public async Task WhenAllTypesHaveDependenciesOutside_ShouldFail()
 			{
@@ -359,8 +375,10 @@ public sealed partial class ThatTypes
 				];
 
 				async Task Act()
-					=> await That(subject)
+				{
+					await That(subject)
 						.DoesNotComplyWith(they => they.HaveDependenciesOutside(Layer1Namespace));
+				}
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage($"""
@@ -371,6 +389,24 @@ public sealed partial class ThatTypes
 					                OnlyLayer2 depends on ["{Layer2Namespace}"]
 					              ]
 					              """);
+			}
+
+			[Fact]
+			public async Task WhenSomeTypeDependsOnlyOnAllowedNamespaces_ShouldSucceed()
+			{
+				IEnumerable<Type?> subject =
+				[
+					typeof(Layer1AndLayer2),
+					typeof(OnlyLayer1),
+				];
+
+				async Task Act()
+				{
+					await That(subject)
+						.DoesNotComplyWith(they => they.HaveDependenciesOutside(Layer1Namespace));
+				}
+
+				await That(Act).DoesNotThrow();
 			}
 		}
 	}

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.HaveNoDependencyCycles.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.HaveNoDependencyCycles.Tests.cs
@@ -35,21 +35,6 @@ public sealed partial class ThatTypes
 		public sealed class Tests
 		{
 			[Fact]
-			public async Task WhenSetIsAcyclic_ShouldSucceed()
-			{
-				IEnumerable<Type?> subject =
-				[
-					typeof(HighType),
-					typeof(LowType),
-				];
-
-				async Task Act()
-					=> await That(subject).HaveNoDependencyCycles();
-
-				await That(Act).DoesNotThrow();
-			}
-
-			[Fact]
 			public async Task WhenCollectionContainsNull_ShouldIgnoreNull()
 			{
 				IEnumerable<Type?> subject =
@@ -60,76 +45,11 @@ public sealed partial class ThatTypes
 				];
 
 				async Task Act()
-					=> await That(subject).HaveNoDependencyCycles();
+				{
+					await That(subject).HaveNoDependencyCycles();
+				}
 
 				await That(Act).DoesNotThrow();
-			}
-
-			[Fact]
-			public async Task WhenTwoNamespacesFormCycle_ShouldFailAndListBothNamespaces()
-			{
-				IEnumerable<Type?> subject =
-				[
-					typeof(TwoOrders.Order),
-					typeof(TwoBilling.Invoice),
-				];
-
-				async Task Act()
-					=> await That(subject).HaveNoDependencyCycles();
-
-				await That(Act).Throws<XunitException>()
-					.WithMessage($"""
-					              Expected that subject
-					              have no dependency cycles,
-					              but it had a dependency cycle:
-					                {Prefix}.Two.Billing -> {Prefix}.Two.Orders -> {Prefix}.Two.Billing
-					              """);
-			}
-
-			[Fact]
-			public async Task WhenThreeNamespacesFormCycle_ShouldDetectTheLongerCycle()
-			{
-				IEnumerable<Type?> subject =
-				[
-					typeof(ThreeA.TypeA),
-					typeof(ThreeB.TypeB),
-					typeof(ThreeC.TypeC),
-				];
-
-				async Task Act()
-					=> await That(subject).HaveNoDependencyCycles();
-
-				await That(Act).Throws<XunitException>()
-					.WithMessage($"""
-					              Expected that subject
-					              have no dependency cycles,
-					              but it had a dependency cycle:
-					                {Prefix}.Three.A -> {Prefix}.Three.B -> {Prefix}.Three.C -> {Prefix}.Three.A
-					              """);
-			}
-
-			[Fact]
-			public async Task WhenOnlyDependingOnFrameworkTypes_ShouldSucceed()
-			{
-				IEnumerable<Type?> subject =
-				[
-					typeof(Service),
-				];
-
-				async Task Act()
-					=> await That(subject).HaveNoDependencyCycles();
-
-				await That(Act).DoesNotThrow();
-			}
-
-			[Fact]
-			public async Task WhenUsingNamespaceSource_ShouldDetectCycle()
-			{
-				async Task Act()
-					=> await That(Types.InNamespace($"{Prefix}.Two")).HaveNoDependencyCycles();
-
-				await That(Act).Throws<XunitException>()
-					.WithMessage("*had a dependency cycle*").AsWildcard();
 			}
 
 			[Fact]
@@ -142,9 +62,34 @@ public sealed partial class ThatTypes
 				];
 
 				async Task Act()
-					=> await That(subject).HaveNoDependencyCycles();
+				{
+					await That(subject).HaveNoDependencyCycles();
+				}
 
 				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenGlobalNamespaceIsInACycle_ShouldRenderGlobalNamespace()
+			{
+				IEnumerable<Type?> subject =
+				[
+					typeof(GlobalCycleType),
+					typeof(GlobalRingType),
+				];
+
+				async Task Act()
+				{
+					await That(subject).HaveNoDependencyCycles();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              have no dependency cycles,
+					              but it had a dependency cycle:
+					                <global namespace> -> {Prefix}.GlobalRing -> <global namespace>
+					              """);
 			}
 
 			[Fact]
@@ -160,7 +105,9 @@ public sealed partial class ThatTypes
 				];
 
 				async Task Act()
-					=> await That(subject).HaveNoDependencyCycles();
+				{
+					await That(subject).HaveNoDependencyCycles();
+				}
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage($"""
@@ -173,24 +120,95 @@ public sealed partial class ThatTypes
 			}
 
 			[Fact]
-			public async Task WhenGlobalNamespaceIsInACycle_ShouldRenderGlobalNamespace()
+			public async Task WhenOnlyDependingOnFrameworkTypes_ShouldSucceed()
 			{
 				IEnumerable<Type?> subject =
 				[
-					typeof(GlobalCycleType),
-					typeof(GlobalRingType),
+					typeof(Service),
 				];
 
 				async Task Act()
-					=> await That(subject).HaveNoDependencyCycles();
+				{
+					await That(subject).HaveNoDependencyCycles();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenSetIsAcyclic_ShouldSucceed()
+			{
+				IEnumerable<Type?> subject =
+				[
+					typeof(HighType),
+					typeof(LowType),
+				];
+
+				async Task Act()
+				{
+					await That(subject).HaveNoDependencyCycles();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
+			public async Task WhenThreeNamespacesFormCycle_ShouldDetectTheLongerCycle()
+			{
+				IEnumerable<Type?> subject =
+				[
+					typeof(ThreeA.TypeA),
+					typeof(ThreeB.TypeB),
+					typeof(ThreeC.TypeC),
+				];
+
+				async Task Act()
+				{
+					await That(subject).HaveNoDependencyCycles();
+				}
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage($"""
 					              Expected that subject
 					              have no dependency cycles,
 					              but it had a dependency cycle:
-					                <global namespace> -> {Prefix}.GlobalRing -> <global namespace>
+					                {Prefix}.Three.A -> {Prefix}.Three.B -> {Prefix}.Three.C -> {Prefix}.Three.A
 					              """);
+			}
+
+			[Fact]
+			public async Task WhenTwoNamespacesFormCycle_ShouldFailAndListBothNamespaces()
+			{
+				IEnumerable<Type?> subject =
+				[
+					typeof(TwoOrders.Order),
+					typeof(TwoBilling.Invoice),
+				];
+
+				async Task Act()
+				{
+					await That(subject).HaveNoDependencyCycles();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              have no dependency cycles,
+					              but it had a dependency cycle:
+					                {Prefix}.Two.Billing -> {Prefix}.Two.Orders -> {Prefix}.Two.Billing
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenUsingNamespaceSource_ShouldDetectCycle()
+			{
+				async Task Act()
+				{
+					await That(Types.InNamespace($"{Prefix}.Two")).HaveNoDependencyCycles();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage("*had a dependency cycle*").AsWildcard();
 			}
 		}
 
@@ -206,7 +224,9 @@ public sealed partial class ThatTypes
 				];
 
 				async Task Act()
-					=> await That(subject).DoesNotComplyWith(they => they.HaveNoDependencyCycles());
+				{
+					await That(subject).DoesNotComplyWith(they => they.HaveNoDependencyCycles());
+				}
 
 				await That(Act).DoesNotThrow();
 			}
@@ -221,7 +241,9 @@ public sealed partial class ThatTypes
 				];
 
 				async Task Act()
-					=> await That(subject).DoesNotComplyWith(they => they.HaveNoDependencyCycles());
+				{
+					await That(subject).DoesNotComplyWith(they => they.HaveNoDependencyCycles());
+				}
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage("""
@@ -234,22 +256,6 @@ public sealed partial class ThatTypes
 
 		public sealed class ResolverTests
 		{
-			[Fact]
-			public async Task WithSignatureResolver_ABodyOnlyEdge_ShouldNotFormACycle()
-			{
-				IEnumerable<Type?> subject =
-				[
-					typeof(ResolverA.ResolverA),
-					typeof(ResolverB.ResolverB),
-				];
-
-				async Task Act()
-					=> await That(subject).HaveNoDependencyCycles();
-
-				// Only the signature edge A -> B is visible, so there is no cycle.
-				await That(Act).DoesNotThrow();
-			}
-
 			[Fact]
 			public async Task WhenAResolverSuppliesTheReverseEdge_ShouldDetectTheCycle()
 			{
@@ -269,31 +275,58 @@ public sealed partial class ThatTypes
 					       : builtin(type)))
 				{
 					async Task Act()
-						=> await That(subject).HaveNoDependencyCycles();
+					{
+						await That(subject).HaveNoDependencyCycles();
+					}
 
 					await That(Act).Throws<XunitException>()
 						.WithMessage("*had a dependency cycle*").AsWildcard();
 				}
 			}
+
+			[Fact]
+			public async Task WithSignatureResolver_ABodyOnlyEdge_ShouldNotFormACycle()
+			{
+				IEnumerable<Type?> subject =
+				[
+					typeof(ResolverA.ResolverA),
+					typeof(ResolverB.ResolverB),
+				];
+
+				async Task Act()
+				{
+					await That(subject).HaveNoDependencyCycles();
+				}
+
+				// Only the signature edge A -> B is visible, so there is no cycle.
+				await That(Act).DoesNotThrow();
+			}
 		}
 
 		public sealed class SliceTests
 		{
-			private const string Prefix = HaveNoDependencyCycles.Prefix;
-
 			[Fact]
-			public async Task WhenSubNamespacesShareSlice_ShouldCollapseAndSucceed()
+			public async Task WhenGroupingCollapsesNamespacesIntoSlices_ShouldReportSliceNames()
 			{
 				IEnumerable<Type?> subject =
 				[
-					typeof(SlicedPart1.Part1Type),
-					typeof(SlicedPart2.Part2Type),
+					typeof(GroupedOrdersDomain.OrderDomain),
+					typeof(GroupedOrdersApi.OrderApi),
+					typeof(GroupedBilling.Invoice),
 				];
 
 				async Task Act()
-					=> await That(subject).HaveNoDependencyCycles($"{Prefix}.Sliced");
+				{
+					await That(subject).HaveNoDependencyCycles($"{Prefix}.Grouped");
+				}
 
-				await That(Act).DoesNotThrow();
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              have no dependency cycles when grouped into slices under "{Prefix}.Grouped",
+					              but it had a dependency cycle:
+					                {Prefix}.Grouped.Billing -> {Prefix}.Grouped.Orders -> {Prefix}.Grouped.Billing
+					              """);
 			}
 
 			[Fact]
@@ -306,7 +339,9 @@ public sealed partial class ThatTypes
 				];
 
 				async Task Act()
-					=> await That(subject).HaveNoDependencyCycles();
+				{
+					await That(subject).HaveNoDependencyCycles();
+				}
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage($"""
@@ -318,69 +353,27 @@ public sealed partial class ThatTypes
 			}
 
 			[Fact]
-			public async Task WhenGroupingCollapsesNamespacesIntoSlices_ShouldReportSliceNames()
+			public async Task WhenSubNamespacesShareSlice_ShouldCollapseAndSucceed()
 			{
 				IEnumerable<Type?> subject =
 				[
-					typeof(GroupedOrdersDomain.OrderDomain),
-					typeof(GroupedOrdersApi.OrderApi),
-					typeof(GroupedBilling.Invoice),
+					typeof(SlicedPart1.Part1Type),
+					typeof(SlicedPart2.Part2Type),
 				];
 
 				async Task Act()
-					=> await That(subject).HaveNoDependencyCycles($"{Prefix}.Grouped");
-
-				await That(Act).Throws<XunitException>()
-					.WithMessage($"""
-					              Expected that subject
-					              have no dependency cycles when grouped into slices under "{Prefix}.Grouped",
-					              but it had a dependency cycle:
-					                {Prefix}.Grouped.Billing -> {Prefix}.Grouped.Orders -> {Prefix}.Grouped.Billing
-					              """);
-			}
-		}
-
-		public sealed class SubNamespaceTests
-		{
-			private const string Prefix = HaveNoDependencyCycles.Prefix;
-
-			[Fact]
-			public async Task WhenParentAndChildReferenceEachOther_ShouldSucceedByDefault()
-			{
-				// By default a namespace and its sub-namespaces are one family, so the references do not form a cycle.
-				IEnumerable<Type?> subject =
-				[
-					typeof(FamilyParent),
-					typeof(FamilyChild),
-				];
-
-				async Task Act()
-					=> await That(subject).HaveNoDependencyCycles();
+				{
+					await That(subject).HaveNoDependencyCycles($"{Prefix}.Sliced");
+				}
 
 				await That(Act).DoesNotThrow();
 			}
 
-			[Fact]
-			public async Task WhenExcludingSubNamespaces_ShouldDetectTheFamilyCycle()
-			{
-				IEnumerable<Type?> subject =
-				[
-					typeof(FamilyParent),
-					typeof(FamilyChild),
-				];
+			private const string Prefix = HaveNoDependencyCycles.Prefix;
+		}
 
-				async Task Act()
-					=> await That(subject).HaveNoDependencyCycles().ExcludingSubNamespaces();
-
-				await That(Act).Throws<XunitException>()
-					.WithMessage($"""
-					              Expected that subject
-					              have no dependency cycles,
-					              but it had a dependency cycle:
-					                {Prefix}.Family -> {Prefix}.Family.Inner -> {Prefix}.Family
-					              """);
-			}
-
+		public sealed class SubNamespaceTests
+		{
 			[Fact]
 			public async Task WhenCycleReentersFamilyThroughSubNamespace_ShouldDetectItByDefault()
 			{
@@ -394,7 +387,9 @@ public sealed partial class ThatTypes
 				];
 
 				async Task Act()
-					=> await That(subject).HaveNoDependencyCycles();
+				{
+					await That(subject).HaveNoDependencyCycles();
+				}
 
 				await That(Act).Throws<XunitException>()
 					.WithMessage($"""
@@ -402,6 +397,29 @@ public sealed partial class ThatTypes
 					              have no dependency cycles,
 					              but it had a dependency cycle:
 					                {Prefix}.Indirect.Other -> {Prefix}.Indirect.Parent -> {Prefix}.Indirect.Other
+					              """);
+			}
+
+			[Fact]
+			public async Task WhenExcludingSubNamespaces_ShouldDetectTheFamilyCycle()
+			{
+				IEnumerable<Type?> subject =
+				[
+					typeof(FamilyParent),
+					typeof(FamilyChild),
+				];
+
+				async Task Act()
+				{
+					await That(subject).HaveNoDependencyCycles().ExcludingSubNamespaces();
+				}
+
+				await That(Act).Throws<XunitException>()
+					.WithMessage($"""
+					              Expected that subject
+					              have no dependency cycles,
+					              but it had a dependency cycle:
+					                {Prefix}.Family -> {Prefix}.Family.Inner -> {Prefix}.Family
 					              """);
 			}
 
@@ -418,10 +436,32 @@ public sealed partial class ThatTypes
 				];
 
 				async Task Act()
-					=> await That(subject).HaveNoDependencyCycles().ExcludingSubNamespaces();
+				{
+					await That(subject).HaveNoDependencyCycles().ExcludingSubNamespaces();
+				}
 
 				await That(Act).DoesNotThrow();
 			}
+
+			[Fact]
+			public async Task WhenParentAndChildReferenceEachOther_ShouldSucceedByDefault()
+			{
+				// By default a namespace and its sub-namespaces are one family, so the references do not form a cycle.
+				IEnumerable<Type?> subject =
+				[
+					typeof(FamilyParent),
+					typeof(FamilyChild),
+				];
+
+				async Task Act()
+				{
+					await That(subject).HaveNoDependencyCycles();
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			private const string Prefix = HaveNoDependencyCycles.Prefix;
 		}
 	}
 }

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.HaveNoDependencyCycles.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.HaveNoDependencyCycles.Tests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using aweXpect.Customization;
 using aweXpect.Reflection.Tests.TestHelpers.Dependencies.Cycles.Acyclic.High;

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.HaveOperator.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.HaveOperator.Tests.cs
@@ -173,29 +173,6 @@ public sealed partial class ThatTypes
 			}
 
 			[Fact]
-			public async Task WhenSomeTypeHasTheOperatorWithTypeOperand_ShouldFail()
-			{
-				IEnumerable<Type?> subject = new[]
-				{
-					typeof(Money), typeof(ClassWithoutOperators),
-				};
-
-				async Task Act()
-				{
-					await That(subject).DoNotHaveOperator(Operator.Addition, typeof(Money));
-				}
-
-				await That(Act).ThrowsException()
-					.WithMessage($"""
-					              Expected that subject
-					              all do not have the operator Addition with operand {Formatter.Format(typeof(Money))},
-					              but it contained types with the operator Addition with operand {Formatter.Format(typeof(Money))} [
-					                *
-					              ]
-					              """).AsWildcard();
-			}
-
-			[Fact]
 			public async Task WhenSomeTypeHasTheOperatorWithOperand_ShouldFail()
 			{
 				IEnumerable<Type?> subject = new[]
@@ -213,6 +190,29 @@ public sealed partial class ThatTypes
 					              Expected that subject
 					              all do not have the operator Addition with operand {Formatter.Format(typeof(int))},
 					              but it contained types with the operator Addition with operand {Formatter.Format(typeof(int))} [
+					                *
+					              ]
+					              """).AsWildcard();
+			}
+
+			[Fact]
+			public async Task WhenSomeTypeHasTheOperatorWithTypeOperand_ShouldFail()
+			{
+				IEnumerable<Type?> subject = new[]
+				{
+					typeof(Money), typeof(ClassWithoutOperators),
+				};
+
+				async Task Act()
+				{
+					await That(subject).DoNotHaveOperator(Operator.Addition, typeof(Money));
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage($"""
+					              Expected that subject
+					              all do not have the operator Addition with operand {Formatter.Format(typeof(Money))},
+					              but it contained types with the operator Addition with operand {Formatter.Format(typeof(Money))} [
 					                *
 					              ]
 					              """).AsWildcard();
@@ -320,6 +320,22 @@ public sealed partial class ThatTypes
 			}
 
 			[Fact]
+			public async Task WhenNoTypeHasTheOperatorWithOperand_ShouldSucceed()
+			{
+				IAsyncEnumerable<Type?> subject = new[]
+				{
+					typeof(Money),
+				}.ToTestAsyncEnumerable<Type?>();
+
+				async Task Act()
+				{
+					await That(subject).DoNotHaveOperator<string>(Operator.Addition);
+				}
+
+				await That(Act).DoesNotThrow();
+			}
+
+			[Fact]
 			public async Task WhenSomeTypeDoesNotHaveTheOperator_ShouldFail()
 			{
 				IAsyncEnumerable<Type?> subject = new[]
@@ -340,22 +356,6 @@ public sealed partial class ThatTypes
 					               *
 					             ]
 					             """).AsWildcard();
-			}
-
-			[Fact]
-			public async Task WhenNoTypeHasTheOperatorWithOperand_ShouldSucceed()
-			{
-				IAsyncEnumerable<Type?> subject = new[]
-				{
-					typeof(Money),
-				}.ToTestAsyncEnumerable<Type?>();
-
-				async Task Act()
-				{
-					await That(subject).DoNotHaveOperator<string>(Operator.Addition);
-				}
-
-				await That(Act).DoesNotThrow();
 			}
 
 			[Fact]

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.InheritFrom.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.InheritFrom.Tests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using aweXpect.Reflection.Collections;
 using Xunit.Sdk;
 

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.OnlyHaveNonNullableMembers.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.OnlyHaveNonNullableMembers.Tests.cs
@@ -32,6 +32,30 @@ public sealed partial class ThatTypes
 			}
 
 			[Fact]
+			public async Task WhenCollectionContainsNull_ShouldListNullWithoutViolations()
+			{
+				IEnumerable<Type?> subject =
+				[
+					typeof(ClassWithNonNullableMembers),
+					null,
+				];
+
+				async Task Act()
+				{
+					await That(subject).OnlyHaveNonNullableMembers();
+				}
+
+				await That(Act).ThrowsException()
+					.WithMessage("""
+					             Expected that subject
+					             only have non-nullable members,
+					             but it contained types with nullable members [
+					               <null>
+					             ]
+					             """);
+			}
+
+			[Fact]
 			public async Task WhenTypesContainTypeWithNullableMembers_ShouldFail()
 			{
 				IEnumerable<Type?> subject =
@@ -55,30 +79,6 @@ public sealed partial class ThatTypes
 					                ClassWithSingleNullableProperty with nullable members [{Formatter.Format(property)}]
 					              ]
 					              """);
-			}
-
-			[Fact]
-			public async Task WhenCollectionContainsNull_ShouldListNullWithoutViolations()
-			{
-				IEnumerable<Type?> subject =
-				[
-					typeof(ClassWithNonNullableMembers),
-					null,
-				];
-
-				async Task Act()
-				{
-					await That(subject).OnlyHaveNonNullableMembers();
-				}
-
-				await That(Act).ThrowsException()
-					.WithMessage("""
-					             Expected that subject
-					             only have non-nullable members,
-					             but it contained types with nullable members [
-					               <null>
-					             ]
-					             """);
 			}
 		}
 
@@ -133,8 +133,7 @@ public sealed partial class ThatTypes
 			{
 				IAsyncEnumerable<Type?> subject = new[]
 					{
-						typeof(ClassWithNonNullableMembers),
-						typeof(ClassWithSingleNonNullableProperty),
+						typeof(ClassWithNonNullableMembers), typeof(ClassWithSingleNonNullableProperty),
 					}
 					.ToTestAsyncEnumerable<Type?>();
 
@@ -151,8 +150,7 @@ public sealed partial class ThatTypes
 			{
 				IAsyncEnumerable<Type?> subject = new[]
 					{
-						typeof(ClassWithNonNullableMembers),
-						typeof(ClassWithSingleNullableProperty),
+						typeof(ClassWithNonNullableMembers), typeof(ClassWithSingleNullableProperty),
 					}
 					.ToTestAsyncEnumerable<Type?>();
 

--- a/Tests/aweXpect.Reflection.Tests/ThatTypes.OnlyHaveNullableMembers.Tests.cs
+++ b/Tests/aweXpect.Reflection.Tests/ThatTypes.OnlyHaveNullableMembers.Tests.cs
@@ -32,15 +32,13 @@ public sealed partial class ThatTypes
 			}
 
 			[Fact]
-			public async Task WhenTypesContainTypeWithNonNullableMembers_ShouldFail()
+			public async Task WhenCollectionContainsNull_ShouldListNullWithoutViolations()
 			{
 				IEnumerable<Type?> subject =
 				[
 					typeof(ClassWithNullableMembers),
-					typeof(ClassWithSingleNonNullableProperty),
+					null,
 				];
-				PropertyInfo property = typeof(ClassWithSingleNonNullableProperty)
-					.GetProperty(nameof(ClassWithSingleNonNullableProperty.NonNullableProperty))!;
 
 				async Task Act()
 				{
@@ -48,13 +46,13 @@ public sealed partial class ThatTypes
 				}
 
 				await That(Act).ThrowsException()
-					.WithMessage($"""
-					              Expected that subject
-					              only have nullable members,
-					              but it contained types with non-nullable members [
-					                ClassWithSingleNonNullableProperty with non-nullable members [{Formatter.Format(property)}]
-					              ]
-					              """);
+					.WithMessage("""
+					             Expected that subject
+					             only have nullable members,
+					             but it contained types with non-nullable members [
+					               <null>
+					             ]
+					             """);
 			}
 
 			[Fact]
@@ -85,13 +83,15 @@ public sealed partial class ThatTypes
 			}
 
 			[Fact]
-			public async Task WhenCollectionContainsNull_ShouldListNullWithoutViolations()
+			public async Task WhenTypesContainTypeWithNonNullableMembers_ShouldFail()
 			{
 				IEnumerable<Type?> subject =
 				[
 					typeof(ClassWithNullableMembers),
-					null,
+					typeof(ClassWithSingleNonNullableProperty),
 				];
+				PropertyInfo property = typeof(ClassWithSingleNonNullableProperty)
+					.GetProperty(nameof(ClassWithSingleNonNullableProperty.NonNullableProperty))!;
 
 				async Task Act()
 				{
@@ -99,13 +99,13 @@ public sealed partial class ThatTypes
 				}
 
 				await That(Act).ThrowsException()
-					.WithMessage("""
-					             Expected that subject
-					             only have nullable members,
-					             but it contained types with non-nullable members [
-					               <null>
-					             ]
-					             """);
+					.WithMessage($"""
+					              Expected that subject
+					              only have nullable members,
+					              but it contained types with non-nullable members [
+					                ClassWithSingleNonNullableProperty with non-nullable members [{Formatter.Format(property)}]
+					              ]
+					              """);
 			}
 		}
 
@@ -160,8 +160,7 @@ public sealed partial class ThatTypes
 			{
 				IAsyncEnumerable<Type?> subject = new[]
 					{
-						typeof(ClassWithNullableMembers),
-						typeof(ClassWithSingleNullableProperty),
+						typeof(ClassWithNullableMembers), typeof(ClassWithSingleNullableProperty),
 					}
 					.ToTestAsyncEnumerable<Type?>();
 
@@ -178,8 +177,7 @@ public sealed partial class ThatTypes
 			{
 				IAsyncEnumerable<Type?> subject = new[]
 					{
-						typeof(ClassWithNullableMembers),
-						typeof(ClassWithSingleNonNullableProperty),
+						typeof(ClassWithNullableMembers), typeof(ClassWithSingleNonNullableProperty),
 					}
 					.ToTestAsyncEnumerable<Type?>();
 

--- a/Tests/aweXpect.Reflection.Tests/TypesTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/TypesTests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Reflection;
 using aweXpect.Reflection.Collections;
 using aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope;

--- a/Tests/aweXpect.Reflection.Tests/TypesTests.cs
+++ b/Tests/aweXpect.Reflection.Tests/TypesTests.cs
@@ -11,8 +11,6 @@ namespace aweXpect.Reflection.Tests;
 // ReSharper disable PossibleMultipleEnumeration
 public sealed class TypesTests
 {
-	private const string NamespaceScope = "aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope";
-
 	[Fact]
 	public async Task InAllLoadedAssemblies_ShouldContainTypesFromMultipleAssemblies()
 	{
@@ -66,74 +64,14 @@ public sealed class TypesTests
 	}
 
 	[Fact]
-	public async Task InNamespace_ShouldContainTypesWithinNamespaceIncludingSubNamespaces()
+	public async Task InNamespace_AfterClarification_OriginalShouldStillUseAllLoadedAssemblies()
 	{
-		Filtered.Types sut = Types.InNamespace(NamespaceScope);
+		Filtered.Types.InNamespaceResult sut = Types.InNamespace(NamespaceScope);
+		_ = sut.InAssemblyContaining(typeof(In));
 
 		await That(sut).Contains(typeof(ClassInNamespaceScope));
-		await That(sut).Contains(typeof(ClassInNestedNamespaceScope));
-		await That(sut).DoesNotContain(typeof(ClassInSiblingNamespaceScope));
 		await That(sut.GetDescription())
 			.IsEqualTo($"types within namespace \"{NamespaceScope}\" in all loaded assemblies");
-	}
-
-	[Fact]
-	public async Task InNamespace_ShouldSelectTypesThatCanBeAsserted()
-	{
-		Filtered.Types sut = Types.InNamespace(NamespaceScope);
-
-		async Task Act()
-			=> await That(sut).AreWithinNamespace(NamespaceScope);
-
-		await That(Act).DoesNotThrow();
-	}
-
-	[Fact]
-	public async Task InNamespace_WhenAssertionFails_ShouldReportFullMessage()
-	{
-		Filtered.Types sut = Types.InNamespace(NamespaceScope);
-
-		async Task Act()
-			=> await That(sut)
-				.AreWithinNamespace("aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScopeSibling");
-
-		await That(Act).Throws<XunitException>()
-			.WithMessage("""
-			             Expected that types within namespace "aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope" in all loaded assemblies
-			             are all within namespace "aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScopeSibling",
-			             but it contained not matching types [
-			               *
-			             ]
-			             """).AsWildcard();
-	}
-
-	[Fact]
-	public async Task InNamespace_WhenNegatingMatchingAssertion_ShouldReportFullMessage()
-	{
-		Filtered.Types sut = Types.InNamespace(NamespaceScope);
-
-		async Task Act()
-			=> await That(sut).DoesNotComplyWith(they
-				=> they.AreWithinNamespace(NamespaceScope));
-
-		await That(Act).Throws<XunitException>()
-			.WithMessage("""
-			             Expected that types within namespace "aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope" in all loaded assemblies
-			             are not all within namespace "aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope",
-			             but it only contained matching types [
-			               *
-			             ]
-			             """).AsWildcard();
-	}
-
-	[Fact]
-	public async Task InNamespace_WhenNoTypesAreInNamespace_ShouldBeEmpty()
-	{
-		Filtered.Types sut = Types.InNamespace("Non.Existent.Namespace");
-
-		await That(sut).IsEmpty();
-		await That(sut.GetDescription())
-			.IsEqualTo("types within namespace \"Non.Existent.Namespace\" in all loaded assemblies");
 	}
 
 	[Fact]
@@ -179,13 +117,81 @@ public sealed class TypesTests
 	}
 
 	[Fact]
-	public async Task InNamespace_AfterClarification_OriginalShouldStillUseAllLoadedAssemblies()
+	public async Task InNamespace_ShouldContainTypesWithinNamespaceIncludingSubNamespaces()
 	{
-		Filtered.Types.InNamespaceResult sut = Types.InNamespace(NamespaceScope);
-		_ = sut.InAssemblyContaining(typeof(In));
+		Filtered.Types sut = Types.InNamespace(NamespaceScope);
 
 		await That(sut).Contains(typeof(ClassInNamespaceScope));
+		await That(sut).Contains(typeof(ClassInNestedNamespaceScope));
+		await That(sut).DoesNotContain(typeof(ClassInSiblingNamespaceScope));
 		await That(sut.GetDescription())
 			.IsEqualTo($"types within namespace \"{NamespaceScope}\" in all loaded assemblies");
 	}
+
+	[Fact]
+	public async Task InNamespace_ShouldSelectTypesThatCanBeAsserted()
+	{
+		Filtered.Types sut = Types.InNamespace(NamespaceScope);
+
+		async Task Act()
+		{
+			await That(sut).AreWithinNamespace(NamespaceScope);
+		}
+
+		await That(Act).DoesNotThrow();
+	}
+
+	[Fact]
+	public async Task InNamespace_WhenAssertionFails_ShouldReportFullMessage()
+	{
+		Filtered.Types sut = Types.InNamespace(NamespaceScope);
+
+		async Task Act()
+		{
+			await That(sut)
+				.AreWithinNamespace("aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScopeSibling");
+		}
+
+		await That(Act).Throws<XunitException>()
+			.WithMessage("""
+			             Expected that types within namespace "aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope" in all loaded assemblies
+			             are all within namespace "aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScopeSibling",
+			             but it contained not matching types [
+			               *
+			             ]
+			             """).AsWildcard();
+	}
+
+	[Fact]
+	public async Task InNamespace_WhenNegatingMatchingAssertion_ShouldReportFullMessage()
+	{
+		Filtered.Types sut = Types.InNamespace(NamespaceScope);
+
+		async Task Act()
+		{
+			await That(sut).DoesNotComplyWith(they
+				=> they.AreWithinNamespace(NamespaceScope));
+		}
+
+		await That(Act).Throws<XunitException>()
+			.WithMessage("""
+			             Expected that types within namespace "aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope" in all loaded assemblies
+			             are not all within namespace "aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope",
+			             but it only contained matching types [
+			               *
+			             ]
+			             """).AsWildcard();
+	}
+
+	[Fact]
+	public async Task InNamespace_WhenNoTypesAreInNamespace_ShouldBeEmpty()
+	{
+		Filtered.Types sut = Types.InNamespace("Non.Existent.Namespace");
+
+		await That(sut).IsEmpty();
+		await That(sut.GetDescription())
+			.IsEqualTo("types within namespace \"Non.Existent.Namespace\" in all loaded assemblies");
+	}
+
+	private const string NamespaceScope = "aweXpect.Reflection.Tests.TestHelpers.Types.NamespaceScope";
 }


### PR DESCRIPTION
Normalizes all .cs files to a consistent encoding and applies a repo-wide code style cleanup. No behavioral changes — the public API and the test set are unchanged.

- Encoding normalization: All .cs files are now UTF-8 with BOM, enforced via .editorconfig (charset = utf-8-bom). This stops tools that create or rewrite files with no-BOM defaults from producing spurious encoding-only diffs.
- Code style cleanup: Member reordering, lambda/expression formatting, field → auto-property conversion, alphabetical test ordering, README table alignment.

**Fixes during stabilization**

- Native line endings for .cs checkouts: The normalization commit initially forced *.cs text eol=crlf in .gitattributes, which made Linux checkouts CRLF — raw string literals in tests then contained \r\n while assertion messages are built with Environment.NewLine (\n on Linux), failing ~2,500 message-assertion tests on ubuntu CI. Reverted to *.cs text: blobs stay LF-normalized, the
working tree uses platform-native line endings (CRLF on Windows, LF on Linux/macOS). A comment in .gitattributes documents why eol=crlf must not be used. The BOM rule is unaffected (git cannot enforce BOMs; that lives in .editorconfig).
- Restored sealed modifiers: The cleanup pass stripped sealed from two overrides in TypeFilters.MemberAccess.Tests.cs despite a "do not remove" comment. Without the explicit modifier the compiler does not emit final, so MethodInfo.IsFinal is false and ShouldChainSealedBeforeMethods fails. Now guarded with // ReSharper disable SealedMemberInSealedClass so future cleanup passes keep them.

- Native line endings for .cs checkouts: The normalization commit initially forced *.cs text eol=crlf in .gitattributes, which made Linux checkouts CRLF — raw string literals in tests then contained \r\n while assertion messages are built with Environment.NewLine (\n on Linux), failing ~2,500 message-assertion tests on ubuntu CI. Reverted to *.cs text: blobs stay LF-normalized, the working tree uses platform-native line endings (CRLF on Windows, LF on Linux/macOS). A comment in .gitattributes documents why eol=crlf must not be used. The BOM rule is unaffected (git cannot enforce BOMs; that lives in .editorconfig).
- Restored sealed modifiers: The cleanup pass stripped sealed from two overrides in TypeFilters.MemberAccess.Tests.cs despite a "do not remove" comment. Without the explicit modifier the compiler does not emit final, so MethodInfo.IsFinal is false and ShouldChainSealedBeforeMethods fails. Now guarded with // ReSharper disable SealedMemberInSealedClass so future cleanup passes keep them.